### PR TITLE
Add Shoonya broker + LIVE_BROKER switch; reorganize Dependencies into per-broker subfolders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ env/
 # Environment / secrets
 .env
 .env.*
+# Shoonya/Noren session token, if ever written to disk (broker session secret)
+shoonyakey.txt
 
 # Generated outputs (downloaded OHLC data, backtest results, logs)
 Backtest Outputs/

--- a/Dependencies/Kotak API/diagnose_kotak_symbol.py
+++ b/Dependencies/Kotak API/diagnose_kotak_symbol.py
@@ -1,0 +1,122 @@
+"""
+Diagnostic for Kotak option symbol resolution (and an optional REAL test order).
+
+Run during a LIVE Kotak session (it prompts for a TOTP at login):
+
+    python "Multithreading/Dependencies/diagnose_kotak_symbol.py" [OPT] [STRIKE]
+    # e.g. python ".../diagnose_kotak_symbol.py" CE 23950
+
+It downloads the NSE F&O scrip master ONCE (the same cache the live runner uses),
+then shows how Kotak stores NIFTY option rows near your strike, the available
+expiries, and whether our resolver finds the exact pTrdSymbol. Read-only by default.
+
+Optional REAL round-trip test order (BUY then auto square-off) - REAL MONEY:
+    python ".../diagnose_kotak_symbol.py" CE 23950 --place-order [--qty 75]
+It places a 1-lot market BUY on the resolved nearest-expiry contract, confirms the
+fill, then immediately SELLs to flatten. Requires typing YES to confirm.
+"""
+import datetime as dt
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import kotak_execution as ke  # handles sys.path to the SDK + loads .env
+
+
+def _arg_val(name, default):
+    """Read `--name VALUE` or `--name=VALUE` from argv; else `default`."""
+    for i, a in enumerate(sys.argv):
+        if a == name and i + 1 < len(sys.argv):
+            return sys.argv[i + 1]
+        if a.startswith(name + "="):
+            return a.split("=", 1)[1]
+    return default
+
+
+# Positional args (OPT, STRIKE) ignore any --flags so the two can be combined.
+_POS = [a for a in sys.argv[1:] if not a.startswith("--")]
+UNDERLYING = "NIFTY"
+OPT = _POS[0].upper() if len(_POS) > 0 else "CE"
+STRIKE = int(_POS[1]) if len(_POS) > 1 else 23950
+PLACE_ORDER = "--place-order" in sys.argv
+QTY = int(_arg_val("--qty", "75"))  # NIFTY lot = 75
+FIELDS = ["pSymbolName", "pOptionType", "_expiry_str", "dStrikePrice;", "pTrdSymbol"]
+
+
+def place_round_trip_test_order(client, symbol, qty, broker="Kotak"):
+    """Place a REAL 1-lot market BUY, confirm the fill, then auto SELL to flatten.
+    Guarded by a typed YES confirmation. REAL MONEY."""
+    print("\n" + "=" * 72)
+    print(f"REAL ROUND-TRIP TEST ORDER on {broker}")
+    print(f"  BUY {qty} {symbol} (product=INTRADAY), then auto SELL {qty} to flatten.")
+    print("  THIS PLACES REAL ORDERS WITH REAL MONEY.")
+    try:
+        confirm = input("  Type exactly YES to proceed (anything else aborts): ").strip()
+    except (EOFError, OSError):
+        confirm = ""
+    if confirm != "YES":
+        print("  Aborted (no confirmation).")
+        return
+    print(f"  Placing BUY {qty} {symbol} ...")
+    try:
+        entry = client.place_market_order(symbol=symbol, side="BUY", quantity=qty, product_type="INTRADAY")
+    except Exception as exc:
+        print(f"  ENTRY FAILED: {exc}\n  No position opened.")
+        return
+    print(f"  ENTRY filled. OrderId={client.extract_order_id(entry)}")
+    print(f"  Squaring off: SELL {qty} {symbol} ...")
+    try:
+        ex = client.place_market_order(symbol=symbol, side="SELL", quantity=qty, product_type="INTRADAY")
+        print(f"  EXIT filled. OrderId={client.extract_order_id(ex)} -> flat. Round-trip OK.")
+    except Exception as exc:
+        print(f"  !! EXIT FAILED: {exc}")
+        print(f"  !! A LIVE long position in {symbol} (qty={qty}) IS OPEN. SQUARE IT OFF MANUALLY NOW.")
+
+
+def main():
+    client = ke.kotak_execution_client
+    print("Logging in (you'll be prompted for a TOTP)...")
+    if not client.preload_scrip_master():
+        print("Could not log in / load the scrip master. Check the messages above.")
+        return
+
+    df = client._scrip_df
+    print(f"\nScrip master rows: {len(df)}")
+    base = df[(df["_sym_u"] == UNDERLYING) & (df["_opt_u"] == OPT)]
+    print(f"{UNDERLYING} {OPT} rows: {len(base)}")
+    if base.empty:
+        print("No NIFTY rows for that option type - check pSymbolName values:",
+              sorted(df["_sym_u"].dropna().unique().tolist())[:20])
+        return
+
+    # Sort by actual date (the _expiry_str "DDMMMYYYY" strings sort by day-of-month
+    # if compared as text, which looks scrambled).
+    expiries = sorted(base["_expiry_str"].dropna().unique().tolist(),
+                      key=lambda s: dt.datetime.strptime(s, "%d%b%Y"))
+    print(f"available expiries ({len(expiries)}):", expiries[:15])
+
+    # Show rows near our strike on the x100 scale, across the nearest expiries.
+    near = base[(base["_strike_f"] >= STRIKE * 100 - 5000) & (base["_strike_f"] <= STRIKE * 100 + 5000)]
+    print(f"\nrows near strike {STRIKE} (x100 = {STRIKE * 100}): {len(near)}")
+    for rec in near.sort_values(["_strike_f"])[FIELDS].head(12).to_dict("records"):
+        print("   ", rec)
+
+    # Try the actual resolver against the nearest available expiry as a demo.
+    sym = ""
+    if expiries:
+        demo_exp = dt.datetime.strptime(expiries[0], "%d%b%Y").date()
+        sym = client.resolve_option_symbol(UNDERLYING, demo_exp, OPT, STRIKE)
+        print(f"\nresolve_option_symbol({UNDERLYING}, {demo_exp}, {OPT}, {STRIKE}) -> {sym!r}")
+    print("\nIf the rows above show your strike but resolve returns '', compare the")
+    print("'_expiry_str' values to the expiry your strategy actually trades.")
+
+    # Optional REAL round-trip test order (only when --place-order is passed).
+    if PLACE_ORDER:
+        if sym:
+            place_round_trip_test_order(client, sym, QTY, broker="Kotak")
+        else:
+            print("\n--place-order requested but the symbol did not resolve; no order placed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/Dependencies/Kotak API/kotak_execution.py
+++ b/Dependencies/Kotak API/kotak_execution.py
@@ -89,7 +89,8 @@ for _ancestor in Path(__file__).resolve().parents:
 try:
     from dotenv import load_dotenv
 
-    load_dotenv(dotenv_path=Path(__file__).resolve().parent / ".env", override=False)
+    # .env lives one level up in Dependencies/ (this file is in Dependencies/Kotak API/).
+    load_dotenv(dotenv_path=Path(__file__).resolve().parent.parent / ".env", override=False)
 except Exception:
     pass
 
@@ -268,8 +269,27 @@ class KotakExecutionClient:
                 print(f"  totp_validate -> {validate_resp}")
                 return False
 
+            # Surface the ORDER-critical fields too, not just edit_token/edit_sid.
+            # place_order authorizes with Auth(edit_token) + Sid(edit_sid) +
+            # sId(serverId); login + scrip lookups (which authorize via
+            # consumer_key) can succeed while serverId is empty, in which case
+            # orders are rejected as "unauthorized".
             self.is_logged_in = True
-            print("Kotak execution client login successful (2FA complete).")
+            server_id = getattr(cfg, "serverId", None)
+            print(
+                "Kotak execution client login successful (2FA complete). "
+                f"serverId={server_id!r}, "
+                f"base_url={'set' if getattr(cfg, 'base_url', None) else 'MISSING'}, "
+                f"data_center={getattr(cfg, 'data_center', None)!r}"
+            )
+            if not server_id:
+                print(
+                    "WARNING: Kotak login returned NO serverId (hsServerId). The order "
+                    "endpoint needs Auth+Sid+serverId, so order placement will be rejected "
+                    "as 'unauthorized' (data + scrip lookups still work via consumer_key). "
+                    "This usually means the account/API key is not enabled for live order "
+                    "placement - check Trade API order permission / F&O segment with Kotak."
+                )
             return True
         except Exception as exc:
             # Reset state on any failure so a stale half-session never leaks.

--- a/Dependencies/Shoonya API/NorenApi.py
+++ b/Dependencies/Shoonya API/NorenApi.py
@@ -1,0 +1,1034 @@
+import json
+import requests
+import threading
+import websocket
+import logging
+import enum
+import datetime
+import hashlib
+import time
+import urllib
+from time import sleep
+from datetime import datetime as dt
+
+logger = logging.getLogger(__name__)
+
+class ProductType:
+    Delivery = 'C'
+    Intraday = 'I'
+    Normal   = 'M'
+    CF       = 'M'
+
+class FeedType:
+    TOUCHLINE = 1    
+    SNAPQUOTE = 2
+    
+class PriceType:
+    Market = 'MKT'
+    Limit = 'LMT'
+    StopLossLimit = 'SL-LMT'
+    StopLossMarket = 'SL-MKT'
+
+class BuyorSell:
+    Buy = 'B'
+    Sell = 'S'
+    
+def reportmsg(msg):
+    #print(msg)
+    logger.debug(msg)
+
+def reporterror(msg):
+    #print(msg)
+    logger.error(msg)
+
+def reportinfo(msg):
+    #print(msg)
+    logger.info(msg)
+
+class NorenApi:
+    __service_config = {
+      'host': 'http://wsapihost/',
+      'routes': {
+          'authorize': '/QuickAuth',
+          'logout': '/Logout',
+          'forgot_password': '/ForgotPassword',
+          'change_password': '/Changepwd',
+          'watchlist_names': '/MWList',
+          'watchlist': '/MarketWatch',
+          'watchlist_add': '/AddMultiScripsToMW',
+          'watchlist_delete': '/DeleteMultiMWScrips',
+          'placeorder': '/PlaceOrder',
+          'modifyorder': '/ModifyOrder',
+          'cancelorder': '/CancelOrder',
+          'exitorder': '/ExitSNOOrder',
+          'product_conversion': '/ProductConversion',
+          'orderbook': '/OrderBook',
+          'tradebook': '/TradeBook',          
+          'singleorderhistory': '/SingleOrdHist',
+          'searchscrip': '/SearchScrip',
+          'TPSeries' : '/TPSeries',     
+          'optionchain' : '/GetOptionChain',     
+          'holdings' : '/Holdings',
+          'limits' : '/Limits',
+          'positions': '/PositionBook',
+          'scripinfo': '/GetSecurityInfo',
+          'getquotes': '/GetQuotes',
+      },
+      'websocket_endpoint': 'wss://wsendpoint/',
+      'eoddata_endpoint' : 'http://eodhost/'
+    }
+
+    def __init__(self):
+        self.__service_config['host'] = 'https://api.shoonya.com/NorenWClientTP/'
+        self.__service_config['websocket_endpoint'] = 'wss://api.shoonya.com/NorenWSTP/'
+        self.__service_config['eoddata_endpoint'] = 'https://api.shoonya.com/chartApi/getdata/'
+
+        self.__websocket = None
+        self.__websocket_connected = False
+        self.__ws_mutex = threading.Lock()
+        self.__on_error = None
+        self.__on_disconnect = None
+        self.__on_open = None
+        self.__subscribe_callback = None
+        self.__order_update_callback = None
+        self.__subscribers = {}
+        self.__market_status_messages = []
+        self.__exchange_messages = []
+
+    def __ws_run_forever(self):
+        
+        while self.__stop_event.is_set() == False:
+            try:
+                self.__websocket.run_forever( ping_interval=3,  ping_payload='{"t":"h"}')
+            except Exception as e:
+                logger.warning(f"websocket run forever ended in exception, {e}")
+            
+            sleep(0.1) # Sleep for 100ms between reconnection.
+
+    def __ws_send(self, *args, **kwargs):
+        while self.__websocket_connected == False:
+            sleep(0.05)  # sleep for 50ms if websocket is not connected, wait for reconnection
+        with self.__ws_mutex:
+            ret = self.__websocket.send(*args, **kwargs)
+        return ret
+
+    def __on_close_callback(self, wsapp, close_status_code, close_msg):
+        reportmsg(close_status_code)
+        reportmsg(wsapp)
+
+        self.__websocket_connected = False
+        if self.__on_disconnect:
+            self.__on_disconnect()
+
+    def __on_open_callback(self, ws=None):
+        self.__websocket_connected = True
+
+        #prepare the data
+        values              = { "t": "c" }
+        values["uid"]       = self.__username        
+        values["actid"]     = self.__username
+        values["susertoken"]    = self.__susertoken
+        values["source"]    = 'API'                
+
+        payload = json.dumps(values)
+
+        reportmsg(payload)
+        self.__ws_send(payload)
+
+        #self.__resubscribe()
+        
+
+    def __on_error_callback(self, ws=None, error=None):
+        if(type(ws) is not websocket.WebSocketApp): # This workaround is to solve the websocket_client's compatiblity issue of older versions. ie.0.40.0 which is used in upstox. Now this will work in both 0.40.0 & newer version of websocket_client
+            error = ws
+        if self.__on_error:
+            self.__on_error(error)
+
+    def __on_data_callback(self, ws=None, message=None, data_type=None, continue_flag=None):
+        #print(ws)
+        #print(message)
+        #print(data_type)
+        #print(continue_flag)
+
+        res = json.loads(message)
+
+        if(self.__subscribe_callback is not None):
+            if res['t'] == 'tk' or res['t'] == 'tf':
+                self.__subscribe_callback(res)
+                return
+            if res['t'] == 'dk' or res['t'] == 'df':
+                self.__subscribe_callback(res)
+                return
+
+        if(self.__on_error is not None):
+            if res['t'] == 'ck' and res['s'] != 'OK':
+                self.__on_error(res)
+                return
+
+        if(self.__order_update_callback is not None):
+            if res['t'] == 'om':
+                self.__order_update_callback(res)
+                return
+
+        if self.__on_open:
+            if res['t'] == 'ck' and res['s'] == 'OK':
+                self.__on_open()
+                return
+
+
+    def start_websocket(self, subscribe_callback = None, 
+                        order_update_callback = None,
+                        socket_open_callback = None,
+                        socket_close_callback = None,
+                        socket_error_callback = None):        
+        """ Start a websocket connection for getting live data """
+        self.__on_open = socket_open_callback
+        self.__on_disconnect = socket_close_callback
+        self.__on_error = socket_error_callback
+        self.__subscribe_callback = subscribe_callback
+        self.__order_update_callback = order_update_callback
+        self.__stop_event = threading.Event()
+        url = self.__service_config['websocket_endpoint'].format(access_token=self.__susertoken)
+        reportmsg('connecting to {}'.format(url))
+
+        self.__websocket = websocket.WebSocketApp(url,
+                                                on_data=self.__on_data_callback,
+                                                on_error=self.__on_error_callback,
+                                                on_close=self.__on_close_callback,
+                                                on_open=self.__on_open_callback)
+        #th = threading.Thread(target=self.__send_heartbeat)
+        #th.daemon = True
+        #th.start()
+        #if run_in_background is True:
+        self.__ws_thread = threading.Thread(target=self.__ws_run_forever)
+        self.__ws_thread.daemon = True
+        self.__ws_thread.start()
+        
+    def close_websocket(self):
+        if self.__websocket_connected == False:
+            return
+        self.__stop_event.set()        
+        self.__websocket_connected = False
+        self.__websocket.close()
+        self.__ws_thread.join()
+
+    def login(self, userid, password, twoFA, vendor_code, api_secret, imei):
+        config = NorenApi.__service_config
+
+        #prepare the uri
+        url = f"{config['host']}{config['routes']['authorize']}" 
+        reportmsg(url)
+
+        #Convert to SHA 256 for password and app key
+        pwd = hashlib.sha256(password.encode('utf-8')).hexdigest()
+        u_app_key = '{0}|{1}'.format(userid, api_secret)
+        app_key=hashlib.sha256(u_app_key.encode('utf-8')).hexdigest()
+        #prepare the data
+        values              = { "source": "API" , "apkversion": "1.0.0"}
+        values["uid"]       = userid
+        values["pwd"]       = pwd
+        values["factor2"]   = twoFA
+        values["vc"]        = vendor_code
+        values["appkey"]    = app_key        
+        values["imei"]      = imei        
+
+        payload = 'jData=' + json.dumps(values)
+        reportmsg("Req:" + payload)
+
+        res = requests.post(url, data=payload)
+        reportmsg("Reply:" + res.text)
+
+        resDict = json.loads(res.text)
+        if resDict['stat'] != 'Ok':            
+            return None
+        
+        self.__username   = userid
+        self.__accountid  = userid
+        self.__password   = password
+        self.__susertoken = resDict['susertoken']
+        f=open("shoonyakey.txt",'w')
+        f.write(resDict['susertoken'])
+        f.close()
+        #reportmsg(self.__susertoken)
+
+        return resDict
+
+    def token_setter(self):
+        token = open("shoonyakey.txt",'r').read().rstrip()
+        self.__susertoken = token
+        self.__username = "FA15563"
+        self.__password = "Temp123####"
+        self.__accountid = "FA15563"
+
+    def set_session(self, userid, password, usertoken):
+        
+        self.__username   = userid
+        self.__accountid  = userid
+        self.__password   = password
+        self.__susertoken = usertoken
+
+        reportmsg(f'{userid} session set to : {self.__susertoken}')
+
+        return True
+
+    def forgot_password(self, userid, pan, dob):
+        config = NorenApi.__service_config
+
+        #prepare the uri
+        url = f"{config['host']}{config['routes']['forgot_password']}" 
+        reportmsg(url)
+
+        #prepare the data
+        values              = { "source": "API" }
+        values["uid"]       = userid
+        values["pan"]       = pan
+        values["dob"]       = dob
+
+        payload = 'jData=' + json.dumps(values)
+        reportmsg("Req:" + payload)
+
+        res = requests.post(url, data=payload)
+        reportmsg("Reply:" + res.text)
+
+        resDict = json.loads(res.text)
+        
+        if resDict['stat'] != 'Ok':            
+            return None
+        
+        return resDict
+
+    def logout(self):
+        config = NorenApi.__service_config
+
+        #prepare the uri
+        url = f"{config['host']}{config['routes']['logout']}" 
+        reportmsg(url)
+        #prepare the data
+        values              = {'ordersource':'API'}
+        values["uid"]       = self.__username
+        
+        payload = 'jData=' + json.dumps(values) + f'&jKey={self.__susertoken}'
+        
+        reportmsg(payload)
+
+        res = requests.post(url, data=payload)
+        reportmsg(res.text)
+
+        resDict = json.loads(res.text)
+        if resDict['stat'] != 'Ok':            
+            return None
+
+        self.__username   = None
+        self.__accountid  = None
+        self.__password   = None
+        self.__susertoken = None
+
+        return resDict
+
+    def subscribe(self, instrument, feed_type=FeedType.TOUCHLINE):
+        values = {}
+
+        if(feed_type == FeedType.TOUCHLINE):
+            values['t'] =  't'
+        elif(feed_type == FeedType.SNAPQUOTE):
+            values['t'] =  'd'
+        else:
+            values['t'] =  str(feed_type)
+
+        if type(instrument) == list:
+            values['k'] = '#'.join(instrument)
+        else :
+            values['k'] = instrument
+
+        data = json.dumps(values)
+
+        #print(data)
+        self.__ws_send(data)
+
+    def unsubscribe(self, instrument, feed_type=FeedType.TOUCHLINE):
+        values = {}
+
+        if(feed_type == FeedType.TOUCHLINE):
+            values['t'] =  'u'
+        elif(feed_type == FeedType.SNAPQUOTE):
+            values['t'] =  'ud'
+        
+        if type(instrument) == list:
+            values['k'] = '#'.join(instrument)
+        else :
+            values['k'] = instrument
+
+        data = json.dumps(values)
+
+        #print(data)
+        self.__ws_send(data)
+
+    def subscribe_orders(self):
+        values = {'t': 'o'}
+        values['actid'] = self.__accountid        
+
+        data = json.dumps(values)
+
+        reportmsg(data)
+        self.__ws_send(data)
+
+    def get_watch_list_names(self):
+        config = NorenApi.__service_config
+
+        #prepare the uri
+        url = f"{config['host']}{config['routes']['watchlist_names']}" 
+        reportmsg(url)
+        #prepare the data
+        values              = {'ordersource':'API'}
+        values["uid"]       = self.__username
+        
+        payload = 'jData=' + json.dumps(values) + f'&jKey={self.__susertoken}'
+        
+        reportmsg(payload)
+
+        res = requests.post(url, data=payload)
+        reportmsg(res.text)
+
+        resDict = json.loads(res.text)
+        if resDict['stat'] != 'Ok':            
+            return None
+
+        return resDict
+
+    def get_watch_list(self, wlname):
+        config = NorenApi.__service_config
+
+        #prepare the uri
+        url = f"{config['host']}{config['routes']['watchlist']}" 
+        reportmsg(url)
+        #prepare the data
+        values              = {'ordersource':'API'}
+        values["uid"]       = self.__username
+        values["wlname"]    = wlname
+        
+        payload = 'jData=' + json.dumps(values) + f'&jKey={self.__susertoken}'
+        
+        reportmsg(payload)
+
+        res = requests.post(url, data=payload)
+        reportmsg(res.text)
+
+        resDict = json.loads(res.text)
+        if resDict['stat'] != 'Ok':            
+            return None
+
+        return resDict
+
+
+    def add_watch_list_scrip(self, wlname, instrument):
+        config = NorenApi.__service_config
+
+        #prepare the uri
+        url = f"{config['host']}{config['routes']['watchlist_add']}" 
+        reportmsg(url)
+        #prepare the data
+        values              = {'ordersource':'API'}
+        values["uid"]       = self.__username
+        values["wlname"]    = wlname
+
+        if type(instrument) == list:
+            values['scrips'] = '#'.join(instrument)
+        else :
+            values['scrips'] = instrument
+        payload = 'jData=' + json.dumps(values) + f'&jKey={self.__susertoken}'
+        
+        reportmsg(payload)
+
+        res = requests.post(url, data=payload)
+        reportmsg(res.text)
+
+        resDict = json.loads(res.text)
+        if resDict['stat'] != 'Ok':            
+            return None
+
+        return resDict
+
+    def delete_watch_list_scrip(self, wlname, instrument):
+        config = NorenApi.__service_config
+
+        #prepare the uri
+        url = f"{config['host']}{config['routes']['watchlist_delete']}" 
+        reportmsg(url)
+        #prepare the data
+        values              = {'ordersource':'API'}
+        values["uid"]       = self.__username
+        values["wlname"]    = wlname
+
+        if type(instrument) == list:
+            values['scrips'] = '#'.join(instrument)
+        else :
+            values['scrips'] = instrument
+        payload = 'jData=' + json.dumps(values) + f'&jKey={self.__susertoken}'
+        
+        reportmsg(payload)
+
+        res = requests.post(url, data=payload)
+        reportmsg(res.text)
+
+        resDict = json.loads(res.text)
+        if resDict['stat'] != 'Ok':            
+            return None
+
+        return resDict
+
+
+    def place_order(self, buy_or_sell, product_type,
+                    exchange, tradingsymbol, quantity, discloseqty,
+                    price_type, price=0.0, trigger_price=None,
+                    retention='DAY', amo='NO', remarks=None, bookloss_price = 0.0, bookprofit_price = 0.0, trail_price = 0.0):
+        config = NorenApi.__service_config
+
+        #prepare the uri
+        url = f"{config['host']}{config['routes']['placeorder']}" 
+        reportmsg(url)
+        #prepare the data
+        values              = {'ordersource':'API'}
+        values["uid"]       = self.__username
+        values["actid"]     = self.__accountid
+        values["trantype"]  = buy_or_sell
+        values["prd"]       = product_type
+        values["exch"]      = exchange
+        values["tsym"]      = urllib.parse.quote_plus(tradingsymbol)
+        values["qty"]       = str(quantity)
+        values["dscqty"]    = str(discloseqty)        
+        values["prctyp"]    = price_type
+        values["prc"]       = str(price)
+        values["trgprc"]    = str(trigger_price)
+        values["ret"]       = retention
+        values["remarks"]   = remarks
+        values["amo"]       = amo
+        
+        #if cover order or high leverage order
+        if product_type == 'H':            
+            values["blprc"]       = str(bookloss_price)
+            #trailing price
+            if trail_price != 0.0:
+                values["trailprc"] = str(trail_price)
+
+        #bracket order
+        if product_type == 'B':            
+            values["blprc"]       = str(bookloss_price)
+            values["bpprc"]       = str(bookprofit_price)
+            #trailing price
+            if trail_price != 0.0:
+                values["trailprc"] = str(trail_price)
+
+        payload = 'jData=' + json.dumps(values) + f'&jKey={self.__susertoken}'
+        
+        reportmsg(payload)
+
+        res = requests.post(url, data=payload)
+        reportmsg(res.text)
+
+        resDict = json.loads(res.text)
+        if resDict['stat'] != 'Ok':            
+            return None
+
+        return resDict
+
+    def modify_order(self, orderno, exchange, tradingsymbol, newquantity,
+                    newprice_type, newprice=0.0, newtrigger_price=None, bookloss_price = 0.0, bookprofit_price = 0.0, trail_price = 0.0):
+        config = NorenApi.__service_config
+
+        #prepare the uri
+        url = f"{config['host']}{config['routes']['modifyorder']}" 
+        print(url)
+
+        #prepare the data
+        values                  = {'ordersource':'API'}
+        values["uid"]           = self.__username
+        values["actid"]         = self.__accountid
+        values["norenordno"]    = str(orderno)
+        values["exch"]          = exchange
+        values["tsym"]          = urllib.parse.quote_plus(tradingsymbol)
+        values["qty"]           = str(newquantity)
+        values["prctyp"]        = newprice_type        
+        values["prc"]           = str(newprice)
+
+        if (newprice_type == 'SL-LMT') or (newprice_type == 'SL-MKT'):
+            if (newtrigger_price != None):
+                values["trgprc"] = str(newtrigger_price)
+            else:
+                reporterror('trigger price is missing')
+                return None
+
+        #if cover order or high leverage order
+        if bookloss_price != 0.0:            
+            values["blprc"]       = str(bookloss_price)
+        #trailing price
+        if trail_price != 0.0:
+            values["trailprc"] = str(trail_price)         
+        #book profit of bracket order   
+        if bookprofit_price != 0.0:
+            values["bpprc"]       = str(bookprofit_price)
+        
+        payload = 'jData=' + json.dumps(values) + f'&jKey={self.__susertoken}'
+        
+        reportmsg(payload)
+
+        res = requests.post(url, data=payload)
+        reportmsg(res.text)
+
+        resDict = json.loads(res.text)
+        if resDict['stat'] != 'Ok':            
+            return None
+
+        return resDict
+
+    def cancel_order(self, orderno):
+        config = NorenApi.__service_config
+
+        #prepare the uri
+        url = f"{config['host']}{config['routes']['cancelorder']}" 
+        print(url)
+
+        #prepare the data
+        values              = {'ordersource':'API'}
+        values["uid"]       = self.__username
+        values["norenordno"]    = str(orderno)
+        
+        payload = 'jData=' + json.dumps(values) + f'&jKey={self.__susertoken}'
+        
+        reportmsg(payload)
+
+        res = requests.post(url, data=payload)
+        print(res.text)
+
+        resDict = json.loads(res.text)
+        if resDict['stat'] != 'Ok':            
+            return None
+
+        return resDict
+
+    def exit_order(self, orderno, product_type):
+        config = NorenApi.__service_config
+
+        #prepare the uri
+        url = f"{config['host']}{config['routes']['exitorder']}" 
+        print(url)
+
+        #prepare the data
+        values              = {'ordersource':'API'}
+        values["uid"]       = self.__username
+        values["norenordno"]    = orderno
+        values["prd"]           = product_type
+        
+        payload = 'jData=' + json.dumps(values) + f'&jKey={self.__susertoken}'
+        
+        reportmsg(payload)
+
+        res = requests.post(url, data=payload)
+        reportmsg(res.text)
+
+        resDict = json.loads(res.text)
+        if resDict['stat'] != 'Ok':            
+            return None
+
+        return resDict
+
+    def position_product_conversion(self, exchange, tradingsymbol, quantity, new_product_type, previous_product_type, buy_or_sell, day_or_cf):
+        '''
+        Coverts a day or carryforward position from one product to another. 
+        '''
+        config = NorenApi.__service_config
+
+        #prepare the uri
+        url = f"{config['host']}{config['routes']['product_conversion']}" 
+        print(url)
+
+        #prepare the data
+        values              = {'ordersource':'API'}
+        values["uid"]       = self.__username
+        values["actid"]     = self.__accountid        
+        values["exch"]      = exchange
+        values["tsym"]      = urllib.parse.quote_plus(tradingsymbol)
+        values["qty"]       = str(quantity)
+        values["prd"]       = new_product_type
+        values["prevprd"]   = previous_product_type
+        values["trantype"]  = buy_or_sell
+        values["postype"]   = day_or_cf
+        
+        payload = 'jData=' + json.dumps(values) + f'&jKey={self.__susertoken}'
+        
+        reportmsg(payload)
+
+        res = requests.post(url, data=payload)
+        reportmsg(res.text)
+
+        resDict = json.loads(res.text)
+        
+        if resDict['stat'] != 'Ok':            
+            return None
+
+        return resDict
+
+
+    def single_order_history(self, orderno):
+        config = NorenApi.__service_config
+
+        #prepare the uri
+        url = f"{config['host']}{config['routes']['singleorderhistory']}" 
+        print(url)
+        
+        #prepare the data
+        values              = {'ordersource':'API'}
+        values["uid"]       = self.__username
+        values["norenordno"]    = orderno
+        
+        payload = 'jData=' + json.dumps(values) + f'&jKey={self.__susertoken}'
+        
+        reportmsg(payload)
+
+        res = requests.post(url, data=payload)
+        reportmsg(res.text)
+
+        resDict = json.loads(res.text)
+        #error is a json with stat and msg wchih we printed earlier.
+        if type(resDict) != list:                            
+                return None
+
+        return resDict
+
+
+    def get_order_book(self):
+        config = NorenApi.__service_config
+
+        #prepare the uri
+        url = f"{config['host']}{config['routes']['orderbook']}" 
+        reportmsg(url)
+
+        #prepare the data
+        values              = {'ordersource':'API'}
+        values["uid"]       = self.__username
+        
+        payload = 'jData=' + json.dumps(values) + f'&jKey={self.__susertoken}'
+        
+        reportmsg(payload)
+
+        res = requests.post(url, data=payload)
+        reportmsg(res.text)
+
+        resDict = json.loads(res.text)
+        
+        #error is a json with stat and msg wchih we printed earlier.
+        if type(resDict) != list:                            
+                return None
+
+        return resDict
+
+    def get_trade_book(self):
+        config = NorenApi.__service_config
+
+        #prepare the uri
+        url = f"{config['host']}{config['routes']['tradebook']}" 
+        reportmsg(url)
+
+        #prepare the data
+        values              = {'ordersource':'API'}
+        values["uid"]       = self.__username
+        values["actid"]     = self.__accountid
+        
+        payload = 'jData=' + json.dumps(values) + f'&jKey={self.__susertoken}'
+        
+        reportmsg(payload)
+
+        res = requests.post(url, data=payload)
+        reportmsg(res.text)
+
+        resDict = json.loads(res.text)
+        
+        #error is a json with stat and msg wchih we printed earlier.
+        if type(resDict) != list:                            
+                return None
+
+        return resDict
+
+    def searchscrip(self, exchange, searchtext):
+        config = NorenApi.__service_config
+
+        #prepare the uri
+        url = f"{config['host']}{config['routes']['searchscrip']}" 
+        reportmsg(url)
+        
+        if searchtext == None:
+            reporterror('search text cannot be null')
+            return None
+        
+        values              = {}
+        values["uid"]       = self.__username
+        values["exch"]      = exchange
+        values["stext"]     = urllib.parse.quote_plus(searchtext)       
+        
+        payload = 'jData=' + json.dumps(values) + f'&jKey={self.__susertoken}'
+        
+        reportmsg(payload)
+
+        res = requests.post(url, data=payload)
+        reportmsg(res.text)
+
+        resDict = json.loads(res.text)
+
+        if resDict['stat'] != 'Ok':            
+            return None        
+
+        return resDict
+
+    def get_option_chain(self, exchange, tradingsymbol, strikeprice, count=2):
+        config = NorenApi.__service_config
+
+        #prepare the uri
+        url = f"{config['host']}{config['routes']['optionchain']}" 
+        reportmsg(url)
+        
+        
+        values              = {}
+        values["uid"]       = self.__username
+        values["exch"]      = exchange
+        values["tsym"]      = urllib.parse.quote_plus(tradingsymbol)       
+        values["strprc"]    = str(strikeprice)
+        values["cnt"]       = str(count)       
+        
+        
+        payload = 'jData=' + json.dumps(values) + f'&jKey={self.__susertoken}'
+        
+        reportmsg(payload)
+
+        res = requests.post(url, data=payload)
+        reportmsg(res.text)
+
+        resDict = json.loads(res.text)
+
+        if resDict['stat'] != 'Ok':            
+            return None        
+
+        return resDict
+
+    def get_security_info(self, exchange, token):
+        config = NorenApi.__service_config
+
+        #prepare the uri
+        url = f"{config['host']}{config['routes']['scripinfo']}" 
+        reportmsg(url)        
+        
+        values              = {}
+        values["uid"]       = self.__username
+        values["exch"]      = exchange
+        values["token"]     = token       
+        
+        payload = 'jData=' + json.dumps(values) + f'&jKey={self.__susertoken}'
+        
+        reportmsg(payload)
+
+        res = requests.post(url, data=payload)
+        reportmsg(res.text)
+
+        resDict = json.loads(res.text)
+
+        if resDict['stat'] != 'Ok':            
+            return None        
+
+        return resDict
+
+    def get_quotes(self, exchange, token):
+        config = NorenApi.__service_config
+
+        #prepare the uri
+        url = f"{config['host']}{config['routes']['getquotes']}" 
+        reportmsg(url)        
+        
+        values              = {}
+        values["uid"]       = self.__username
+        values["exch"]      = exchange
+        values["token"]     = token       
+        
+        payload = 'jData=' + json.dumps(values) + f'&jKey={self.__susertoken}'
+        
+        reportmsg(payload)
+
+        res = requests.post(url, data=payload)
+        reportmsg(res.text)
+
+        resDict = json.loads(res.text)
+
+        if resDict['stat'] != 'Ok':            
+            return None        
+
+        return resDict
+
+    def get_time_price_series(self, exchange, token, starttime=None, endtime=None, interval= None):
+        '''
+        gets the chart data 
+        interval possible values 1, 3, 5 , 10, 15, 30, 60, 120, 240
+        '''
+        config = NorenApi.__service_config
+
+        #prepare the uri
+        url = f"{config['host']}{config['routes']['TPSeries']}" 
+        reportmsg(url)
+
+        #prepare the data
+        if starttime == None:
+            timestring = time.strftime('%d-%m-%Y') + ' 00:00:00'
+            timeobj = time.strptime(timestring,'%d-%m-%Y %H:%M:%S')
+            starttime = time.mktime(timeobj)
+
+        #
+        values              = {'ordersource':'API'}
+        values["uid"]       = self.__username
+        values["exch"]      = exchange
+        values["token"]     = token
+        values["st"] = str(starttime)
+        if endtime != None:
+            values["et"]   = str(endtime)
+        if interval != None:
+            values["intrv"] = str(interval)
+
+        payload = 'jData=' + json.dumps(values) + f'&jKey={self.__susertoken}'
+        
+        reportmsg(payload)
+
+        res = requests.post(url, data=payload)
+        reportmsg(res.text)
+
+        resDict = json.loads(res.text)
+        
+        #error is a json with stat and msg wchih we printed earlier.
+        if type(resDict) != list:                            
+                return None
+
+        return resDict
+
+    def get_daily_price_series(self, exchange, tradingsymbol, startdate=None, enddate=None):
+        config = NorenApi.__service_config
+
+        #prepare the uri
+        url = f"{config['eoddata_endpoint']}" 
+        reportmsg(url)
+
+        #prepare the data
+        if startdate == None:  
+            week_ago = datetime.date.today() - datetime.timedelta(days=7)
+            startdate = dt.combine(week_ago, dt.min.time()).timestamp()
+
+        if enddate == None:            
+            enddate = dt.now().timestamp()
+
+        #
+        values              = {}
+        values["uid"]       = self.__username
+        values["sym"]      = '{0}:{1}'.format(exchange, tradingsymbol)
+        values["from"]     = str(startdate)
+        values["to"]       = str(enddate)
+        
+        #payload = 'jData=' + json.dumps(values) + f'&jKey={self.__susertoken}'
+        payload = json.dumps(values)
+        reportmsg(payload)
+
+        headers = {"Content-Type": "application/json; charset=utf-8"}
+        res = requests.post(url, data=payload, headers=headers)
+        reportmsg(res)
+
+        if res.status_code != 200:
+            return None
+
+        if len(res.text) == 0:
+            return None
+
+        resDict = json.loads(res.text)
+        
+        #error is a json with stat and msg wchih we printed earlier.
+        if type(resDict) != list:                            
+            return None
+
+        return resDict
+        
+    def get_holdings(self, product_type = None):
+        config = NorenApi.__service_config
+
+        #prepare the uri
+        url = f"{config['host']}{config['routes']['holdings']}" 
+        reportmsg(url)
+        
+        if product_type == None:
+            product_type = ProductType.Delivery
+        
+        values              = {}
+        values["uid"]       = self.__username
+        values["actid"]     = self.__accountid
+        values["prd"]       = product_type       
+        
+        payload = 'jData=' + json.dumps(values) + f'&jKey={self.__susertoken}'
+        
+        reportmsg(payload)
+
+        res = requests.post(url, data=payload)
+        reportmsg(res.text)
+
+        resDict = json.loads(res.text)
+
+        if type(resDict) != list:                            
+                return None
+
+        return resDict
+
+    def get_limits(self, product_type = None, segment = None, exchange = None):
+        config = NorenApi.__service_config
+
+        #prepare the uri
+        url = f"{config['host']}{config['routes']['limits']}" 
+        reportmsg(url)        
+        
+        values              = {}
+        values["uid"]       = self.__username
+        values["actid"]     = self.__accountid
+        
+        if product_type != None:
+            values["prd"]       = product_type       
+        
+        if product_type != None:
+            values["seg"]       = segment       
+        
+        if exchange != None:
+            values["exch"]       = exchange       
+        
+        payload = 'jData=' + json.dumps(values) + f'&jKey={self.__susertoken}'
+        
+        reportmsg(payload)
+
+        res = requests.post(url, data=payload)
+        reportmsg(res.text)
+
+        resDict = json.loads(res.text)        
+
+        return resDict
+
+    def get_positions(self):
+        config = NorenApi.__service_config
+
+        #prepare the uri
+        url = f"{config['host']}{config['routes']['positions']}" 
+        reportmsg(url)        
+        
+        values              = {}
+        values["uid"]       = self.__username
+        values["actid"]     = self.__accountid
+        
+        payload = 'jData=' + json.dumps(values) + f'&jKey={self.__susertoken}'
+        
+        reportmsg(payload)
+
+        res = requests.post(url, data=payload)
+        reportmsg(res.text)
+
+        resDict = json.loads(res.text)
+
+        if type(resDict) != list:                            
+            return None
+
+        return resDict
+

--- a/Dependencies/Shoonya API/NorenApi.py
+++ b/Dependencies/Shoonya API/NorenApi.py
@@ -246,9 +246,11 @@ class NorenApi:
         self.__accountid  = userid
         self.__password   = password
         self.__susertoken = resDict['susertoken']
-        f=open("shoonyakey.txt",'w')
-        f.write(resDict['susertoken'])
-        f.close()
+        # NOTE: upstream NorenApi persists the session token to "shoonyakey.txt" in
+        # the CWD here (for token_setter() reuse). This wrapper never calls
+        # token_setter() and keeps the token in memory only, so we DO NOT write it
+        # to disk -- a live broker session token in the repo root is a secret-
+        # hygiene risk and could be accidentally committed.
         #reportmsg(self.__susertoken)
 
         return resDict

--- a/Dependencies/Shoonya API/diagnose_shoonya_symbol.py
+++ b/Dependencies/Shoonya API/diagnose_shoonya_symbol.py
@@ -1,0 +1,122 @@
+"""
+Diagnostic for Shoonya option symbol resolution (and an optional REAL test order).
+
+Run during a LIVE Shoonya session (TOTP auto-generated from SHOONYA_TOTP_SECRET,
+or it prompts):
+
+    python "Multithreading/Dependencies/diagnose_shoonya_symbol.py" [OPT] [STRIKE] [EXPIRY]
+    # e.g. python ".../diagnose_shoonya_symbol.py" CE 23950 26JUN25
+
+It logs in, downloads the NSE F&O symbol master ONCE (the same cache the live
+runner uses), and shows whether our resolver builds a valid tsym for the given
+option type / strike / expiry. Read-only by default.
+
+Optional REAL round-trip test order (BUY then auto square-off) - REAL MONEY:
+    python ".../diagnose_shoonya_symbol.py" CE 23950 26JUN25 --place-order [--qty 75]
+It places a 1-lot market BUY on the resolved contract, confirms the fill, then
+immediately SELLs to flatten. Requires typing YES to confirm. (Needs an EXPIRY.)
+"""
+import datetime as dt
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import shoonya_execution as se  # handles sys.path to the SDK + loads .env
+
+
+def _arg_val(name, default):
+    """Read `--name VALUE` or `--name=VALUE` from argv; else `default`."""
+    for i, a in enumerate(sys.argv):
+        if a == name and i + 1 < len(sys.argv):
+            return sys.argv[i + 1]
+        if a.startswith(name + "="):
+            return a.split("=", 1)[1]
+    return default
+
+
+# Positional args (OPT, STRIKE, EXPIRY) ignore any --flags so they can be combined.
+_POS = [a for a in sys.argv[1:] if not a.startswith("--")]
+UNDERLYING = "NIFTY"
+OPT = _POS[0].upper() if len(_POS) > 0 else "CE"
+STRIKE = int(_POS[1]) if len(_POS) > 1 else 23950
+# Expiry as DDMMMYY (e.g. 26JUN25). Optional; without it we just sample the
+# live symbol format rather than resolving a specific contract.
+EXPIRY = _POS[2].upper() if len(_POS) > 2 else None
+PLACE_ORDER = "--place-order" in sys.argv
+QTY = int(_arg_val("--qty", "75"))  # NIFTY lot = 75
+
+
+def place_round_trip_test_order(client, symbol, qty, broker="Shoonya"):
+    """Place a REAL 1-lot market BUY, confirm the fill, then auto SELL to flatten.
+    Guarded by a typed YES confirmation. REAL MONEY."""
+    print("\n" + "=" * 72)
+    print(f"REAL ROUND-TRIP TEST ORDER on {broker}")
+    print(f"  BUY {qty} {symbol} (product=INTRADAY), then auto SELL {qty} to flatten.")
+    print("  THIS PLACES REAL ORDERS WITH REAL MONEY.")
+    try:
+        confirm = input("  Type exactly YES to proceed (anything else aborts): ").strip()
+    except (EOFError, OSError):
+        confirm = ""
+    if confirm != "YES":
+        print("  Aborted (no confirmation).")
+        return
+    print(f"  Placing BUY {qty} {symbol} ...")
+    try:
+        entry = client.place_market_order(symbol=symbol, side="BUY", quantity=qty, product_type="INTRADAY")
+    except Exception as exc:
+        print(f"  ENTRY FAILED: {exc}\n  No position opened.")
+        return
+    print(f"  ENTRY filled. OrderId={client.extract_order_id(entry)}")
+    print(f"  Squaring off: SELL {qty} {symbol} ...")
+    try:
+        ex = client.place_market_order(symbol=symbol, side="SELL", quantity=qty, product_type="INTRADAY")
+        print(f"  EXIT filled. OrderId={client.extract_order_id(ex)} -> flat. Round-trip OK.")
+    except Exception as exc:
+        print(f"  !! EXIT FAILED: {exc}")
+        print(f"  !! A LIVE long position in {symbol} (qty={qty}) IS OPEN. SQUARE IT OFF MANUALLY NOW.")
+
+
+def main():
+    client = se.shoonya_execution_client
+    print("Logging in to Shoonya...")
+    if not client.preload_scrip_master():
+        print("Could not log in / load the symbol master. Check the messages above.")
+        return
+
+    symbols = client._symbol_set or set()
+    print(f"\nNFO symbol master: {len(symbols)} trading symbols.")
+    nifty_syms = sorted(s for s in symbols if s.startswith(UNDERLYING))
+    print(f"{UNDERLYING}* symbols: {len(nifty_syms)}")
+
+    if EXPIRY is None:
+        print(f"\nNo expiry given (3rd arg, e.g. 26JUN25). Showing a few sample "
+              f"{UNDERLYING} {OPT[0]} symbols so you can read the live format:")
+        for s in sorted(s for s in nifty_syms if OPT[0] in s)[:10]:
+            print("   ", s)
+        if PLACE_ORDER:
+            print("\n--place-order needs an EXPIRY (3rd arg) to resolve the contract; no order placed.")
+        return
+
+    try:
+        expiry = dt.datetime.strptime(EXPIRY, "%d%b%y").date()
+    except ValueError:
+        print(f"Could not parse expiry {EXPIRY!r}; expected DDMMMYY like 26JUN25.")
+        return
+
+    sym = client.resolve_option_symbol(UNDERLYING, expiry, OPT, STRIKE)
+    print(f"\nresolve_option_symbol({UNDERLYING}, {expiry}, {OPT}, {STRIKE}) -> {sym!r}")
+    if not sym:
+        near_prefix = f"{UNDERLYING}{EXPIRY}{OPT[0]}"
+        near = sorted(s for s in symbols if s.startswith(near_prefix))
+        print(f"  sample {near_prefix}* symbols: {near[:5]} ... {near[-5:] if near else ''}")
+
+    # Optional REAL round-trip test order (only when --place-order is passed).
+    if PLACE_ORDER:
+        if sym:
+            place_round_trip_test_order(client, sym, QTY, broker="Shoonya")
+        else:
+            print("\n--place-order requested but the symbol did not resolve; no order placed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/Dependencies/Shoonya API/shoonya_execution.py
+++ b/Dependencies/Shoonya API/shoonya_execution.py
@@ -1,0 +1,604 @@
+"""
+Shared Shoonya (Finvasia NorenApi) order-execution layer for the Multithreading runner.
+
+============================== Plain-English overview ==========================
+This file is the ONE place that talks to the Shoonya (Finvasia) broker to place
+real orders. The strategies decide *what* to trade; this module knows *how* to
+send that order to Shoonya. When a strategy is in "paper" mode it never touches
+this file at all; only "real"/live strategies do.
+
+It is a drop-in replacement for the old Kotak Neo execution layer: it exposes the
+SAME public methods the master runner already calls -- ensure_logged_in(),
+preload_scrip_master(), resolve_option_symbol(), place_market_order(),
+extract_order_id(), logout(), and the `is_logged_in` flag -- so the rest of the
+runner did not have to change shape.
+
+Glossary for newcomers (the broker world is full of jargon):
+- TOTP   : the 6-digit code from an authenticator app that changes every 30s.
+           Shoonya 2FA can be AUTOMATED: we store the TOTP *secret seed* and
+           compute the current code with `pyotp`, so no typing at startup.
+- 2FA    : two-factor authentication (here: password + TOTP factor2).
+- vendor_code / api_secret / imei : the Shoonya API app credentials.
+- lot    : options trade in fixed bundles ("lots"), e.g. 1 NIFTY lot = 75 units.
+           quantity = lot_size * number_of_lots.
+- MIS / NRML : product types. MIS = intraday (Shoonya code "I"); NRML =
+           carry-forward (Shoonya code "M").
+- tsym   : Shoonya's trading symbol for a contract, e.g. "NIFTY26JUN25C23950".
+           Unlike Kotak's opaque pTrdSymbol it is DERIVABLE from the contract:
+           <UNDERLYING><DDMMMYY><C|P><STRIKE> (proven by helper_shoonya.py).
+- thread / lock : the runner uses many parallel "threads" (one per strategy). A
+           "lock" makes sure only one thread talks to Shoonya at a time, because
+           the session is not safe to use from two threads at once.
+- lazy login : we only log in the first time it is actually needed, not at import.
+===============================================================================
+
+Design rules (mirrors the previous Dependencies/kotak_execution.py):
+- This file owns ONLY order-side concerns. No strategy logic, no market-data
+  logic. The master runner still resolves every contract from DhanHQ and passes
+  the underlying/expiry/strike/option-type through; we turn that into a Shoonya
+  tsym and place the order.
+
+Why a dedicated module:
+- The Shoonya NorenApi client lives in the top-level "Shoonya API/" folder
+  (vendored from the existing repo). We add that folder to `sys.path` here so
+  `from NorenApi import NorenApi` resolves without a global pip install.
+- 24 strategy workers run as threads sharing ONE process. This wrapper holds a
+  single authenticated session behind a lock, logs in lazily on the first real
+  order, and is therefore safe to call from any worker thread.
+
+How the master file uses this module:
+1. `from Dependencies.shoonya_execution import shoonya_execution_client` (guarded
+   by try/except so pure-paper runs work even without the SDK / deps installed).
+2. Workers call `shoonya_execution_client.place_market_order(...)` on a real
+   entry/exit leg. Login happens automatically on the first such call.
+3. `logout()` is called during graceful shutdown.
+"""
+
+import os
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import pandas as pd
+
+# --- Make the vendored "Shoonya API" SDK importable ---------------------------
+# The NorenApi client may live in a "Shoonya API" folder somewhere above this
+# file, but the depth differs by repo layout. Rather than hardcode a parents[]
+# index, walk UP the directory tree and use the first "Shoonya API" folder found.
+# If none exists (the module was pip installed instead) we skip this and rely on
+# the plain `from NorenApi import NorenApi`.
+for _ancestor in Path(__file__).resolve().parents:
+    _sdk_dir = _ancestor / "Shoonya API"
+    if _sdk_dir.exists():
+        if str(_sdk_dir) not in sys.path:
+            sys.path.insert(0, str(_sdk_dir))
+        break
+
+# Defensively load the runner's .env so credentials are available even when this
+# module is imported/used outside the master file (e.g. in unit tests). The
+# master file also loads this same .env with override=False, so this is a no-op
+# in the normal run.
+try:
+    from dotenv import load_dotenv
+
+    # .env lives one level up in Dependencies/ (this file is in Dependencies/Shoonya API/).
+    load_dotenv(dotenv_path=Path(__file__).resolve().parent.parent / ".env", override=False)
+except Exception:
+    pass
+
+from NorenApi import NorenApi  # noqa: E402  (resolved from "Shoonya API")
+
+
+# Shoonya's API expects short codes, not friendly words. These dicts translate
+# the readable values our code uses (left) into the exact codes Shoonya wants
+# (right). Example: we say "BUY", Shoonya wants "B"; "INTRADAY" -> "I".
+_PRODUCT_MAP = {"INTRADAY": "I", "NORMAL": "M"}
+_SIDE_MAP = {"BUY": "B", "SELL": "S"}
+
+# Where Shoonya publishes the full NSE F&O contract list (used only to VALIDATE
+# the trading symbols we construct -- order placement does not require it).
+_NFO_SYMBOL_MASTER_URL = "https://api.shoonya.com/NFO_symbols.txt.zip"
+
+# Fill confirmation: place_order only ACKNOWLEDGES that the request was accepted
+# -- the broker can still reject it or leave it unfilled. After an ack we poll
+# single_order_history until the order reaches a terminal state. Market orders
+# normally fill in well under a second; we wait a few seconds then give up.
+_FILL_TIMEOUT_SECONDS = 8.0
+_FILL_POLL_INTERVAL = 0.5
+# Shoonya order-status values, lower-cased.
+_FILLED_ORDER_STATES = {"complete", "completed"}
+_FAILED_ORDER_STATES = {"rejected", "cancelled", "canceled"}
+
+
+class ShoonyaExecutionClient:
+    """
+    One shared "phone line" to Shoonya that every live strategy uses.
+
+    Think of an instance of this class as a single logged-in Shoonya session that
+    the whole program shares. It is:
+    - "lazy-login": it only logs in the first time someone actually needs it.
+    - "thread-safe": many strategy threads can call it at once; a lock makes sure
+      only one of them is talking to Shoonya at any moment. Orders are infrequent,
+      so this queuing has no real cost.
+
+    The module creates ONE instance at the bottom (`shoonya_execution_client`) and
+    everything imports and reuses that single object.
+    """
+
+    def __init__(self) -> None:
+        # The live Shoonya SDK object. Stays None until we successfully log in.
+        self.client: Optional[NorenApi] = None
+        # Simple flag so we don't re-login every call once we're authenticated.
+        self.is_logged_in = False
+        # The "one thread at a time" gate for login + orders + symbol lookups.
+        self._lock = threading.Lock()
+        # Remember symbols we've already resolved, so we don't rebuild/re-validate
+        # for the same contract. Key = (underlying, expiry "DDMMMYY", "CE"/"PE",
+        # strike-as-int) -> Shoonya tsym string.
+        self._symbol_cache: Dict[tuple, str] = {}
+        # The set of valid NFO trading symbols (uppercased), downloaded once and
+        # reused for validation. Stays None until first loaded.
+        self._symbol_set: Optional[set] = None
+
+    # ------------------------------------------------------------------
+    # Authentication
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _generate_totp(secret: str) -> str:
+        """
+        Compute the current 6-digit TOTP from a stored secret seed via pyotp.
+
+        Returns "" if the secret is blank, pyotp is unavailable, or generation
+        fails (the caller then falls back to an interactive prompt / aborts).
+        """
+        secret = str(secret).strip().replace(" ", "")
+        if not secret:
+            return ""
+        try:
+            import pyotp
+        except Exception as exc:
+            print(f"Shoonya TOTP secret is set but pyotp is not installed: {exc}")
+            return ""
+        try:
+            return pyotp.TOTP(secret).now()
+        except Exception as exc:
+            print(f"Shoonya TOTP generation failed: {exc}")
+            return ""
+
+    @staticmethod
+    def _prompt_totp() -> str:
+        """
+        Interactively read the current 6-digit TOTP from the authenticator app.
+
+        Used only when no SHOONYA_TOTP_SECRET is configured. Returns "" if no
+        input is available (e.g. a headless run), which the caller treats as an
+        aborted login -> paper fallback.
+        """
+        try:
+            return input("Enter Shoonya TOTP (6 digits from your authenticator app): ").strip()
+        except (EOFError, OSError):
+            return ""
+
+    def _login_locked(self) -> bool:
+        """
+        Do the actual Shoonya login and return True on success. "_locked" means
+        the caller must already hold self._lock (so two threads never log in at
+        the same time).
+
+        Flow: read credentials from .env -> get the 2FA code (auto from the
+        stored secret, else interactive) -> call NorenApi.login -> verify the
+        response carries a real session token (stat == "Ok").
+        """
+        try:
+            userid = (os.getenv("SHOONYA_USERID") or "").strip()
+            password = (os.getenv("SHOONYA_PASSWORD") or "").strip()
+            vendor_code = (os.getenv("SHOONYA_VENDOR_CODE") or "").strip()
+            api_secret = (os.getenv("SHOONYA_API_SECRET") or "").strip()
+            imei = (os.getenv("SHOONYA_IMEI") or "abc1234").strip() or "abc1234"
+            totp_secret = (os.getenv("SHOONYA_TOTP_SECRET") or "").strip()
+
+            # Fail early (with a clear message) if any required key is blank.
+            missing = []
+            if not userid:
+                missing.append("SHOONYA_USERID")
+            if not password:
+                missing.append("SHOONYA_PASSWORD")
+            if not vendor_code:
+                missing.append("SHOONYA_VENDOR_CODE")
+            if not api_secret:
+                missing.append("SHOONYA_API_SECRET")
+            if missing:
+                raise ValueError("Missing Shoonya env keys: " + ", ".join(missing))
+
+            # Auto-generate the 2FA code from the stored secret seed; if none is
+            # configured, fall back to an interactive prompt (typed 6-digit code).
+            two_fa = self._generate_totp(totp_secret) if totp_secret else self._prompt_totp()
+            if not two_fa:
+                self.is_logged_in = False
+                self.client = None
+                print("Shoonya login aborted: no TOTP available "
+                      "(set SHOONYA_TOTP_SECRET, or enter a code when prompted).")
+                return False
+
+            # Initialise the client and perform the login handshake.
+            self.client = NorenApi()
+            resp = self.client.login(
+                userid=userid,
+                password=password,
+                twoFA=two_fa,
+                vendor_code=vendor_code,
+                api_secret=api_secret,
+                imei=imei,
+            )
+
+            # NorenApi.login returns the response dict (with susertoken) on
+            # success and None on failure; treat anything without stat == "Ok" as
+            # a failed login so the caller falls back to paper.
+            if not isinstance(resp, dict) or str(resp.get("stat", "")).strip().lower() != "ok":
+                self.is_logged_in = False
+                self.client = None
+                print(f"Shoonya login failed (no valid session). Raw response: {resp}")
+                return False
+
+            self.is_logged_in = True
+            print(
+                "Shoonya execution client login successful "
+                f"(uid={userid}, name={resp.get('uname', '')!r})."
+            )
+            return True
+        except Exception as exc:
+            # Reset state on any failure so a stale half-session never leaks.
+            self.is_logged_in = False
+            self.client = None
+            # NorenApi.login() does json.loads() on the raw reply with no status
+            # check, so a Shoonya-side HTTP error (e.g. a 502 Bad Gateway or a
+            # maintenance HTML page) surfaces here as a cryptic JSON decode error.
+            # Add a clear hint so this transient, server-side condition is obvious.
+            hint = ""
+            if type(exc).__name__ == "JSONDecodeError" or "Expecting value" in str(exc):
+                hint = (" -- Shoonya returned a non-JSON response (e.g. an HTTP 502 / "
+                        "maintenance page), which usually means the broker API is "
+                        "temporarily down. This is server-side; retry in a few minutes.")
+            print(f"Shoonya execution client login failed: {exc}{hint}")
+            return False
+
+    def ensure_logged_in(self) -> bool:
+        """
+        Make sure we have a live Shoonya session, logging in the first time only.
+
+        Call this before any order/lookup. If we're already logged in it returns
+        immediately; otherwise it performs the one-time login. Returns True when a
+        usable session exists, False if login failed (caller falls back to paper).
+        """
+        with self._lock:  # only one thread may log in at a time
+            if self.is_logged_in and self.client is not None:
+                return True  # already authenticated - nothing to do
+            return self._login_locked()
+
+    # ------------------------------------------------------------------
+    # Symbol resolution (contract -> Shoonya tsym)
+    # ------------------------------------------------------------------
+    def preload_scrip_master(self) -> bool:
+        """
+        Download + cache the NSE F&O symbol master NOW (e.g. at startup) so the
+        first live order can be VALIDATED without paying a download cost mid-
+        session. Unlike Kotak this is optional: symbols are derivable, so a failed
+        download just disables validation (orders are still constructed + sent).
+        Returns True if the master is loaded.
+        """
+        if not self.ensure_logged_in():
+            return False
+        with self._lock:
+            return self._ensure_scrip_master_locked()
+
+    def _ensure_scrip_master_locked(self) -> bool:
+        """
+        Download Shoonya's full NSE F&O symbol list ONCE and keep the set of valid
+        trading symbols in memory. "_locked" => the caller already holds
+        self._lock. Returns True if the set is ready. (Caller holds _lock.)
+        """
+        if self._symbol_set is not None:
+            return True  # already downloaded earlier in this run
+        try:
+            # pandas infers compression="zip" from the .zip URL extension (the
+            # same call helper_shoonya.py uses for the symbol master).
+            df = pd.read_csv(_NFO_SYMBOL_MASTER_URL)
+            df = df.rename(columns=lambda c: str(c).strip())  # trim stray spaces
+        except Exception as exc:
+            print(f"Shoonya NFO symbol master download/parse failed: {exc}")
+            return False
+        if "TradingSymbol" not in df.columns:
+            print(f"Shoonya NFO symbol master missing 'TradingSymbol' column: {list(df.columns)}")
+            return False
+        try:
+            self._symbol_set = set(df["TradingSymbol"].astype(str).str.strip().str.upper())
+            print(f"Shoonya NSE F&O symbol master loaded ({len(df)} rows).")
+            return True
+        except Exception as exc:
+            print(f"Shoonya NFO symbol master parse failed: {exc}")
+            return False
+
+    def resolve_option_symbol(
+        self,
+        underlying: str,
+        expiry,
+        option_type: str,
+        strike: float,
+        exchange_segment: str = "NFO",
+    ) -> str:
+        """
+        Resolve a Shoonya `tsym` for an option contract, cached.
+
+        Shoonya's place_order expects `tradingsymbol` in the form
+        <UNDERLYING><DDMMMYY><C|P><STRIKE>, e.g. "NIFTY26JUN25C23950" (proven by
+        helper_shoonya.getOptionFormat). We BUILD that string here. If the symbol
+        master has been preloaded we also VALIDATE the contract exists (returning
+        "" on a miss, so the caller falls back to paper for that leg, mirroring
+        the old Kotak safety). If the master is not loaded we trust the construction.
+
+        Inputs: underlying e.g. "NIFTY"; expiry as a date object; option_type
+        "CE"/"PE"; strike e.g. 23950.
+        """
+        # Guard against obviously bad inputs before doing any work.
+        if expiry is None or strike is None or float(strike) <= 0:
+            print(f"Shoonya resolve skipped (bad inputs): expiry={expiry!r} strike={strike!r}")
+            return ""
+        underlying = str(underlying).strip().upper()
+        option_type = str(option_type).strip().upper()
+        if option_type not in ("CE", "PE"):
+            print(f"Shoonya resolve skipped (bad option_type): {option_type!r}")
+            return ""
+        try:
+            # Shoonya uses a 2-digit year, zero-padded day: "26JUN25".
+            expiry_str = expiry.strftime("%d%b%y").upper()
+        except Exception:
+            print(f"Shoonya resolve skipped (expiry not a date): expiry={expiry!r} "
+                  f"type={type(expiry).__name__}")
+            return ""
+        int_strike = int(round(float(strike)))
+        cache_key = (underlying, expiry_str, option_type, int_strike)
+
+        # Fast path: have we already resolved this exact contract today?
+        with self._lock:
+            cached = self._symbol_cache.get(cache_key)
+            if cached is not None:
+                return cached
+
+        # Build the trading symbol: e.g. "NIFTY" + "26JUN25" + "C" + "23950".
+        tsym = f"{underlying}{expiry_str}{option_type[0]}{int_strike}"
+
+        with self._lock:
+            cached = self._symbol_cache.get(cache_key)  # re-check: another thread may have filled it
+            if cached is not None:
+                return cached
+            # If we have the symbol master loaded, validate the contract exists.
+            if self._symbol_set is not None and tsym.upper() not in self._symbol_set:
+                self._log_resolution_miss(underlying, option_type, expiry_str, int_strike, tsym)
+                return ""
+            self._symbol_cache[cache_key] = tsym  # remember it for next time
+            return tsym
+
+    def _log_resolution_miss(
+        self, underlying: str, option_type: str, expiry_str: str, int_strike: int, tsym: str
+    ) -> None:
+        """
+        Print a helpful breakdown when a constructed symbol is not in the master,
+        so we can tell WHICH part is wrong (expiry vs strike). Debug aid only.
+        """
+        print(f"Shoonya symbol NOT in NFO master: {tsym} "
+              f"({underlying}/{option_type}/{expiry_str}/strike {int_strike}).")
+        if self._symbol_set:
+            prefix = f"{underlying}{expiry_str}{option_type[0]}"
+            sample = sorted(s for s in self._symbol_set if s.startswith(prefix))
+            if sample:
+                print(f"  sample {prefix}* symbols: {sample[:3]} ... {sample[-3:]}; wanted {tsym}")
+            else:
+                print(f"  no {prefix}* symbols found - check the expiry ({expiry_str}).")
+
+    # ------------------------------------------------------------------
+    # Order placement
+    # ------------------------------------------------------------------
+    def place_market_order(
+        self,
+        symbol: str,
+        side: str,
+        quantity: int,
+        exchange_segment: str = "NFO",
+        product_type: str = "INTRADAY",
+    ) -> Dict[str, Any]:
+        """
+        Place ONE market order (buy or sell at the current price) on Shoonya.
+
+        Parameters:
+          symbol   : Shoonya tsym for the contract (from resolve_option_symbol).
+          side     : "BUY" or "SELL".
+          quantity : total units (lot_size * lots), NOT number of lots.
+          product_type : "INTRADAY" (MIS, same-day) or "NORMAL" (NRML, overnight).
+
+        This RAISES an exception on ANY problem (bad input, not logged in, or the
+        broker rejecting the order). The caller catches that and falls back to
+        paper, so we never silently record an order that didn't actually happen.
+        """
+        if not self.ensure_logged_in():
+            raise RuntimeError("Shoonya login failed; cannot place real order.")
+
+        # Normalise + validate inputs before sending anything to the broker.
+        side_norm = str(side).upper().strip()
+        product_norm = str(product_type).upper().strip()
+        if side_norm not in _SIDE_MAP:
+            raise ValueError(f"Invalid side: {side!r}")
+        if product_norm not in _PRODUCT_MAP:
+            raise ValueError(f"Invalid product_type: {product_type!r}")
+        if not symbol:
+            raise ValueError("Missing trading symbol for order.")
+        if int(quantity) <= 0:
+            raise ValueError(f"Invalid quantity: {quantity!r}")
+
+        exchange = str(exchange_segment).strip() or "NFO"
+
+        with self._lock:  # only one order goes over the shared session at a time
+            if self.client is None:
+                raise RuntimeError("Shoonya client is not initialised.")
+            try:
+                resp = self.client.place_order(
+                    buy_or_sell=_SIDE_MAP[side_norm],
+                    product_type=_PRODUCT_MAP[product_norm],
+                    exchange=exchange,
+                    tradingsymbol=str(symbol),
+                    quantity=int(quantity),
+                    discloseqty=0,
+                    price_type="MKT",
+                    price=0,
+                    trigger_price=0,
+                    retention="DAY",
+                    remarks="multistrategy_master",
+                )
+            except Exception as exc:
+                raise Exception(f"Order placement failed: {exc}") from exc
+
+        # NorenApi.place_order returns the response dict (with norenordno) on
+        # success and None when stat != "Ok". Treat anything without a genuine
+        # order acknowledgement as a failure so the caller falls back to paper.
+        if not self._is_order_ack(resp):
+            raise Exception(f"Shoonya did not acknowledge the order: {resp}")
+
+        # Acceptance != fill: the broker can still reject or leave it unfilled
+        # after the ack. Confirm a REAL fill before returning success.
+        order_id = self.extract_order_id(resp)
+        if not order_id:
+            raise Exception(f"Shoonya acknowledged the order but returned no order id: {resp}")
+        self._confirm_fill(order_id, int(quantity))
+        return resp
+
+    def _order_status(self, order_id: str):
+        """
+        Read the latest state of one order via single_order_history.
+
+        Returns (state, filled_qty, order_qty, reason). `state` is None when the
+        status cannot be read yet (a transient error, or the order not visible
+        yet), in which case the caller should simply keep polling.
+        """
+        with self._lock:  # single_order_history is a broker call -> needs the session
+            if self.client is None:
+                return (None, 0, 0, "client not initialised")
+            try:
+                rows = self.client.single_order_history(order_id)
+            except Exception as exc:
+                return (None, 0, 0, f"single_order_history error: {exc}")
+        # Shoonya shape: a LIST of history rows (newest first). Prefer a terminal
+        # row (complete/rejected/cancelled); otherwise fall back to the newest.
+        if not isinstance(rows, list) or not rows:
+            return (None, 0, 0, f"unrecognised single_order_history: {rows}")
+        chosen = None
+        for row in rows:
+            st = str(row.get("status", "")).strip().lower()
+            if st in _FILLED_ORDER_STATES or st in _FAILED_ORDER_STATES:
+                chosen = row
+                break
+        if chosen is None:
+            chosen = rows[0]
+
+        def _as_int(value) -> int:
+            try:
+                return int(float(value))
+            except (TypeError, ValueError):
+                return 0
+
+        return (
+            str(chosen.get("status", "")).strip().lower(),
+            _as_int(chosen.get("fillshares", 0)),
+            _as_int(chosen.get("qty", 0)),
+            str(chosen.get("rejreason", "")).strip(),
+        )
+
+    def _confirm_fill(self, order_id: str, want_qty: int) -> None:
+        """
+        Poll single_order_history until the order is fully filled, then return.
+
+        Raises if the order is rejected/cancelled, or if it has not filled within
+        `_FILL_TIMEOUT_SECONDS`. Polling happens OUTSIDE the lock (each status read
+        re-takes it briefly), so a slow fill never blocks other workers' orders.
+        """
+        deadline = time.monotonic() + _FILL_TIMEOUT_SECONDS
+        last_state = "unknown"
+        while time.monotonic() < deadline:
+            state, filled, _order_qty, reason = self._order_status(order_id)
+            if state is not None:
+                last_state = state
+                if state in _FAILED_ORDER_STATES:
+                    raise RuntimeError(f"order {order_id} {state} ({reason or 'no reason given'})")
+                if state in _FILLED_ORDER_STATES and (want_qty <= 0 or filled >= want_qty):
+                    return  # fully filled - confirmed
+            time.sleep(_FILL_POLL_INTERVAL)
+        raise RuntimeError(
+            f"order {order_id} not confirmed filled within "
+            f"{_FILL_TIMEOUT_SECONDS:.0f}s (last status: {last_state})"
+        )
+
+    def _is_order_ack(self, resp: Any) -> bool:
+        """
+        True only when `resp` is a genuine order acknowledgement.
+
+        NorenApi.place_order returns a dict with stat == "Ok" and a norenordno on
+        success (and None otherwise), so we require both.
+        """
+        if not isinstance(resp, dict):
+            return False
+        if str(resp.get("stat", "")).strip().lower() != "ok":
+            return False
+        return bool(resp.get("norenordno"))
+
+    def extract_order_id(self, order_response: Any) -> str:
+        """
+        Dig the broker's order number ("norenordno") out of Shoonya's reply.
+
+        The reply can be a dict, a list, or nested combinations, so this function
+        recurses to search at any depth and returns the first order-id-looking
+        value it finds (or "" if none). Used mainly for logging.
+        """
+        if order_response is None:
+            return ""
+        if isinstance(order_response, dict):
+            for key in ("norenordno", "order_id", "orderId", "id"):
+                if order_response.get(key):
+                    return str(order_response.get(key))
+            for value in order_response.values():
+                found = self.extract_order_id(value)
+                if found:
+                    return found
+            return ""
+        if isinstance(order_response, list):
+            for item in order_response:
+                found = self.extract_order_id(item)
+                if found:
+                    return found
+            return ""
+        if isinstance(order_response, str):
+            return order_response.strip()
+        return ""
+
+    # ------------------------------------------------------------------
+    # Teardown
+    # ------------------------------------------------------------------
+    def logout(self) -> Dict[str, Any]:
+        """Close the Shoonya session cleanly at shutdown (safe to call if never logged in)."""
+        with self._lock:
+            if self.client is None:
+                return {"State": "NOT_OK", "message": "Client not initialised"}
+            try:
+                out = self.client.logout()
+                self.is_logged_in = False
+                self.client = None
+                return out if isinstance(out, dict) else {"State": "OK", "message": str(out)}
+            except Exception as exc:
+                self.is_logged_in = False
+                self.client = None
+                return {"State": "NOT_OK", "message": str(exc)}
+
+
+# The ONE shared instance the whole program uses. Every file that needs to place
+# a real order does `from Dependencies.shoonya_execution import shoonya_execution_client`
+# and reuses this object (so there's a single login + single symbol list).
+shoonya_execution_client = ShoonyaExecutionClient()

--- a/Dependencies/env.example
+++ b/Dependencies/env.example
@@ -898,20 +898,24 @@ GSHEET_OAUTH_CLIENT_FILE=
 GSHEET_OAUTH_TOKEN_FILE=
 
 # =============================================================================
-# KOTAK NEO LIVE EXECUTION (paper vs real, per strategy)
+# LIVE EXECUTION (paper vs real, per strategy) - broker-selectable
 # =============================================================================
-# By default EVERYTHING is paper: KOTAK_LIVE_TRADING_ENABLED=false acts as a
-# global kill-switch. A strategy places REAL orders on Kotak Neo only when BOTH
-# the master switch below AND that strategy's own <PREFIX>_LIVE_TRADING are true.
-# Real orders are routed through Dependencies/kotak_execution.py using the SDK in
-# the top-level "Kotak Neo API" folder. On any order failure the strategy falls
-# back to paper for that trade (it is still recorded/closed as a paper trade).
+# By default EVERYTHING is paper: LIVE_TRADING_ENABLED=false is the global
+# kill-switch. A strategy places REAL orders only when BOTH this master switch
+# AND that strategy's own <PREFIX>_LIVE_TRADING are true. LIVE_BROKER picks which
+# broker those orders route to (KOTAK or SHOONYA) - both share one code path in
+# the runner (Dependencies/Kotak API/kotak_execution.py /
+# Dependencies/Shoonya API/shoonya_execution.py). On any order failure the
+# strategy falls back to paper for that trade.
 
 # ---- Global master kill-switch (must be true for ANY live order) ----
-KOTAK_LIVE_TRADING_ENABLED=false
+LIVE_TRADING_ENABLED=false
 
-# ---- Kotak Neo credentials (required only for live trading) ----
-# COSNSUMER_KEY is the legacy-typo key the wrapper reads; CONSUMER_KEY also works.
+# ---- Active broker for live orders: KOTAK or SHOONYA ----
+LIVE_BROKER=KOTAK
+
+# ---- Kotak Neo credentials (used when LIVE_BROKER=KOTAK) ----
+# COSNSUMER_KEY is the legacy-typo key the wrapper also accepts; CONSUMER_KEY works.
 # Get the consumer key from Kotak Neo app/web -> Invest -> Trade API -> Generate.
 # The TOTP is NOT stored here: the runner prompts you to type the current 6-digit
 # code from your authenticator app once at startup. MOBILE may omit the country
@@ -920,9 +924,20 @@ CONSUMER_KEY=
 MOBILE=
 MPIN=
 UCC=
-
-# ---- Product type for every real order (INTRADAY -> MIS, NORMAL -> NRML) ----
 KOTAK_PRODUCT_TYPE=INTRADAY
+
+# ---- Shoonya (Finvasia) credentials (used when LIVE_BROKER=SHOONYA) ----
+# NOTE: the legacy Shoonya QuickAuth API is being decommissioned; live login may
+# return HTTP 502 until the integration is ported to the new OAuth API. The TOTP
+# is auto-generated from SHOONYA_TOTP_SECRET (base32 seed) via pyotp; leave it
+# blank to be prompted for a 6-digit code instead. VENDOR_CODE is usually "<USERID>_U".
+SHOONYA_USERID=
+SHOONYA_PASSWORD=
+SHOONYA_VENDOR_CODE=
+SHOONYA_API_SECRET=
+SHOONYA_IMEI=
+SHOONYA_TOTP_SECRET=
+SHOONYA_PRODUCT_TYPE=INTRADAY
 
 # ---- Per-strategy live toggles (all default false; flip individually) ----
 # Prefixes match each strategy's existing <PREFIX>_* knobs above.

--- a/Nifty Multi Strategy Front Test - Master File.py
+++ b/Nifty Multi Strategy Front Test - Master File.py
@@ -875,15 +875,25 @@ except Exception as _shoonya_import_exc:  # ImportError when SDK folder/deps mis
 # below, so the per-broker differences (exchange code, product key) live here only.
 # INTRADAY (MIS/I) = squared off same day; NORMAL (NRML/M) = carried overnight.
 LIVE_BROKER = _env_str("LIVE_BROKER", "KOTAK").upper().strip() or "KOTAK"
-if LIVE_BROKER == "SHOONYA":
-    execution_client = shoonya_execution_client
-    LIVE_EXCHANGE_SEGMENT = "NFO"
-    LIVE_PRODUCT_TYPE = _env_str("SHOONYA_PRODUCT_TYPE", "INTRADAY").upper().strip() or "INTRADAY"
-else:  # default / unrecognised -> Kotak
-    LIVE_BROKER = "KOTAK"
+if LIVE_BROKER == "KOTAK":
     execution_client = kotak_execution_client
     LIVE_EXCHANGE_SEGMENT = "nse_fo"
     LIVE_PRODUCT_TYPE = _env_str("KOTAK_PRODUCT_TYPE", "INTRADAY").upper().strip() or "INTRADAY"
+elif LIVE_BROKER == "SHOONYA":
+    execution_client = shoonya_execution_client
+    LIVE_EXCHANGE_SEGMENT = "NFO"
+    LIVE_PRODUCT_TYPE = _env_str("SHOONYA_PRODUCT_TYPE", "INTRADAY").upper().strip() or "INTRADAY"
+else:
+    # Fail CLOSED on an unknown/typo'd broker (e.g. "SHONYA"): leave NO client so
+    # the startup guard forces every strategy to PAPER, and log a loud error. We
+    # must never silently fall back to a different broker for live-money execution.
+    logging.getLogger(LOGGER_NAME).error(
+        "Unknown LIVE_BROKER=%r (expected KOTAK or SHOONYA); live trading DISABLED (paper only).",
+        LIVE_BROKER,
+    )
+    execution_client = None
+    LIVE_EXCHANGE_SEGMENT = ""
+    LIVE_PRODUCT_TYPE = "INTRADAY"
 
 # =============================================================================
 # SIGNAL GENERATOR PORTS (ATM single-leg strategies from the TradingBot repo)

--- a/Nifty Multi Strategy Front Test - Master File.py
+++ b/Nifty Multi Strategy Front Test - Master File.py
@@ -296,7 +296,7 @@ def _env_bool(name: str, default: bool = False) -> bool:
     .env values are always text, so this turns words like "true"/"yes"/"on"/"1"
     into True (case doesn't matter, surrounding quotes are ignored). If the key is
     missing or blank it returns `default`; anything else counts as False.
-    Example: KOTAK_LIVE_TRADING_ENABLED=true  ->  _env_bool("KOTAK_LIVE_TRADING_ENABLED")
+    Example: LIVE_TRADING_ENABLED=true  ->  _env_bool("LIVE_TRADING_ENABLED")
     """
     raw = os.getenv(name, "")
     if raw is None:
@@ -832,30 +832,58 @@ CPR_LOGIC = load_module(
 )
 
 # -----------------------------------------------------------------------------
-# Kotak Neo live-execution layer (optional).
+# Live-execution layer (optional) - selectable broker: Kotak Neo or Shoonya.
 # -----------------------------------------------------------------------------
-# This is how real (non-paper) orders reach the broker. We load the helper in
-# Dependencies/kotak_execution.py and grab its single shared client object.
-# The whole thing is wrapped in try/except on purpose: if the "Kotak Neo API"
-# SDK folder isn't present, importing it fails, we set the client to None, and
-# the runner simply keeps working in paper-only mode (no crash). main() then
-# forces any "live" strategy back to paper because there's no client.
+# This is how real (non-paper) orders reach the broker. Both helpers
+# (Dependencies/Kotak API/kotak_execution.py and Dependencies/Shoonya API/
+# shoonya_execution.py) expose the SAME surface (ensure_logged_in /
+# preload_scrip_master / resolve_option_symbol / place_market_order /
+# extract_order_id / logout / is_logged_in), so the runner uses whichever one
+# LIVE_BROKER selects via a single generic `execution_client`. Each import is
+# wrapped in try/except on purpose: if a broker's SDK/deps are missing, that
+# client is set to None and the runner keeps working (the OTHER broker, or
+# paper-only). main() forces any "live" strategy back to paper when the selected
+# client is None.
 try:
     _kotak_execution_module = load_module(
         "master_kotak_execution",
-        Path(__file__).resolve().parent / "Dependencies" / "kotak_execution.py",
+        Path(__file__).resolve().parent / "Dependencies" / "Kotak API" / "kotak_execution.py",
     )
     kotak_execution_client = _kotak_execution_module.kotak_execution_client
 except Exception as _kotak_import_exc:  # ImportError when SDK folder/deps missing
     kotak_execution_client = None
     logging.getLogger(LOGGER_NAME).warning(
-        "Kotak execution layer unavailable (%s); live trading disabled, paper only.",
+        "Kotak execution layer unavailable (%s); Kotak live trading disabled.",
         _kotak_import_exc,
     )
 
-# Which "product" every real order uses. INTRADAY (MIS) = squared off the same
-# day; NORMAL (NRML) = can be carried overnight. Read once from .env at startup.
-KOTAK_PRODUCT_TYPE = _env_str("KOTAK_PRODUCT_TYPE", "INTRADAY").upper().strip() or "INTRADAY"
+try:
+    _shoonya_execution_module = load_module(
+        "master_shoonya_execution",
+        Path(__file__).resolve().parent / "Dependencies" / "Shoonya API" / "shoonya_execution.py",
+    )
+    shoonya_execution_client = _shoonya_execution_module.shoonya_execution_client
+except Exception as _shoonya_import_exc:  # ImportError when SDK folder/deps missing
+    shoonya_execution_client = None
+    logging.getLogger(LOGGER_NAME).warning(
+        "Shoonya execution layer unavailable (%s); Shoonya live trading disabled.",
+        _shoonya_import_exc,
+    )
+
+# Pick the active broker from .env (default KOTAK). The rest of the runner only
+# touches the generic `execution_client` / LIVE_EXCHANGE_SEGMENT / LIVE_PRODUCT_TYPE
+# below, so the per-broker differences (exchange code, product key) live here only.
+# INTRADAY (MIS/I) = squared off same day; NORMAL (NRML/M) = carried overnight.
+LIVE_BROKER = _env_str("LIVE_BROKER", "KOTAK").upper().strip() or "KOTAK"
+if LIVE_BROKER == "SHOONYA":
+    execution_client = shoonya_execution_client
+    LIVE_EXCHANGE_SEGMENT = "NFO"
+    LIVE_PRODUCT_TYPE = _env_str("SHOONYA_PRODUCT_TYPE", "INTRADAY").upper().strip() or "INTRADAY"
+else:  # default / unrecognised -> Kotak
+    LIVE_BROKER = "KOTAK"
+    execution_client = kotak_execution_client
+    LIVE_EXCHANGE_SEGMENT = "nse_fo"
+    LIVE_PRODUCT_TYPE = _env_str("KOTAK_PRODUCT_TYPE", "INTRADAY").upper().strip() or "INTRADAY"
 
 # =============================================================================
 # SIGNAL GENERATOR PORTS (ATM single-leg strategies from the TradingBot repo)
@@ -2603,26 +2631,27 @@ class BasePaperStrategyWorker(threading.Thread):
         self.trade_event_queue = None
 
         # Per-strategy execution mode. Defaults to paper; main() flips this to
-        # True after construction when KOTAK_LIVE_TRADING_ENABLED and this
-        # strategy's <PREFIX>_LIVE_TRADING are both on. When True, the take-trade
-        # logic places real Kotak Neo orders (see `_place_real_leg`) in addition
-        # to the usual paper bookkeeping.
+        # True after construction when LIVE_TRADING_ENABLED and this strategy's
+        # <PREFIX>_LIVE_TRADING are both on. When True, the take-trade logic places
+        # real orders on the active broker (see `_place_real_leg`) in addition to
+        # the usual paper bookkeeping.
         self.live_trading = False
 
     def _place_real_leg(self, side: str, leg: dict) -> bool:
         """
-        Send ONE real buy/sell order to Kotak for a single option ("leg").
+        Send ONE real buy/sell order to the active broker for a single option ("leg").
 
         This is the bridge between "paper" and "real": in paper mode it does
         nothing and just returns True, so the rest of the trade code can call it
         without caring which mode we're in. In live mode it actually places the
-        order. A "leg" is one option contract (a spread has two legs).
+        order via the selected `execution_client` (Kotak or Shoonya). A "leg" is
+        one option contract (a spread has two legs).
 
         `leg` is a dict describing the option:
             {"option_type": "CE"/"PE", "strike": float, "expiry": date,
              "quantity": int, "dhan_symbol": str}
-        The Kotak order symbol (pTrdSymbol) is resolved from Kotak's own scrip
-        master via `resolve_option_symbol` because it differs from Dhan's symbol.
+        The broker order symbol is built/resolved by the client's
+        `resolve_option_symbol` from the contract details.
 
         Returns True on success. When this worker is not in live mode this is a
         no-op that returns True, so every call site can invoke it unconditionally.
@@ -2636,44 +2665,45 @@ class BasePaperStrategyWorker(threading.Thread):
             return True
         quantity = leg["quantity"]
         dhan_symbol = leg.get("dhan_symbol", "")
-        if kotak_execution_client is None:
+        if execution_client is None:
             self.log.warning(
-                "REAL ORDER SKIPPED (no Kotak client) | %s %s qty=%s dhan=%s | falling back to paper.",
-                self.strategy_name, side, quantity, dhan_symbol,
+                "REAL ORDER SKIPPED (no %s client) | %s %s qty=%s dhan=%s | falling back to paper.",
+                LIVE_BROKER, self.strategy_name, side, quantity, dhan_symbol,
             )
             return False
-        # Resolve the Dhan contract to Kotak's pTrdSymbol before ordering.
-        kotak_symbol = kotak_execution_client.resolve_option_symbol(
+        # Resolve the broker's order symbol for this contract before ordering.
+        broker_symbol = execution_client.resolve_option_symbol(
             underlying=UNDERLYING,
             expiry=leg.get("expiry"),
             option_type=leg.get("option_type", ""),
             strike=leg.get("strike", 0.0),
         )
-        if not kotak_symbol:
+        if not broker_symbol:
             self.log.warning(
-                "REAL ORDER SKIPPED (Kotak symbol not found) | %s %s strike=%s %s dhan=%s | "
+                "REAL ORDER SKIPPED (%s symbol not found) | %s %s strike=%s %s dhan=%s | "
                 "falling back to paper.",
-                self.strategy_name, side, leg.get("strike"), leg.get("option_type"), dhan_symbol,
+                LIVE_BROKER, self.strategy_name, side, leg.get("strike"),
+                leg.get("option_type"), dhan_symbol,
             )
             return False
         try:
-            resp = kotak_execution_client.place_market_order(
-                symbol=kotak_symbol,
+            resp = execution_client.place_market_order(
+                symbol=broker_symbol,
                 side=side,
                 quantity=quantity,
-                exchange_segment="nse_fo",
-                product_type=KOTAK_PRODUCT_TYPE,
+                exchange_segment=LIVE_EXCHANGE_SEGMENT,
+                product_type=LIVE_PRODUCT_TYPE,
             )
             self.log.info(
-                "REAL ORDER OK | %s %s qty=%s kotak=%s (dhan=%s) | KotakOrderId=%s",
-                self.strategy_name, side, quantity, kotak_symbol, dhan_symbol,
-                kotak_execution_client.extract_order_id(resp),
+                "REAL ORDER OK | %s %s %s qty=%s sym=%s (dhan=%s) | OrderId=%s",
+                LIVE_BROKER, self.strategy_name, side, quantity, broker_symbol, dhan_symbol,
+                execution_client.extract_order_id(resp),
             )
             return True
         except Exception as exc:
             self.log.warning(
-                "REAL ORDER FAILED (falling back to paper) | %s %s qty=%s kotak=%s (dhan=%s) | %s",
-                self.strategy_name, side, quantity, kotak_symbol, dhan_symbol, exc,
+                "REAL ORDER FAILED (falling back to paper) | %s %s %s qty=%s sym=%s (dhan=%s) | %s",
+                LIVE_BROKER, self.strategy_name, side, quantity, broker_symbol, dhan_symbol, exc,
             )
             return False
 
@@ -3295,7 +3325,7 @@ class AtmSingleLegStrategyWorker(BasePaperStrategyWorker):
         })
         exec_mode = self._exec_mode_tag(real_ok)
 
-        # If a LIVE exit did not confirm a fill, the real Kotak position is still
+        # If a LIVE exit did not confirm a fill, the real broker position is still
         # open. Do NOT flatten the books - keep the position active so the worker
         # retries the exit on its next cycle, and alert for manual square-off.
         if self.live_trading and not real_ok:
@@ -8312,13 +8342,14 @@ def main() -> None:
     # Decide which strategies trade for real vs on paper.
     # -------------------------------------------------------------------------
     # A strategy trades LIVE only if TWO switches are both on:
-    #   1) the global master switch KOTAK_LIVE_TRADING_ENABLED, and
+    #   1) the global master switch LIVE_TRADING_ENABLED, and
     #   2) that strategy's own <PREFIX>_LIVE_TRADING flag.
     # This double-gate is a safety net: one switch can't accidentally send
     # everything live. We work it out ONCE here (not inside the threads) and set
     # each worker's `live_trading` flag. Default stays paper; if a strategy has no
     # known prefix it is left on paper and an error is logged so it's noticed.
-    master_live = _env_bool("KOTAK_LIVE_TRADING_ENABLED", False)
+    # Real orders go to whichever broker LIVE_BROKER selected (see execution_client).
+    master_live = _env_bool("LIVE_TRADING_ENABLED", False)
     live_count = 0  # how many strategies ended up live (for the summary log)
     for worker in workers:
         prefix = STRATEGY_ENV_PREFIX.get(worker.strategy_name)
@@ -8327,54 +8358,54 @@ def main() -> None:
         if worker.live_trading:
             live_count += 1
             logger.warning(
-                "LIVE TRADING ENABLED for %s -> real Kotak Neo orders (product=%s).",
-                worker.strategy_name, KOTAK_PRODUCT_TYPE,
+                "LIVE TRADING ENABLED for %s -> real %s orders (product=%s).",
+                worker.strategy_name, LIVE_BROKER, LIVE_PRODUCT_TYPE,
             )
         elif prefix is None:
             logger.error(
                 "No env prefix mapped for strategy %s; forcing PAPER.", worker.strategy_name
             )
 
-    # Startup guard: never attempt live trading without a working Kotak client.
-    if live_count > 0 and kotak_execution_client is None:
+    # Startup guard: never attempt live trading without a working broker client.
+    if live_count > 0 and execution_client is None:
         logger.error(
-            '%d strateg(ies) flagged for LIVE trading but the Kotak execution layer is '
-            'unavailable ("Kotak Neo API" SDK missing or failed to import). '
+            '%d strateg(ies) flagged for LIVE trading but the %s execution layer is '
+            "unavailable (SDK/deps missing or failed to import). "
             "Forcing ALL strategies back to PAPER.",
-            live_count,
+            live_count, LIVE_BROKER,
         )
         for worker in workers:
             worker.live_trading = False
         live_count = 0
 
-    # Eagerly establish the Kotak session NOW (at startup, while you're at the
-    # console to type the TOTP) so worker threads never block on the interactive
-    # TOTP prompt mid-session. If 2FA fails here, force every strategy to PAPER
-    # rather than failing one order at a time later.
-    if live_count > 0 and kotak_execution_client is not None:
-        logger.warning("Logging in to Kotak for LIVE trading - you will be prompted for a TOTP now.")
-        if not kotak_execution_client.ensure_logged_in():
-            logger.error("Kotak login failed at startup; forcing ALL strategies back to PAPER.")
+    # Eagerly establish the broker session NOW (at startup) so worker threads never
+    # block on login mid-session (Kotak prompts for a TOTP; Shoonya auto-generates
+    # it). If login/2FA fails here, force every strategy to PAPER rather than
+    # failing one order at a time later.
+    if live_count > 0 and execution_client is not None:
+        logger.warning("Logging in to %s for LIVE trading now.", LIVE_BROKER)
+        if not execution_client.ensure_logged_in():
+            logger.error("%s login failed at startup; forcing ALL strategies back to PAPER.", LIVE_BROKER)
             for worker in workers:
                 worker.live_trading = False
             live_count = 0
         else:
-            # One-time scrip-master download so the first real order doesn't pay
-            # the multi-second download cost mid-session.
-            logger.info("Kotak login OK; downloading NSE F&O scrip master (one-time)...")
-            if not kotak_execution_client.preload_scrip_master():
+            # One-time scrip/symbol-master download so live orders can be resolved
+            # without paying the download cost mid-session.
+            logger.info("%s login OK; downloading NSE F&O scrip master (one-time)...", LIVE_BROKER)
+            if not execution_client.preload_scrip_master():
                 logger.warning(
                     "Scrip master preload failed; symbols will be resolved lazily on first order."
                 )
 
     if master_live:
         logger.warning(
-            "KOTAK_LIVE_TRADING_ENABLED=true: %d of %d strategies will place REAL orders.",
-            live_count, len(workers),
+            "LIVE_TRADING_ENABLED=true (broker=%s): %d of %d strategies will place REAL orders.",
+            LIVE_BROKER, live_count, len(workers),
         )
     else:
         logger.info(
-            "Live trading master switch OFF (KOTAK_LIVE_TRADING_ENABLED=false); all strategies PAPER."
+            "Live trading master switch OFF (LIVE_TRADING_ENABLED=false); all strategies PAPER."
         )
 
     # Optional Telegram notifier: a queue-based consumer thread that posts a
@@ -8439,15 +8470,15 @@ def main() -> None:
         else:
             logger.info("All threads exited cleanly.")
 
-        # Politely log out of Kotak on the way out, but only if we ever logged in
-        # (pure-paper runs never do). Wrapped in try/except so a logout hiccup
+        # Politely log out of the broker on the way out, but only if we ever logged
+        # in (pure-paper runs never do). Wrapped in try/except so a logout hiccup
         # can't stop the rest of shutdown.
-        if kotak_execution_client is not None and getattr(kotak_execution_client, "is_logged_in", False):
+        if execution_client is not None and getattr(execution_client, "is_logged_in", False):
             try:
-                kotak_execution_client.logout()
-                logger.info("Kotak execution session logged out.")
+                execution_client.logout()
+                logger.info("%s execution session logged out.", LIVE_BROKER)
             except Exception as exc:
-                logger.warning("Kotak logout failed: %s", exc)
+                logger.warning("%s logout failed: %s", LIVE_BROKER, exc)
 
     # End-of-day instrument master refresh. Runs unconditionally (even after
     # Ctrl+C or a partial shutdown) because the scheduler that re-launches


### PR DESCRIPTION
## Summary
Makes the live-execution layer **broker-selectable** (Kotak Neo **or** Shoonya) via a single `LIVE_BROKER` switch in `.env`. The runner loads both execution clients and routes real orders through one generic `execution_client`; the global kill-switch is now broker-agnostic (`KOTAK_LIVE_TRADING_ENABLED` -> `LIVE_TRADING_ENABLED`).

## Changes
- **Master**: dual guarded imports + broker selection (`LIVE_BROKER` / `execution_client` / `LIVE_EXCHANGE_SEGMENT` / `LIVE_PRODUCT_TYPE`); `_place_real_leg`, startup, shutdown and logs genericized.
- **Dependencies reorganized into per-broker subfolders**:
  - `Dependencies/Shoonya API/` -> `NorenApi.py` (vendored Finvasia client), `shoonya_execution.py`, `diagnose_shoonya_symbol.py`
  - `Dependencies/Kotak API/` -> `kotak_execution.py` (moved), `diagnose_kotak_symbol.py`
- **Shoonya execution layer** mirrors Kotak's public surface (lazy login w/ auto-TOTP, NFO symbol resolution, market orders confirmed via `single_order_history`).
- **Diagnostics**: opt-in, confirmation-gated round-trip test order (`--place-order`).
- **env.example**: broker-switch section (blank placeholders for Kotak + Shoonya).
- Folds in the Kotak login serverId / order-permission warning.

## Notes
- Default `LIVE_BROKER=KOTAK`; everything still defaults to paper (`LIVE_TRADING_ENABLED=false`).
- The legacy Shoonya QuickAuth endpoint is being decommissioned by Finvasia (HTTP 502); Shoonya live login may need the new OAuth API before it works - Kotak is unaffected.
- Verified: all touched Python files byte-compile; both relocated execution modules import cleanly from their new subfolders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)