### PR TITLE
[codex] Add Subhamoy strategy generators and backtests

### DIFF
--- a/My Backtest Files (For Reference)/Readme.md
+++ b/My Backtest Files (For Reference)/Readme.md
@@ -9,6 +9,8 @@ Link: https://kernc.github.io/backtesting.py/
 | File | Strategy | Imports from `Signal Generators/` |
 |---|---|---|
 | `Nifty CPR Strategy Backtest.py` | CPR PDF strategy on 5-minute candles, with Algo 1, Algo 2, and RSI divergence | `Signal Generators/CPR Strategy/cpr_strategy_logic.py` |
+| `Subhamoy Strategies/Nifty Goldmine Strategy Backtest.py` | Goldmine SMA20/SMA200 pullback strategy with engulfing entry | `Signal Generators/Subhamoy Strategies/goldmine_strategy_logic.py` |
+| `Subhamoy Strategies/Nifty Money Machine Strategy Backtest.py` | Money Machine SMA20/SMA200 compression strategy with Hulk/Marubozu entry | `Signal Generators/Subhamoy Strategies/money_machine_strategy_logic.py` |
 | `Nifty EMA Trend Strategy Backtest.py` | 4/11/18 EMA trend, ADX-filtered | `ema_trend_strategy_logic.py` |
 | `Nifty Heiken Ashi Futures 5Y Backtest.py` | Heikin Ashi + Bollinger Bands | (self-contained) |
 | `Nifty Renko Strategy Backtest.py` | Renko + 9/21 EMA | `renko_strategy_logic_9_21.py` |
@@ -23,6 +25,12 @@ By default each backtest reads `<repo_root>/Backtest Outputs/nifty_renko_futures
 Run the CPR backtest with:
 ```
 python "My Backtest Files (For Reference)/Nifty CPR Strategy Backtest.py" --dataset nifty --data "Backtest Outputs/nifty_renko_futures_5y_1min_data.csv"
+```
+
+Run the Subhamoy backtests with already-prepared 5-minute OHLC CSVs:
+```
+python "My Backtest Files (For Reference)/Subhamoy Strategies/Nifty Goldmine Strategy Backtest.py" --dataset nifty --data "path/to/five_minute_data.csv"
+python "My Backtest Files (For Reference)/Subhamoy Strategies/Nifty Money Machine Strategy Backtest.py" --dataset nifty --data "path/to/five_minute_data.csv"
 ```
 
 # Where outputs land

--- a/My Backtest Files (For Reference)/Subhamoy Strategies/Nifty Goldmine Strategy Backtest.py
+++ b/My Backtest Files (For Reference)/Subhamoy Strategies/Nifty Goldmine Strategy Backtest.py
@@ -1,0 +1,434 @@
+"""
+Backtest the NIFTY Goldmine strategy using backtesting.py.
+
+Beginner flow:
+1. Load an already-prepared 5-minute OHLC CSV.
+2. Validate that the file really is 5-minute data. No resampling happens here.
+3. Precompute Goldmine indicators and setup candles.
+4. Submit market entries after a completed setup candle.
+5. Sync the actual next-open fill, then attach stop/target levels.
+6. Use the shared Goldmine engine for time exits and any manual exit decisions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from backtesting import Backtest, Strategy
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+ROOT_DIR = SCRIPT_DIR.parents[1]
+SIGNAL_GENERATOR_DIR = ROOT_DIR / "Signal Generators" / "Subhamoy Strategies"
+if str(SIGNAL_GENERATOR_DIR) not in sys.path:
+    # The repo stores signal generators and backtests in different top-level
+    # folders. This path bridge lets the backtest import the shared Goldmine
+    # engine no matter where the command is launched from.
+    sys.path.insert(0, str(SIGNAL_GENERATOR_DIR))
+
+from goldmine_strategy_logic import (
+    GoldminePositionContext,
+    GoldmineSignalEngine,
+    GoldmineStrategyConfig,
+    build_goldmine_with_indicators,
+)
+from subhamoy_backtest_common import (
+    AUTO_ADJUST_MARGIN,
+    DAILY_MAX_LOSS_PCT,
+    ENTRY_START_TIME,
+    MARGIN_REQUIREMENT,
+    MIN_MARGIN_FLOOR,
+    POSITION_SIZE,
+    SQUARE_OFF_TIME,
+    STARTING_CAPITAL,
+    build_output_paths,
+    env_float,
+    env_int,
+    load_ohlc_data,
+    log_selected_stats,
+    normalize_dataset_key,
+    save_outputs,
+    setup_logging,
+)
+
+
+STRATEGY_CONFIG = GoldmineStrategyConfig(
+    sma_fast_period=env_int("GOLDMINE_SMA_FAST_PERIOD", 20),
+    sma_slow_period=env_int("GOLDMINE_SMA_SLOW_PERIOD", 200),
+    atr_period=env_int("GOLDMINE_ATR_PERIOD", 14),
+    slope_lookback=env_int("GOLDMINE_SLOPE_LOOKBACK", 3),
+    pullback_lookback=env_int("GOLDMINE_PULLBACK_LOOKBACK", 3),
+    pullback_min_count=env_int("GOLDMINE_PULLBACK_MIN_COUNT", 2),
+    near_sma_atr_multiple=env_float("GOLDMINE_NEAR_SMA_ATR_MULT", 0.5),
+    engulf_tolerance=env_float("GOLDMINE_ENGULF_TOLERANCE", 0.05),
+    target_atr_multiple=env_float("GOLDMINE_TARGET_ATR_MULT", 2.0),
+    max_bars_in_trade=env_int("GOLDMINE_MAX_BARS_IN_TRADE", 6),
+)
+
+
+class NiftyGoldmineStrategyBacktest(Strategy):
+    """
+    backtesting.py strategy class for the Goldmine futures strategy.
+
+    Think of this class as the backtest "orchestrator":
+    - the shared Goldmine module decides whether a candle is a valid setup
+    - this class decides when an order can be placed, how it fills, and how
+      session-level protections like square-off and daily loss caps behave
+    """
+
+    lot_size = POSITION_SIZE
+
+    def init(self) -> None:
+        """Prepare strategy state for the whole backtest run."""
+        # The shared signal engine owns Goldmine rules. The backtest owns only
+        # execution simulation and risk bookkeeping.
+        self.signal_engine = GoldmineSignalEngine(STRATEGY_CONFIG)
+        self.last_processed_candle_ts = None
+
+        # `pending_entry` means a signal candle has completed and a market order
+        # has been submitted, but backtesting.py has not yet filled it at the
+        # next bar open.
+        self.pending_entry: dict[str, object] | None = None
+        # These fields mirror the currently open trade in simple underlying
+        # prices so the shared engine can evaluate exits without depending on
+        # backtesting.py internals.
+        self.trade_direction = ""
+        self.entry_underlying = 0.0
+        self.stop_underlying = 0.0
+        self.target_underlying = 0.0
+        self.bars_in_trade = 0
+
+        self.signal_count = 0
+        self.entry_submit_count = 0
+        self.exit_count = 0
+        self.square_off_count = 0
+        self.daily_loss_halt_count = 0
+        self.margin_skip_count = 0
+        self.last_closed_trade_count = 0
+
+        # Daily risk state resets at each new trading date. It is kept in the
+        # strategy object so the saved daily-loss CSV can show what happened.
+        self.current_day = None
+        self.day_start_equity = None
+        self.day_loss_limit = STARTING_CAPITAL * DAILY_MAX_LOSS_PCT
+        self.day_trading_blocked = False
+        self.square_off_requested_date = None
+        self.daily_loss_tracker: dict[object, float] = {}
+        self.margin_skip_logged_dates = set()
+
+        # Precompute all indicator columns once from the already-loaded 5-minute
+        # data. During `next()` we slice only the candles visible up to the
+        # current bar, so the strategy still avoids lookahead.
+        source = pd.DataFrame(
+            {
+                "timestamp": pd.DatetimeIndex(self.data.index),
+                "open": np.asarray(self.data.Open, dtype=float),
+                "high": np.asarray(self.data.High, dtype=float),
+                "low": np.asarray(self.data.Low, dtype=float),
+                "close": np.asarray(self.data.Close, dtype=float),
+                "volume": np.asarray(self.data.Volume, dtype=float),
+            }
+        )
+        self.goldmine_candles = build_goldmine_with_indicators(source, STRATEGY_CONFIG)
+
+    def _reset_trade_state(self) -> None:
+        """Clear custom state after a trade closes."""
+        # backtesting.py has already closed the framework position; this helper
+        # clears our parallel bookkeeping so the next setup can be considered.
+        self.pending_entry = None
+        self.trade_direction = ""
+        self.entry_underlying = 0.0
+        self.stop_underlying = 0.0
+        self.target_underlying = 0.0
+        self.bars_in_trade = 0
+
+    def _can_afford_entry(self, entry_price: float):
+        """Check if current equity can support the new futures position."""
+        equity = float(self.equity)
+        notional = float(entry_price) * float(self.lot_size)
+        if notional <= 0.0:
+            return False, MARGIN_REQUIREMENT, 0.0, equity
+
+        if AUTO_ADJUST_MARGIN:
+            # The default margin can be too high after drawdown on a small test
+            # account. This mirrors the existing project behavior: use as much
+            # margin as possible without exceeding current equity, bounded by a
+            # small floor so leverage does not become unrealistic.
+            affordable_margin = (equity * 0.98) / notional
+            effective_margin = min(MARGIN_REQUIREMENT, max(MIN_MARGIN_FLOOR, affordable_margin))
+        else:
+            effective_margin = MARGIN_REQUIREMENT
+
+        required_margin = notional * effective_margin
+        return required_margin <= equity, effective_margin, required_margin, equity
+
+    def _sync_closed_trade_state(self) -> None:
+        """Detect stop/target/framework closures that happened since last bar."""
+        # Attached SL/TP orders can close trades inside backtesting.py without
+        # this class explicitly calling `position.close()`. Counting closed
+        # trades lets us notice those exits and reset our local state.
+        closed_count = len(self.closed_trades)
+        if closed_count <= self.last_closed_trade_count:
+            return
+        self.exit_count += closed_count - self.last_closed_trade_count
+        self.last_closed_trade_count = closed_count
+        self._reset_trade_state()
+
+    def _sync_open_trade_state(self) -> None:
+        """Turn a pending next-open order into active trade state after it fills."""
+        if not self.position or self.trade_direction or self.pending_entry is None:
+            return
+
+        # With `trade_on_close=False`, a market order placed after setup candle T
+        # fills at candle T+1 open. We use the framework's actual fill price for
+        # target math so opening gaps are modeled honestly.
+        active_trade = self.trades[-1] if self.trades else None
+        actual_entry = float(active_trade.entry_price) if active_trade is not None else float(self.data.Open[-1])
+        signal_atr = float(self.pending_entry["signal_atr"])
+        direction = str(self.pending_entry["direction"]).strip().upper()
+        stop = float(self.pending_entry["stop_underlying"])
+        if direction == "LONG":
+            target = actual_entry + float(STRATEGY_CONFIG.target_atr_multiple) * signal_atr
+        else:
+            target = actual_entry - float(STRATEGY_CONFIG.target_atr_multiple) * signal_atr
+
+        self.trade_direction = direction
+        self.entry_underlying = actual_entry
+        self.stop_underlying = stop
+        self.target_underlying = target
+        self.bars_in_trade = 0
+        self.pending_entry = None
+
+        if active_trade is not None:
+            # Attach stop-loss and take-profit to the framework trade only after
+            # the entry fill is known. That keeps target = actual entry +/- 2 ATR.
+            if direction == "LONG" and stop < actual_entry < target:
+                active_trade.sl = stop
+                active_trade.tp = target
+            elif direction == "SHORT" and target < actual_entry < stop:
+                active_trade.sl = stop
+                active_trade.tp = target
+            else:
+                # If a huge next-open gap invalidates the planned risk shape,
+                # close immediately rather than carrying an undefined trade.
+                self.position.close()
+
+    def _position_context(self) -> GoldminePositionContext:
+        """Build the position object expected by the shared signal engine."""
+        return GoldminePositionContext(
+            direction=self.trade_direction,
+            entry_underlying=self.entry_underlying,
+            stop_underlying=self.stop_underlying,
+            target_underlying=self.target_underlying,
+            bars_in_trade=self.bars_in_trade,
+        )
+
+    def _submit_next_open_entry(self, decision, bar_date, bar_time) -> None:
+        """Submit a market entry that backtesting.py fills at the next bar open."""
+        # The decision's `entry_underlying` is the setup close. It is a useful
+        # affordability estimate, but the real entry is synchronized later from
+        # the framework's next-open fill.
+        can_enter, eff_margin, req_margin, equity_now = self._can_afford_entry(decision.entry_underlying)
+        if not can_enter:
+            self.margin_skip_count += 1
+            if bar_date not in self.margin_skip_logged_dates:
+                logging.warning(
+                    "Goldmine entry skipped due to margin | date=%s | time=%s | side=%s | "
+                    "equity=%.2f | required=%.2f | effective_margin=%.4f",
+                    bar_date,
+                    bar_time,
+                    decision.action,
+                    equity_now,
+                    req_margin,
+                    eff_margin,
+                )
+                self.margin_skip_logged_dates.add(bar_date)
+            return
+
+        direction = "LONG" if decision.action == "ENTER_LONG" else "SHORT"
+        signal_atr = float(decision.debug.get("signal_atr", 0.0))
+        if not np.isfinite(signal_atr) or signal_atr <= 0.0:
+            # ATR is required for target distance. If it is missing, skip the
+            # signal rather than creating a trade with undefined risk.
+            return
+
+        if direction == "LONG":
+            self.buy(size=self.lot_size, tag="GOLDMINE_LONG_ENTRY")
+        else:
+            self.sell(size=self.lot_size, tag="GOLDMINE_SHORT_ENTRY")
+
+        self.entry_submit_count += 1
+        self.pending_entry = {
+            "direction": direction,
+            "stop_underlying": float(decision.stop_underlying),
+            "signal_atr": signal_atr,
+        }
+
+    def next(self) -> None:
+        """Main bar-by-bar backtest loop."""
+        # First sync framework state, then process the current candle. This
+        # order lets us react to fills/exits that happened at the new bar open.
+        self._sync_closed_trade_state()
+        self._sync_open_trade_state()
+
+        bar_ts = pd.Timestamp(self.data.index[-1])
+        bar_date = bar_ts.date()
+        bar_time = bar_ts.time()
+
+        if self.current_day != bar_date:
+            # A new date gets a fresh daily loss baseline and allows trading
+            # again unless the new day later hits its own cap.
+            self.current_day = bar_date
+            self.day_start_equity = float(self.equity)
+            self.day_trading_blocked = False
+            self.square_off_requested_date = None
+            self.daily_loss_tracker[bar_date] = 0.0
+
+        if self.day_start_equity is None:
+            self.day_start_equity = float(self.equity)
+        day_loss = max(0.0, float(self.day_start_equity) - float(self.equity))
+        if day_loss > float(self.daily_loss_tracker.get(bar_date, 0.0)):
+            self.daily_loss_tracker[bar_date] = float(day_loss)
+
+        if (not self.day_trading_blocked) and day_loss >= self.day_loss_limit:
+            # Once the daily loss cap is hit, no new entries are allowed and any
+            # existing position is closed by the branch below.
+            self.day_trading_blocked = True
+            self.daily_loss_halt_count += 1
+            logging.warning(
+                "Daily loss cap hit | date=%s | time=%s | day_loss=%.2f | cap=%.2f",
+                bar_date,
+                bar_time,
+                day_loss,
+                self.day_loss_limit,
+            )
+
+        if self.day_trading_blocked:
+            self.pending_entry = None
+            if self.position:
+                self.position.close()
+            return
+
+        if bar_time >= SQUARE_OFF_TIME:
+            self.pending_entry = None
+            if self.position and self.square_off_requested_date != bar_date:
+                self.position.close()
+                self.square_off_count += 1
+                self.square_off_requested_date = bar_date
+            return
+
+        if bar_time < ENTRY_START_TIME:
+            return
+
+        current_len = len(self.data.Close)
+        # Slice the precomputed indicator table to the visible history only.
+        # This preserves causal evaluation while avoiding expensive recalculation
+        # on every bar.
+        candles = self.goldmine_candles.iloc[:current_len]
+        if candles.empty:
+            return
+
+        latest_ts = candles.iloc[-1]["timestamp"]
+        if self.last_processed_candle_ts == latest_ts:
+            return
+        self.last_processed_candle_ts = latest_ts
+
+        if self.position and self.trade_direction:
+            # Goldmine has a six-bar time exit, so the backtest increments our
+            # custom bar counter before asking the shared engine about exits.
+            self.bars_in_trade += 1
+            decision = self.signal_engine.evaluate_candle(candles, position=self._position_context())
+            if decision.action == "EXIT":
+                self.position.close()
+            return
+
+        if self.pending_entry is not None:
+            # A signal has already submitted an order waiting for next-open fill.
+            # Do not stack another signal while that order is pending.
+            return
+
+        if not (ENTRY_START_TIME <= bar_time < SQUARE_OFF_TIME):
+            return
+
+        decision = self.signal_engine.evaluate_candle(candles)
+        if decision.signal_triggered:
+            self.signal_count += 1
+        if decision.action in ("ENTER_LONG", "ENTER_SHORT"):
+            self._submit_next_open_entry(decision, bar_date, bar_time)
+
+
+def run_backtest(data_path: Path | str, dataset_key: str = "nifty"):
+    """Load data, run the Goldmine strategy, and return stats plus strategy object."""
+    data = load_ohlc_data(data_path)
+    logging.info(
+        "Loaded Goldmine data | rows=%s | start=%s | end=%s",
+        len(data),
+        data.index.min(),
+        data.index.max(),
+    )
+
+    effective_margin = MIN_MARGIN_FLOOR if AUTO_ADJUST_MARGIN else MARGIN_REQUIREMENT
+    # trade_on_close=False is essential here: it makes market orders submitted
+    # after a setup candle fill on the next candle open, matching the strategy
+    # rules from the extracted notes.
+    bt = Backtest(
+        data,
+        NiftyGoldmineStrategyBacktest,
+        cash=STARTING_CAPITAL,
+        margin=effective_margin,
+        commission=0.0,
+        trade_on_close=False,
+        exclusive_orders=True,
+        hedging=False,
+        finalize_trades=True,
+    )
+    stats = bt.run()
+    strategy_obj = stats.get("_strategy", None)
+    if strategy_obj is not None:
+        logging.info(
+            "Goldmine counters | signals=%s | entries=%s | exits=%s | square_offs=%s | "
+            "daily_loss_halts=%s | margin_skips=%s",
+            getattr(strategy_obj, "signal_count", "NA"),
+            getattr(strategy_obj, "entry_submit_count", "NA"),
+            getattr(strategy_obj, "exit_count", "NA"),
+            getattr(strategy_obj, "square_off_count", "NA"),
+            getattr(strategy_obj, "daily_loss_halt_count", "NA"),
+            getattr(strategy_obj, "margin_skip_count", "NA"),
+        )
+    return stats, strategy_obj
+
+
+def main() -> None:
+    """CLI entrypoint."""
+    parser = argparse.ArgumentParser(description="NIFTY Goldmine strategy futures backtest")
+    parser.add_argument("--data", required=True, help="Path to an already-prepared 5-minute OHLC CSV")
+    parser.add_argument("--dataset", default="nifty", help="Output label: nifty, banknifty, or finnifty")
+    args = parser.parse_args()
+
+    dataset_key = normalize_dataset_key(args.dataset)
+    output_paths = build_output_paths(dataset_key, "goldmine_strategy")
+    setup_logging(output_paths["log"])
+
+    logging.info(
+        "Config | strategy=Goldmine | dataset=%s | data=%s | capital=%s | qty=%s | "
+        "margin=%s | entry_start=%s | square_off=%s",
+        dataset_key,
+        args.data,
+        STARTING_CAPITAL,
+        POSITION_SIZE,
+        MARGIN_REQUIREMENT,
+        ENTRY_START_TIME,
+        SQUARE_OFF_TIME,
+    )
+    stats, strategy_obj = run_backtest(args.data, dataset_key)
+    save_outputs(stats, output_paths, strategy_obj=strategy_obj)
+    log_selected_stats(stats)
+
+
+if __name__ == "__main__":
+    main()

--- a/My Backtest Files (For Reference)/Subhamoy Strategies/Nifty Money Machine Strategy Backtest.py
+++ b/My Backtest Files (For Reference)/Subhamoy Strategies/Nifty Money Machine Strategy Backtest.py
@@ -1,0 +1,416 @@
+"""
+Backtest the NIFTY Money Machine strategy using backtesting.py.
+
+Beginner flow:
+1. Load an already-prepared 5-minute OHLC CSV.
+2. Validate that the file really is 5-minute data. No resampling happens here.
+3. Precompute Money Machine indicators and setup candles.
+4. Submit market entries after a completed Hulk/Marubozu setup candle.
+5. Sync the actual next-open fill, then attach stop/target levels.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from backtesting import Backtest, Strategy
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+ROOT_DIR = SCRIPT_DIR.parents[1]
+SIGNAL_GENERATOR_DIR = ROOT_DIR / "Signal Generators" / "Subhamoy Strategies"
+if str(SIGNAL_GENERATOR_DIR) not in sys.path:
+    # The repo stores signal generators and backtests in different top-level
+    # folders. This path bridge lets the backtest import the shared Money
+    # Machine engine no matter where the command is launched from.
+    sys.path.insert(0, str(SIGNAL_GENERATOR_DIR))
+
+from money_machine_strategy_logic import (
+    MoneyMachinePositionContext,
+    MoneyMachineSignalEngine,
+    MoneyMachineStrategyConfig,
+    build_money_machine_with_indicators,
+)
+from subhamoy_backtest_common import (
+    AUTO_ADJUST_MARGIN,
+    DAILY_MAX_LOSS_PCT,
+    ENTRY_START_TIME,
+    MARGIN_REQUIREMENT,
+    MIN_MARGIN_FLOOR,
+    POSITION_SIZE,
+    SQUARE_OFF_TIME,
+    STARTING_CAPITAL,
+    build_output_paths,
+    env_float,
+    env_int,
+    load_ohlc_data,
+    log_selected_stats,
+    normalize_dataset_key,
+    save_outputs,
+    setup_logging,
+)
+
+
+STRATEGY_CONFIG = MoneyMachineStrategyConfig(
+    sma_fast_period=env_int("MONEY_MACHINE_SMA_FAST_PERIOD", 20),
+    sma_slow_period=env_int("MONEY_MACHINE_SMA_SLOW_PERIOD", 200),
+    atr_period=env_int("MONEY_MACHINE_ATR_PERIOD", 14),
+    slope_lookback=env_int("MONEY_MACHINE_SLOPE_LOOKBACK", 3),
+    near_sma_atr_multiple=env_float("MONEY_MACHINE_NEAR_SMA_ATR_MULT", 0.5),
+    compression_window=env_int("MONEY_MACHINE_COMPRESSION_WINDOW", 3),
+    compression_range_atr_multiple=env_float("MONEY_MACHINE_COMPRESSION_RANGE_ATR_MULT", 0.75),
+    marubozu_body_min_ratio=env_float("MONEY_MACHINE_MARUBOZU_BODY_MIN_RATIO", 0.80),
+    marubozu_wick_max_ratio=env_float("MONEY_MACHINE_MARUBOZU_WICK_MAX_RATIO", 0.15),
+    require_breakout_close=bool(env_int("MONEY_MACHINE_REQUIRE_BREAKOUT_CLOSE", 1)),
+    target_atr_multiple=env_float("MONEY_MACHINE_TARGET_ATR_MULT", 2.0),
+)
+
+
+class NiftyMoneyMachineStrategyBacktest(Strategy):
+    """
+    backtesting.py strategy class for the Money Machine futures strategy.
+
+    The shared Money Machine module decides whether a candle is a valid setup.
+    This class handles the practical backtest mechanics around that decision:
+    next-open fills, attached stop/target orders, daily risk limits, and output
+    counters.
+    """
+
+    lot_size = POSITION_SIZE
+
+    def init(self) -> None:
+        """Prepare strategy state for the whole backtest run."""
+        # The signal engine is intentionally kept separate from execution
+        # simulation so strategy rules can be reused by front-tests later.
+        self.signal_engine = MoneyMachineSignalEngine(STRATEGY_CONFIG)
+        self.last_processed_candle_ts = None
+
+        # Pending entry means: "a signal happened, a market order was submitted,
+        # and we are waiting for backtesting.py to fill it on the next open."
+        self.pending_entry: dict[str, object] | None = None
+        # These fields are a plain-language mirror of the active framework trade.
+        self.trade_direction = ""
+        self.entry_underlying = 0.0
+        self.stop_underlying = 0.0
+        self.target_underlying = 0.0
+
+        self.signal_count = 0
+        self.entry_submit_count = 0
+        self.exit_count = 0
+        self.square_off_count = 0
+        self.daily_loss_halt_count = 0
+        self.margin_skip_count = 0
+        self.last_closed_trade_count = 0
+
+        # Daily risk state. This mirrors the other repo backtests and makes the
+        # saved daily max-loss output possible.
+        self.current_day = None
+        self.day_start_equity = None
+        self.day_loss_limit = STARTING_CAPITAL * DAILY_MAX_LOSS_PCT
+        self.day_trading_blocked = False
+        self.square_off_requested_date = None
+        self.daily_loss_tracker: dict[object, float] = {}
+        self.margin_skip_logged_dates = set()
+
+        # Precompute indicators once. In `next()` we slice this table to the
+        # current visible candle count, so future rows are never evaluated.
+        source = pd.DataFrame(
+            {
+                "timestamp": pd.DatetimeIndex(self.data.index),
+                "open": np.asarray(self.data.Open, dtype=float),
+                "high": np.asarray(self.data.High, dtype=float),
+                "low": np.asarray(self.data.Low, dtype=float),
+                "close": np.asarray(self.data.Close, dtype=float),
+                "volume": np.asarray(self.data.Volume, dtype=float),
+            }
+        )
+        self.money_machine_candles = build_money_machine_with_indicators(source, STRATEGY_CONFIG)
+
+    def _reset_trade_state(self) -> None:
+        """Clear custom state after a trade closes."""
+        # The framework position is already gone; reset our local mirror so the
+        # next valid setup can be traded.
+        self.pending_entry = None
+        self.trade_direction = ""
+        self.entry_underlying = 0.0
+        self.stop_underlying = 0.0
+        self.target_underlying = 0.0
+
+    def _can_afford_entry(self, entry_price: float):
+        """Check if current equity can support the new futures position."""
+        equity = float(self.equity)
+        notional = float(entry_price) * float(self.lot_size)
+        if notional <= 0.0:
+            return False, MARGIN_REQUIREMENT, 0.0, equity
+
+        if AUTO_ADJUST_MARGIN:
+            # Same margin behavior as the other strategy backtests: use the
+            # configured margin when possible, otherwise reduce it within a
+            # controlled floor so the simulation can continue after drawdown.
+            affordable_margin = (equity * 0.98) / notional
+            effective_margin = min(MARGIN_REQUIREMENT, max(MIN_MARGIN_FLOOR, affordable_margin))
+        else:
+            effective_margin = MARGIN_REQUIREMENT
+
+        required_margin = notional * effective_margin
+        return required_margin <= equity, effective_margin, required_margin, equity
+
+    def _sync_closed_trade_state(self) -> None:
+        """Detect stop/target/framework closures that happened since last bar."""
+        # Attached stop/target orders can close a position without an explicit
+        # call from this class. Counting framework closed trades keeps our local
+        # mirror synchronized.
+        closed_count = len(self.closed_trades)
+        if closed_count <= self.last_closed_trade_count:
+            return
+        self.exit_count += closed_count - self.last_closed_trade_count
+        self.last_closed_trade_count = closed_count
+        self._reset_trade_state()
+
+    def _sync_open_trade_state(self) -> None:
+        """Turn a pending next-open order into active trade state after it fills."""
+        if not self.position or self.trade_direction or self.pending_entry is None:
+            return
+
+        # Money Machine targets are based on actual entry plus/minus 2 x signal
+        # ATR. Using actual_entry captures next-open gaps realistically.
+        active_trade = self.trades[-1] if self.trades else None
+        actual_entry = float(active_trade.entry_price) if active_trade is not None else float(self.data.Open[-1])
+        signal_atr = float(self.pending_entry["signal_atr"])
+        direction = str(self.pending_entry["direction"]).strip().upper()
+        stop = float(self.pending_entry["stop_underlying"])
+        if direction == "LONG":
+            target = actual_entry + float(STRATEGY_CONFIG.target_atr_multiple) * signal_atr
+        else:
+            target = actual_entry - float(STRATEGY_CONFIG.target_atr_multiple) * signal_atr
+
+        self.trade_direction = direction
+        self.entry_underlying = actual_entry
+        self.stop_underlying = stop
+        self.target_underlying = target
+        self.pending_entry = None
+
+        if active_trade is not None:
+            # Attach the protective stop and profit target only after entry
+            # exists. backtesting.py then handles intrabar touches from here.
+            if direction == "LONG" and stop < actual_entry < target:
+                active_trade.sl = stop
+                active_trade.tp = target
+            elif direction == "SHORT" and target < actual_entry < stop:
+                active_trade.sl = stop
+                active_trade.tp = target
+            else:
+                # If the next-open gap breaks the planned risk shape, exit
+                # immediately instead of carrying a trade with inverted levels.
+                self.position.close()
+
+    def _position_context(self) -> MoneyMachinePositionContext:
+        """Build the position object expected by the shared signal engine."""
+        return MoneyMachinePositionContext(
+            direction=self.trade_direction,
+            entry_underlying=self.entry_underlying,
+            stop_underlying=self.stop_underlying,
+            target_underlying=self.target_underlying,
+        )
+
+    def _submit_next_open_entry(self, decision, bar_date, bar_time) -> None:
+        """Submit a market entry that backtesting.py fills at the next bar open."""
+        # The signal candle close is used only for a margin estimate. The true
+        # fill is synchronized from backtesting.py on the next bar.
+        can_enter, eff_margin, req_margin, equity_now = self._can_afford_entry(decision.entry_underlying)
+        if not can_enter:
+            self.margin_skip_count += 1
+            if bar_date not in self.margin_skip_logged_dates:
+                logging.warning(
+                    "Money Machine entry skipped due to margin | date=%s | time=%s | side=%s | "
+                    "equity=%.2f | required=%.2f | effective_margin=%.4f",
+                    bar_date,
+                    bar_time,
+                    decision.action,
+                    equity_now,
+                    req_margin,
+                    eff_margin,
+                )
+                self.margin_skip_logged_dates.add(bar_date)
+            return
+
+        direction = "LONG" if decision.action == "ENTER_LONG" else "SHORT"
+        signal_atr = float(decision.debug.get("signal_atr", 0.0))
+        if not np.isfinite(signal_atr) or signal_atr <= 0.0:
+            # ATR drives target distance. No valid ATR means no reliable trade.
+            return
+
+        if direction == "LONG":
+            self.buy(size=self.lot_size, tag="MONEY_MACHINE_LONG_ENTRY")
+        else:
+            self.sell(size=self.lot_size, tag="MONEY_MACHINE_SHORT_ENTRY")
+
+        self.entry_submit_count += 1
+        self.pending_entry = {
+            "direction": direction,
+            "stop_underlying": float(decision.stop_underlying),
+            "signal_atr": signal_atr,
+        }
+
+    def next(self) -> None:
+        """Main bar-by-bar backtest loop."""
+        # Synchronize framework events first so entries/exits from the new bar
+        # open are reflected before evaluating the latest completed candle.
+        self._sync_closed_trade_state()
+        self._sync_open_trade_state()
+
+        bar_ts = pd.Timestamp(self.data.index[-1])
+        bar_date = bar_ts.date()
+        bar_time = bar_ts.time()
+
+        if self.current_day != bar_date:
+            # New trading day, new loss baseline, and trading can resume.
+            self.current_day = bar_date
+            self.day_start_equity = float(self.equity)
+            self.day_trading_blocked = False
+            self.square_off_requested_date = None
+            self.daily_loss_tracker[bar_date] = 0.0
+
+        if self.day_start_equity is None:
+            self.day_start_equity = float(self.equity)
+        day_loss = max(0.0, float(self.day_start_equity) - float(self.equity))
+        if day_loss > float(self.daily_loss_tracker.get(bar_date, 0.0)):
+            self.daily_loss_tracker[bar_date] = float(day_loss)
+
+        if (not self.day_trading_blocked) and day_loss >= self.day_loss_limit:
+            # Once the daily cap is hit, stop trading for the rest of the day.
+            self.day_trading_blocked = True
+            self.daily_loss_halt_count += 1
+            logging.warning(
+                "Daily loss cap hit | date=%s | time=%s | day_loss=%.2f | cap=%.2f",
+                bar_date,
+                bar_time,
+                day_loss,
+                self.day_loss_limit,
+            )
+
+        if self.day_trading_blocked:
+            self.pending_entry = None
+            if self.position:
+                self.position.close()
+            return
+
+        if bar_time >= SQUARE_OFF_TIME:
+            self.pending_entry = None
+            if self.position and self.square_off_requested_date != bar_date:
+                self.position.close()
+                self.square_off_count += 1
+                self.square_off_requested_date = bar_date
+            return
+
+        if bar_time < ENTRY_START_TIME:
+            return
+
+        current_len = len(self.data.Close)
+        # Use only history visible to the current bar. The indicators were
+        # precomputed for speed, but this slice keeps evaluation causal.
+        candles = self.money_machine_candles.iloc[:current_len]
+        if candles.empty:
+            return
+
+        latest_ts = candles.iloc[-1]["timestamp"]
+        if self.last_processed_candle_ts == latest_ts:
+            return
+        self.last_processed_candle_ts = latest_ts
+
+        if self.position and self.trade_direction:
+            # While in a trade, skip new entries and ask the shared engine only
+            # whether the current candle hit stop/target conditions.
+            decision = self.signal_engine.evaluate_candle(candles, position=self._position_context())
+            if decision.action == "EXIT":
+                self.position.close()
+            return
+
+        if self.pending_entry is not None:
+            # A signal order is waiting for next-open fill; do not stack another
+            # order before the first one resolves.
+            return
+
+        if not (ENTRY_START_TIME <= bar_time < SQUARE_OFF_TIME):
+            return
+
+        decision = self.signal_engine.evaluate_candle(candles)
+        if decision.signal_triggered:
+            self.signal_count += 1
+        if decision.action in ("ENTER_LONG", "ENTER_SHORT"):
+            self._submit_next_open_entry(decision, bar_date, bar_time)
+
+
+def run_backtest(data_path: Path | str, dataset_key: str = "nifty"):
+    """Load data, run the Money Machine strategy, and return stats plus strategy object."""
+    data = load_ohlc_data(data_path)
+    logging.info(
+        "Loaded Money Machine data | rows=%s | start=%s | end=%s",
+        len(data),
+        data.index.min(),
+        data.index.max(),
+    )
+
+    effective_margin = MIN_MARGIN_FLOOR if AUTO_ADJUST_MARGIN else MARGIN_REQUIREMENT
+    # trade_on_close=False models the planned next-open entry behavior.
+    bt = Backtest(
+        data,
+        NiftyMoneyMachineStrategyBacktest,
+        cash=STARTING_CAPITAL,
+        margin=effective_margin,
+        commission=0.0,
+        trade_on_close=False,
+        exclusive_orders=True,
+        hedging=False,
+        finalize_trades=True,
+    )
+    stats = bt.run()
+    strategy_obj = stats.get("_strategy", None)
+    if strategy_obj is not None:
+        logging.info(
+            "Money Machine counters | signals=%s | entries=%s | exits=%s | square_offs=%s | "
+            "daily_loss_halts=%s | margin_skips=%s",
+            getattr(strategy_obj, "signal_count", "NA"),
+            getattr(strategy_obj, "entry_submit_count", "NA"),
+            getattr(strategy_obj, "exit_count", "NA"),
+            getattr(strategy_obj, "square_off_count", "NA"),
+            getattr(strategy_obj, "daily_loss_halt_count", "NA"),
+            getattr(strategy_obj, "margin_skip_count", "NA"),
+        )
+    return stats, strategy_obj
+
+
+def main() -> None:
+    """CLI entrypoint."""
+    parser = argparse.ArgumentParser(description="NIFTY Money Machine strategy futures backtest")
+    parser.add_argument("--data", required=True, help="Path to an already-prepared 5-minute OHLC CSV")
+    parser.add_argument("--dataset", default="nifty", help="Output label: nifty, banknifty, or finnifty")
+    args = parser.parse_args()
+
+    dataset_key = normalize_dataset_key(args.dataset)
+    output_paths = build_output_paths(dataset_key, "money_machine_strategy")
+    setup_logging(output_paths["log"])
+
+    logging.info(
+        "Config | strategy=Money Machine | dataset=%s | data=%s | capital=%s | qty=%s | "
+        "margin=%s | entry_start=%s | square_off=%s",
+        dataset_key,
+        args.data,
+        STARTING_CAPITAL,
+        POSITION_SIZE,
+        MARGIN_REQUIREMENT,
+        ENTRY_START_TIME,
+        SQUARE_OFF_TIME,
+    )
+    stats, strategy_obj = run_backtest(args.data, dataset_key)
+    save_outputs(stats, output_paths, strategy_obj=strategy_obj)
+    log_selected_stats(stats)
+
+
+if __name__ == "__main__":
+    main()

--- a/My Backtest Files (For Reference)/Subhamoy Strategies/subhamoy_backtest_common.py
+++ b/My Backtest Files (For Reference)/Subhamoy Strategies/subhamoy_backtest_common.py
@@ -1,0 +1,233 @@
+"""
+Shared backtest utilities for Subhamoy strategy backtests.
+
+These helpers keep Goldmine and Money Machine backtests consistent:
+- same 5-minute CSV validation
+- same output file naming
+- same brokerage-adjusted artifacts
+- same risk/margin defaults
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from datetime import time as dt_time
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+SIGNAL_GENERATOR_DIR = ROOT_DIR / "Signal Generators" / "Subhamoy Strategies"
+if str(SIGNAL_GENERATOR_DIR) not in sys.path:
+    # Repo-local backtests live in `My Backtest Files (For Reference)`, while
+    # their reusable signal modules live in `Signal Generators`. Adding the
+    # signal folder here keeps CLI runs and tests from needing manual PYTHONPATH.
+    sys.path.insert(0, str(SIGNAL_GENERATOR_DIR))
+
+from subhamoy_strategy_common import normalize_ohlc_frame, validate_five_minute_spacing
+
+
+OUTPUT_DIR = ROOT_DIR / "Backtest Outputs"
+
+# These constants intentionally mirror the existing project backtests so that a
+# Goldmine/Money Machine run feels familiar when compared with CPR, EMA, Renko,
+# or Profit Shooter results.
+STARTING_CAPITAL = 600000
+LOT_SIZE = 65
+LOTS = 3
+POSITION_SIZE = LOT_SIZE * LOTS
+MARGIN_REQUIREMENT = 0.15
+AUTO_ADJUST_MARGIN = True
+MIN_MARGIN_FLOOR = 0.02
+ENTRY_START_TIME = dt_time(9, 25)
+SQUARE_OFF_TIME = dt_time(15, 15)
+DAILY_MAX_LOSS_PCT = 0.03
+
+
+def env_float(name: str, default: float) -> float:
+    """
+    Read a float from environment variables without crashing on typos.
+
+    This lets the user tune a backtest through environment variables while still
+    getting a sensible default if an env var is missing or malformed.
+    """
+    raw = os.getenv(name, "")
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return float(default)
+
+
+def env_int(name: str, default: int) -> int:
+    """
+    Read an integer from environment variables without crashing on typos.
+
+    `int(float(raw))` accepts common values like `3` and `3.0`, which is useful
+    when config is copied from spreadsheets or `.env` files.
+    """
+    raw = os.getenv(name, "")
+    try:
+        return int(float(raw))
+    except (TypeError, ValueError):
+        return int(default)
+
+
+BROKERAGE = env_float("BROKERAGE", env_float("BROGERAGE", 80.0))
+
+
+def normalize_dataset_key(value: str) -> str:
+    """Map friendly CLI dataset names to stable internal output-name keys."""
+    # Dataset does not choose a default input file for these new backtests. It
+    # is only used to label output artifacts, because the user explicitly passes
+    # the already-resampled 5-minute CSV with `--data`.
+    key = str(value or "nifty").strip().lower()
+    aliases = {
+        "nifty50": "nifty",
+        "bank-nifty": "banknifty",
+        "bank_nifty": "banknifty",
+        "fin-nifty": "finnifty",
+        "fin_nifty": "finnifty",
+    }
+    key = aliases.get(key, key)
+    allowed = {"nifty", "banknifty", "finnifty"}
+    if key not in allowed:
+        raise ValueError(f"Unsupported dataset `{value}`. Choose from: {', '.join(sorted(allowed))}")
+    return key
+
+
+def build_output_paths(dataset_key: str, strategy_slug: str) -> dict[str, Path]:
+    """Build consistent output paths for one strategy/dataset pair."""
+    dataset = normalize_dataset_key(dataset_key)
+    # Keep filenames descriptive enough that multiple strategy runs can coexist
+    # in `Backtest Outputs` without overwriting each other.
+    prefix = f"{dataset}_{strategy_slug}_futures_5y"
+    return {
+        "log": OUTPUT_DIR / f"{prefix}_backtest.log",
+        "trades": OUTPUT_DIR / f"{prefix}_trades.csv",
+        "daily_equity": OUTPUT_DIR / f"{prefix}_daily_equity.csv",
+        "stats": OUTPUT_DIR / f"{prefix}_stats.txt",
+        "daily_loss": OUTPUT_DIR / f"{dataset}_{strategy_slug}_futures_daily_max_loss.csv",
+    }
+
+
+def setup_logging(log_path: Path) -> None:
+    """Log to both the console and a strategy-specific file."""
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    # Remove existing root handlers so importing/running multiple backtests in
+    # one Python process does not duplicate every log line.
+    for handler in logging.root.handlers[:]:
+        logging.root.removeHandler(handler)
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s | %(levelname)s | %(message)s",
+        handlers=[logging.FileHandler(log_path), logging.StreamHandler()],
+    )
+
+
+def load_ohlc_data(csv_path: Path | str) -> pd.DataFrame:
+    """
+    Load a 5-minute OHLC CSV and return backtesting.py OHLCV format.
+
+    This function validates timeframe only. It never resamples.
+    """
+    path = Path(csv_path)
+    if not path.exists():
+        raise FileNotFoundError(f"Data file not found: {path}")
+
+    raw = pd.read_csv(path)
+    candles = normalize_ohlc_frame(raw)
+    if candles.empty:
+        raise ValueError(f"No usable OHLC candles found in {path}")
+    # The user asked for no resampling in these modules. This check rejects
+    # 1-minute files with a direct message instead of quietly changing data.
+    validate_five_minute_spacing(candles)
+
+    bt_df = candles.rename(
+        columns={
+            "open": "Open",
+            "high": "High",
+            "low": "Low",
+            "close": "Close",
+            "volume": "Volume",
+        }
+    )
+    bt_df = bt_df.set_index("timestamp")
+    bt_df.index = pd.DatetimeIndex(bt_df.index)
+    if "Volume" not in bt_df.columns:
+        # backtesting.py expects a Volume column, even though these strategies
+        # do not use volume in their signal rules.
+        bt_df["Volume"] = 0.0
+    return bt_df[["Open", "High", "Low", "Close", "Volume"]]
+
+
+def save_outputs(stats: Any, output_paths: dict[str, Path], strategy_obj=None) -> None:
+    """Write trades, equity, stats, and daily max-loss artifacts."""
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    trades = stats.get("_trades", pd.DataFrame())
+    if isinstance(trades, pd.DataFrame):
+        trades_to_save = trades.copy()
+        if "PnL" in trades_to_save.columns:
+            # Keep raw framework PnL and add final PnL after per-trade brokerage
+            # so the output remains easy to audit.
+            pnl_values = pd.to_numeric(trades_to_save["PnL"], errors="coerce")
+            trades_to_save["Brokerage"] = float(BROKERAGE)
+            trades_to_save["FinalPnL"] = pnl_values - float(BROKERAGE)
+            trades_to_save["CumulativeFinalPnL"] = trades_to_save["FinalPnL"].cumsum()
+        trades_to_save.to_csv(output_paths["trades"], index=False)
+
+    equity = stats.get("_equity_curve", pd.DataFrame())
+    if isinstance(equity, pd.DataFrame) and not equity.empty:
+        # Daily equity is lighter to inspect than the full per-bar equity curve
+        # and matches the output style used by existing strategy backtests.
+        eq = equity.copy()
+        eq.index = pd.to_datetime(eq.index, errors="coerce")
+        eq = eq[eq.index.notna()]
+        eq[["Equity"]].resample("D").last().dropna().to_csv(
+            output_paths["daily_equity"],
+            index_label="date",
+        )
+
+    with open(output_paths["stats"], "w", encoding="ascii", errors="ignore") as file_obj:
+        file_obj.write(str(stats))
+
+    if strategy_obj is not None:
+        tracker = getattr(strategy_obj, "daily_loss_tracker", None)
+        if isinstance(tracker, dict) and tracker:
+            # The strategy object records the maximum intraday drawdown seen for
+            # each date. Saving it makes daily loss cap behavior visible later.
+            daily_loss = pd.DataFrame(
+                {
+                    "date": pd.to_datetime(list(tracker.keys())),
+                    "max_intraday_loss": [float(value) for value in tracker.values()],
+                    "daily_loss_cap": STARTING_CAPITAL * DAILY_MAX_LOSS_PCT,
+                }
+            ).sort_values("date")
+            daily_loss.to_csv(output_paths["daily_loss"], index=False, date_format="%Y-%m-%d")
+
+    logging.info("Trades saved: %s", output_paths["trades"])
+    logging.info("Daily equity saved: %s", output_paths["daily_equity"])
+    logging.info("Stats saved: %s", output_paths["stats"])
+
+
+def log_selected_stats(stats: Any) -> None:
+    """Print the most useful backtest stats into the configured logger."""
+    for key in [
+        "Start",
+        "End",
+        "Duration",
+        "Equity Final [$]",
+        "Return [%]",
+        "Buy & Hold Return [%]",
+        "Max. Drawdown [%]",
+        "Win Rate [%]",
+        "# Trades",
+        "Profit Factor",
+        "Sharpe Ratio",
+    ]:
+        if key in stats.index:
+            logging.info("%s: %s", key, stats[key])

--- a/Signal Generators/Readme.md
+++ b/Signal Generators/Readme.md
@@ -8,6 +8,7 @@ Signal generator expects the OHLC data DataFrame as an argument(which will be pr
 - Claude Opus 4.7 Max: Generated Donchian Signal Generator Bearish.py and Supertrend Signal Generator Bullish.py
 - GPT-5.4-xhigh: Generated ema_trend_strategy_logic.py, heikin_ashi_strategy_logic.py, profit_shooter_strategy_logic.py, renko_strategy_logic.py and renko_strategy_logic_9_21.py
 - GPT-5: Generated the CPR Strategy folder with shared CPR logic, Algo 1, Algo 2, and combined signal-generator wrappers
+- GPT-5: Generated the Subhamoy Strategies folder with Goldmine and Money Machine shared engines and NIFTY wrappers
 
 # Where each generator is used
 | File | Shape | Used by |
@@ -16,6 +17,10 @@ Signal generator expects the OHLC data DataFrame as an argument(which will be pr
 | `CPR Strategy/Nifty CPR Algo 1 Signal Generator.py` | Algo 1 trend-only CPR wrapper | CPR trend-only callers |
 | `CPR Strategy/Nifty CPR Algo 2 Signal Generator.py` | Algo 2 sideways/reversal CPR wrapper | CPR sideways/reversal callers |
 | `CPR Strategy/Nifty CPR Combined Signal Generator.py` | Full CPR PDF strategy wrapper | CPR backtest + future front-test integration |
+| `Subhamoy Strategies/goldmine_strategy_logic.py` | Stateful Goldmine pullback/engulfing engine | Goldmine backtest + future front-test integration |
+| `Subhamoy Strategies/money_machine_strategy_logic.py` | Stateful Money Machine compression/Hulk engine | Money Machine backtest + future front-test integration |
+| `Subhamoy Strategies/Nifty Goldmine Signal Generator.py` | Thin NIFTY Goldmine wrapper | Goldmine callers that prefer wrapper functions |
+| `Subhamoy Strategies/Nifty Money Machine Signal Generator.py` | Thin NIFTY Money Machine wrapper | Money Machine callers that prefer wrapper functions |
 | `Donchian Signal Generator Bearish.py` | DataFrame in -> DataFrame with signal columns out (stateless) | front-test master |
 | `Supertrend Signal Generator Bullish.py` | DataFrame in -> DataFrame with signal columns out (stateless) | front-test master |
 | `ema_trend_strategy_logic.py` | Stateful signal engine (class) | EMA backtest + front-test master |

--- a/Signal Generators/Subhamoy Strategies/Nifty Goldmine Signal Generator.py
+++ b/Signal Generators/Subhamoy Strategies/Nifty Goldmine Signal Generator.py
@@ -1,0 +1,49 @@
+"""
+NIFTY Goldmine Signal Generator.
+
+This wrapper keeps the public file naming style used by the repo while the
+actual strategy math lives in `goldmine_strategy_logic.py`.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import pandas as pd
+
+from goldmine_strategy_logic import (
+    GoldmineDecision,
+    GoldminePositionContext,
+    GoldmineSignalGenerator,
+    GoldmineStrategyConfig,
+    generate_goldmine_signals,
+    get_latest_goldmine_signal,
+)
+
+
+class NiftyGoldmineSignalGenerator(GoldmineSignalGenerator):
+    """NIFTY-flavored wrapper around the shared Goldmine signal generator."""
+
+
+def generate_nifty_goldmine_signals(
+    data: pd.DataFrame,
+    config: Optional[GoldmineStrategyConfig] = None,
+) -> pd.DataFrame:
+    """Return full-history NIFTY Goldmine signals."""
+    return generate_goldmine_signals(data, config=config)
+
+
+def get_latest_nifty_goldmine_signal(
+    data: pd.DataFrame,
+    config: Optional[GoldmineStrategyConfig] = None,
+    position: Optional[GoldminePositionContext] = None,
+) -> GoldmineDecision:
+    """Return only the newest NIFTY Goldmine decision."""
+    return get_latest_goldmine_signal(data, config=config, position=position)
+
+
+__all__ = [
+    "NiftyGoldmineSignalGenerator",
+    "generate_nifty_goldmine_signals",
+    "get_latest_nifty_goldmine_signal",
+]

--- a/Signal Generators/Subhamoy Strategies/Nifty Money Machine Signal Generator.py
+++ b/Signal Generators/Subhamoy Strategies/Nifty Money Machine Signal Generator.py
@@ -1,0 +1,49 @@
+"""
+NIFTY Money Machine Signal Generator.
+
+This wrapper keeps the public file naming style used by the repo while the
+actual strategy math lives in `money_machine_strategy_logic.py`.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import pandas as pd
+
+from money_machine_strategy_logic import (
+    MoneyMachineDecision,
+    MoneyMachinePositionContext,
+    MoneyMachineSignalGenerator,
+    MoneyMachineStrategyConfig,
+    generate_money_machine_signals,
+    get_latest_money_machine_signal,
+)
+
+
+class NiftyMoneyMachineSignalGenerator(MoneyMachineSignalGenerator):
+    """NIFTY-flavored wrapper around the shared Money Machine signal generator."""
+
+
+def generate_nifty_money_machine_signals(
+    data: pd.DataFrame,
+    config: Optional[MoneyMachineStrategyConfig] = None,
+) -> pd.DataFrame:
+    """Return full-history NIFTY Money Machine signals."""
+    return generate_money_machine_signals(data, config=config)
+
+
+def get_latest_nifty_money_machine_signal(
+    data: pd.DataFrame,
+    config: Optional[MoneyMachineStrategyConfig] = None,
+    position: Optional[MoneyMachinePositionContext] = None,
+) -> MoneyMachineDecision:
+    """Return only the newest NIFTY Money Machine decision."""
+    return get_latest_money_machine_signal(data, config=config, position=position)
+
+
+__all__ = [
+    "NiftyMoneyMachineSignalGenerator",
+    "generate_nifty_money_machine_signals",
+    "get_latest_nifty_money_machine_signal",
+]

--- a/Signal Generators/Subhamoy Strategies/README.md
+++ b/Signal Generators/Subhamoy Strategies/README.md
@@ -1,0 +1,37 @@
+# Subhamoy Strategies
+
+This folder groups strategy files from Subhamoy-style setups.
+
+Included strategies in this repo folder:
+- Goldmine
+- Money Machine
+
+Profit Shooter already exists at `Signal Generators/profit_shooter_strategy_logic.py`
+and `My Backtest Files (For Reference)/profit_shooter_backtest.py`, so this folder
+contains only the new Subhamoy signal-generator files added by this change.
+
+## Signal Generators
+
+- `goldmine_strategy_logic.py`
+- `money_machine_strategy_logic.py`
+- `Nifty Goldmine Signal Generator.py`
+- `Nifty Money Machine Signal Generator.py`
+
+The Goldmine and Money Machine modules expect already-prepared 5-minute OHLC
+data. They do not resample 1-minute data because that belongs in the front-test
+or data-preparation file.
+
+## Backtests
+
+- `Nifty Goldmine Strategy Backtest.py`
+- `Nifty Money Machine Strategy Backtest.py`
+
+Run the new backtests with an explicit 5-minute CSV:
+
+```powershell
+python "My Backtest Files (For Reference)\Subhamoy Strategies\Nifty Goldmine Strategy Backtest.py" --data "path\to\five_minute_data.csv" --dataset nifty
+python "My Backtest Files (For Reference)\Subhamoy Strategies\Nifty Money Machine Strategy Backtest.py" --data "path\to\five_minute_data.csv" --dataset nifty
+```
+
+Both backtests write logs, trades, daily equity, stats, and daily max-loss files
+under `Backtest Outputs`.

--- a/Signal Generators/Subhamoy Strategies/goldmine_strategy_logic.py
+++ b/Signal Generators/Subhamoy Strategies/goldmine_strategy_logic.py
@@ -1,0 +1,531 @@
+"""
+Shared Goldmine strategy logic for already-prepared 5-minute OHLC candles.
+
+What this module does:
+1. Calculates SMA20, SMA200, and ATR with TA-Lib first.
+2. Finds the Goldmine pullback + engulfing setup on completed candles.
+3. Returns a simple decision object that front-tests and backtests can share.
+
+Important:
+- This file does not resample. Pass 5-minute OHLC candles from your front-test
+  or data-preparation layer.
+- A signal is emitted on the completed setup candle, but `debug["entry_timing"]`
+  is `NEXT_OPEN` because the planned execution is the next candle open/market.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+import numpy as np
+import pandas as pd
+
+from subhamoy_strategy_common import (
+    add_candle_anatomy,
+    atr,
+    falling_over_lookback,
+    finite,
+    normalize_ohlc_frame,
+    require_columns,
+    rising_over_lookback,
+    sma,
+)
+
+
+@dataclass(frozen=True)
+class GoldmineStrategyConfig:
+    """
+    All tunable Goldmine settings live in one beginner-friendly object.
+
+    A config dataclass makes the strategy easier to experiment with because the
+    user can change periods, thresholds, and target behavior in one place
+    without hunting through the signal engine.
+    """
+
+    sma_fast_period: int = 20
+    sma_slow_period: int = 200
+    atr_period: int = 14
+    slope_lookback: int = 3
+    pullback_lookback: int = 3
+    pullback_min_count: int = 2
+    near_sma_atr_multiple: float = 0.5
+    engulf_tolerance: float = 0.05
+    target_atr_multiple: float = 2.0
+    max_bars_in_trade: int = 6
+
+    def __post_init__(self) -> None:
+        """
+        Validate the config immediately after dataclass construction.
+
+        Beginner note:
+        - Indicator periods and lookbacks must be positive integers.
+        - Ratio/multiple values must be non-negative where they represent a
+          tolerance, or strictly positive where they represent a target.
+        - Catching mistakes here gives the caller a clear error before any
+          candle calculations start.
+        """
+        positive_ints = {
+            "sma_fast_period": self.sma_fast_period,
+            "sma_slow_period": self.sma_slow_period,
+            "atr_period": self.atr_period,
+            "slope_lookback": self.slope_lookback,
+            "pullback_lookback": self.pullback_lookback,
+            "pullback_min_count": self.pullback_min_count,
+            "max_bars_in_trade": self.max_bars_in_trade,
+        }
+        invalid = [name for name, value in positive_ints.items() if int(value) <= 0]
+        if invalid:
+            raise ValueError(f"Config values must be positive: {', '.join(invalid)}")
+        if int(self.pullback_min_count) > int(self.pullback_lookback):
+            raise ValueError("pullback_min_count cannot be larger than pullback_lookback.")
+        if float(self.near_sma_atr_multiple) < 0.0:
+            raise ValueError("near_sma_atr_multiple must be non-negative.")
+        if float(self.engulf_tolerance) < 0.0:
+            raise ValueError("engulf_tolerance must be non-negative.")
+        if float(self.target_atr_multiple) <= 0.0:
+            raise ValueError("target_atr_multiple must be greater than zero.")
+
+
+@dataclass
+class GoldminePositionContext:
+    """
+    Small snapshot of an already-open Goldmine trade.
+
+    The engine receives this object when a trade is already live. It then skips
+    entry logic and checks only exit rules, which prevents accidental duplicate
+    entries while a position is open.
+    """
+
+    direction: str
+    entry_underlying: float
+    stop_underlying: float
+    target_underlying: float
+    bars_in_trade: int = 0
+
+
+@dataclass
+class GoldmineDecision:
+    """
+    Standard decision returned by the Goldmine signal engine.
+
+    `action` is intentionally simple:
+    - HOLD means do nothing.
+    - ENTER_LONG / ENTER_SHORT means a setup candle just completed.
+    - EXIT means an existing position should be closed.
+
+    Numeric fields are left at 0.0 when they do not apply to the action.
+    """
+
+    action: str = "HOLD"
+    entry_underlying: float = 0.0
+    stop_underlying: float = 0.0
+    target_underlying: float = 0.0
+    exit_underlying: float = 0.0
+    exit_reason: str = ""
+    signal_triggered: bool = False
+    debug: dict[str, Any] = field(default_factory=dict)
+
+
+def _recent_count(mask: pd.Series, lookback: int, min_count: int) -> pd.Series:
+    """
+    Count recent pullback candles before the current signal candle.
+
+    The final `.shift(1)` matters: the current engulfing candle should not be
+    counted as part of the pullback that came before it.
+    """
+    return mask.rolling(window=int(lookback), min_periods=int(lookback)).sum().shift(1) >= int(min_count)
+
+
+def _build_bullish_engulfing(frame: pd.DataFrame, tolerance: float) -> pd.Series:
+    """Bullish engulfing body pattern from the extracted Goldmine rules."""
+    # The previous candle must show selling pressure, and the current candle
+    # must reverse that pressure with a green body.
+    previous_red = frame["close"].shift(1) < frame["open"].shift(1)
+    current_green = frame["close"] > frame["open"]
+    # We compare candle bodies, not full high/low ranges, because the video
+    # definition talks about the real body engulfing the previous real body.
+    body_engulfs = (
+        frame["open"] <= frame["close"].shift(1) + float(tolerance)
+    ) & (
+        frame["close"] >= frame["open"].shift(1) - float(tolerance)
+    )
+    return previous_red & current_green & body_engulfs
+
+
+def _build_bearish_engulfing(frame: pd.DataFrame, tolerance: float) -> pd.Series:
+    """Bearish engulfing body pattern from the extracted Goldmine rules."""
+    # This is the exact mirror image of the bullish engulfing check:
+    # prior candle green, current candle red, and current real body wraps the
+    # previous real body.
+    previous_green = frame["close"].shift(1) > frame["open"].shift(1)
+    current_red = frame["close"] < frame["open"]
+    body_engulfs = (
+        frame["open"] >= frame["close"].shift(1) - float(tolerance)
+    ) & (
+        frame["close"] <= frame["open"].shift(1) + float(tolerance)
+    )
+    return previous_green & current_red & body_engulfs
+
+
+def _price_near_sma20(frame: pd.DataFrame, config: GoldmineStrategyConfig) -> pd.Series:
+    """
+    Convert "price is close to SMA20" into repeatable code.
+
+    A candle is accepted when either:
+    - its range touches SMA20, or
+    - its close is within the configured ATR distance.
+    """
+    candle_touches_sma = (frame["low"] <= frame["sma20"]) & (frame["high"] >= frame["sma20"])
+    close_near_sma = (
+        (frame["atr"] > 0.0)
+        & ((frame["close"] - frame["sma20"]).abs() <= float(config.near_sma_atr_multiple) * frame["atr"])
+    )
+    return candle_touches_sma | close_near_sma
+
+
+def build_goldmine_with_indicators(
+    ohlc: pd.DataFrame,
+    config: Optional[GoldmineStrategyConfig] = None,
+) -> pd.DataFrame:
+    """
+    Return OHLC candles enriched with Goldmine indicators and setup columns.
+
+    The returned DataFrame is designed for two uses:
+    1. A signal engine can read the newest row and make one decision.
+    2. A tester can inspect intermediate columns like `near_sma20` or
+       `bullish_engulfing` to understand why a signal did or did not happen.
+    """
+    config = config or GoldmineStrategyConfig()
+    frame = normalize_ohlc_frame(ohlc)
+    if frame.empty:
+        return frame
+
+    # Indicator stage:
+    # SMA20/SMA200 describe trend and trading zone; ATR gives the volatility
+    # scale for "near SMA20" and the 2 x ATR target.
+    close = frame["close"].astype(float)
+    frame["sma20"] = sma(close, config.sma_fast_period)
+    frame["sma200"] = sma(close, config.sma_slow_period)
+    frame["atr"] = atr(frame, config.atr_period)
+    frame = add_candle_anatomy(frame)
+
+    # Trend-zone stage:
+    # The strategy wants the 20-SMA moving in the trade direction and price
+    # close enough to that SMA to count as a pullback entry zone.
+    frame["sma20_rising"] = rising_over_lookback(frame["sma20"], config.slope_lookback)
+    frame["sma20_falling"] = falling_over_lookback(frame["sma20"], config.slope_lookback)
+    frame["near_sma20"] = _price_near_sma20(frame, config)
+
+    # Pullback stage:
+    # The signal candle itself is an engulfing reversal, so the pullback count
+    # intentionally looks at the candles before the signal candle.
+    down_close = frame["close"] < frame["close"].shift(1)
+    up_close = frame["close"] > frame["close"].shift(1)
+    frame["recent_long_pullback"] = _recent_count(
+        down_close,
+        config.pullback_lookback,
+        config.pullback_min_count,
+    )
+    frame["recent_short_pullback"] = _recent_count(
+        up_close,
+        config.pullback_lookback,
+        config.pullback_min_count,
+    )
+
+    frame["bullish_engulfing"] = _build_bullish_engulfing(frame, config.engulf_tolerance)
+    frame["bearish_engulfing"] = _build_bearish_engulfing(frame, config.engulf_tolerance)
+
+    # Final setup stage:
+    # Every condition must be true on the same completed candle before the
+    # engine is allowed to emit an entry decision.
+    frame["long_setup"] = (
+        (frame["close"] > frame["sma200"])
+        & (frame["sma20"] > frame["sma200"])
+        & frame["sma20_rising"]
+        & frame["near_sma20"]
+        & frame["recent_long_pullback"]
+        & frame["bullish_engulfing"]
+    )
+    frame["short_setup"] = (
+        (frame["close"] < frame["sma200"])
+        & (frame["sma20"] < frame["sma200"])
+        & frame["sma20_falling"]
+        & frame["near_sma20"]
+        & frame["recent_short_pullback"]
+        & frame["bearish_engulfing"]
+    )
+
+    # Risk stage:
+    # Goldmine uses the full two-candle engulfing pattern for stop placement,
+    # which is a little more conservative than using only the signal candle.
+    pattern_low = pd.concat([frame["low"], frame["low"].shift(1)], axis=1).min(axis=1)
+    pattern_high = pd.concat([frame["high"], frame["high"].shift(1)], axis=1).max(axis=1)
+    frame["long_entry_price"] = frame["close"]
+    frame["short_entry_price"] = frame["close"]
+    frame["long_stop_from_setup"] = pattern_low
+    frame["short_stop_from_setup"] = pattern_high
+    frame["long_target_from_setup"] = frame["long_entry_price"] + float(config.target_atr_multiple) * frame["atr"]
+    frame["short_target_from_setup"] = frame["short_entry_price"] - float(config.target_atr_multiple) * frame["atr"]
+    frame["signal_atr"] = frame["atr"]
+    return frame
+
+
+class GoldmineSignalEngine:
+    """Decision engine for Goldmine entries and exits."""
+
+    def __init__(self, config: Optional[GoldmineStrategyConfig] = None) -> None:
+        """
+        Store one config object for all later evaluations.
+
+        Keeping the config on the engine prevents subtle drift where a caller
+        builds indicators with one set of values but evaluates entries with
+        another set.
+        """
+        self.config = config or GoldmineStrategyConfig()
+
+    def minimum_history_bars(self) -> int:
+        """Return the warm-up length needed before entries are trusted."""
+        return (
+            max(self.config.sma_fast_period, self.config.sma_slow_period, self.config.atr_period)
+            + max(self.config.slope_lookback, self.config.pullback_lookback)
+            + 1
+        )
+
+    @staticmethod
+    def _hold(reason: str = "", *, signal_triggered: bool = False) -> GoldmineDecision:
+        """Return a consistent HOLD decision."""
+        return GoldmineDecision(
+            action="HOLD",
+            signal_triggered=signal_triggered,
+            debug={"reason": reason} if reason else {},
+        )
+
+    @staticmethod
+    def _direction(direction: str) -> str:
+        """Normalize direction strings like 'long' or ' LONG '."""
+        return str(direction).strip().upper()
+
+    def _evaluate_exit(self, current: pd.Series, position: GoldminePositionContext) -> GoldmineDecision:
+        """Evaluate stop, target, and time exit for an open Goldmine trade."""
+        direction = self._direction(position.direction)
+        high = float(current["high"])
+        low = float(current["low"])
+        close = float(current["close"])
+        stop = float(position.stop_underlying)
+        target = float(position.target_underlying)
+
+        if direction == "LONG":
+            # Conservative ordering: if a candle touches both stop and target,
+            # the stop branch wins because we cannot know intrabar sequence from
+            # OHLC alone.
+            if low <= stop:
+                return GoldmineDecision(action="EXIT", exit_underlying=stop, exit_reason="STOP")
+            if high >= target:
+                return GoldmineDecision(action="EXIT", exit_underlying=target, exit_reason="TARGET")
+            if int(position.bars_in_trade) >= int(self.config.max_bars_in_trade):
+                return GoldmineDecision(action="EXIT", exit_underlying=close, exit_reason="TIME_EXIT")
+            return self._hold()
+
+        if direction == "SHORT":
+            # Short exits mirror the long exits: stop is above price, target is
+            # below price, and the same stop-first rule is used.
+            if high >= stop:
+                return GoldmineDecision(action="EXIT", exit_underlying=stop, exit_reason="STOP")
+            if low <= target:
+                return GoldmineDecision(action="EXIT", exit_underlying=target, exit_reason="TARGET")
+            if int(position.bars_in_trade) >= int(self.config.max_bars_in_trade):
+                return GoldmineDecision(action="EXIT", exit_underlying=close, exit_reason="TIME_EXIT")
+            return self._hold()
+
+        return self._hold("Unknown position direction.")
+
+    def evaluate_candle(
+        self,
+        candles_with_indicators: pd.DataFrame,
+        position: Optional[GoldminePositionContext] = None,
+    ) -> GoldmineDecision:
+        """Evaluate the newest candle and return HOLD, ENTER_LONG, ENTER_SHORT, or EXIT."""
+        if candles_with_indicators is None or candles_with_indicators.empty:
+            return self._hold("No candles supplied.")
+        require_columns(candles_with_indicators, ["open", "high", "low", "close"])
+        current = candles_with_indicators.iloc[-1]
+
+        if position is not None:
+            # Position supplied means the caller is already in a trade. Entry
+            # setups are ignored until that trade exits.
+            return self._evaluate_exit(current, position)
+
+        required = [
+            "sma20",
+            "sma200",
+            "atr",
+            "long_setup",
+            "short_setup",
+            "long_entry_price",
+            "short_entry_price",
+            "long_stop_from_setup",
+            "short_stop_from_setup",
+            "long_target_from_setup",
+            "short_target_from_setup",
+        ]
+        require_columns(candles_with_indicators, required)
+        if len(candles_with_indicators) < self.minimum_history_bars():
+            return self._hold("Insufficient history.")
+
+        if bool(current["long_setup"]) and bool(current["short_setup"]):
+            return self._hold("Conflict: both long and short Goldmine setups are true.")
+
+        if bool(current["long_setup"]):
+            # Entry price is the setup close for the signal payload. The
+            # backtest/front-test uses debug["entry_timing"] to execute on the
+            # next candle open instead of pretending the setup candle was tradable.
+            entry = float(current["long_entry_price"])
+            stop = float(current["long_stop_from_setup"])
+            target = float(current["long_target_from_setup"])
+            if all(finite(value) for value in [entry, stop, target]) and stop < entry < target:
+                return GoldmineDecision(
+                    action="ENTER_LONG",
+                    entry_underlying=entry,
+                    stop_underlying=stop,
+                    target_underlying=target,
+                    signal_triggered=True,
+                    debug={
+                        "entry_timing": "NEXT_OPEN",
+                        "timestamp": current.get("timestamp"),
+                        "pattern": "BULLISH_ENGULFING",
+                        "signal_atr": float(current.get("signal_atr", np.nan)),
+                    },
+                )
+            return self._hold("Invalid long entry prices.", signal_triggered=True)
+
+        if bool(current["short_setup"]):
+            # The short branch is deliberately shaped like the long branch so a
+            # beginner can compare them side by side.
+            entry = float(current["short_entry_price"])
+            stop = float(current["short_stop_from_setup"])
+            target = float(current["short_target_from_setup"])
+            if all(finite(value) for value in [entry, stop, target]) and target < entry < stop:
+                return GoldmineDecision(
+                    action="ENTER_SHORT",
+                    entry_underlying=entry,
+                    stop_underlying=stop,
+                    target_underlying=target,
+                    signal_triggered=True,
+                    debug={
+                        "entry_timing": "NEXT_OPEN",
+                        "timestamp": current.get("timestamp"),
+                        "pattern": "BEARISH_ENGULFING",
+                        "signal_atr": float(current.get("signal_atr", np.nan)),
+                    },
+                )
+            return self._hold("Invalid short entry prices.", signal_triggered=True)
+
+        return self._hold("No Goldmine setup on latest candle.")
+
+
+class GoldmineSignalGenerator:
+    """Convenience wrapper for full-history and latest-candle Goldmine signals."""
+
+    def __init__(self, config: Optional[GoldmineStrategyConfig] = None) -> None:
+        """
+        Create one reusable signal engine for this generator instance.
+
+        Full-history generation walks candle by candle, so reusing the engine
+        keeps the public API simple and mirrors the other strategy folders.
+        """
+        self.config = config or GoldmineStrategyConfig()
+        self.engine = GoldmineSignalEngine(self.config)
+
+    def generate(self, data: pd.DataFrame) -> pd.DataFrame:
+        """Return enriched candles plus repo-style signal stream columns."""
+        frame = build_goldmine_with_indicators(data, self.config)
+        if frame.empty:
+            return frame
+
+        actions: list[str] = []
+        entries: list[float] = []
+        stops: list[float] = []
+        targets: list[float] = []
+        stream: list[int] = []
+        position: Optional[GoldminePositionContext] = None
+
+        for index in range(len(frame)):
+            # The generator simulates a very simple single-position stream:
+            # once a position is open, later candles are passed as position
+            # management checks until an EXIT resets the state.
+            if position is not None:
+                position.bars_in_trade += 1
+            decision = self.engine.evaluate_candle(frame.iloc[: index + 1], position=position)
+            actions.append(decision.action)
+            entries.append(decision.entry_underlying)
+            stops.append(decision.stop_underlying)
+            targets.append(decision.target_underlying)
+
+            if decision.action == "ENTER_LONG":
+                stream.append(1)
+                position = GoldminePositionContext(
+                    direction="LONG",
+                    entry_underlying=decision.entry_underlying,
+                    stop_underlying=decision.stop_underlying,
+                    target_underlying=decision.target_underlying,
+                )
+            elif decision.action == "ENTER_SHORT":
+                stream.append(-1)
+                position = GoldminePositionContext(
+                    direction="SHORT",
+                    entry_underlying=decision.entry_underlying,
+                    stop_underlying=decision.stop_underlying,
+                    target_underlying=decision.target_underlying,
+                )
+            elif decision.action == "EXIT":
+                stream.append(2)
+                position = None
+            else:
+                stream.append(0)
+
+        result = frame.copy()
+        result["signalAction"] = actions
+        result["entryUnderlying"] = entries
+        result["stopUnderlying"] = stops
+        result["targetUnderlying"] = targets
+        result["backtestStream"] = stream
+        return result
+
+    def latest_signal(
+        self,
+        data: pd.DataFrame,
+        position: Optional[GoldminePositionContext] = None,
+    ) -> GoldmineDecision:
+        """Return only the newest Goldmine decision."""
+        frame = build_goldmine_with_indicators(data, self.config)
+        return self.engine.evaluate_candle(frame, position=position)
+
+
+def generate_goldmine_signals(
+    data: pd.DataFrame,
+    config: Optional[GoldmineStrategyConfig] = None,
+) -> pd.DataFrame:
+    """Functional wrapper for full-history Goldmine signals."""
+    return GoldmineSignalGenerator(config=config).generate(data)
+
+
+def get_latest_goldmine_signal(
+    data: pd.DataFrame,
+    config: Optional[GoldmineStrategyConfig] = None,
+    position: Optional[GoldminePositionContext] = None,
+) -> GoldmineDecision:
+    """Functional wrapper for the latest Goldmine decision."""
+    return GoldmineSignalGenerator(config=config).latest_signal(data, position=position)
+
+
+__all__ = [
+    "GoldmineStrategyConfig",
+    "GoldminePositionContext",
+    "GoldmineDecision",
+    "build_goldmine_with_indicators",
+    "GoldmineSignalEngine",
+    "GoldmineSignalGenerator",
+    "generate_goldmine_signals",
+    "get_latest_goldmine_signal",
+]

--- a/Signal Generators/Subhamoy Strategies/money_machine_strategy_logic.py
+++ b/Signal Generators/Subhamoy Strategies/money_machine_strategy_logic.py
@@ -1,0 +1,507 @@
+"""
+Shared Money Machine strategy logic for already-prepared 5-minute OHLC candles.
+
+Money Machine uses the same SMA20/SMA200 trend context as Goldmine, but its
+trigger is different:
+1. Price compresses in a narrow range for several candles.
+2. A strong Marubozu/Hulk candle breaks out of that compression.
+3. Execution is planned for the next candle open/market.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+import numpy as np
+import pandas as pd
+
+from subhamoy_strategy_common import (
+    add_candle_anatomy,
+    atr,
+    falling_over_lookback,
+    finite,
+    normalize_ohlc_frame,
+    require_columns,
+    rising_over_lookback,
+    sma,
+)
+
+
+@dataclass(frozen=True)
+class MoneyMachineStrategyConfig:
+    """
+    All tunable Money Machine settings live in one beginner-friendly object.
+
+    The video leaves several phrases qualitative, such as "narrow range" and
+    "very small wick." These fields convert those chart-reading phrases into
+    explicit numbers that can be tested and tuned.
+    """
+
+    sma_fast_period: int = 20
+    sma_slow_period: int = 200
+    atr_period: int = 14
+    slope_lookback: int = 3
+    near_sma_atr_multiple: float = 0.5
+    compression_window: int = 3
+    compression_range_atr_multiple: float = 0.75
+    marubozu_body_min_ratio: float = 0.80
+    marubozu_wick_max_ratio: float = 0.15
+    require_breakout_close: bool = True
+    target_atr_multiple: float = 2.0
+
+    def __post_init__(self) -> None:
+        """
+        Validate all Money Machine parameters before calculations begin.
+
+        Beginner note:
+        - Period/window fields must be positive because rolling indicators need
+          at least one candle.
+        - Ratio fields must stay between 0 and 1 because they represent a
+          fraction of candle range.
+        - Target multiple must be positive because target distance cannot be
+          zero or negative.
+        """
+        positive_ints = {
+            "sma_fast_period": self.sma_fast_period,
+            "sma_slow_period": self.sma_slow_period,
+            "atr_period": self.atr_period,
+            "slope_lookback": self.slope_lookback,
+            "compression_window": self.compression_window,
+        }
+        invalid = [name for name, value in positive_ints.items() if int(value) <= 0]
+        if invalid:
+            raise ValueError(f"Config values must be positive: {', '.join(invalid)}")
+        bounded_ratios = {
+            "marubozu_body_min_ratio": self.marubozu_body_min_ratio,
+            "marubozu_wick_max_ratio": self.marubozu_wick_max_ratio,
+        }
+        invalid_ratios = [
+            name for name, value in bounded_ratios.items() if not (0.0 <= float(value) <= 1.0)
+        ]
+        if invalid_ratios:
+            raise ValueError(f"Ratios must be between 0 and 1: {', '.join(invalid_ratios)}")
+        if float(self.near_sma_atr_multiple) < 0.0:
+            raise ValueError("near_sma_atr_multiple must be non-negative.")
+        if float(self.compression_range_atr_multiple) < 0.0:
+            raise ValueError("compression_range_atr_multiple must be non-negative.")
+        if float(self.target_atr_multiple) <= 0.0:
+            raise ValueError("target_atr_multiple must be greater than zero.")
+
+
+@dataclass
+class MoneyMachinePositionContext:
+    """
+    Small snapshot of an already-open Money Machine trade.
+
+    Passing this object into the engine tells it: "we are managing a trade now,
+    so ignore fresh entries and only check stop/target exits."
+    """
+
+    direction: str
+    entry_underlying: float
+    stop_underlying: float
+    target_underlying: float
+
+
+@dataclass
+class MoneyMachineDecision:
+    """
+    Standard decision returned by the Money Machine signal engine.
+
+    The same decision shape is used for entries, exits, and holds so callers do
+    not have to switch between different return types.
+    """
+
+    action: str = "HOLD"
+    entry_underlying: float = 0.0
+    stop_underlying: float = 0.0
+    target_underlying: float = 0.0
+    exit_underlying: float = 0.0
+    exit_reason: str = ""
+    signal_triggered: bool = False
+    debug: dict[str, Any] = field(default_factory=dict)
+
+
+def _price_near_sma20(frame: pd.DataFrame, config: MoneyMachineStrategyConfig) -> pd.Series:
+    """Accept candles that touch SMA20 or close within an ATR-based buffer."""
+    candle_touches_sma = (frame["low"] <= frame["sma20"]) & (frame["high"] >= frame["sma20"])
+    close_near_sma = (
+        (frame["atr"] > 0.0)
+        & ((frame["close"] - frame["sma20"]).abs() <= float(config.near_sma_atr_multiple) * frame["atr"])
+    )
+    return candle_touches_sma | close_near_sma
+
+
+def _build_hulk_masks(frame: pd.DataFrame, config: MoneyMachineStrategyConfig) -> tuple[pd.Series, pd.Series]:
+    """Return bullish and bearish Marubozu/Hulk masks."""
+    # Replace zero ranges with NaN so a flat/bad candle cannot accidentally pass
+    # the ratio tests through division by zero.
+    range_safe = frame["candle_range"].replace(0.0, np.nan)
+    body_ratio = frame["body"] / range_safe
+    upper_ratio = frame["upper_wick"] / range_safe
+    lower_ratio = frame["lower_wick"] / range_safe
+
+    # A Hulk candle needs two things at once:
+    # 1. A large real body.
+    # 2. Tiny upper and lower wicks.
+    strong_body = body_ratio >= float(config.marubozu_body_min_ratio)
+    tiny_wicks = (
+        upper_ratio <= float(config.marubozu_wick_max_ratio)
+    ) & (
+        lower_ratio <= float(config.marubozu_wick_max_ratio)
+    )
+    bullish = (frame["close"] > frame["open"]) & strong_body & tiny_wicks
+    bearish = (frame["close"] < frame["open"]) & strong_body & tiny_wicks
+    return bullish, bearish
+
+
+def build_money_machine_with_indicators(
+    ohlc: pd.DataFrame,
+    config: Optional[MoneyMachineStrategyConfig] = None,
+) -> pd.DataFrame:
+    """
+    Return OHLC candles enriched with Money Machine indicators and setup columns.
+
+    The intermediate columns are intentionally verbose. A user can open the
+    DataFrame and see exactly which rule failed: trend, near-SMA, compression,
+    Hulk geometry, or breakout.
+    """
+    config = config or MoneyMachineStrategyConfig()
+    frame = normalize_ohlc_frame(ohlc)
+    if frame.empty:
+        return frame
+
+    # Indicator stage:
+    # SMA20/SMA200 define the trend and trading zone. ATR gives us a volatility
+    # scale for both "near SMA20" and "previous range is narrow."
+    close = frame["close"].astype(float)
+    frame["sma20"] = sma(close, config.sma_fast_period)
+    frame["sma200"] = sma(close, config.sma_slow_period)
+    frame["atr"] = atr(frame, config.atr_period)
+    frame = add_candle_anatomy(frame)
+
+    frame["sma20_rising"] = rising_over_lookback(frame["sma20"], config.slope_lookback)
+    frame["sma20_falling"] = falling_over_lookback(frame["sma20"], config.slope_lookback)
+    frame["near_sma20"] = _price_near_sma20(frame, config)
+    # Start with explicit False columns so the output has predictable columns
+    # even if a future edit changes the helper implementation.
+    frame["bullish_hulk"] = False
+    frame["bearish_hulk"] = False
+    frame["bullish_hulk"], frame["bearish_hulk"] = _build_hulk_masks(frame, config)
+
+    # Compression stage:
+    # The rolling range is built from the candles BEFORE the signal candle. The
+    # signal candle itself should be the breakout from that range, not part of it.
+    previous_high = frame["high"].shift(1).rolling(
+        window=config.compression_window,
+        min_periods=config.compression_window,
+    ).max()
+    previous_low = frame["low"].shift(1).rolling(
+        window=config.compression_window,
+        min_periods=config.compression_window,
+    ).min()
+    previous_range = previous_high - previous_low
+
+    # The compression range is compared to ATR available on the signal candle.
+    # This keeps the rule simple and causal: no future data is used.
+    frame["compression_high"] = previous_high
+    frame["compression_low"] = previous_low
+    frame["compression_range"] = previous_range
+    frame["compression_ok"] = (
+        (frame["atr"] > 0.0)
+        & (previous_range <= float(config.compression_range_atr_multiple) * frame["atr"])
+    )
+
+    if config.require_breakout_close:
+        # Close-based breakout is stricter and avoids signals where price poked
+        # outside the range intrabar but closed back inside.
+        frame["bullish_compression_breakout"] = frame["close"] > previous_high
+        frame["bearish_compression_breakout"] = frame["close"] < previous_low
+    else:
+        # High/low breakout is more permissive and is available for experiments.
+        frame["bullish_compression_breakout"] = frame["high"] > previous_high
+        frame["bearish_compression_breakout"] = frame["low"] < previous_low
+
+    # Final setup stage:
+    # Money Machine requires trend, trading-zone location, compression, Hulk
+    # candle geometry, and breakout direction to agree on the same candle.
+    frame["long_setup"] = (
+        (frame["close"] > frame["sma200"])
+        & (frame["sma20"] > frame["sma200"])
+        & frame["sma20_rising"]
+        & frame["near_sma20"]
+        & frame["compression_ok"]
+        & frame["bullish_hulk"]
+        & frame["bullish_compression_breakout"]
+    )
+    frame["short_setup"] = (
+        (frame["close"] < frame["sma200"])
+        & (frame["sma20"] < frame["sma200"])
+        & frame["sma20_falling"]
+        & frame["near_sma20"]
+        & frame["compression_ok"]
+        & frame["bearish_hulk"]
+        & frame["bearish_compression_breakout"]
+    )
+
+    # Risk stage:
+    # The video places the stop at the Hulk candle extreme and the target at
+    # 2 x ATR from entry. The backtest later recomputes target from actual next
+    # open, but these values are still useful for front-test signal payloads.
+    frame["long_entry_price"] = frame["close"]
+    frame["short_entry_price"] = frame["close"]
+    frame["long_stop_from_setup"] = frame["low"]
+    frame["short_stop_from_setup"] = frame["high"]
+    frame["long_target_from_setup"] = frame["long_entry_price"] + float(config.target_atr_multiple) * frame["atr"]
+    frame["short_target_from_setup"] = frame["short_entry_price"] - float(config.target_atr_multiple) * frame["atr"]
+    frame["signal_atr"] = frame["atr"]
+    return frame
+
+
+class MoneyMachineSignalEngine:
+    """Decision engine for Money Machine entries and exits."""
+
+    def __init__(self, config: Optional[MoneyMachineStrategyConfig] = None) -> None:
+        """
+        Store one config object for all later evaluations.
+
+        This avoids mixing indicator settings and signal settings when a caller
+        evaluates many candles over time.
+        """
+        self.config = config or MoneyMachineStrategyConfig()
+
+    def minimum_history_bars(self) -> int:
+        """Return the warm-up length needed before entries are trusted."""
+        return (
+            max(self.config.sma_fast_period, self.config.sma_slow_period, self.config.atr_period)
+            + max(self.config.slope_lookback, self.config.compression_window)
+            + 1
+        )
+
+    @staticmethod
+    def _hold(reason: str = "", *, signal_triggered: bool = False) -> MoneyMachineDecision:
+        """Return a consistent HOLD decision."""
+        return MoneyMachineDecision(
+            action="HOLD",
+            signal_triggered=signal_triggered,
+            debug={"reason": reason} if reason else {},
+        )
+
+    @staticmethod
+    def _direction(direction: str) -> str:
+        """Normalize direction strings like 'short' or ' SHORT '."""
+        return str(direction).strip().upper()
+
+    def _evaluate_exit(self, current: pd.Series, position: MoneyMachinePositionContext) -> MoneyMachineDecision:
+        """Evaluate stop and target for an open Money Machine trade."""
+        direction = self._direction(position.direction)
+        high = float(current["high"])
+        low = float(current["low"])
+        stop = float(position.stop_underlying)
+        target = float(position.target_underlying)
+
+        if direction == "LONG":
+            # Stop is checked before target so same-candle stop+target touches
+            # are handled conservatively from OHLC data.
+            if low <= stop:
+                return MoneyMachineDecision(action="EXIT", exit_underlying=stop, exit_reason="STOP")
+            if high >= target:
+                return MoneyMachineDecision(action="EXIT", exit_underlying=target, exit_reason="TARGET")
+            return self._hold()
+
+        if direction == "SHORT":
+            # Short exit logic is the mirror image of long exit logic.
+            if high >= stop:
+                return MoneyMachineDecision(action="EXIT", exit_underlying=stop, exit_reason="STOP")
+            if low <= target:
+                return MoneyMachineDecision(action="EXIT", exit_underlying=target, exit_reason="TARGET")
+            return self._hold()
+
+        return self._hold("Unknown position direction.")
+
+    def evaluate_candle(
+        self,
+        candles_with_indicators: pd.DataFrame,
+        position: Optional[MoneyMachinePositionContext] = None,
+    ) -> MoneyMachineDecision:
+        """Evaluate the newest candle and return HOLD, ENTER_LONG, ENTER_SHORT, or EXIT."""
+        if candles_with_indicators is None or candles_with_indicators.empty:
+            return self._hold("No candles supplied.")
+        require_columns(candles_with_indicators, ["open", "high", "low", "close"])
+        current = candles_with_indicators.iloc[-1]
+
+        if position is not None:
+            # Open position means entry checks are skipped. The engine should
+            # only manage the existing trade until it exits.
+            return self._evaluate_exit(current, position)
+
+        required = [
+            "sma20",
+            "sma200",
+            "atr",
+            "long_setup",
+            "short_setup",
+            "long_entry_price",
+            "short_entry_price",
+            "long_stop_from_setup",
+            "short_stop_from_setup",
+            "long_target_from_setup",
+            "short_target_from_setup",
+        ]
+        require_columns(candles_with_indicators, required)
+        if len(candles_with_indicators) < self.minimum_history_bars():
+            return self._hold("Insufficient history.")
+
+        if bool(current["long_setup"]) and bool(current["short_setup"]):
+            return self._hold("Conflict: both long and short Money Machine setups are true.")
+
+        if bool(current["long_setup"]):
+            # The signal payload uses the completed setup close, while
+            # debug["entry_timing"] tells the caller to execute on next open.
+            entry = float(current["long_entry_price"])
+            stop = float(current["long_stop_from_setup"])
+            target = float(current["long_target_from_setup"])
+            if all(finite(value) for value in [entry, stop, target]) and stop < entry < target:
+                return MoneyMachineDecision(
+                    action="ENTER_LONG",
+                    entry_underlying=entry,
+                    stop_underlying=stop,
+                    target_underlying=target,
+                    signal_triggered=True,
+                    debug={
+                        "entry_timing": "NEXT_OPEN",
+                        "timestamp": current.get("timestamp"),
+                        "pattern": "BULLISH_HULK",
+                        "signal_atr": float(current.get("signal_atr", np.nan)),
+                    },
+                )
+            return self._hold("Invalid long entry prices.", signal_triggered=True)
+
+        if bool(current["short_setup"]):
+            # This branch mirrors the long branch for readability and easier
+            # future tuning.
+            entry = float(current["short_entry_price"])
+            stop = float(current["short_stop_from_setup"])
+            target = float(current["short_target_from_setup"])
+            if all(finite(value) for value in [entry, stop, target]) and target < entry < stop:
+                return MoneyMachineDecision(
+                    action="ENTER_SHORT",
+                    entry_underlying=entry,
+                    stop_underlying=stop,
+                    target_underlying=target,
+                    signal_triggered=True,
+                    debug={
+                        "entry_timing": "NEXT_OPEN",
+                        "timestamp": current.get("timestamp"),
+                        "pattern": "BEARISH_HULK",
+                        "signal_atr": float(current.get("signal_atr", np.nan)),
+                    },
+                )
+            return self._hold("Invalid short entry prices.", signal_triggered=True)
+
+        return self._hold("No Money Machine setup on latest candle.")
+
+
+class MoneyMachineSignalGenerator:
+    """Convenience wrapper for full-history and latest-candle Money Machine signals."""
+
+    def __init__(self, config: Optional[MoneyMachineStrategyConfig] = None) -> None:
+        """
+        Create one reusable engine for this generator instance.
+
+        The wrapper is intentionally small: all trading rules stay in the shared
+        engine, while this class only adds full-history iteration.
+        """
+        self.config = config or MoneyMachineStrategyConfig()
+        self.engine = MoneyMachineSignalEngine(self.config)
+
+    def generate(self, data: pd.DataFrame) -> pd.DataFrame:
+        """Return enriched candles plus repo-style signal stream columns."""
+        frame = build_money_machine_with_indicators(data, self.config)
+        if frame.empty:
+            return frame
+
+        actions: list[str] = []
+        entries: list[float] = []
+        stops: list[float] = []
+        targets: list[float] = []
+        stream: list[int] = []
+        position: Optional[MoneyMachinePositionContext] = None
+
+        for index in range(len(frame)):
+            # Full-history generation keeps one simple simulated position so
+            # output streams do not show overlapping entries.
+            decision = self.engine.evaluate_candle(frame.iloc[: index + 1], position=position)
+            actions.append(decision.action)
+            entries.append(decision.entry_underlying)
+            stops.append(decision.stop_underlying)
+            targets.append(decision.target_underlying)
+
+            if decision.action == "ENTER_LONG":
+                stream.append(1)
+                position = MoneyMachinePositionContext(
+                    direction="LONG",
+                    entry_underlying=decision.entry_underlying,
+                    stop_underlying=decision.stop_underlying,
+                    target_underlying=decision.target_underlying,
+                )
+            elif decision.action == "ENTER_SHORT":
+                stream.append(-1)
+                position = MoneyMachinePositionContext(
+                    direction="SHORT",
+                    entry_underlying=decision.entry_underlying,
+                    stop_underlying=decision.stop_underlying,
+                    target_underlying=decision.target_underlying,
+                )
+            elif decision.action == "EXIT":
+                stream.append(2)
+                position = None
+            else:
+                stream.append(0)
+
+        result = frame.copy()
+        result["signalAction"] = actions
+        result["entryUnderlying"] = entries
+        result["stopUnderlying"] = stops
+        result["targetUnderlying"] = targets
+        result["backtestStream"] = stream
+        return result
+
+    def latest_signal(
+        self,
+        data: pd.DataFrame,
+        position: Optional[MoneyMachinePositionContext] = None,
+    ) -> MoneyMachineDecision:
+        """Return only the newest Money Machine decision."""
+        frame = build_money_machine_with_indicators(data, self.config)
+        return self.engine.evaluate_candle(frame, position=position)
+
+
+def generate_money_machine_signals(
+    data: pd.DataFrame,
+    config: Optional[MoneyMachineStrategyConfig] = None,
+) -> pd.DataFrame:
+    """Functional wrapper for full-history Money Machine signals."""
+    return MoneyMachineSignalGenerator(config=config).generate(data)
+
+
+def get_latest_money_machine_signal(
+    data: pd.DataFrame,
+    config: Optional[MoneyMachineStrategyConfig] = None,
+    position: Optional[MoneyMachinePositionContext] = None,
+) -> MoneyMachineDecision:
+    """Functional wrapper for the latest Money Machine decision."""
+    return MoneyMachineSignalGenerator(config=config).latest_signal(data, position=position)
+
+
+__all__ = [
+    "MoneyMachineStrategyConfig",
+    "MoneyMachinePositionContext",
+    "MoneyMachineDecision",
+    "build_money_machine_with_indicators",
+    "MoneyMachineSignalEngine",
+    "MoneyMachineSignalGenerator",
+    "generate_money_machine_signals",
+    "get_latest_money_machine_signal",
+]

--- a/Signal Generators/Subhamoy Strategies/subhamoy_strategy_common.py
+++ b/Signal Generators/Subhamoy Strategies/subhamoy_strategy_common.py
@@ -1,0 +1,194 @@
+"""
+Shared helpers for Subhamoy strategy signal generators and backtests.
+
+This file deliberately does NOT resample data. The front-test/data-fetch layer
+is responsible for preparing 5-minute candles before calling these strategies.
+
+Beginner mental model:
+1. Normalize the caller's OHLC table into predictable lowercase columns.
+2. Calculate standard indicators through TA-Lib first whenever it is available.
+3. Fall back to pandas only so the files remain usable on machines where the
+   native TA-Lib package has not been installed yet.
+4. Keep small reusable candle helpers here so Goldmine and Money Machine do not
+   each carry their own copy of the same boilerplate.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, Optional
+
+import numpy as np
+import pandas as pd
+
+try:
+    # TA-Lib is the preferred indicator backend in this repo because it matches
+    # the user's request for standard library indicator implementations.
+    import talib  # type: ignore
+except ImportError:  # pragma: no cover - used only when TA-Lib is absent
+    talib = None  # type: ignore
+
+
+OHLC_COLUMNS = ["open", "high", "low", "close"]
+
+
+def find_first_col(frame: pd.DataFrame, names: Iterable[str]) -> Optional[str]:
+    """Find the first matching column name using case-insensitive comparison."""
+    lookup = {str(column).strip().lower(): column for column in frame.columns}
+    for name in names:
+        key = str(name).strip().lower()
+        if key in lookup:
+            return lookup[key]
+    return None
+
+
+def require_columns(frame: pd.DataFrame, required_columns: list[str]) -> None:
+    """Raise a clear beginner-friendly error when required columns are absent."""
+    missing = [column for column in required_columns if column not in frame.columns]
+    if missing:
+        raise ValueError(f"Missing required columns: {', '.join(missing)}")
+
+
+def normalize_ohlc_frame(data: pd.DataFrame) -> pd.DataFrame:
+    """
+    Return clean, time-sorted candles with lowercase OHLC column names.
+
+    Accepted timestamp inputs:
+    - a `timestamp`, `datetime`, `date`, or `time` column
+    - a datetime-like DataFrame index
+
+    This helper drops invalid rows but never changes candle timeframe.
+    """
+    if data is None or not isinstance(data, pd.DataFrame):
+        raise ValueError("OHLC input must be a pandas DataFrame.")
+    if data.empty:
+        return pd.DataFrame(columns=["timestamp", "open", "high", "low", "close", "volume"])
+
+    ts_col = find_first_col(data, ["timestamp", "datetime", "date", "time"])
+    o_col = find_first_col(data, ["open"])
+    h_col = find_first_col(data, ["high"])
+    l_col = find_first_col(data, ["low"])
+    c_col = find_first_col(data, ["close"])
+    v_col = find_first_col(data, ["volume", "vol"])
+
+    missing = []
+    if o_col is None:
+        missing.append("open")
+    if h_col is None:
+        missing.append("high")
+    if l_col is None:
+        missing.append("low")
+    if c_col is None:
+        missing.append("close")
+    if missing:
+        raise ValueError(f"Missing required columns: {', '.join(missing)}")
+
+    result = pd.DataFrame(index=data.index)
+    if ts_col is not None:
+        result["timestamp"] = pd.to_datetime(data[ts_col], errors="coerce")
+    else:
+        result["timestamp"] = pd.to_datetime(pd.Series(data.index, index=data.index), errors="coerce")
+
+    if result["timestamp"].isna().all():
+        raise ValueError("A valid timestamp/datetime column or datetime-like index is required.")
+
+    result["open"] = pd.to_numeric(data[o_col], errors="coerce")
+    result["high"] = pd.to_numeric(data[h_col], errors="coerce")
+    result["low"] = pd.to_numeric(data[l_col], errors="coerce")
+    result["close"] = pd.to_numeric(data[c_col], errors="coerce")
+    if v_col is not None:
+        result["volume"] = pd.to_numeric(data[v_col], errors="coerce").fillna(0.0)
+    else:
+        result["volume"] = 0.0
+
+    result = result.dropna(subset=["timestamp", "open", "high", "low", "close"])
+    result = result.sort_values("timestamp").drop_duplicates("timestamp").reset_index(drop=True)
+    return result
+
+
+def validate_five_minute_spacing(frame: pd.DataFrame) -> None:
+    """
+    Confirm that data is already approximately 5-minute OHLC.
+
+    A 1-minute file is rejected here on purpose. Resampling belongs in the
+    user's front-test/data-preparation workflow, not inside these strategy files.
+    """
+    if frame is None or frame.empty or len(frame) < 2:
+        return
+    require_columns(frame, ["timestamp"])
+    deltas = frame["timestamp"].diff().dropna().dt.total_seconds() / 60.0
+    positive_deltas = deltas[deltas > 0]
+    if positive_deltas.empty:
+        return
+    median_minutes = float(positive_deltas.median())
+    if not (4.5 <= median_minutes <= 5.5):
+        raise ValueError(
+            "Subhamoy strategy backtests expect already-prepared 5-minute OHLC data; "
+            f"detected median spacing of {median_minutes:.2f} minutes. "
+            "Please resample in the front-test/data-preparation file before running this backtest."
+        )
+
+
+def sma(values: pd.Series, period: int) -> pd.Series:
+    """Calculate simple moving average with TA-Lib first, then pandas."""
+    if talib is not None:
+        return pd.Series(
+            talib.SMA(values.to_numpy(dtype="float64"), timeperiod=int(period)),  # type: ignore[union-attr]
+            index=values.index,
+        )
+    return values.rolling(window=int(period), min_periods=int(period)).mean()
+
+
+def atr(frame: pd.DataFrame, period: int) -> pd.Series:
+    """Calculate ATR with TA-Lib first, then Wilder-style pandas smoothing."""
+    high = frame["high"].astype(float)
+    low = frame["low"].astype(float)
+    close = frame["close"].astype(float)
+    if talib is not None:
+        return pd.Series(
+            talib.ATR(  # type: ignore[union-attr]
+                high.to_numpy(dtype="float64"),
+                low.to_numpy(dtype="float64"),
+                close.to_numpy(dtype="float64"),
+                timeperiod=int(period),
+            ),
+            index=frame.index,
+        )
+
+    previous_close = close.shift(1)
+    true_range = pd.concat(
+        [
+            (high - low).abs(),
+            (high - previous_close).abs(),
+            (low - previous_close).abs(),
+        ],
+        axis=1,
+    ).max(axis=1)
+    return true_range.ewm(alpha=1.0 / int(period), adjust=False, min_periods=int(period)).mean()
+
+
+def add_candle_anatomy(frame: pd.DataFrame) -> pd.DataFrame:
+    """Add body, wick, and range columns used by both candle-pattern strategies."""
+    result = frame.copy()
+    result["candle_range"] = (result["high"] - result["low"]).abs()
+    result["body"] = (result["close"] - result["open"]).abs()
+    result["upper_wick"] = result["high"] - result[["open", "close"]].max(axis=1)
+    result["lower_wick"] = result[["open", "close"]].min(axis=1) - result["low"]
+    return result
+
+
+def rising_over_lookback(values: pd.Series, lookback: int) -> pd.Series:
+    """True when the latest value is above the value `lookback` bars ago."""
+    return values > values.shift(int(lookback))
+
+
+def falling_over_lookback(values: pd.Series, lookback: int) -> pd.Series:
+    """True when the latest value is below the value `lookback` bars ago."""
+    return values < values.shift(int(lookback))
+
+
+def finite(value: object) -> bool:
+    """Return True only for real finite numbers."""
+    try:
+        return bool(np.isfinite(float(value)))
+    except (TypeError, ValueError):
+        return False

--- a/Signal Generators/Subhamoy Strategies/test_subhamoy_strategy_signal_generators.py
+++ b/Signal Generators/Subhamoy Strategies/test_subhamoy_strategy_signal_generators.py
@@ -1,0 +1,311 @@
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import pandas as pd
+
+
+STRATEGY_DIR = Path(__file__).resolve().parent
+REPO_ROOT = STRATEGY_DIR.parents[1]
+BACKTEST_DIR = REPO_ROOT / "My Backtest Files (For Reference)" / "Subhamoy Strategies"
+
+
+def load_module(path: Path, module_name: str):
+    """Load a module from a file path, including filenames with spaces."""
+    assert path.exists(), f"Expected module at {path}"
+    if str(path.parent) not in sys.path:
+        sys.path.insert(0, str(path.parent))
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def build_base_rows(rows=40, start_price=100.0, step=0.12):
+    """Create simple 5-minute OHLC rows with a mild trend."""
+    start = pd.Timestamp("2026-06-01 09:15")
+    candles = []
+    for index in range(rows):
+        close = start_price + index * step
+        candles.append(
+            {
+                "timestamp": start + pd.Timedelta(minutes=5 * index),
+                "open": close - 0.05,
+                "high": close + 0.35,
+                "low": close - 0.35,
+                "close": close,
+                "volume": 1000 + index,
+            }
+        )
+    return candles
+
+
+def build_goldmine_long_frame():
+    """Make the last candle a bullish engulfing setup near the rising SMA20."""
+    rows = build_base_rows(rows=40, start_price=100.0, step=0.12)
+    rows[-4].update({"open": 104.40, "high": 104.55, "low": 104.05, "close": 104.20})
+    rows[-3].update({"open": 104.20, "high": 104.35, "low": 103.80, "close": 104.00})
+    rows[-2].update({"open": 104.05, "high": 104.12, "low": 103.70, "close": 103.82})
+    rows[-1].update({"open": 103.78, "high": 104.45, "low": 103.65, "close": 104.25})
+    return pd.DataFrame(rows)
+
+
+def build_goldmine_short_frame():
+    """Make the last candle a bearish engulfing setup near the falling SMA20."""
+    rows = build_base_rows(rows=40, start_price=110.0, step=-0.12)
+    rows[-4].update({"open": 105.60, "high": 105.95, "low": 105.40, "close": 105.78})
+    rows[-3].update({"open": 105.78, "high": 106.10, "low": 105.60, "close": 105.95})
+    rows[-2].update({"open": 105.92, "high": 106.25, "low": 105.85, "close": 106.15})
+    rows[-1].update({"open": 106.20, "high": 106.35, "low": 105.45, "close": 105.75})
+    return pd.DataFrame(rows)
+
+
+def build_money_machine_long_frame():
+    """Make the last candle a bullish Hulk breakout after compression."""
+    rows = build_base_rows(rows=40, start_price=100.0, step=0.12)
+    rows[-4].update({"open": 104.00, "high": 104.25, "low": 103.95, "close": 104.10})
+    rows[-3].update({"open": 104.08, "high": 104.28, "low": 103.98, "close": 104.18})
+    rows[-2].update({"open": 104.16, "high": 104.30, "low": 104.00, "close": 104.08})
+    rows[-1].update({"open": 104.02, "high": 105.20, "low": 104.00, "close": 105.12})
+    return pd.DataFrame(rows)
+
+
+def build_money_machine_short_frame():
+    """Make the last candle a bearish Hulk breakdown after compression."""
+    rows = build_base_rows(rows=40, start_price=110.0, step=-0.12)
+    rows[-4].update({"open": 105.95, "high": 106.10, "low": 105.78, "close": 105.88})
+    rows[-3].update({"open": 105.90, "high": 106.08, "low": 105.75, "close": 105.82})
+    rows[-2].update({"open": 105.84, "high": 106.00, "low": 105.72, "close": 105.92})
+    rows[-1].update({"open": 105.98, "high": 106.00, "low": 104.78, "close": 104.86})
+    return pd.DataFrame(rows)
+
+
+class TestSubhamoyStrategySignalGenerators(unittest.TestCase):
+    def test_goldmine_generates_long_signal_from_bullish_engulfing_pullback(self):
+        module = load_module(STRATEGY_DIR / "goldmine_strategy_logic.py", "goldmine_strategy_logic_long")
+        config = module.GoldmineStrategyConfig(
+            sma_fast_period=5,
+            sma_slow_period=20,
+            atr_period=5,
+            slope_lookback=3,
+            pullback_lookback=3,
+            pullback_min_count=2,
+            near_sma_atr_multiple=2.0,
+        )
+
+        enriched = module.build_goldmine_with_indicators(build_goldmine_long_frame(), config)
+        decision = module.GoldmineSignalEngine(config).evaluate_candle(enriched)
+
+        self.assertEqual(decision.action, "ENTER_LONG")
+        self.assertTrue(decision.signal_triggered)
+        self.assertEqual(decision.debug["entry_timing"], "NEXT_OPEN")
+        self.assertLess(decision.stop_underlying, decision.entry_underlying)
+        self.assertGreater(decision.target_underlying, decision.entry_underlying)
+
+    def test_goldmine_generates_short_signal_from_bearish_engulfing_pullback(self):
+        module = load_module(STRATEGY_DIR / "goldmine_strategy_logic.py", "goldmine_strategy_logic_short")
+        config = module.GoldmineStrategyConfig(
+            sma_fast_period=5,
+            sma_slow_period=20,
+            atr_period=5,
+            slope_lookback=3,
+            pullback_lookback=3,
+            pullback_min_count=2,
+            near_sma_atr_multiple=2.0,
+        )
+
+        enriched = module.build_goldmine_with_indicators(build_goldmine_short_frame(), config)
+        decision = module.GoldmineSignalEngine(config).evaluate_candle(enriched)
+
+        self.assertEqual(decision.action, "ENTER_SHORT")
+        self.assertTrue(decision.signal_triggered)
+        self.assertEqual(decision.debug["entry_timing"], "NEXT_OPEN")
+        self.assertGreater(decision.stop_underlying, decision.entry_underlying)
+        self.assertLess(decision.target_underlying, decision.entry_underlying)
+
+    def test_goldmine_stop_wins_when_stop_and_target_hit_same_candle(self):
+        module = load_module(STRATEGY_DIR / "goldmine_strategy_logic.py", "goldmine_strategy_logic_exit")
+        config = module.GoldmineStrategyConfig(max_bars_in_trade=6)
+        candles = pd.DataFrame(
+            [
+                {
+                    "timestamp": pd.Timestamp("2026-06-01 10:00"),
+                    "open": 100.0,
+                    "high": 103.0,
+                    "low": 97.0,
+                    "close": 101.0,
+                    "atr": 1.0,
+                }
+            ]
+        )
+        position = module.GoldminePositionContext(
+            direction="LONG",
+            entry_underlying=100.0,
+            stop_underlying=98.0,
+            target_underlying=102.0,
+            bars_in_trade=1,
+        )
+
+        decision = module.GoldmineSignalEngine(config).evaluate_candle(candles, position=position)
+
+        self.assertEqual(decision.action, "EXIT")
+        self.assertEqual(decision.exit_reason, "STOP")
+        self.assertEqual(decision.exit_underlying, 98.0)
+
+    def test_goldmine_exits_after_configured_time_limit(self):
+        module = load_module(STRATEGY_DIR / "goldmine_strategy_logic.py", "goldmine_strategy_logic_time_exit")
+        config = module.GoldmineStrategyConfig(max_bars_in_trade=6)
+        candles = pd.DataFrame(
+            [
+                {
+                    "timestamp": pd.Timestamp("2026-06-01 10:30"),
+                    "open": 100.8,
+                    "high": 101.0,
+                    "low": 100.2,
+                    "close": 100.6,
+                    "atr": 1.0,
+                }
+            ]
+        )
+        position = module.GoldminePositionContext(
+            direction="LONG",
+            entry_underlying=100.0,
+            stop_underlying=98.0,
+            target_underlying=103.0,
+            bars_in_trade=6,
+        )
+
+        decision = module.GoldmineSignalEngine(config).evaluate_candle(candles, position=position)
+
+        self.assertEqual(decision.action, "EXIT")
+        self.assertEqual(decision.exit_reason, "TIME_EXIT")
+        self.assertEqual(decision.exit_underlying, 100.6)
+
+    def test_money_machine_generates_long_signal_from_hulk_breakout(self):
+        module = load_module(STRATEGY_DIR / "money_machine_strategy_logic.py", "money_machine_strategy_logic_long")
+        config = module.MoneyMachineStrategyConfig(
+            sma_fast_period=5,
+            sma_slow_period=20,
+            atr_period=5,
+            slope_lookback=3,
+            near_sma_atr_multiple=2.0,
+            compression_range_atr_multiple=1.5,
+        )
+
+        enriched = module.build_money_machine_with_indicators(build_money_machine_long_frame(), config)
+        decision = module.MoneyMachineSignalEngine(config).evaluate_candle(enriched)
+
+        self.assertEqual(decision.action, "ENTER_LONG")
+        self.assertTrue(decision.signal_triggered)
+        self.assertEqual(decision.debug["entry_timing"], "NEXT_OPEN")
+        self.assertLess(decision.stop_underlying, decision.entry_underlying)
+        self.assertGreater(decision.target_underlying, decision.entry_underlying)
+
+    def test_money_machine_generates_short_signal_from_hulk_breakdown(self):
+        module = load_module(STRATEGY_DIR / "money_machine_strategy_logic.py", "money_machine_strategy_logic_short")
+        config = module.MoneyMachineStrategyConfig(
+            sma_fast_period=5,
+            sma_slow_period=20,
+            atr_period=5,
+            slope_lookback=3,
+            near_sma_atr_multiple=2.0,
+            compression_range_atr_multiple=1.5,
+        )
+
+        enriched = module.build_money_machine_with_indicators(build_money_machine_short_frame(), config)
+        decision = module.MoneyMachineSignalEngine(config).evaluate_candle(enriched)
+
+        self.assertEqual(decision.action, "ENTER_SHORT")
+        self.assertTrue(decision.signal_triggered)
+        self.assertEqual(decision.debug["entry_timing"], "NEXT_OPEN")
+        self.assertGreater(decision.stop_underlying, decision.entry_underlying)
+        self.assertLess(decision.target_underlying, decision.entry_underlying)
+
+    def test_money_machine_holds_when_latest_candle_is_not_marubozu(self):
+        module = load_module(STRATEGY_DIR / "money_machine_strategy_logic.py", "money_machine_strategy_logic_hold")
+        data = build_money_machine_long_frame()
+        data.loc[data.index[-1], ["open", "high", "low", "close"]] = [104.20, 105.20, 103.90, 104.35]
+        config = module.MoneyMachineStrategyConfig(
+            sma_fast_period=5,
+            sma_slow_period=20,
+            atr_period=5,
+            slope_lookback=3,
+            near_sma_atr_multiple=2.0,
+        )
+
+        enriched = module.build_money_machine_with_indicators(data, config)
+        decision = module.MoneyMachineSignalEngine(config).evaluate_candle(enriched)
+
+        self.assertEqual(decision.action, "HOLD")
+        self.assertFalse(decision.signal_triggered)
+
+    def test_missing_ohlc_columns_raise_clear_error(self):
+        goldmine = load_module(STRATEGY_DIR / "goldmine_strategy_logic.py", "goldmine_strategy_logic_missing")
+
+        with self.assertRaisesRegex(ValueError, "Missing required columns"):
+            goldmine.build_goldmine_with_indicators(pd.DataFrame({"timestamp": [pd.Timestamp("2026-06-01")]}))
+
+    def test_wrapper_files_import_and_expose_latest_functions(self):
+        goldmine_wrapper = load_module(
+            STRATEGY_DIR / "Nifty Goldmine Signal Generator.py",
+            "nifty_goldmine_signal_generator",
+        )
+        money_wrapper = load_module(
+            STRATEGY_DIR / "Nifty Money Machine Signal Generator.py",
+            "nifty_money_machine_signal_generator",
+        )
+
+        self.assertTrue(hasattr(goldmine_wrapper, "get_latest_nifty_goldmine_signal"))
+        self.assertTrue(hasattr(money_wrapper, "get_latest_nifty_money_machine_signal"))
+
+
+class TestSubhamoyStrategyBacktests(unittest.TestCase):
+    def _write_csv(self, rows, directory: Path, name: str) -> Path:
+        path = directory / name
+        pd.DataFrame(rows).to_csv(path, index=False)
+        return path
+
+    def test_goldmine_backtest_loader_accepts_five_minute_data_and_rejects_one_minute_data(self):
+        module = load_module(
+            BACKTEST_DIR / "Nifty Goldmine Strategy Backtest.py",
+            "nifty_goldmine_strategy_backtest_loader",
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            five_minute_csv = self._write_csv(build_base_rows(rows=30), tmp_path, "five_minute.csv")
+            one_minute_rows = build_base_rows(rows=30)
+            start = pd.Timestamp("2026-06-01 09:15")
+            for index, row in enumerate(one_minute_rows):
+                row["timestamp"] = start + pd.Timedelta(minutes=index)
+            one_minute_csv = self._write_csv(one_minute_rows, tmp_path, "one_minute.csv")
+
+            loaded = module.load_ohlc_data(five_minute_csv)
+            self.assertEqual(list(loaded.columns), ["Open", "High", "Low", "Close", "Volume"])
+            with self.assertRaisesRegex(ValueError, "5-minute"):
+                module.load_ohlc_data(one_minute_csv)
+
+    def test_backtest_modules_run_smoke_backtests_on_synthetic_five_minute_data(self):
+        goldmine = load_module(
+            BACKTEST_DIR / "Nifty Goldmine Strategy Backtest.py",
+            "nifty_goldmine_strategy_backtest_smoke",
+        )
+        money = load_module(
+            BACKTEST_DIR / "Nifty Money Machine Strategy Backtest.py",
+            "nifty_money_machine_strategy_backtest_smoke",
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            csv_path = self._write_csv(build_base_rows(rows=260, start_price=100.0, step=0.02), Path(tmp), "smoke.csv")
+
+            goldmine_stats, _ = goldmine.run_backtest(csv_path, "nifty")
+            money_stats, _ = money.run_backtest(csv_path, "nifty")
+
+        self.assertIn("# Trades", goldmine_stats.index)
+        self.assertIn("# Trades", money_stats.index)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
﻿## Summary
- add Subhamoy Strategies signal-generator folder with shared Goldmine and Money Machine engines, wrappers, helper utilities, and tests
- add matching Subhamoy Strategies backtest folder under My Backtest Files (For Reference) with repo-local import path handling
- document the new signal generators and backtests in the existing README indexes

## Verification
- python -m pytest "Signal Generators\Subhamoy Strategies\test_subhamoy_strategy_signal_generators.py" -q
- python -m py_compile "Signal Generators\Subhamoy Strategies\subhamoy_strategy_common.py" "Signal Generators\Subhamoy Strategies\goldmine_strategy_logic.py" "Signal Generators\Subhamoy Strategies\money_machine_strategy_logic.py" "Signal Generators\Subhamoy Strategies\Nifty Goldmine Signal Generator.py" "Signal Generators\Subhamoy Strategies\Nifty Money Machine Signal Generator.py" "My Backtest Files (For Reference)\Subhamoy Strategies\subhamoy_backtest_common.py" "My Backtest Files (For Reference)\Subhamoy Strategies\Nifty Goldmine Strategy Backtest.py" "My Backtest Files (For Reference)\Subhamoy Strategies\Nifty Money Machine Strategy Backtest.py"
- python "My Backtest Files (For Reference)\Subhamoy Strategies\Nifty Goldmine Strategy Backtest.py" --help
- python "My Backtest Files (For Reference)\Subhamoy Strategies\Nifty Money Machine Strategy Backtest.py" --help

## Co-authorship
- Commit includes DoRmAmMu1997 and Codex co-author trailers.
