### PR TITLE
docs: update READMEs for broker-selectable live execution

### DIFF
--- a/Dependencies/Readme.md
+++ b/Dependencies/Readme.md
@@ -1,0 +1,66 @@
+# Dependencies
+
+Shared configuration and the live-execution layer used by the front-test master file.
+Nothing here is needed for paper trading except `.env` (for tunable parameters); the
+broker subfolders only come into play when live trading is switched on.
+
+## Contents
+```
+Dependencies/
+├── env.example          # template; copy to .env (git-ignored) and fill in
+├── dhan_token_setup.py  # one-time DhanHQ OAuth login; writes DHAN_ACCESS_TOKEN into .env
+├── Kotak API/           # Kotak Neo live execution
+│   ├── kotak_execution.py        # KotakExecutionClient (shared singleton)
+│   └── diagnose_kotak_symbol.py  # read-only symbol check + optional test order
+└── Shoonya API/         # Shoonya (Finvasia) live execution
+    ├── NorenApi.py               # vendored Finvasia NorenApi client
+    ├── shoonya_execution.py      # ShoonyaExecutionClient (shared singleton)
+    └── diagnose_shoonya_symbol.py# read-only symbol check + optional test order
+```
+
+`.env` itself is git-ignored (it holds secrets); `env.example` is the committed template.
+Both execution modules load `.env` from this `Dependencies/` folder.
+
+## How live execution works
+The master file loads **both** broker clients (each guarded — a missing SDK just
+disables that broker) and then picks one with `LIVE_BROKER` (`KOTAK` or `SHOONYA`).
+The rest of the runner only touches a single generic `execution_client`, so the two
+brokers are interchangeable. Both clients expose the **same surface**:
+`ensure_logged_in()`, `preload_scrip_master()`, `resolve_option_symbol()`,
+`place_market_order()` (with fill confirmation), `extract_order_id()`, `logout()`,
+and an `is_logged_in` flag.
+
+Safety gates (all in `.env`):
+- `LIVE_TRADING_ENABLED` — global kill-switch (default `false` = everything paper).
+- `LIVE_BROKER` — `KOTAK` or `SHOONYA`. An unrecognised value **fails closed**
+  (live disabled, paper only) rather than guessing a broker.
+- `<PREFIX>_LIVE_TRADING` — per strategy. A strategy goes live only when the global
+  switch **and** its own flag are both true.
+- On any order failure (login, unresolved symbol, reject, unconfirmed fill) the
+  strategy falls back to paper for that trade.
+
+Product/exchange per broker is derived from `LIVE_BROKER`: Kotak uses `nse_fo` +
+`KOTAK_PRODUCT_TYPE`; Shoonya uses `NFO` + `SHOONYA_PRODUCT_TYPE` (INTRADAY → MIS/I,
+NORMAL → NRML/M).
+
+## Credentials (in `.env`)
+- **Kotak Neo:** `CONSUMER_KEY`, `MOBILE`, `MPIN`, `UCC`. TOTP is typed at startup
+  (not stored). Needs `pip install neo_api_client`.
+- **Shoonya:** `SHOONYA_USERID`, `SHOONYA_PASSWORD`, `SHOONYA_VENDOR_CODE`,
+  `SHOONYA_API_SECRET`, `SHOONYA_IMEI`, `SHOONYA_TOTP_SECRET` (base32 seed; the TOTP
+  is auto-generated via `pyotp`, or you're prompted if blank). The client is vendored
+  here; needs `pip install pyotp websocket-client`.
+
+> Note: Finvasia is decommissioning the legacy Shoonya QuickAuth endpoint (it returns
+> HTTP 502), so Shoonya live login needs the new OAuth API before it works again.
+> Kotak Neo is the working live path today.
+
+## Diagnostics (read-only, with an optional REAL test order)
+Each broker has a diagnostic that logs in and shows whether a contract resolves to a
+valid trading symbol. Passing `--place-order` additionally places a **real**,
+confirmation-gated **round-trip** order (1-lot BUY, confirm fill, then auto SELL to
+flatten) — it asks you to type `YES` first:
+```
+python "Dependencies/Kotak API/diagnose_kotak_symbol.py" CE 23950 --place-order
+python "Dependencies/Shoonya API/diagnose_shoonya_symbol.py" CE 23950 26JUN25 --place-order
+```

--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@ Although I own the code, the coding itself was done entirely using GPT-5.4-xhigh
 - The backtest files I used to backtest
 - The signal generators I created to generate signals
 - The main front test file which uses miltithreading to execute all strategies together
+- Live order execution to a real broker — selectable between **Kotak Neo** and **Shoonya (Finvasia)** — gated by a global kill-switch and per-strategy paper/live toggles (everything defaults to paper)
 - Live Telegram alerts: the front-test master file can post every entry/exit (option instrument, lot size, entry/exit price, and P&L) to a Telegram group/channel
 
 # Recent additions
+- **Live broker execution is now broker-selectable (Kotak Neo or Shoonya).** The front-test master can place REAL orders, not just paper. `LIVE_BROKER` (in `.env`) picks the broker — `KOTAK` or `SHOONYA` — and the runner routes every real order through one generic `execution_client` to whichever is selected. It is gated by two switches: the global `LIVE_TRADING_ENABLED` kill-switch AND each strategy's own `<PREFIX>_LIVE_TRADING` flag — a strategy goes live only when both are true, and an unrecognised `LIVE_BROKER` fails closed (live disabled, paper only). The per-broker code lives under `Dependencies/Kotak API/` and `Dependencies/Shoonya API/`, each with its execution client plus a read-only diagnostic that can optionally place a confirmation-gated round-trip test order (`--place-order`). Both brokers share one surface (login, symbol resolution, market order with fill confirmation), and any order failure falls back to paper for that trade. Everything defaults to paper. (Note: Shoonya's legacy QuickAuth endpoint is being decommissioned by Finvasia, so Kotak Neo is the working live path today.)
 - **End-of-day P&L is now written to a Google Sheet.** When all workers exit on a clean end of day, the master parses the run's log for each strategy's realised P&L and writes it into a tracker sheet — one row per strategy, one column per calendar day — overwriting today's cell and backfilling any blank earlier-this-month cells from the (append-mode) log. Auth is OAuth user-token via `gspread`; configure `GSHEET_ID` + an OAuth client in `.env` (see Setup). It's a safe no-op when unconfigured, so it never disturbs shutdown.
 - **13 TradingBot signal-generator ports added — the front test now runs 24 workers.** Thirteen more ATM single-leg strategies were ported into `Signal Generators/` (SMA Crossover, Bollinger Bands, Keltner Squeeze, Mean Reversion Z-Score, ML Ensemble, Multi-Timeframe, Opening Range Breakout, Parabolic SAR, RSI Divergence, RSI Reversal, Stochastic, Supertrend, Volatility Breakout), all sharing `misc_strategy_common.py` (TA-Lib-first indicator helpers). They're wired into the master via one shared factory as `AtmSingleLegStrategyWorker`s — the same family as Renko/Goldmine/CPR — and each is fully tunable from `.env` by its own prefix (e.g. `SMA_CROSSOVER_*`, `KELTNER_SQUEEZE_*`). This brings the runner to **24 workers** (21 ATM single-leg + 2 Hedged Puts + 1 Delta-0.2). ML Ensemble needs `scikit-learn`.
 - **CPR (Central Pivot Range) strategy is now live in the front test.** It runs as an ATM single-leg worker (`CPRStrategyWorker`) alongside the other strategies: the master file feeds it 1-min OHLC, the CPR logic resamples to complete 5-min candles internally, and a LONG/SHORT signal buys the ATM CE/PE of the next-next expiry. Tunable via `CPR_*` knobs in the `.env` (lots, max-loss, poll, 09:25-15:15 window). (This brought the master file to nine workers at the time; see the latest addition at the top of this list for the current total.)
@@ -23,10 +25,15 @@ You might have to adjust the import addresses from which the files are to be imp
 # Repository structure
 ```
 .
-├── Nifty Multi Strategy Front Test - Master File.py   # multithreaded paper-trading runner
+├── Nifty Multi Strategy Front Test - Master File.py   # multithreaded paper + live runner (24 strategies)
 ├── Data Extractors/                                   # 1m OHLC downloaders + shared helper
 ├── My Backtest Files (For Reference)/                 # backtesting.py-based backtests
-└── Signal Generators/                                 # strategy / signal logic modules
+├── Signal Generators/                                 # strategy / signal logic modules
+└── Dependencies/                                      # shared config + live-execution layer
+    ├── env.example                                    # copy to Dependencies/.env and fill in
+    ├── dhan_token_setup.py                            # one-time DhanHQ OAuth token setup
+    ├── Kotak API/                                     # kotak_execution.py + diagnose_kotak_symbol.py
+    └── Shoonya API/                                   # NorenApi.py + shoonya_execution.py + diagnose_shoonya_symbol.py
 ```
 Each subfolder has its own `Readme.md` with the details.
 
@@ -36,12 +43,12 @@ Each subfolder has its own `Readme.md` with the details.
    ```
    pip install dhanhq pandas numpy backtesting python-dotenv gspread
    ```
-3. Set Dhan credentials as environment variables:
+   For live trading you'll also need your broker's client: Kotak Neo (`pip install neo_api_client`) and/or Shoonya (the client is vendored in `Dependencies/Shoonya API/`; it needs `pip install pyotp websocket-client`).
+3. Configure credentials. Copy `Dependencies/env.example` to `Dependencies/.env` and fill it in (`.env` is git-ignored). Set your Dhan credentials there, then run the one-time token setup:
    ```
-   DHAN_CLIENT_CODE=your_client_code
-   DHAN_TOKEN_ID=your_access_token
+   python "Dependencies/dhan_token_setup.py"
    ```
-   The backtests and the front-test master file additionally each load a local `.env` from their own folder for tunable strategy parameters.
+   It walks you through the DhanHQ OAuth login and writes a fresh `DHAN_ACCESS_TOKEN` back into `.env`. All tunable strategy parameters live in this same `.env`.
 4. (Optional) Turn on Telegram trade alerts by adding these to the master file's `.env`:
    ```
    TELEGRAM_ENABLED=true
@@ -58,9 +65,21 @@ Each subfolder has its own `Readme.md` with the details.
    ```
    Auth is OAuth user-token via `gspread`: in Google Cloud enable the Sheets API, create an OAuth client of type **Desktop app**, download its JSON to `GSHEET_OAUTH_CLIENT_FILE`, and share the sheet with your Google account. The first run opens a browser once for consent and caches a token at `GSHEET_OAUTH_TOKEN_FILE`. The sheet needs one row per strategy in column A with exact labels (e.g. `Renko Strategy`, `SMA Crossover Strategy`, `Stochastic Oscillator Strategy`, `Supertrend Strategy`, …); unmatched strategies are skipped with a warning. Leave `GSHEET_ID` blank to disable (safe no-op).
 
+6. (Optional) Live broker execution. Everything is paper by default. To place REAL orders, set in `Dependencies/.env`:
+   ```
+   LIVE_TRADING_ENABLED=true        # global kill-switch (default false)
+   LIVE_BROKER=KOTAK                # KOTAK or SHOONYA
+   RENKO_LIVE_TRADING=true          # flip the specific strategies you want live
+   ```
+   Then fill the selected broker's credential block (Kotak: `CONSUMER_KEY`/`MOBILE`/`MPIN`/`UCC`; Shoonya: `SHOONYA_USERID`/`SHOONYA_PASSWORD`/`SHOONYA_VENDOR_CODE`/`SHOONYA_API_SECRET`/`SHOONYA_IMEI`/`SHOONYA_TOTP_SECRET`). A strategy trades live only when `LIVE_TRADING_ENABLED` **and** its own `<PREFIX>_LIVE_TRADING` are both true; any order failure falls back to paper for that trade. Check connectivity first with the read-only diagnostics — they can place a confirmation-gated round-trip (buy + auto square-off) test order via `--place-order`:
+   ```
+   python "Dependencies/Kotak API/diagnose_kotak_symbol.py" CE 23950 --place-order
+   python "Dependencies/Shoonya API/diagnose_shoonya_symbol.py" CE 23950 26JUN25 --place-order
+   ```
+
 # Typical workflow
 1. Pull historical data — e.g. `python "Data Extractors/Nifty 1m 5Y Data Fetch Dhan.py"`. The CSV lands in `Backtest Outputs/`.
 2. Run a backtest against that CSV — e.g. `python "My Backtest Files (For Reference)/Nifty Renko Strategy Backtest.py"`.
-3. Once a strategy looks good, run `Nifty Multi Strategy Front Test - Master File.py` for paper-traded multi-strategy execution.
+3. Once a strategy looks good, run `Nifty Multi Strategy Front Test - Master File.py` for multi-strategy execution — paper by default, or live once you've configured a broker (Setup step 6).
 
 The `Backtest Outputs/` folder is `.gitignore`-d, so generated CSVs/logs stay local.


### PR DESCRIPTION
﻿## Summary
Brings the docs up to date with the broker-selectable live execution that merged in #14 (the docs commit landed on that branch just after it was merged, so it never made it into `main`).

## Changes
- **README.md**
  - New "Recent additions" entry + "What is included" bullet documenting live broker execution (Kotak Neo / Shoonya via `LIVE_BROKER`, gated by `LIVE_TRADING_ENABLED` + per-strategy `<PREFIX>_LIVE_TRADING`, fail-closed on unknown broker, paper fallback).
  - Repository-structure block now includes `Dependencies/` (with `Kotak API/` and `Shoonya API/` subfolders); master relabeled paper + live.
  - Setup refreshed: `.env` from `env.example` + `dhan_token_setup.py`, broker SDK installs, and a dedicated live-execution step with the `--place-order` diagnostics.
- **Dependencies/Readme.md** (new) - documents the live-execution layer: contents, broker selection, the safety gates, per-broker credentials, the Shoonya endpoint caveat, and the diagnostics.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
