### PR TITLE
README: add live track-record note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # My-Algo-Trading-Code
 This contains all the code I have written for the signal generation and the front test where I fetch data using Dhan API
 
+# Live track record
+I have been running these strategies **live** (real broker orders) since **May 2026**. The day-by-day results are recorded here:
+
+📈 **[Live results spreadsheet](https://docs.google.com/spreadsheets/d/1y4VgThcLywZbOibKC_pyKbh0A5u1xtgL_cZvyHp3FYg/edit?gid=0#gid=0)**
+
 # The code
 Although I own the code, the coding itself was done entirely using GPT-5.4-xhigh, GPT-5.5-xhigh and Claude Opus 4.7, Claude Opus 4.8 on Max effort. GPT wrote majority of the signal generators and the data fetch files. Claude wrote the big one - the multithreaded Front Test worker. I just did the reviews and the testing
 


### PR DESCRIPTION
﻿## Summary
Adds the **Live track record** note to the README (running these strategies live since May 2026, with a link to the results spreadsheet).

Background: this change was committed on the PR #18 branch *after* that PR was merged, so it never landed in `main`. This re-applies it on top of the current `main`.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
