### PR TITLE
Add SL Hunting AI Agent (optional LLM-driven NIFTY options strategy)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,8 +22,9 @@ One process, cooperating threads:
   and one **long-strangle** worker (time-based dual-leg BUY of OTM1 CE+PE, with momentum re-entry).
   One **optional, opt-in** 27th worker is LLM-driven: the **SL Hunting AI Agent** (a Claude agent via
   `claude-agent-sdk`) — off by default (`SL_HUNTING_ENABLED`), it decides once per completed 5-min bar
-  and acts through the same ATM `enter_position`/`exit_position`; its deps are lazily imported so a
-  missing dep just disables it.
+  (with BankNIFTY cross-confirmation, fetched per bar like CPR Algo 3, and dynamic ~₹2500 risk-based
+  sizing) and acts through the same ATM `enter_position`/`exit_position`; its deps are lazily imported
+  so a missing dep just disables it.
 - Each entry/exit is published to a `queue.Queue` consumed by a single `TelegramMessageWorker`
   (best-effort alerts; never blocks trading).
 - Real orders go through ONE shared, lock-guarded broker session via a broker-agnostic

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,10 @@ One process, cooperating threads:
   (multi-instrument: spot + ITM CE + ITM PE) / Opening-Strike + 13 ported TradingBot strategies), two
   **hedged-puts** workers, one **Delta-0.2** hedged-spread worker,
   and one **long-strangle** worker (time-based dual-leg BUY of OTM1 CE+PE, with momentum re-entry).
+  One **optional, opt-in** 27th worker is LLM-driven: the **SL Hunting AI Agent** (a Claude agent via
+  `claude-agent-sdk`) — off by default (`SL_HUNTING_ENABLED`), it decides once per completed 5-min bar
+  and acts through the same ATM `enter_position`/`exit_position`; its deps are lazily imported so a
+  missing dep just disables it.
 - Each entry/exit is published to a `queue.Queue` consumed by a single `TelegramMessageWorker`
   (best-effort alerts; never blocks trading).
 - Real orders go through ONE shared, lock-guarded broker session via a broker-agnostic
@@ -34,7 +38,8 @@ test_nifty_multi_strategy_master.py                # unittest suite for the mast
 requirements.txt                                   # core deps (+ commented optional broker/ML deps)
 Data Extractors/                                   # DhanHQ 1-min OHLC downloaders (shared engine + per-index wrappers)
 My Backtest Files (For Reference)/                 # backtesting.py backtests (+ Subhamoy Strategies/)
-Signal Generators/                                 # strategy signal logic (+ CPR Strategy/, Subhamoy Strategies/)
+Signal Generators/                                 # strategy signal logic (+ CPR Strategy/, Subhamoy Strategies/,
+                                                   #   SL Hunting AI Agent/ — optional Claude-agent strategy)
 Dependencies/
   env.example                                      # template; copy to Dependencies/.env (gitignored)
   dhan_token_setup.py                              # one-time DhanHQ OAuth token setup

--- a/Dependencies/env.example
+++ b/Dependencies/env.example
@@ -1048,8 +1048,9 @@ VOLATILITY_BREAKOUT_LIVE_TRADING=false
 # =============================================================================
 # SL Hunting AI Agent (OPTIONAL, LLM-driven) — opt-in add-on strategy
 # =============================================================================
-# A Claude-Agent-SDK trader for the discretionary "SL Hunting" price-action
-# method on NIFTY ATM options. Requires `pip install claude-agent-sdk pydantic`
+# A Claude-Agent-SDK trader for the discretionary "SL Hunting" price-action method
+# on NIFTY ATM options, with BankNIFTY cross-confirmation and dynamic ~Rs.2500
+# risk-based position sizing. Requires `pip install claude-agent-sdk pydantic`
 # and a one-time `claude` CLI login. IMPORTANT: keep ANTHROPIC_API_KEY UNSET so
 # the agent draws on your Claude subscription's Agent SDK credit, not per-token
 # API billing.
@@ -1065,12 +1066,25 @@ SL_HUNTING_FAST_MODE=false
 # Evaluate once per completed N-minute bar (the method favours 5-min).
 SL_HUNTING_DERIVED_TIMEFRAME_MINUTES=5
 SL_HUNTING_POLL_SECONDS=5
+# SL_HUNTING_LOTS is only a FALLBACK; position size is dynamic (see RISK_BUDGET).
 SL_HUNTING_LOTS=1
+# Dynamic position sizing: ~this many rupees of worst-case risk per trade, sized
+# from the agent's underlying stop distance (same convention/default as Profit
+# Shooter). The agent does NOT choose lots; this budget does.
+SL_HUNTING_RISK_BUDGET=2500
 SL_HUNTING_STARTING_CAPITAL=600000.0
 SL_HUNTING_DAILY_MAX_LOSS_PCT=0.03
 SL_HUNTING_TRADING_START_HOUR=9
 SL_HUNTING_TRADING_START_MINUTE=25
 SL_HUNTING_SQUARE_OFF_HOUR=15
 SL_HUNTING_SQUARE_OFF_MINUTE=15
+# BankNIFTY cross-confirmation (advisory). true = the agent also reads BankNIFTY
+# (fetched per bar via the shared broker, like CPR Algo 3) and applies the NF/BNF
+# rules; false = NIFTY-only. Any BankNIFTY fetch failure auto-degrades to NIFTY-only.
+SL_HUNTING_USE_BNF=true
+# BankNIFTY index identity for that fetch (DhanHQ: security_id 25 on the IDX_I segment).
+BANKNIFTY_INDEX_SECURITY_ID=25
+BANKNIFTY_INDEX_EXCHANGE_SEGMENT=IDX_I
+BANKNIFTY_INDEX_INSTRUMENT_TYPE=INDEX
 # Real orders ONLY if this AND LIVE_TRADING_ENABLED (above) are both true.
 SL_HUNTING_LIVE_TRADING=false

--- a/Dependencies/env.example
+++ b/Dependencies/env.example
@@ -1044,3 +1044,33 @@ RSI_REVERSAL_LIVE_TRADING=false
 STOCHASTIC_LIVE_TRADING=false
 SUPERTREND_PORT_LIVE_TRADING=false
 VOLATILITY_BREAKOUT_LIVE_TRADING=false
+
+# =============================================================================
+# SL Hunting AI Agent (OPTIONAL, LLM-driven) — opt-in add-on strategy
+# =============================================================================
+# A Claude-Agent-SDK trader for the discretionary "SL Hunting" price-action
+# method on NIFTY ATM options. Requires `pip install claude-agent-sdk pydantic`
+# and a one-time `claude` CLI login. IMPORTANT: keep ANTHROPIC_API_KEY UNSET so
+# the agent draws on your Claude subscription's Agent SDK credit, not per-token
+# API billing.
+#
+# Off by default. Set SL_HUNTING_ENABLED=true to include it in the master roster.
+# It trades on PAPER unless BOTH LIVE_TRADING_ENABLED (global, above) AND
+# SL_HUNTING_LIVE_TRADING are true; the live broker is the existing LIVE_BROKER.
+SL_HUNTING_ENABLED=false
+# Model: claude-opus-4-8 (best judgement, default) or claude-sonnet-4-6 (cheaper).
+SL_HUNTING_MODEL=claude-opus-4-8
+# true = disable extended thinking (lower latency, lower quality).
+SL_HUNTING_FAST_MODE=false
+# Evaluate once per completed N-minute bar (the method favours 5-min).
+SL_HUNTING_DERIVED_TIMEFRAME_MINUTES=5
+SL_HUNTING_POLL_SECONDS=5
+SL_HUNTING_LOTS=1
+SL_HUNTING_STARTING_CAPITAL=600000.0
+SL_HUNTING_DAILY_MAX_LOSS_PCT=0.03
+SL_HUNTING_TRADING_START_HOUR=9
+SL_HUNTING_TRADING_START_MINUTE=25
+SL_HUNTING_SQUARE_OFF_HOUR=15
+SL_HUNTING_SQUARE_OFF_MINUTE=15
+# Real orders ONLY if this AND LIVE_TRADING_ENABLED (above) are both true.
+SL_HUNTING_LIVE_TRADING=false

--- a/Nifty Multi Strategy Front Test - Master File.py
+++ b/Nifty Multi Strategy Front Test - Master File.py
@@ -61,6 +61,15 @@ independent per-leg trailing stops and momentum re-entry. Together they bring th
 runner to TWENTY-SIX strategies total: 22 ATM single-leg + 2 Hedged Puts +
 1 Delta-0.2 + 1 Long Strangle.
 
+One OPTIONAL, opt-in 27th worker can also be loaded: the SL Hunting AI Agent
+(under "Signal Generators/SL Hunting AI Agent/"). Unlike every other strategy it
+is LLM-driven -- a Claude agent (claude-agent-sdk, on your Claude subscription)
+decides once per completed 5-min bar via in-process tools, then acts through this
+runner's own enter_position/exit_position (so it is just another ATM single-leg
+member of the family). It is OFF by default; SL_HUNTING_ENABLED=true includes it,
+and its optional deps (claude-agent-sdk, pydantic) are imported behind try/except
+so a missing dep simply disables it without touching the rest of the runner.
+
 EXPIRY RULES (the explicit if-else the user asked for)
 ------------------------------------------------------
 Different strategies pick different expiries. Rather than burying this
@@ -1044,6 +1053,48 @@ SUPERTREND_PORT_LOGIC = load_module(
 VOLATILITY_BREAKOUT_LOGIC = load_module(
     "master_volatility_breakout", SIGNAL_GEN_DIR / "Nifty Volatility Breakout Signal Generator.py"
 )
+
+# =============================================================================
+# SL HUNTING AI AGENT (optional, LLM-driven strategy)
+# =============================================================================
+# A Claude-Agent-SDK strategy that trades the discretionary "SL Hunting" price-
+# action method on NIFTY ATM options. It is OPT-IN via SL_HUNTING_ENABLED and an
+# OPTIONAL component: its extra deps (claude-agent-sdk, pydantic) are imported
+# here behind try/except exactly like the broker layer above, so a missing dep
+# just disables this one worker and never breaks the rest of the runner or the
+# unittest suite. The heavy Claude Agent SDK is imported lazily at decision time
+# (inside the agent), so only `pydantic` must be importable for the worker to load.
+#
+# The folder has cross-importing modules all prefixed `sl_hunting_*`, so we add it
+# to sys.path once and import by name (cleaner than load_module for a multi-file
+# folder; the unique prefix avoids any sys.modules collision).
+SL_HUNTING_ENABLED = _env_bool("SL_HUNTING_ENABLED", False)
+SL_HUNTING_DIR = SIGNAL_GEN_DIR / "SL Hunting AI Agent"
+SL_HUNTING_AVAILABLE = False
+SL_HUNTING_AGENT_MODULE = None
+SL_HUNTING_EXECUTOR_MODULE = None
+SL_HUNTING_INDICATOR_CONFIG = None
+if SL_HUNTING_ENABLED:
+    try:
+        if str(SL_HUNTING_DIR) not in sys.path:
+            sys.path.insert(0, str(SL_HUNTING_DIR))
+        SL_HUNTING_AGENT_MODULE = importlib.import_module("sl_hunting_agent")
+        SL_HUNTING_EXECUTOR_MODULE = importlib.import_module("sl_hunting_executor")
+        SL_HUNTING_INDICATOR_CONFIG = importlib.import_module(
+            "sl_hunting_indicators"
+        ).SLHuntingIndicatorConfig()
+        SL_HUNTING_AVAILABLE = True
+        logging.getLogger(LOGGER_NAME).info(
+            "SL Hunting AI Agent loaded (model=%s); add SL_HUNTING_LIVE_TRADING + "
+            "LIVE_TRADING_ENABLED for real orders.",
+            _env_str("SL_HUNTING_MODEL", "claude-opus-4-8"),
+        )
+    except Exception as _sl_hunting_import_exc:  # missing pydantic / SDK / import error
+        logging.getLogger(LOGGER_NAME).warning(
+            "SL Hunting AI Agent unavailable (%s); that strategy is disabled. "
+            "Install its deps with `pip install claude-agent-sdk pydantic`.",
+            _sl_hunting_import_exc,
+        )
 
 # Each port is fully namespaced by its own prefix (<STRATEGY>_<FIELD>), so every
 # operational knob (poll/lots/timing/risk) and every indicator field is an
@@ -8698,6 +8749,84 @@ STRATEGY_ENV_PREFIX = {
 }
 
 
+# -----------------------------------------------------------------------------
+# SL Hunting AI Agent worker (optional, LLM brain)
+# -----------------------------------------------------------------------------
+# Unlike the deterministic ATM workers above, this one asks a Claude agent for a
+# decision once per completed N-min bar. The agent ACTS by calling its single
+# env-selected order tool, which routes through a MasterWorkerExecutor back into
+# this worker's own safe enter_position / exit_position -- so paper-vs-live, the
+# broker choice (LIVE_BROKER), max-loss, square-off and Telegram all behave
+# exactly like every other strategy. Defined only when the optional agent loaded;
+# otherwise SLHuntingAIWorker stays None and main() simply skips it.
+SLHuntingAIWorker = None
+if SL_HUNTING_AVAILABLE:
+    _sl_hunting_ops = _signal_gen_ops("SL_HUNTING")
+
+    class SLHuntingAIWorker(AtmSingleLegStrategyWorker):  # noqa: F811 - optional definition
+        """ATM single-leg worker whose entries/exits come from the SL Hunting agent."""
+
+        strategy_name = "SL Hunting AI"
+        timeframe = "1"
+        poll_seconds = _sl_hunting_ops["poll_seconds"]
+        lots = _sl_hunting_ops["lots"]
+        max_loss = _sl_hunting_ops["max_loss"]
+        trading_start_hour = _sl_hunting_ops["trading_start_hour"]
+        trading_start_minute = _sl_hunting_ops["trading_start_minute"]
+        square_off_hour = _sl_hunting_ops["square_off_hour"]
+        square_off_minute = _sl_hunting_ops["square_off_minute"]
+        derived_timeframe_minutes = _sl_hunting_ops["derived_timeframe_minutes"]
+
+        def __init__(self, store, stop_event, broker):
+            super().__init__(store, stop_event, broker)
+            self.agent = SL_HUNTING_AGENT_MODULE.SLHuntingAgent(
+                model=_env_str("SL_HUNTING_MODEL", "claude-opus-4-8"),
+                fast_mode=_env_bool("SL_HUNTING_FAST_MODE", False),
+                indicator_config=SL_HUNTING_INDICATOR_CONFIG,
+            )
+            # The order tool routes through this executor into our own safe methods.
+            self._executor = SL_HUNTING_EXECUTOR_MODULE.MasterWorkerExecutor(self)
+            # Throttle: consult the LLM only once per NEW completed bar (not per poll).
+            self._last_decision_bar = None
+
+        def minimum_strategy_rows(self) -> int:
+            # Enough derived bars for swings / fibo / structure, with a margin.
+            return max(40, int(getattr(SL_HUNTING_INDICATOR_CONFIG, "swing_lookback", 120)) // 2)
+
+        def build_strategy_frame(self, ohlc: pd.DataFrame) -> pd.DataFrame:
+            return resample_ohlc_from_1m(ohlc, self.derived_timeframe_minutes)
+
+        def process_strategy_frame(self, strategy_frame: pd.DataFrame) -> None:
+            if strategy_frame is None or strategy_frame.empty:
+                return
+            # Only call the agent when a NEW bar has completed since last time.
+            latest_bar = strategy_frame["timestamp"].iloc[-1]
+            if latest_bar == self._last_decision_bar:
+                return
+            self._last_decision_bar = latest_bar
+
+            # The agent acts via the order tool DURING decide() (it calls our
+            # enter_position / exit_position through the executor); the returned
+            # decision is the agent's own record of what it did, for the log.
+            decision = self.agent.decide(
+                strategy_frame,
+                self._executor,
+                live_active=bool(self.live_trading),
+                broker=LIVE_BROKER,
+            )
+            if decision.action != "HOLD":
+                self.log.info(
+                    "SL Hunting AI: %s (conf=%d, setup=%s) stop=%s target=%s :: %s",
+                    decision.action, decision.confidence, decision.setup,
+                    decision.stop, decision.target, decision.reasoning,
+                )
+
+    SLHuntingAIWorker.__name__ = "SLHuntingAIWorker"
+    SLHuntingAIWorker.__qualname__ = "SLHuntingAIWorker"
+    # Wire the live-trading flag lookup (same pattern as every other strategy).
+    STRATEGY_ENV_PREFIX["SL Hunting AI"] = "SL_HUNTING"
+
+
 # =============================================================================
 # END-OF-DAY HELPERS
 # =============================================================================
@@ -9405,7 +9534,8 @@ def main() -> None:
     stop_event = threading.Event()
 
     # One producer (fetcher) + 26 consumers (22 ATM single-leg + 2 Hedged +
-    # 1 Delta-0.2 + 1 Long Strangle).
+    # 1 Delta-0.2 + 1 Long Strangle), plus the optional SL Hunting AI agent
+    # (appended below when SL_HUNTING_ENABLED).
     fetcher = CentralMarketDataFetcher(store, stop_event, broker)
 
     # ----- ATM single-leg family: each BUYS the ATM CE (LONG) / PE (SHORT) of the
@@ -9443,6 +9573,13 @@ def main() -> None:
         # ----- Long Strangle family: time-based, BUY OTM1 CE+PE, two independent legs. -----
         LongStrangleWorker(store, stop_event, broker),
     ]
+
+    # ----- SL Hunting AI agent (optional): LLM-driven ATM single-leg. Appended
+    #       only when the agent module loaded AND SL_HUNTING_ENABLED is set. Stays
+    #       paper unless SL_HUNTING_LIVE_TRADING + LIVE_TRADING_ENABLED are both on
+    #       (the live-wiring below applies the same double-gate as every strategy).
+    if SLHuntingAIWorker is not None:
+        workers.append(SLHuntingAIWorker(store, stop_event, broker))
 
     # -------------------------------------------------------------------------
     # Decide which strategies trade for real vs on paper.

--- a/Nifty Multi Strategy Front Test - Master File.py
+++ b/Nifty Multi Strategy Front Test - Master File.py
@@ -8828,6 +8828,23 @@ if SL_HUNTING_AVAILABLE:
         def process_strategy_frame(self, strategy_frame: pd.DataFrame) -> None:
             if strategy_frame is None or strategy_frame.empty:
                 return
+
+            # Enforce the agent's UNDERLYING stop/target on EVERY poll (not just once
+            # per bar), so the ~Rs.2500 risk is actually bounded between the agent's
+            # bar-cadence decisions -- the agent only re-decides per completed bar, so
+            # we cannot wait for it to call EXIT. Mirrors CPR Algo 3's spot stop/target
+            # check; _get_underlying_spot reads the live LTP cache.
+            if self.pos.active:
+                spot = self._get_underlying_spot(fallback=0.0)
+                if spot > 0:
+                    hit = SL_HUNTING_EXECUTOR_MODULE.stop_or_target_hit(
+                        self.pos.direction, self.pos.stop_underlying, self.pos.target_underlying, spot
+                    )
+                    if hit:
+                        self.log.info("SL Hunting %s hit at spot=%.2f; exiting.", hit, spot)
+                        self.exit_position(hit)
+                        return
+
             # Only call the agent when a NEW bar has completed since last time.
             latest_bar = strategy_frame["timestamp"].iloc[-1]
             if latest_bar == self._last_decision_bar:

--- a/Nifty Multi Strategy Front Test - Master File.py
+++ b/Nifty Multi Strategy Front Test - Master File.py
@@ -398,6 +398,13 @@ INTRADAY_LOOKBACK_DAYS = _env_int("INTRADAY_LOOKBACK_DAYS", 7)
 NIFTY_INDEX_SECURITY_ID = _env_int("NIFTY_INDEX_SECURITY_ID", 13)
 NIFTY_INDEX_EXCHANGE_SEGMENT = _env_str("NIFTY_INDEX_EXCHANGE_SEGMENT", "IDX_I")
 NIFTY_INDEX_INSTRUMENT_TYPE = _env_str("NIFTY_INDEX_INSTRUMENT_TYPE", "INDEX")
+# BankNIFTY index identity (DhanHQ security_id 25 on the IDX_I segment). Only the
+# optional SL Hunting AI Agent uses these today, to fetch BankNIFTY 1-min OHLC for
+# its NF/BNF cross-confirmation (the same fetch_index_1m_ohlc path the fetcher and
+# CPR Algo 3 use). Env-overridable like the NIFTY constants above.
+BANKNIFTY_INDEX_SECURITY_ID = _env_int("BANKNIFTY_INDEX_SECURITY_ID", 25)
+BANKNIFTY_INDEX_EXCHANGE_SEGMENT = _env_str("BANKNIFTY_INDEX_EXCHANGE_SEGMENT", "IDX_I")
+BANKNIFTY_INDEX_INSTRUMENT_TYPE = _env_str("BANKNIFTY_INDEX_INSTRUMENT_TYPE", "INDEX")
 OPTION_EXCHANGE_SEGMENT = _env_str("OPTION_EXCHANGE_SEGMENT", "NSE_FNO")
 # Instrument type for index OPTIONS in DhanHQ's intraday/historical APIs. Used to
 # pull 1-minute OHLC for a specific option strike (e.g. CPR Algo 3's observation
@@ -8762,6 +8769,10 @@ STRATEGY_ENV_PREFIX = {
 SLHuntingAIWorker = None
 if SL_HUNTING_AVAILABLE:
     _sl_hunting_ops = _signal_gen_ops("SL_HUNTING")
+    # Dynamic position sizing: ~Rs.2500 worst-case risk per trade (the same house
+    # convention/default as Profit Shooter). The agent does NOT choose lots; this is
+    # computed from the agent's underlying stop distance.
+    SL_HUNTING_RISK_BUDGET = _env_float("SL_HUNTING_RISK_BUDGET", 2500.0)
 
     class SLHuntingAIWorker(AtmSingleLegStrategyWorker):  # noqa: F811 - optional definition
         """ATM single-leg worker whose entries/exits come from the SL Hunting agent."""
@@ -8788,10 +8799,28 @@ if SL_HUNTING_AVAILABLE:
             self._executor = SL_HUNTING_EXECUTOR_MODULE.MasterWorkerExecutor(self)
             # Throttle: consult the LLM only once per NEW completed bar (not per poll).
             self._last_decision_bar = None
+            # Optional BankNIFTY cross-confirmation, fetched per bar via self.broker
+            # exactly like CPR Algo 3 fetches its observation legs.
+            self._use_bnf = _env_bool("SL_HUNTING_USE_BNF", True)
 
         def minimum_strategy_rows(self) -> int:
             # Enough derived bars for swings / fibo / structure, with a margin.
             return max(40, int(getattr(SL_HUNTING_INDICATOR_CONFIG, "swing_lookback", 120)) // 2)
+
+        def _compute_entry_lots(self, entry_underlying: float, stop_underlying: float, lot_size: int) -> int:
+            """Dynamic risk-based sizing (~SL_HUNTING_RISK_BUDGET, default Rs.2500),
+            from the agent's UNDERLYING stop distance. Shares ONE implementation with
+            the standalone executor via `risk_based_lots`, and matches the Profit
+            Shooter sizer (ceil, minimum 1 lot — a setup trades at >=1 lot or not at all).
+            """
+            lots = SL_HUNTING_EXECUTOR_MODULE.risk_based_lots(
+                entry_underlying, stop_underlying, lot_size, SL_HUNTING_RISK_BUDGET, self.lots
+            )
+            self.log.info(
+                "SL Hunting dynamic sizing: entry=%.2f stop=%.2f lot_size=%s risk_budget=%.0f -> lots=%s qty=%s.",
+                entry_underlying, stop_underlying, lot_size, SL_HUNTING_RISK_BUDGET, lots, lots * lot_size,
+            )
+            return lots
 
         def build_strategy_frame(self, ohlc: pd.DataFrame) -> pd.DataFrame:
             return resample_ohlc_from_1m(ohlc, self.derived_timeframe_minutes)
@@ -8805,12 +8834,30 @@ if SL_HUNTING_AVAILABLE:
                 return
             self._last_decision_bar = latest_bar
 
+            # Optional BankNIFTY for the agent's NF/BNF cross-confirmation. Fetched
+            # on-demand via the shared broker (same fetch_index_1m_ohlc path as the
+            # central fetcher / CPR Algo 3). Any failure -> NIFTY-only this bar.
+            bnf_candles = None
+            if self._use_bnf:
+                try:
+                    bnf_1m = self.broker.fetch_index_1m_ohlc(
+                        BANKNIFTY_INDEX_SECURITY_ID,
+                        BANKNIFTY_INDEX_EXCHANGE_SEGMENT,
+                        BANKNIFTY_INDEX_INSTRUMENT_TYPE,
+                    )
+                    bnf_candles = resample_ohlc_from_1m(bnf_1m, self.derived_timeframe_minutes)
+                except Exception as exc:
+                    self.log.warning(
+                        "BankNIFTY fetch failed (%s); SL Hunting goes NIFTY-only this bar.", exc
+                    )
+
             # The agent acts via the order tool DURING decide() (it calls our
             # enter_position / exit_position through the executor); the returned
             # decision is the agent's own record of what it did, for the log.
             decision = self.agent.decide(
                 strategy_frame,
                 self._executor,
+                bnf_candles=bnf_candles,
                 live_active=bool(self.live_trading),
                 broker=LIVE_BROKER,
             )

--- a/Signal Generators/SL Hunting AI Agent/README.md
+++ b/Signal Generators/SL Hunting AI Agent/README.md
@@ -18,22 +18,25 @@ Once per **completed N-minute bar** (default 5), the agent is handed the recent
 NIFTY candles and runs one agentic pass:
 1. It calls **read-only context tools** for deterministic facts —
    `pivot_and_levels`, `candle_patterns` (with confirmation status), `fibo_levels`,
-   `market_structure`, `position_state`.
+   `market_structure`, `position_state`, plus `bank_nifty` and `cross_index` for
+   the **BankNIFTY cross-confirmation** (the NF/BNF rules; advisory).
 2. If — and only if — a confirmed setup at a real level with a tight stop and a
    worthwhile target is present, it calls its **single order tool** to act.
 3. Its final message is a strict `SLHuntingDecision` JSON object (logged as a
    record of what it did).
 
 `ENTER_LONG` buys an ATM **CALL**; `ENTER_SHORT` buys an ATM **PUT**. Stops and
-targets are levels on the NIFTY **underlying** (spot).
+targets are levels on the NIFTY **underlying** (spot). The agent does **not** choose
+the lot count — position size is computed automatically so the worst-case risk is
+**~₹2500 per trade** (`SL_HUNTING_RISK_BUDGET`), from the agent's stop distance.
 
 ## Files
 | File | Purpose |
 |---|---|
 | `sl_hunting_doc.md` | Verbatim source methodology (the agent's ground truth). |
 | `sl_hunting_knowledge.py` | `build_system_prompt()` + strict-JSON `FINAL_OUTPUT_INSTRUCTION` — the agent's "brain". |
-| `sl_hunting_indicators.py` | Deterministic detectors (pivot/levels, fibo, candlestick patterns + confirmation, structure). |
-| `sl_hunting_tools.py` | In-process MCP server: 5 read-only tools + 1 env-selected order tool. |
+| `sl_hunting_indicators.py` | Deterministic detectors (pivot/levels, fibo, candlestick patterns + confirmation, structure, NF/BNF cross-index). |
+| `sl_hunting_tools.py` | In-process MCP server: 7 read-only tools (incl. `bank_nifty`/`cross_index`) + 1 env-selected order tool. |
 | `sl_hunting_executor.py` | `StandaloneExecutor` (paper) and `MasterWorkerExecutor` (delegates to the master worker). |
 | `sl_hunting_ai_validation.py` | `StrictAIModel` + `parse_with_retry` (bounded retry on malformed JSON). |
 | `sl_hunting_agent.py` | `SLHuntingAgent` + the strict `SLHuntingDecision` schema. |
@@ -56,6 +59,10 @@ python sl_hunting_runner.py --synthetic --fake
 
 # Replay a real 1-min NIFTY CSV with the live agent, capped to 30 decisions:
 python sl_hunting_runner.py --csv path/to/nifty_1m.csv --max-bars 30
+
+# Add BankNIFTY for cross-confirmation (pair a 1-min BankNIFTY CSV with the NIFTY one);
+# --synthetic generates a correlated BankNIFTY automatically:
+python sl_hunting_runner.py --csv nifty_1m.csv --bnf-csv banknifty_1m.csv --max-bars 30
 ```
 The standalone runner is **paper-only** by design (its P&L is a proxy on the
 underlying, to validate decisions — not option pricing).
@@ -87,8 +94,16 @@ master's one shared, lock-guarded broker session and its `enter_position` /
 pytest "Signal Generators/SL Hunting AI Agent/tests"
 ```
 
-## Scope (v1)
-NIFTY-only. The original method cross-checks Bank Nifty (BNF); BNF is **not** in the
-master's live data store, so the agent judges on NIFTY alone (and is told to be a
-bit more conservative because that cross-check is missing). BNF cross-confirmation
-is a future enhancement requiring a second live instrument feed.
+## BankNIFTY cross-confirmation (v2)
+The agent applies the method's NF/BNF rules via the `bank_nifty` + `cross_index`
+tools. BankNIFTY 1-min OHLC is **not** in the master's shared store, so the worker
+fetches it on demand each bar through the shared broker (`fetch_index_1m_ohlc`, the
+same path CPR Algo 3 uses) — set `SL_HUNTING_USE_BNF=false` to disable. It is
+**advisory**: it strengthens/weakens a NIFTY setup but never hard-gates, and any
+BankNIFTY fetch failure auto-degrades to NIFTY-only for that bar.
+
+## Source images (v2)
+The source doc's ~108 pages of annotated chart screenshots were exported and
+reviewed; they are illustrative of the prose rules and contained **no net-new
+knowledge**, so nothing was added to the agent's knowledge from them (see the note
+at the top of `sl_hunting_doc.md`).

--- a/Signal Generators/SL Hunting AI Agent/README.md
+++ b/Signal Generators/SL Hunting AI Agent/README.md
@@ -1,0 +1,94 @@
+# SL Hunting AI Agent
+
+An **LLM-driven** NIFTY index-options strategy. Instead of a deterministic signal
+engine, a **Claude agent** (via the [`claude-agent-sdk`](https://pypi.org/project/claude-agent-sdk/))
+trades the discretionary *"SL Hunting"* price-action method: pivot retests,
+previous-day OHLC, Fibonacci 50/61/78 reversals, the mandatory *candlestick
+pattern + confirmation candle* rule, trendline "3rd-point / break" logic, W/M
+patterns, the gap-up/down playbook, and the core psychology of trading **opposite
+to where retail stop-losses sit**.
+
+It mirrors the in-house agent pattern from the sibling `Streamlit Scanner App`
+repo: `claude-agent-sdk` on your Claude subscription (no API key), in-process MCP
+tool servers, an injectable `runner=` testing seam, a Windows-safe async→sync
+bridge, and strict Pydantic output validation.
+
+## How it works
+Once per **completed N-minute bar** (default 5), the agent is handed the recent
+NIFTY candles and runs one agentic pass:
+1. It calls **read-only context tools** for deterministic facts —
+   `pivot_and_levels`, `candle_patterns` (with confirmation status), `fibo_levels`,
+   `market_structure`, `position_state`.
+2. If — and only if — a confirmed setup at a real level with a tight stop and a
+   worthwhile target is present, it calls its **single order tool** to act.
+3. Its final message is a strict `SLHuntingDecision` JSON object (logged as a
+   record of what it did).
+
+`ENTER_LONG` buys an ATM **CALL**; `ENTER_SHORT` buys an ATM **PUT**. Stops and
+targets are levels on the NIFTY **underlying** (spot).
+
+## Files
+| File | Purpose |
+|---|---|
+| `sl_hunting_doc.md` | Verbatim source methodology (the agent's ground truth). |
+| `sl_hunting_knowledge.py` | `build_system_prompt()` + strict-JSON `FINAL_OUTPUT_INSTRUCTION` — the agent's "brain". |
+| `sl_hunting_indicators.py` | Deterministic detectors (pivot/levels, fibo, candlestick patterns + confirmation, structure). |
+| `sl_hunting_tools.py` | In-process MCP server: 5 read-only tools + 1 env-selected order tool. |
+| `sl_hunting_executor.py` | `StandaloneExecutor` (paper) and `MasterWorkerExecutor` (delegates to the master worker). |
+| `sl_hunting_ai_validation.py` | `StrictAIModel` + `parse_with_retry` (bounded retry on malformed JSON). |
+| `sl_hunting_agent.py` | `SLHuntingAgent` + the strict `SLHuntingDecision` schema. |
+| `sl_hunting_runner.py` | Standalone PAPER harness (synthetic/CSV replay). |
+| `tests/` | pytest suite — runs with a fake runner, no SDK/CLI/network. |
+
+## Setup (one-time)
+```bash
+pip install claude-agent-sdk pydantic
+claude login            # sign in once with your Claude subscription
+# Ensure ANTHROPIC_API_KEY is UNSET so the agent bills your plan, not per-token API.
+```
+
+## Run standalone (paper-first)
+```bash
+cd "Signal Generators/SL Hunting AI Agent"
+
+# Zero-cost pipeline smoke test (no data file, no SDK):
+python sl_hunting_runner.py --synthetic --fake
+
+# Replay a real 1-min NIFTY CSV with the live agent, capped to 30 decisions:
+python sl_hunting_runner.py --csv path/to/nifty_1m.csv --max-bars 30
+```
+The standalone runner is **paper-only** by design (its P&L is a proxy on the
+underlying, to validate decisions — not option pricing).
+
+## Run inside the master front-test (the live path)
+Set in `Dependencies/.env`:
+```
+SL_HUNTING_ENABLED=true          # include the worker in the master roster
+SL_HUNTING_MODEL=claude-opus-4-8 # or claude-sonnet-4-6 to cut cost
+```
+Then run the master as usual (`python algo.py run`). It trades on **paper** unless
+both `LIVE_TRADING_ENABLED` and `SL_HUNTING_LIVE_TRADING` are `true`; the live
+broker is the existing `LIVE_BROKER` (`KOTAK`/`SHOONYA`). Live orders go through the
+master's one shared, lock-guarded broker session and its `enter_position` /
+`exit_position` (so max-loss, square-off and Telegram all apply). See the
+`SL_HUNTING_*` block in `Dependencies/env.example` for all knobs.
+
+## Safety
+- **Paper by default.** The agent is given exactly **one** order tool, chosen by
+  the env (`place_paper_order` / `place_kotak_order` / `place_shoonya_order`) — it
+  can never pick paper-vs-real or the broker.
+- The agent **never raises** into the trading loop: any failure (SDK missing,
+  malformed output, usage limit) returns a safe `HOLD`.
+- Both extra deps are **lazily imported**, so a missing dep just disables this one
+  worker — the rest of the master and its test suite are unaffected.
+
+## Tests
+```bash
+pytest "Signal Generators/SL Hunting AI Agent/tests"
+```
+
+## Scope (v1)
+NIFTY-only. The original method cross-checks Bank Nifty (BNF); BNF is **not** in the
+master's live data store, so the agent judges on NIFTY alone (and is told to be a
+bit more conservative because that cross-check is missing). BNF cross-confirmation
+is a future enhancement requiring a second live instrument feed.

--- a/Signal Generators/SL Hunting AI Agent/conftest.py
+++ b/Signal Generators/SL Hunting AI Agent/conftest.py
@@ -1,0 +1,16 @@
+"""Pytest bootstrap for the SL Hunting AI Agent.
+
+The folder name contains spaces and the modules import each other by bare name
+(`import sl_hunting_tools`, etc.), so we add this folder to ``sys.path`` before the
+tests import anything. pytest auto-loads this ``conftest.py`` because it sits above
+the ``tests/`` directory.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+if _HERE not in sys.path:
+    sys.path.insert(0, _HERE)

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_agent.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_agent.py
@@ -1,0 +1,390 @@
+"""The SL Hunting AI Agent — a Claude-Agent-SDK trader for NIFTY index options.
+
+What this is (beginner note)
+----------------------------
+This is the "brain". On each completed bar it is handed the recent NIFTY candles
+and a `TradeExecutor`, and it runs ONE agentic pass: Claude calls the read-only
+context tools (pivot/levels, fibo, candle patterns, structure, position state),
+decides whether a confirmed SL-Hunting setup is present, and — if so — calls its
+single order tool to act. Its final message is a strict `SLHuntingDecision` JSON
+object recording what it did (for logging/provenance).
+
+It mirrors the house pattern in
+`../Streamlit Scanner App/backend/technical/technical_agent.py`:
+- the Claude Agent SDK is imported LAZILY inside the runner, so this module imports
+  cleanly even when `claude-agent-sdk` is not installed (tests inject a fake runner);
+- the agentic loop is `query(prompt, options=ClaudeAgentOptions(...))`;
+- a Windows-safe async→sync bridge runs it from threaded/sync code;
+- `runner=` is an injectable seam so unit tests never spawn the Claude CLI;
+- output is a strict Pydantic model validated with `parse_with_retry`.
+
+Subscription billing note: keep ``ANTHROPIC_API_KEY`` UNSET so the SDK draws on your
+Claude plan's Agent SDK credit instead of per-token API billing (same as the
+Scanner app). The agent NEVER raises into the trading loop — any failure returns a
+safe HOLD decision.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import json
+import logging
+import re
+import sys
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any, Literal
+
+import pandas as pd
+from pydantic import Field, ValidationError, field_validator
+
+from sl_hunting_ai_validation import StrictAIModel, parse_with_retry
+from sl_hunting_knowledge import FINAL_OUTPUT_INSTRUCTION, build_system_prompt
+from sl_hunting_indicators import SLHuntingIndicatorConfig, prepare_candles
+from sl_hunting_tools import SLHuntingToolContext, build_sl_hunting_mcp_server
+from sl_hunting_executor import TradeExecutor
+
+logger = logging.getLogger(__name__)
+
+# How many recent candles to show the model for orientation (it gets precise facts
+# from the tools; this is just context). Keep small to bound tokens/cost.
+_SNAPSHOT_BARS = 40
+SL_HUNTING_PROMPT_VERSION = "sl-hunting-v1"
+
+
+@dataclass
+class AgentRunResult:
+    """One agentic loop's final text plus its (optional) reported cost."""
+
+    text: str
+    cost_usd: float | None = None
+
+
+class SLHuntingAgentError(RuntimeError):
+    """Infrastructure failure (SDK missing, CLI error, bad final output)."""
+
+
+class SLHuntingUsageLimitError(SLHuntingAgentError):
+    """The Claude subscription's Agent SDK usage limit was hit."""
+
+
+# A runner drives one full agentic loop and returns the final message text.
+# Production uses `SLHuntingAgent._default_run`; tests inject a fake.
+RunnerFn = Callable[..., Awaitable[AgentRunResult]]
+
+
+# ---------------------------------------------------------------------------
+# Strict output schema
+# ---------------------------------------------------------------------------
+
+Action = Literal["ENTER_LONG", "ENTER_SHORT", "EXIT", "HOLD"]
+
+
+class SLHuntingDecision(StrictAIModel):
+    """The agent's structured decision for one bar.
+
+    `confidence` is validated with a `@field_validator` (not `Field(ge=, le=)`) so
+    the JSON schema we describe to Claude stays free of `minimum`/`maximum`, which
+    Claude rejects on integer types — same trick as the Scanner's verdict models.
+    """
+
+    action: Action = Field(description="ENTER_LONG, ENTER_SHORT, EXIT or HOLD.")
+    stop: float = Field(default=0.0, description="Underlying stop level for an entry; 0 for EXIT/HOLD.")
+    target: float = Field(default=0.0, description="Underlying target level for an entry; 0 for EXIT/HOLD.")
+    confidence: int = Field(description="0-10 confidence in the decision (10 = textbook).")
+    setup: str = Field(default="none", description="Short name of the setup acted on, or 'none'.")
+    reasoning: str = Field(description="2-4 sentences: level, pattern+confirmation, stop/target, why now.")
+    model_used: str = Field(default="", description="Which model produced this decision.")
+
+    @field_validator("confidence")
+    @classmethod
+    def _validate_confidence_range(cls, value: int) -> int:
+        if not 0 <= value <= 10:
+            raise ValueError(f"confidence must be between 0 and 10 inclusive, got {value}")
+        return value
+
+
+def _extract_json_object(text: str) -> dict[str, Any] | None:
+    """Pull the SLHuntingDecision JSON object out of the model's final message.
+
+    Tolerant of a stray ```json fence or a leading sentence: looks for a fenced
+    block first, then falls back to the outermost {...} span. Returns None when
+    nothing parses (mirrors the Scanner's extractor).
+    """
+    if not text:
+        return None
+    fenced = re.search(r"```(?:json)?\s*(\{.*\})\s*```", text, re.DOTALL)
+    if fenced:
+        candidate = fenced.group(1)
+    else:
+        start = text.find("{")
+        end = text.rfind("}")
+        if start == -1 or end == -1 or end < start:
+            return None
+        candidate = text[start : end + 1]
+    try:
+        parsed = json.loads(candidate)
+    except json.JSONDecodeError:
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _mentions_usage_limit(*texts: str | None) -> bool:
+    blob = " ".join(t for t in texts if t).lower()
+    return any(k in blob for k in ("usage limit", "rate limit", "429", "quota"))
+
+
+# ---------------------------------------------------------------------------
+# Agent
+# ---------------------------------------------------------------------------
+
+
+class SLHuntingAgent:
+    """Per-bar SL-Hunting agent backed by the Claude Agent SDK + Claude subscription.
+
+    One instance is reused across bars. The agentic loop is driven by an injectable
+    `runner` so unit tests avoid spawning the CLI; production uses `_default_run`,
+    which lazily imports `claude_agent_sdk`.
+    """
+
+    MAX_TURNS = 12  # up to 5 context tools + 1 order tool + reasoning + final JSON
+
+    def __init__(
+        self,
+        model: str,
+        *,
+        runner: RunnerFn | None = None,
+        fast_mode: bool = False,
+        indicator_config: SLHuntingIndicatorConfig | None = None,
+        attempts: int = 2,
+    ) -> None:
+        if not model:
+            raise ValueError("SLHuntingAgent: model is required.")
+        self._model = model
+        self._runner = runner
+        self._fast_mode = bool(fast_mode)
+        self._cfg = indicator_config or SLHuntingIndicatorConfig()
+        self._attempts = max(1, int(attempts))
+        self._system_prompt = build_system_prompt() + FINAL_OUTPUT_INSTRUCTION
+
+    # ------------------------------------------------------------------
+    # Prompt construction
+    # ------------------------------------------------------------------
+
+    def _snapshot_csv(self, candles: pd.DataFrame) -> str:
+        recent = candles.tail(_SNAPSHOT_BARS)
+        lines = ["time,open,high,low,close"]
+        for row in recent.itertuples(index=False):
+            ts = str(getattr(row, "timestamp", ""))[:19]
+            lines.append(f"{ts},{float(row.open):.2f},{float(row.high):.2f},{float(row.low):.2f},{float(row.close):.2f}")
+        return "\n".join(lines)
+
+    def _build_user_prompt(self, candles: pd.DataFrame, position: dict[str, Any]) -> str:
+        last_price = float(candles["close"].iloc[-1]) if not candles.empty else 0.0
+        pos_line = (
+            f"You currently HOLD a {position.get('direction')} position "
+            f"(entry {position.get('entry')}, stop {position.get('stop')}, target {position.get('target')})."
+            if position.get("in_position")
+            else "You are currently FLAT (no open position)."
+        )
+        return (
+            f"Instrument: NIFTY index (options). Current underlying price: {last_price:.2f}.\n"
+            f"{pos_line}\n\n"
+            f"Recent candles (CSV, for orientation only — get precise facts from your tools):\n"
+            f"{self._snapshot_csv(candles)}\n\n"
+            "Call your tools (pivot_and_levels, candle_patterns, fibo_levels, "
+            "market_structure, position_state) to gather the facts, apply the "
+            "SL-Hunting method, and decide. If — and only if — a confirmed setup with "
+            "a tight stop and a worthwhile target is present, call your single order "
+            f"tool to act. Set model_used to '{self._model}'. Then output the "
+            "SLHuntingDecision JSON exactly per the FINAL OUTPUT FORMAT."
+        )
+
+    # ------------------------------------------------------------------
+    # Default runner (Claude Agent SDK)
+    # ------------------------------------------------------------------
+
+    async def _default_run(
+        self,
+        prompt: str,
+        *,
+        system_prompt: str,
+        model: str,
+        max_turns: int,
+        tool_context: SLHuntingToolContext,
+    ) -> AgentRunResult:
+        """Run one agentic loop on the Claude Agent SDK and return final text.
+
+        Imports `claude_agent_sdk` lazily so this module imports without the SDK.
+        Registers the in-process MCP server for THIS bar and restricts the agent to
+        our tools only (`allowed_tools` + `permission_mode="dontAsk"`).
+        """
+        try:
+            import claude_agent_sdk as claude_sdk  # type: ignore[import-not-found, unused-ignore]
+            from claude_agent_sdk import (  # type: ignore[import-not-found, unused-ignore]
+                AssistantMessage,
+                ClaudeAgentOptions,
+                CLINotFoundError,
+                ProcessError,
+                ResultMessage,
+                query,
+            )
+        except ImportError as exc:  # pragma: no cover - environment dependent
+            raise SLHuntingAgentError(
+                "claude-agent-sdk is not installed. Run `pip install claude-agent-sdk` "
+                "and sign in once with the bundled Claude CLI (using your Claude "
+                "subscription) to enable the SL Hunting AI Agent. Keep ANTHROPIC_API_KEY "
+                "UNSET so it bills your plan, not per-token API usage."
+            ) from exc
+
+        ThinkingConfigDisabled = getattr(claude_sdk, "ThinkingConfigDisabled", None)
+        mcp_servers, allowed_tools = build_sl_hunting_mcp_server(tool_context)
+
+        options_kwargs: dict[str, Any] = {
+            "model": model,
+            "system_prompt": system_prompt,
+            "max_turns": max_turns,
+            "mcp_servers": mcp_servers,
+            "allowed_tools": allowed_tools,
+            # "dontAsk" denies any tool not in allowed_tools, so the agent can never
+            # reach the built-in filesystem/bash tools in a headless run.
+            "permission_mode": "dontAsk",
+            "setting_sources": [],
+        }
+        if self._fast_mode and ThinkingConfigDisabled is not None:
+            options_kwargs["thinking"] = ThinkingConfigDisabled()
+        elif self._fast_mode:
+            logger.warning("SL Hunting fast mode requested but ThinkingConfigDisabled is unavailable; using default thinking.")
+        options = ClaudeAgentOptions(**options_kwargs)
+
+        final_text = ""
+        cost_usd: float | None = None
+        result_message: Any = None
+        try:
+            async for message in query(prompt=prompt, options=options):
+                if isinstance(message, ResultMessage):
+                    result_message = message
+                    cost_usd = getattr(message, "total_cost_usd", None)
+                    if getattr(message, "result", None):
+                        final_text = message.result
+                elif isinstance(message, AssistantMessage):
+                    for block in getattr(message, "content", None) or []:
+                        block_text = getattr(block, "text", None)
+                        if block_text:
+                            final_text = block_text
+        except CLINotFoundError as exc:
+            raise SLHuntingAgentError(
+                "The bundled Claude CLI could not be found. Reinstall with "
+                "`pip install --force-reinstall claude-agent-sdk`."
+            ) from exc
+        except ProcessError as exc:
+            if _mentions_usage_limit(str(exc), getattr(exc, "stderr", None)):
+                raise SLHuntingUsageLimitError() from exc
+            raise SLHuntingAgentError(f"Claude Agent SDK process error: {exc}") from exc
+
+        if result_message is not None and getattr(result_message, "is_error", False):
+            if getattr(result_message, "api_error_status", None) == 429:
+                raise SLHuntingUsageLimitError()
+            raise SLHuntingAgentError(
+                f"SL Hunting agent run failed: {str(getattr(result_message, 'result', '') or '')[:300]}".strip()
+            )
+        return AgentRunResult(text=final_text, cost_usd=cost_usd)
+
+    # ------------------------------------------------------------------
+    # Sync bridge (Windows-safe; lets threaded master code drive the async SDK)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _run_sync(coro: Awaitable[AgentRunResult]) -> AgentRunResult:
+        """Run an async coroutine to completion from sync/threaded code.
+
+        Uses a dedicated worker thread with its OWN event loop so we never collide
+        with any running loop. On Windows a ProactorEventLoop is required because
+        the Agent SDK launches the Claude CLI as a subprocess (identical to the
+        Scanner app's bridge).
+        """
+
+        def _runner() -> AgentRunResult:
+            if sys.platform == "win32":
+                loop = asyncio.ProactorEventLoop()
+            else:
+                loop = asyncio.new_event_loop()
+            try:
+                asyncio.set_event_loop(loop)
+                return loop.run_until_complete(coro)
+            finally:
+                asyncio.set_event_loop(None)
+                loop.close()
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+            return executor.submit(_runner).result()
+
+    # ------------------------------------------------------------------
+    # Public entry point
+    # ------------------------------------------------------------------
+
+    def decide(
+        self,
+        candles: pd.DataFrame,
+        executor: TradeExecutor,
+        *,
+        live_active: bool = False,
+        broker: str | None = None,
+    ) -> SLHuntingDecision:
+        """Run one agentic pass for the latest bar and return the decision.
+
+        The agent ACTS by calling its order tool during the loop (the tool drives
+        `executor`), so by the time this returns, `executor` already reflects any
+        trade. The returned decision is the agent's own record of what it did.
+
+        This NEVER raises into the trading loop: on any failure it returns a safe
+        HOLD decision with `setup="agent_error"` so the worker simply does nothing.
+        """
+        prepared = prepare_candles(candles)
+        if prepared.empty:
+            return SLHuntingDecision(action="HOLD", confidence=0, setup="no_data", reasoning="No candles available.", model_used=self._model)
+
+        tool_context = SLHuntingToolContext.build(
+            prepared, executor, cfg=self._cfg, live_active=live_active, broker=broker
+        )
+        position = executor.snapshot()
+        prompt = self._build_user_prompt(prepared, position)
+        runner = self._runner or self._default_run
+
+        def _run_once() -> str:
+            run_result = self._run_sync(
+                runner(
+                    prompt,
+                    system_prompt=self._system_prompt,
+                    model=self._model,
+                    max_turns=self.MAX_TURNS,
+                    tool_context=tool_context,
+                )
+            )
+            if run_result.cost_usd is not None:
+                logger.info("SLHuntingAgent decision cost ~$%.4f", run_result.cost_usd)
+            return run_result.text
+
+        def _parse(text: str) -> SLHuntingDecision:
+            payload = _extract_json_object(text)
+            if payload is None:
+                raise SLHuntingAgentError("Agent did not return a parseable SLHuntingDecision JSON object.")
+            decision = SLHuntingDecision.model_validate(payload)
+            return decision.model_copy(update={"model_used": self._model})
+
+        try:
+            return parse_with_retry(
+                _run_once,
+                _parse,
+                attempts=self._attempts,
+                retry_on=(SLHuntingAgentError, ValidationError),
+                label="SLHuntingDecision",
+            )
+        except Exception as exc:  # noqa: BLE001 - never kill the trading loop
+            logger.warning("SLHuntingAgent.decide failed (%s); holding.", type(exc).__name__, exc_info=True)
+            return SLHuntingDecision(
+                action="HOLD", confidence=0, setup="agent_error",
+                reasoning=f"Agent unavailable or returned invalid output ({type(exc).__name__}); holding.",
+                model_used=self._model,
+            )

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_agent.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_agent.py
@@ -39,7 +39,7 @@ from typing import Any, Literal
 import pandas as pd
 from pydantic import Field, ValidationError, field_validator
 
-from sl_hunting_ai_validation import StrictAIModel, parse_with_retry
+from sl_hunting_ai_validation import StrictAIModel
 from sl_hunting_knowledge import FINAL_OUTPUT_INSTRUCTION, build_system_prompt
 from sl_hunting_indicators import SLHuntingIndicatorConfig, prepare_candles
 from sl_hunting_tools import SLHuntingToolContext, build_sl_hunting_mcp_server
@@ -157,7 +157,6 @@ class SLHuntingAgent:
         runner: RunnerFn | None = None,
         fast_mode: bool = False,
         indicator_config: SLHuntingIndicatorConfig | None = None,
-        attempts: int = 2,
     ) -> None:
         if not model:
             raise ValueError("SLHuntingAgent: model is required.")
@@ -165,7 +164,6 @@ class SLHuntingAgent:
         self._runner = runner
         self._fast_mode = bool(fast_mode)
         self._cfg = indicator_config or SLHuntingIndicatorConfig()
-        self._attempts = max(1, int(attempts))
         self._system_prompt = build_system_prompt() + FINAL_OUTPUT_INSTRUCTION
 
     # ------------------------------------------------------------------
@@ -375,18 +373,25 @@ class SLHuntingAgent:
             decision = SLHuntingDecision.model_validate(payload)
             return decision.model_copy(update={"model_used": self._model})
 
-        try:
-            return parse_with_retry(
-                _run_once,
-                _parse,
-                attempts=self._attempts,
-                retry_on=(SLHuntingAgentError, ValidationError),
-                label="SLHuntingDecision",
-            )
-        except Exception as exc:  # noqa: BLE001 - never kill the trading loop
-            logger.warning("SLHuntingAgent.decide failed (%s); holding.", type(exc).__name__, exc_info=True)
+        def _hold(reasoning: str) -> SLHuntingDecision:
             return SLHuntingDecision(
                 action="HOLD", confidence=0, setup="agent_error",
-                reasoning=f"Agent unavailable or returned invalid output ({type(exc).__name__}); holding.",
-                model_used=self._model,
+                reasoning=reasoning, model_used=self._model,
             )
+
+        # IMPORTANT: do NOT retry the agentic loop. Unlike the read-only Scanner
+        # agents, our order tool has SIDE EFFECTS — the agent ENTERS/EXITS via the
+        # executor DURING the loop. Re-running the loop after a malformed final JSON
+        # could double-fire an order or act against already-changed state. So we run
+        # exactly ONCE: the executor state is the source of truth for any trade, and
+        # a bad/missing final JSON simply yields a safe HOLD record (no further action).
+        try:
+            text = _run_once()
+        except Exception as exc:  # noqa: BLE001 - infra failure (SDK/CLI/usage limit)
+            logger.warning("SLHuntingAgent run failed (%s); holding.", type(exc).__name__, exc_info=True)
+            return _hold(f"Agent unavailable ({type(exc).__name__}); holding.")
+        try:
+            return _parse(text)
+        except (SLHuntingAgentError, ValidationError) as exc:
+            logger.warning("SLHuntingAgent returned invalid output (%s); holding.", type(exc).__name__)
+            return _hold(f"Agent returned invalid output ({type(exc).__name__}); holding.")

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_agent.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_agent.py
@@ -329,6 +329,7 @@ class SLHuntingAgent:
         candles: pd.DataFrame,
         executor: TradeExecutor,
         *,
+        bnf_candles: pd.DataFrame | None = None,
         live_active: bool = False,
         broker: str | None = None,
     ) -> SLHuntingDecision:
@@ -346,7 +347,8 @@ class SLHuntingAgent:
             return SLHuntingDecision(action="HOLD", confidence=0, setup="no_data", reasoning="No candles available.", model_used=self._model)
 
         tool_context = SLHuntingToolContext.build(
-            prepared, executor, cfg=self._cfg, live_active=live_active, broker=broker
+            prepared, executor, cfg=self._cfg, live_active=live_active, broker=broker,
+            bnf_candles=bnf_candles,
         )
         position = executor.snapshot()
         prompt = self._build_user_prompt(prepared, position)

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_ai_validation.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_ai_validation.py
@@ -1,0 +1,78 @@
+"""Bounded attempt budget around strict AI-output parsing.
+
+Self-contained copy of the house helper used in
+`../Streamlit Scanner App/backend/ai_validation.py`, kept local so this folder has
+no cross-repo import. The agent asks Claude for a single strict-schema JSON object;
+models occasionally return malformed output. `parse_with_retry` re-runs the agentic
+loop a bounded number of times on parse/validation failures only — never on
+infrastructure errors (SDK/CLI/usage-limit), which a retry cannot fix.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import TypeVar
+
+from pydantic import BaseModel, ConfigDict
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+
+class StrictAIModel(BaseModel):
+    """Strict base class for model-produced JSON (no coercion, no extra fields)."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+
+class AIValidationError(RuntimeError):
+    """Raised when AI output still fails strict parsing after every retry.
+
+    Only safe structural metadata is exposed (attempt count + last error type) —
+    never raw model text, which parser exceptions may contain.
+    """
+
+    def __init__(self, *, attempts: int, last_error_type: str) -> None:
+        self.attempts = max(1, int(attempts))
+        self.last_error_type = str(last_error_type)
+        noun = "attempt" if self.attempts == 1 else "attempts"
+        super().__init__(
+            "AI output failed strict validation after "
+            f"{self.attempts} {noun} (last error: {self.last_error_type})."
+        )
+
+
+def parse_with_retry(
+    run_once: Callable[[], str],
+    parse_once: Callable[[str], T],
+    *,
+    attempts: int,
+    retry_on: tuple[type[BaseException], ...],
+    label: str = "AI output",
+) -> T:
+    """Run an AI call and strictly parse it, retrying parse failures up to ``attempts``.
+
+    ``run_once`` produces the model's raw final text; any exception it raises
+    (SDK/CLI/usage-limit) propagates immediately and is NOT retried. ``parse_once``
+    turns that text into the validated object, or raises one of ``retry_on`` when
+    the output is malformed — those are retried. After every attempt fails, raises
+    :class:`AIValidationError`.
+    """
+    total = max(1, int(attempts))
+    for attempt in range(1, total + 1):
+        text = run_once()  # infrastructure errors here propagate (outside the try)
+        try:
+            return parse_once(text)
+        except retry_on as exc:
+            if attempt >= total:
+                raise AIValidationError(
+                    attempts=total,
+                    last_error_type=type(exc).__name__,
+                ) from None
+            logger.warning(
+                "%s failed validation on attempt %d/%d (%s); retrying.",
+                label, attempt, total, type(exc).__name__,
+            )
+    raise RuntimeError("parse_with_retry ran zero attempts")  # pragma: no cover

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -1,0 +1,233 @@
+# SL Hunting — Source Methodology (verbatim reference)
+
+> This is the verbatim text of the strategy author's Google Doc, kept here as the
+> agent's **ground-truth reference**. The agent's actual system prompt is the
+> *curated* version in `knowledge.py` (`build_system_prompt()`); this file is the
+> source it was distilled from, preserved so the curation can always be reviewed
+> against the original.
+>
+> NOTE: the original doc interleaves many chart screenshots (shown below as
+> `[image]`). The images are **not** reproduced here — only the prose rules are.
+> The agent therefore reasons from the written rules plus deterministic
+> tool-computed facts (pivot, fibo, candlestick patterns, structure), not from the
+> original chart pictures. (Source doc:
+> https://docs.google.com/document/d/1lzUwGFlILcELHsv1X6nMY3PNU5WqkQ6lhaoyfJdYCBs )
+
+---
+
+## Daily Trades (tf 1 min)
+
+1. Mark pivot, OHLC of previous day.
+2. Don't trade on the first candle.
+3. If market comes below pivot, wait for candlestick pattern formation with a confirmation candle (e.g. for an inside-bar / bearish-harami, wait for the confirmation candle to close below the low of the mother candle) for a sell trade.
+4. If small-small candles are forming then traders are not interested in that direction and the market may reverse.
+5. Wait for the level to come. If a doji forms with a wick above a resistance level followed by a strong confirmation red candle, take a sell trade. Market falls and gives a pullback. During the pullback it doesn't give any bullish pattern followed by confirmation, so no need to fear the slow up-move — continue the trade.
+
+- After that, it breaks pivot and support; people will sell, we'll buy after seeing bullish price action. Here we find an inside-bar candle and then a strong confirmation candle.
+- The next entry comes when it breaks the previous high (wicked high above resistance). If the market takes the exact resistance of the previous wick then we would not have taken that. Targets are all the hammer points after which the market went up.
+- If the market touches the trendline a third time, we trade in the direction of the trend; here bullish — but if there is no bullish pattern followed by confirmation the trade is avoided.
+- After a trendline break, everyone will think to sell; we look to buy after confirmation of a bullish pattern. Where will the candle turn back from? We get it from fibo (50/61/78) levels of the last low–high swing.
+- A breakout of a triangle pattern can't be sold if it has taken the exact resistance of a level. After taking the exact resistance, an upward trade activates and cancels the earlier sell activation of the triangle breakout. After it takes the resistance, check the bullish pattern at the fibo level because everyone has sold at the resistance.
+
+General rules:
+1. Any long-wicked candle (instead of a doji) can be used for entry after proper confirmation.
+2. If a candle breaks a closing, think about an upside trade, especially after a gap up.
+3. If a candle breaks a resistance (so it "has to" come down) and a psych level like 25K is within range, it will not come down heavily since a major chunk of money sits on the psych level.
+4. If a trendline break occurs to the downside but a psych level is upside, it is more confirmed to buy; the trade can be taken on the first engulfing candle itself without confirmation.
+5. Entry off the first candle's high or low, if cut by a wick, can be taken.
+6. If the market crosses a resistance, that resistance becomes support; if the market comes back to the support and creates a wick there, it will go up.
+7. Simultaneously observe BNF too: if a similar setup forms in BNF we can trade Nifty. E.g. if BNF breaks 55500 we can trade Nifty for a downward setup. If Nifty breaks a triangle upward and BNF is just about to break 55500, wait for it to break that psych level then look for a downward setup in Nifty. While falling the market may pull back from a resistance-turned-support or FVG area, but we watch the candles and wait.
+8. Most money is made in a sideways-to-trending market, not in a trending market, because we can't know where a trend will go. A purely sideways market won't make money either.
+9. If BNF breaks today's low and Nifty doesn't, the market will go up.
+10. The first candle's low and high are used for trapping. Target is the opposite side of the first candle.
+11. If a bullish candlestick forms and then the next 2-3 candles form inside it, the pattern remains valid; if confirmation comes later we can take the trade — otherwise the confirmation candle has to form immediately.
+12. If the SL is coming out large, take a pullback entry or avoid it.
+13. If the market goes fast in one direction and slow in the other, the slow-side reversal is used for SL hunting.
+14. Trade fibo levels 50/61/78 — look for a pattern to form there.
+15. The market will hunt the SLs of major turning points.
+16. A reversal bar consists of two candles; after that we need a confirmation candle.
+17. If open and low are together, treat it as a zone, not a single line.
+18. If price opens gap-down it tends toward the previous closing.
+19. If the market keeps going one way, we don't get an entry. After that small-small candles from retailers form; their SLs get hunted from above coming down.
+20. If a reverse ("ulta") fibo is plotted on the first candle, then 161 / 261 levels are reversing levels.
+21. After a long move it won't come down the first time; it will take the SL and then come.
+22. If price goes up it will fall from a fibo level to book profit.
+23. If the market takes support from the pivot, we can take a trade.
+24. If the market goes up, then after a correction it will go up again.
+25. If at the previous day's low the market forms a bullish pattern, we can enter to buy.
+26. An engulfing candle should cover the wicks too.
+27. If a candle breaks the pivot and then takes its resistance with a pin bar, we can take a sell entry — pivot-point retest.
+28. The next target is the immediate swing; the max target is the day's low.
+29. If Nifty is within ~50 points of a psych level and BNF is within ~100 points, the psych level attracts the market.
+30. If Nifty takes a resistance and BNF breaks out of some level, the market will fall.
+31. If Nifty takes support of pivot and BNF breaks some support (like the day's low), the support break will fail. If the same support line is broken again and the target is not met we can exit.
+32. If, after a trend, the market retraces up to a retracement level and then follows the trend, in following sessions don't enter near that retracement level — the market may reverse from there again.
+33. There are buyers above a level and sellers below a level.
+
+More:
+- Along with OHLC and psych level, also mark yesterday's trendline (may be relevant today) and the fibo levels between yesterday's close and today's open, so the market may reverse at the 50% level — but look for a candlestick pattern there.
+- If the market reaches support-turned-resistance and forms a bearish candlestick pattern, trade down; if it starts hovering below that level, look for a bullish pattern.
+- If the market breaks a level (lower SL / money is gone) and then forms a hammer followed by a full-body green candle, that confirms a bullish trade — but check target vs SL.
+- If the market makes a slow move it may reverse; the market only trends with fast movement so no one can enter.
+- After a gap up, wait for it to reach the closing point.
+- If the market starts falling after a gap up, it may form an N/M pattern at the 50% fibo and then fall again to reach the closing point. Otherwise if it breaks today's high everyone thinks to buy; the market will go slow there and wait for a bearish setup.
+- If the market is going up and there is a double top, that is the target; after breaching the double top the market falls.
+- Psychology means: the direction the market is going — do we have retail SLs there? The market only goes to eat retailers' SLs.
+- Trendline break after the 4th point → trade upward.
+- M-pattern breakdown, support breakdown, trendline breakdown and then activation below the line → the market can't go down now, look for a bullish trade.
+- Where a setup forms and then fails, expect a small target there.
+- Double-bottom breakdown, SL over → the market will go up.
+- First candle's high & low marked: its low gets broken but BNF takes support at that time. Everyone shorts but we buy (psychology confirmation) — but we need candlestick confirmation (technical confirmation). Here we have a reversal pattern plus a confirmation candle.
+- Inside-bar candle then a very long confirmation candle making SL 20 pts — at max our SL should be 15 points in spot, so here we compulsorily wait for a pullback. Nobody knows whether it will come, but only if it comes do we take the trade.
+
+---
+
+## Logic
+
+1. Retailer price actions: act opposite to them.
+2. Price action starts and expires at S/R levels; after expiring, a new price action may start.
+3. The market takes resistance → it goes up; it takes support → it goes down (i.e., a clean break of the level). If it traps by a wick or an immediately-returning candle at S/R, it reverses.
+4. Before entering, look for a candlestick pattern AND confirmation. The pattern may consist of multiple candles, but a confirmation candle is still needed after it.
+5. The market is a fierce battle — die-or-kill. Retailers come unprepared (money, entry, SL, risk management) and lose; they are greedy and impatient, entering without waiting for the setup and exiting quickly. Insiders come fully prepared, patient, with confidence in their setup; they wait for the setup, the right entry, and exit after the target.
+6. Market moves fast in a trend, then moves slow the opposite way to create SLs.
+7. At a turning point all SLs are gone, so the market takes a pullback after a turning point.
+8. When the market has gone down twice and sellers' SLs are available, the market moves up to take those SLs; how far up it can go is found by fibo on the first candle low–high (the low and high so far).
+
+### Entry and exit candles
+1. A long-wicked candle (hammer, etc.) tells us a target and hence exit/entry — money is parked there. The longer the wick, the more money/SL is there.
+2. A full-body candle is the confirmation candle for entry confirmation at a reversal point.
+3. After a hammer, direction depends on where the full-body confirmation candle closes — above the high or below the low of the hammer. Color does not matter for wicked candles.
+4. For engulfing patterns, we need a later confirmation candle after the two engulfing candles. The market goes in the last engulfing candle's color direction. **Color matters.**
+5. Inside bar is the opposite of engulfing — again direction is of the second candle, but the confirmation candle should confirm at the end of the mother candle. **Color matters.**
+6. Reversal-bar setup: the second candle should be the same length as the first; the market goes in the second candle's direction. Formed at S/R levels. Still need a strong confirmation candle (length may be smaller). **Color matters.**
+7. Activation: buyers accumulating, SLs below — so the market can sweep them.
+
+### S/R behavior
+- A falling market that stays above a level → buyers' SLs accumulate below the level.
+- A rising market slowing below a resistance is inviting sellers; their SLs are above the level. Works at all levels (OHLC, psych level).
+- If equal SLs are on both sides, it may trap below and then go up.
+- After a breakout, if the market stops, it will come down.
+- When taking a level trade, the candlestick pattern must form at the very top (of the level), not in between.
+- 4-candle rule: at any level, 4 candles should stop at that level.
+- If a level is broken both up and down, it's of no value (not tradeable).
+- A falling market taking support at a level means it will go further down; if it makes a bullish pattern above the level it may go up. Exception: the pivot line, and only the first time — there the market may take resistance/support directly.
+- Support can be taken at resistance-turned-support. If the move is long, the market may not retrace fully to support; for a small move it will.
+- If a candle forms a wick at support, it must be a bullish trade, not bearish.
+
+### NF/BNF comparison
+- If both indices take exact support → trade down.
+- If both indices break down → trade up.
+- If one breaks down/up and the other does not, the break will fail and the one that took support/resistance wins.
+- If one supports and the other takes resistance, wait until both align.
+- If the market makes a wick at a level, the activation there is considered failed.
+- If after a fall the market retraces to a fibo level (50/61/78), it must stop *above* a level, not below (we expect it to keep falling). If it stops below a certain level (maybe a pivot), ignore that logic.
+
+---
+
+## Trendline Logic
+
+- For a trendline's 2nd point to be enabled, the market must retrace by at least 50% of the previous swing; only then can we take the trade at the 3rd point.
+- The market just turns back after crossing a high because SLs are over there.
+- Take the trendline trade only on the 3rd point, not the 4th/5th/later. After that, think of a break and then trade.
+- At the 3rd point we can take the trade if it takes support and also if it breaks support. From the 3rd point onward we trade only on a trendline break.
+- At the 3rd point, if it breaks and then goes below 78% of the swing previous to the broken level, even then we can take a bullish trade (it may do activation below the level).
+- On a trendline, the up direction has fast movement and the down direction (pullback) has slow movement with wicks.
+- If a psych level or closing point lies in our trade direction, the success rate increases. A psych point attracts the market within ~50 points (Nifty) and ~100 points (BNF), but there's no such distance for closing-point attraction.
+- In a sideways market, first wait for the market to break one direction (to collect SLs from that side); then trade the *opposite* direction from where it first breaks.
+- A successful trendline first breaks the double top (to take all SLs and show bullishness), then falls. It may make a big red candle to entice us, but wait for a proper bearish candlestick setup.
+- After the fall, be alert at all SL levels (trendline points): activation above → falls further; activation below → may go up (slower move = better) before eventually falling, then we may sell again at the 50% fibo retracement.
+- Targets below the trendline are doji/wicked patterns at the points on the trendline; be alert at fibo levels from the lowest to the highest point of the trendline.
+- A trendline breakdown fails if it hasn't trapped the double-top buyers.
+- After a trendline breakdown, don't trade down (everyone is trading there) — wait for an upside opportunity.
+- If the first two points are close in time, treat them as one point and count the next as the next point.
+- If two points are close in time they count as one; later we get the "4th" point.
+
+---
+
+## Trade Setups (summary)
+1. After a gap down, let it come to the closing and find a bearish pattern.
+2. After a gap up, let it come to the closing and find a bullish pattern.
+3. At a trendline: support or break from the 3rd point in trend direction; from the 4th point on, only after a trendline break.
+4. Double top / double bottom break: take a reversal trade after the break.
+5. OHLC, pivot and psych-level trades.
+6. W and M pattern trades.
+7. Fibo level (50/61/78) trades.
+
+Pivot can be used as S/R directly or after retracement. Pivot changes if the timeframe changes.
+
+---
+
+## Gap up / Gap down (normal case ≈ 50 pt Nifty, 200 pt BNF)
+1. The closing point holds both buyers' and sellers' SLs, so the closing attracts the market.
+2. After a gap up, look for a downward setup; if you don't get a trade, let the market reach the closing point then look for an up trade. Mirror for gap down.
+- Why does the market gap? If there's no SL on the down side, it has to open gap-up or go up after opening.
+- After a gap down, sellers are in profit (a ₹10 option becomes ₹200); as soon as the market moves up they exit, so the operator can't get their SLs — so the operator shows them more profit (greed), and slowly moves up to create and take SLs. People think the market falls after a gap down; we think the opposite.
+- As soon as it gets a level it moves fast upward.
+- In a gap down, while moving to the closing, if the market gets a level it may retrace ~50% then rise again to reach the closing.
+- If it forms a big candle after opening and then stays a while, it may come down, cut everyone's SL, then move up. Mark the first candle's high & low for the trade.
+- If it gets a level and activates below it, take an up trade.
+- If the market creates a range at opening, it may give a false breakdown then go up to the closing.
+- Down trade after breaking up is risky because the lower target is small — especially in morning time.
+- Logical: if the first move is fast and the second move is too slow to recover, the first move will continue.
+- If it takes support at any OHLC level, it will fall again.
+
+## Big Gap up / Gap down (≈ 150 pt Nifty, 400-500 pt BNF)
+- The retailer has huge profit; if the market moves down the operator gets nothing (retail just exits). So the market keeps going up to give the retailer confidence, creates SLs, traps, and falls a little, again creates SLs, traps and falls — that's how it falls.
+- Better to trade upside from the 50% level — a big fall again is difficult. The operator may take down SLs the next day or later.
+- As soon as the market breaks the trendline it falls sharply.
+
+---
+
+## W and M Patterns
+- Breakout trading is wrong (it may turn back any time). The correct trade is when it *activates below the neckline*. If a psych level is upside it goes there, otherwise it goes to the swing where it started falling from. If a closing point is below, the market won't fall directly — it traps first, then falls.
+- In a lower W pattern we can enter at the low too because the W's first leg is already broken. Be alert at the trendline break; don't fear a resistance at the trendline because it will activate there and break out.
+- When Nifty is breaking the W's neckline and BNF is taking pivot resistance, both fall and the Nifty breakout fails.
+- If Nifty activation is above a level and BNF activation is below a level, wait until both give the same side signal.
+- M-pattern works the same way as W. There are three kinds of M patterns.
+
+---
+
+## Fibo
+1. Whatever logic applies at normal S/R levels applies to fibo levels too (activation, taking support/resistance, etc.).
+2. The market should fall ~20% before a turning point forms and we can apply fibo.
+3. Levels are only 50/61/78. If it takes support at a level it will fall and break it; if it moves up from in between levels it may go up. While going up, resistance at a level → it keeps moving up; if it breaks a level and sustains it may fall. A wick at a level → it goes up. Find the candlestick pattern first. If Nifty is taking support below 50 and BNF has broken down a level, we can take a trade.
+4. Taking support at the 78% level is valid — the market may move up from there. Take confirmation from the second index. The 78% level forms in an FVG area; even without an FVG we trust the 78% level more.
+5. If it breaks the 100% level, all SLs are over, so the chance is to reverse.
+6. For 3-4 day charts, the 38% level may also work.
+7. Fibo is applied to the recent breakout swing.
+8. Once price does a 100% retracement, shift the lower "1" (100% point) to the further-down turning point.
+9. If two OHLC levels appear at the same price it becomes a strong level (lots of SLs). Likewise if a first swing's 100% and a later swing's 78% are at the same point.
+10. 1/2/3 are 50% fibo levels of three swings; level 3 is strongest because most SLs are exhausted by then.
+11. If the bullish move is fast and the retracement on fibo is slow, trade upward only (probability rises). But if the second move is also fast, still trade upward.
+12. For 161 / 261 fibo targets, place fibo on the first correction swing in a series of swings; then 161 and 261 give the targets.
+13. Usually the market reverses from the 100% level; once it leaves into a domain with no levels, 161 and 261 guide us. After breaking 161, to go up after taking 161 support it must make a trap at 161.
+14. Nifty average momentum ≈ 200-250 a day. If Nifty has already made that, look for a level where it can fall.
+15. On a big move (e.g. 261), trade a bearish candle cautiously — V-shape recovery isn't usual; it will trap first then fall.
+
+---
+
+## Pivot Point
+1. Pivot = (H + L + C) / 3. Major SLs are here. Above pivot = buyers' market; below = sellers' market.
+2. Pivot is a neutral/balance point — it can go either way (like a car on a hill crest). Support → up; resistance → down. Activation works here, and direct S/R too — but a candlestick must form.
+3. Pivot can be exact support/resistance and is the strongest S/R.
+4. Below pivot → sell; above pivot → buy (don't overthink today's direction). But if the two indices are on opposite sides of their pivots, treat pivot as a normal S/R.
+
+### Opening setups
+- **Setup 1 (Opening, tf 5 min):** market opens and forms support at the pivot with a hammer (or any bullish candle — doji, reversal bar) and the next candle is a confirmation candle that closes above the hammer. Trade; target is above where the market fell from yesterday. Valid even if both indices are taking support. Usable on 1 min too, but 5 min has higher accuracy (also forex/crypto use 5/15 min).
+  - Better not to trade until the candle touches the pivot; even a full-body candle after the first red candle has its SL below the pivot. After the candle touches the pivot, the range is the low of that candle to the high of the first; the next candles build the range; a candle closing above the range is the bullish trade (SL below that breakout candle). Target = turning points before that (slow movement). Watch for activation before/after the target. A lower wick on the breakout candle means it trapped the in-between candles; otherwise (1 min) it must be a full-body candle. If the breakout candle's low is below earlier candles, it becomes the base pattern and needs another confirmation candle.
+- **Setup 2 (Red candle at opening):** the confirmation candle closes below the first wicked red candle (any wicked candle — body up/down/middle, color irrelevant for wicked candles) or another bearish pattern. SL above the first candle or the pivot.
+- **Setup 2 (Gap up):** wait till the market reaches the pivot. It reaches via smaller successive candles, makes a doji at the pivot, then a confirmation candle. If there's a level at the pivot and it traps that level (or the pivot), even better. Even if gap-down with closing upside, the market will go up to the closing after bouncing from the pivot.
+- **Setup 4 (Opens below pivot):** wait till it reaches the pivot (we know it's below, so it will fall). 2nd candle touches the pivot as a doji; if the 3rd candle doesn't trap the 2nd we'd trade when the 4th closes below the 2nd — but if the 3rd traps the 2nd, the 4th must close below the low of the 3rd. If many candles form the hi/lo range and the market reaches much lower then gives the confirmation candle below the range, don't trade (SL is large and above the pivot). Smaller candles = sellers losing interest; the market may reverse from any level (psych level). A closing below the range is valid for any level. Two hammers with opposite wicks → the market traverses one direction, reverses at that hammer's wick, then hunts the other hammer's SL; keep SL a little beyond to escape SL hunting.
+- **Setup 5 (>50 pt gap up):** can trade other levels between pivot and opening too; but to trade at the pivot, wait for the market to reach it. The pivot can also be a target (market becomes neutral for another trade). Support-taking at the pivot is one-time; after that treat the pivot as a normal S/R. If a closing aligns with the pivot, the market goes up after pivot support (strength enhanced). If a psych level is below the pivot within ~50/100 pts, let the market decide (SLs are down too — it goes down to hunt those first).
+- **Setup 6 (Large gap-down below pivot):** market opens below yesterday's low; trade upside with target just before the pivot (other targets just before levels). After reaching the pivot a new price action starts. If price breaches the pivot, sellers push it down and a hammer forms; if the next candle closes below it, the sell trade is on — but if another red candle forms and price goes back above the pivot, we need a closing below that candle's wick. Target = 50% fibo or where the price action started.
+- **Setup 7 (Reversal sell trade):** price opens above pivot, comes to the pivot, a candle touches the pivot, another closes above it → enter buy with SL below the pivot. If SL hits, immediately reverse to sell. Don't exit till SL hits (unless SL is in the system) — a green hammer at the pivot shows the below-pivot SLs are gone; a green confirmation above the hammer = a buy entry too. At a pivot break, both-side entries are possible. Once a red candle closes below the green hammer, enter the sell trade. Risk exists (not a full body, some wick), but it's mitigated since price did activation above the pivot then came down.
+- **Setup 8 (Gap-down reversal):** if the 3rd candle didn't close below the first candle's wick (it was green), don't sell — the setup is cancelled. After another red candle, need a fresh closing below it (which the next candles didn't do). A 7th hammer candle traps earlier candles → buyers/sellers trapped → goes buy side. Then a green candle closes above the 2nd candle's wick = the entry candle. Main SL below the low (if no level there); now SL is just below the breakout candle (it broke the pivot). If instead a long-upper-wick hammer closing below the pivot forms and the next red candle closes below it, we'd trade down (≈ activation below the pivot). If the market formed a W pattern yesterday, assume activation below the neckline → buy trade.
+- **Setup 9 (Predicts tomorrow's gap):** if the market has been opening below the pivot for ≥2-3 days and then opens above it, the market is bullish; reverse for above→below. Count only bodies vs the pivot. The more days on one side, the more bullish/bearish when it opens on the other side. Same logic for weeks (invest that week). Pivots differ by timeframe: day (15 min), week (4 H), month (D), year. We don't use the standard pivot S/R that everyone uses. Above the Day-level pivot we can start investing (it goes till it finishes the previous top's SLs). Market is bullish above pivot, bearish below.
+
+---
+
+## Misc
+- Niftybees (Nippon Nifty 50 ETF) is for long-term investment — no time decay; can hold if we don't get the target.
+- If the market keeps going one way, at some point it turns back and finds support at a fibo or psych level.
+- To get upside targets, plot fibo on the down-swing; 161 and 261 give the targets.
+- When putting fibo in reverse, look at the first reverse swing; look for reversals at 161 and 261; no trade in between even with confirmation.

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -12,6 +12,15 @@
 > tool-computed facts (pivot, fibo, candlestick patterns, structure), not from the
 > original chart pictures. (Source doc:
 > https://docs.google.com/document/d/1lzUwGFlILcELHsv1X6nMY3PNU5WqkQ6lhaoyfJdYCBs )
+>
+> **v2 image review (verified):** the full doc (108 pages, ~122 MB) was exported to
+> PDF and reviewed — a visual sample of pages spanning every section, plus the
+> complete extracted text layer of all 108 pages. The embedded images are
+> **illustrative** (annotated TradingView screenshots and whiteboard sketches of the
+> setups described in the prose) and contain **no net-new rules**: every page's
+> caption is prose already captured below. So nothing was added to the agent's
+> knowledge from the images — the text rules here, and the curation in
+> `sl_hunting_knowledge.py`, already encode the method.
 
 ---
 

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_executor.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_executor.py
@@ -62,6 +62,31 @@ def risk_based_lots(
     return max(1, math.ceil(float(risk_budget) / (risk_points * int(lot_size))))
 
 
+def stop_or_target_hit(direction: str, stop: float, target: float, price: float) -> str | None:
+    """Return 'AI_STOP' / 'AI_TARGET' / None for a spot `price` vs the open position's
+    underlying stop/target levels.
+
+    Used by the master worker to ENFORCE the agent's stop/target on every poll — the
+    agent only re-decides once per completed bar, so without this an option position
+    would stay open (only max-loss / square-off / a later AI EXIT would close it) and
+    the ~Rs.2500 risk budget would not be bounded. Zero levels mean "not set" (skip).
+    """
+    direction = (direction or "").strip().upper()
+    price = float(price)
+    s, t = float(stop or 0.0), float(target or 0.0)
+    if direction == "LONG":
+        if s and price <= s:
+            return "AI_STOP"
+        if t and price >= t:
+            return "AI_TARGET"
+    elif direction == "SHORT":
+        if s and price >= s:
+            return "AI_STOP"
+        if t and price <= t:
+            return "AI_TARGET"
+    return None
+
+
 def execution_tool_name(live_active: bool, broker: str | None) -> str:
     """Return the single order-tool name the configuration selects.
 

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_executor.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_executor.py
@@ -27,12 +27,39 @@ already in a position, and cannot EXIT while flat.
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Protocol, runtime_checkable
 
 # Valid directions the agent may request. LONG → buy CE (expect up); SHORT → buy PE.
 VALID_DIRECTIONS = ("LONG", "SHORT")
+
+# Default rupee risk budget per trade (used by dynamic position sizing). The agent
+# does NOT choose the lot count — it is computed so the worst-case underlying-points
+# loss is ~= this budget, exactly like the repo's Profit Shooter sizer.
+DEFAULT_RISK_BUDGET = 2500.0
+
+
+def risk_based_lots(
+    entry: float,
+    stop: float,
+    lot_size: int,
+    risk_budget: float = DEFAULT_RISK_BUDGET,
+    fallback_lots: int = 1,
+) -> int:
+    """Lots sized so the worst-case underlying-points loss ~= ``risk_budget``.
+
+    ``risk_points`` is the agent's UNDERLYING (spot) stop distance; the rupee risk
+    proxy is ``risk_points * lot_size`` per lot (a conservative delta~=1 proxy, the
+    same one Profit Shooter / Goldmine / Money Machine use). ``math.ceil`` over a
+    positive ratio guarantees a minimum of 1 lot, so a trade is never sized to zero.
+    Falls back to ``fallback_lots`` when the stop distance is unusable.
+    """
+    risk_points = abs(float(entry) - float(stop))
+    if risk_points <= 0 or int(lot_size) <= 0:
+        return max(1, int(fallback_lots))
+    return max(1, math.ceil(float(risk_budget) / (risk_points * int(lot_size))))
 
 
 def execution_tool_name(live_active: bool, broker: str | None) -> str:
@@ -86,6 +113,7 @@ class _PaperPosition:
     target: float = 0.0
     entry_time: str = ""
     reason: str = ""
+    lots: int = 0
 
 
 class StandaloneExecutor:
@@ -97,9 +125,10 @@ class StandaloneExecutor:
     The closed-trade log is kept so the runner can print a session summary.
     """
 
-    def __init__(self, *, lots: int = 1, lot_size: int = 75) -> None:
-        self.lots = int(lots)
+    def __init__(self, *, lots: int = 1, lot_size: int = 75, risk_budget: float = DEFAULT_RISK_BUDGET) -> None:
+        self.lots = int(lots)  # fallback when the stop distance is unusable
         self.lot_size = int(lot_size)
+        self.risk_budget = float(risk_budget)
         self.pos = _PaperPosition()
         self.closed_trades: list[dict[str, Any]] = []
 
@@ -109,6 +138,8 @@ class StandaloneExecutor:
             return {"accepted": False, "reason": f"invalid direction {direction!r}; expected LONG or SHORT"}
         if self.pos.active:
             return {"accepted": False, "reason": "already in a position; EXIT first before entering again"}
+        # Dynamic sizing: lots chosen so worst-case risk ~= self.risk_budget (Rs.2500).
+        lots = risk_based_lots(float(price), float(stop), self.lot_size, self.risk_budget, self.lots)
         self.pos = _PaperPosition(
             active=True,
             direction=direction,
@@ -117,20 +148,23 @@ class StandaloneExecutor:
             target=round(float(target), 2),
             entry_time=datetime.now().isoformat(timespec="seconds"),
             reason=str(reason)[:300],
+            lots=lots,
         )
-        return {"accepted": True, "action": f"ENTER_{direction}", "entry": self.pos.entry, "stop": self.pos.stop, "target": self.pos.target}
+        return {"accepted": True, "action": f"ENTER_{direction}", "entry": self.pos.entry, "stop": self.pos.stop, "target": self.pos.target, "lots": lots, "quantity": lots * self.lot_size}
 
     def exit(self, reason: str, price: float) -> dict[str, Any]:
         if not self.pos.active:
             return {"accepted": False, "reason": "no open position to exit"}
         last = float(price)
         pts = (last - self.pos.entry) if self.pos.direction == "LONG" else (self.pos.entry - last)
-        pnl = round(pts * self.lots * self.lot_size, 2)
+        lots = self.pos.lots or self.lots
+        pnl = round(pts * lots * self.lot_size, 2)
         trade = {
             "direction": self.pos.direction,
             "entry": self.pos.entry,
             "exit": round(last, 2),
             "points": round(pts, 2),
+            "lots": lots,
             "pnl_proxy": pnl,
             "entry_time": self.pos.entry_time,
             "exit_time": datetime.now().isoformat(timespec="seconds"),
@@ -157,7 +191,8 @@ class StandaloneExecutor:
         if not self.pos.active:
             return {"in_position": False}
         pts = (price - self.pos.entry) if self.pos.direction == "LONG" else (self.pos.entry - price)
-        return {"in_position": True, "points": round(pts, 2), "pnl_proxy": round(pts * self.lots * self.lot_size, 2)}
+        lots = self.pos.lots or self.lots
+        return {"in_position": True, "points": round(pts, 2), "lots": lots, "pnl_proxy": round(pts * lots * self.lot_size, 2)}
 
 
 # ---------------------------------------------------------------------------

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_executor.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_executor.py
@@ -1,0 +1,222 @@
+"""Trade-execution seam for the SL Hunting AI Agent.
+
+Beginner note (why this file exists)
+------------------------------------
+The agent decides WHAT to do (enter long/short, exit). WHERE that order goes —
+paper bookkeeping, or a real Kotak / Shoonya order through the master's shared
+broker session — is a separate concern. This module is that seam.
+
+The agent core never imports a broker. Instead it is handed ONE `TradeExecutor`
+(dependency injection, exactly like the Streamlit Scanner App injects a `runner`):
+
+- `StandaloneExecutor`  — paper-only bookkeeping for the folder's standalone runner
+  (`sl_hunting_runner.py`). P&L is a simple proxy on the NIFTY underlying, which is
+  fine for validating the agent's direction/timing without an option chain.
+- `MasterWorkerExecutor` — used inside the master front-test. It delegates to the
+  worker's existing, safe `enter_position` / `exit_position` methods, which already
+  resolve the ATM option, place paper OR real orders (via `_place_real_leg`),
+  enforce max-loss / square-off, and publish Telegram alerts. The live-vs-paper and
+  Kotak-vs-Shoonya decision therefore stays exactly where the rest of the system
+  makes it — nothing new is invented here.
+
+SAFETY: the agent is only ever given the SINGLE execution tool the configuration
+selected (see `execution_tool_name`). It can never choose paper-vs-real or the
+broker — the environment does. Every executor guards state: you cannot ENTER while
+already in a position, and cannot EXIT while flat.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Protocol, runtime_checkable
+
+# Valid directions the agent may request. LONG → buy CE (expect up); SHORT → buy PE.
+VALID_DIRECTIONS = ("LONG", "SHORT")
+
+
+def execution_tool_name(live_active: bool, broker: str | None) -> str:
+    """Return the single order-tool name the configuration selects.
+
+    This is the literal realisation of "three tools, the env picks one":
+    - not live                     → ``place_paper_order``
+    - live + LIVE_BROKER=KOTAK     → ``place_kotak_order``
+    - live + LIVE_BROKER=SHOONYA   → ``place_shoonya_order``
+
+    Only this one name is ever registered, so the agent cannot pick the venue.
+    """
+    if not live_active:
+        return "place_paper_order"
+    broker_up = (broker or "").strip().upper()
+    if broker_up == "KOTAK":
+        return "place_kotak_order"
+    if broker_up == "SHOONYA":
+        return "place_shoonya_order"
+    # Fail closed: unknown broker → paper (mirrors the master's broker fail-closed).
+    return "place_paper_order"
+
+
+@runtime_checkable
+class TradeExecutor(Protocol):
+    """The minimal surface the execution tool needs. Implemented two ways below."""
+
+    def enter(self, direction: str, stop: float, target: float, reason: str, price: float) -> dict[str, Any]:
+        """Open a position (or reject if already in one). Returns a result dict."""
+        ...
+
+    def exit(self, reason: str, price: float) -> dict[str, Any]:
+        """Close the open position (or reject if flat). Returns a result dict."""
+        ...
+
+    def snapshot(self) -> dict[str, Any]:
+        """Return the current position state for the `position_state` tool."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Standalone (paper) executor
+# ---------------------------------------------------------------------------
+
+@dataclass
+class _PaperPosition:
+    active: bool = False
+    direction: str = ""
+    entry: float = 0.0
+    stop: float = 0.0
+    target: float = 0.0
+    entry_time: str = ""
+    reason: str = ""
+
+
+class StandaloneExecutor:
+    """Paper bookkeeping for the standalone runner.
+
+    P&L is a proxy on the underlying: ``(last - entry)`` for LONG and
+    ``(entry - last)`` for SHORT, in NIFTY points × lots × lot_size. This is
+    deliberately simple — it validates the agent's *decisions*, not option pricing.
+    The closed-trade log is kept so the runner can print a session summary.
+    """
+
+    def __init__(self, *, lots: int = 1, lot_size: int = 75) -> None:
+        self.lots = int(lots)
+        self.lot_size = int(lot_size)
+        self.pos = _PaperPosition()
+        self.closed_trades: list[dict[str, Any]] = []
+
+    def enter(self, direction: str, stop: float, target: float, reason: str, price: float) -> dict[str, Any]:
+        direction = (direction or "").strip().upper()
+        if direction not in VALID_DIRECTIONS:
+            return {"accepted": False, "reason": f"invalid direction {direction!r}; expected LONG or SHORT"}
+        if self.pos.active:
+            return {"accepted": False, "reason": "already in a position; EXIT first before entering again"}
+        self.pos = _PaperPosition(
+            active=True,
+            direction=direction,
+            entry=round(float(price), 2),
+            stop=round(float(stop), 2),
+            target=round(float(target), 2),
+            entry_time=datetime.now().isoformat(timespec="seconds"),
+            reason=str(reason)[:300],
+        )
+        return {"accepted": True, "action": f"ENTER_{direction}", "entry": self.pos.entry, "stop": self.pos.stop, "target": self.pos.target}
+
+    def exit(self, reason: str, price: float) -> dict[str, Any]:
+        if not self.pos.active:
+            return {"accepted": False, "reason": "no open position to exit"}
+        last = float(price)
+        pts = (last - self.pos.entry) if self.pos.direction == "LONG" else (self.pos.entry - last)
+        pnl = round(pts * self.lots * self.lot_size, 2)
+        trade = {
+            "direction": self.pos.direction,
+            "entry": self.pos.entry,
+            "exit": round(last, 2),
+            "points": round(pts, 2),
+            "pnl_proxy": pnl,
+            "entry_time": self.pos.entry_time,
+            "exit_time": datetime.now().isoformat(timespec="seconds"),
+            "exit_reason": str(reason)[:300],
+        }
+        self.closed_trades.append(trade)
+        self.pos = _PaperPosition()
+        return {"accepted": True, "action": "EXIT", **trade}
+
+    def snapshot(self) -> dict[str, Any]:
+        if not self.pos.active:
+            return {"in_position": False}
+        return {
+            "in_position": True,
+            "direction": self.pos.direction,
+            "entry": self.pos.entry,
+            "stop": self.pos.stop,
+            "target": self.pos.target,
+            "entry_time": self.pos.entry_time,
+        }
+
+    def mark(self, price: float) -> dict[str, Any]:
+        """Return the live unrealised P&L proxy for the open position (helper)."""
+        if not self.pos.active:
+            return {"in_position": False}
+        pts = (price - self.pos.entry) if self.pos.direction == "LONG" else (self.pos.entry - price)
+        return {"in_position": True, "points": round(pts, 2), "pnl_proxy": round(pts * self.lots * self.lot_size, 2)}
+
+
+# ---------------------------------------------------------------------------
+# Master-worker executor (live-capable; delegates to the worker)
+# ---------------------------------------------------------------------------
+
+class MasterWorkerExecutor:
+    """Delegates to an `AtmSingleLegStrategyWorker` instance in the master runner.
+
+    The worker already owns the safe path: `enter_position(direction,
+    entry_underlying, stop_underlying, target_underlying)` resolves the ATM
+    option and places a paper OR real order (per `worker.live_trading` +
+    `LIVE_BROKER`), and `exit_position(reason)` closes it — both with max-loss /
+    square-off / Telegram handled. We duck-type the worker so this module never
+    imports the master.
+    """
+
+    def __init__(self, worker: Any) -> None:
+        self._w = worker
+
+    def enter(self, direction: str, stop: float, target: float, reason: str, price: float) -> dict[str, Any]:
+        direction = (direction or "").strip().upper()
+        if direction not in VALID_DIRECTIONS:
+            return {"accepted": False, "reason": f"invalid direction {direction!r}; expected LONG or SHORT"}
+        pos = getattr(self._w, "pos", None)
+        if pos is not None and getattr(pos, "active", False):
+            return {"accepted": False, "reason": "already in a position; EXIT first before entering again"}
+        ok = bool(self._w.enter_position(
+            direction,
+            float(price),
+            stop_underlying=float(stop),
+            target_underlying=float(target),
+        ))
+        if not ok:
+            return {"accepted": False, "reason": "worker rejected the entry (e.g. could not resolve option / outside trading window)"}
+        return {"accepted": True, "action": f"ENTER_{direction}", "entry": round(float(price), 2), "stop": round(float(stop), 2), "target": round(float(target), 2)}
+
+    def exit(self, reason: str, price: float) -> dict[str, Any]:
+        pos = getattr(self._w, "pos", None)
+        if pos is None or not getattr(pos, "active", False):
+            return {"accepted": False, "reason": "no open position to exit"}
+        self._w.exit_position(str(reason)[:300] or "AI_EXIT")
+        return {"accepted": True, "action": "EXIT", "reason": str(reason)[:300]}
+
+    def snapshot(self) -> dict[str, Any]:
+        pos = getattr(self._w, "pos", None)
+        if pos is None or not getattr(pos, "active", False):
+            return {"in_position": False}
+        snap: dict[str, Any] = {
+            "in_position": True,
+            "direction": getattr(pos, "direction", ""),
+            "entry": round(float(getattr(pos, "entry_underlying", 0.0) or 0.0), 2),
+            "stop": round(float(getattr(pos, "stop_underlying", 0.0) or 0.0), 2),
+            "target": round(float(getattr(pos, "target_underlying", 0.0) or 0.0), 2),
+        }
+        getter = getattr(self._w, "_get_open_position_pnl", None)
+        if callable(getter):
+            try:
+                snap["unrealized_pnl"] = round(float(getter()), 2)
+            except Exception:  # noqa: BLE001 - best-effort enrichment only
+                pass
+        return snap

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_indicators.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_indicators.py
@@ -70,6 +70,9 @@ class SLHuntingIndicatorConfig:
     # "Fast vs slow": compare the average body of the latest third of the window to
     # the prior portion; ratio above/below these flags acceleration/deceleration.
     speed_window: int = 20
+    # Cross-index (NF/BNF): how close (fraction of price) the last price must be to a
+    # level to count as "at" that level / pivot.
+    cross_index_band_pct: float = 0.15
 
 
 # ---------------------------------------------------------------------------
@@ -495,4 +498,141 @@ def market_structure(
         "double_top": double_top,
         "double_bottom": double_bottom,
         "note": "Trade a trendline only on the 3rd touch or a confirmed break (4th+). For W/M, trade the activation after the neckline break, not the breakout itself.",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Cross-index (NIFTY vs BankNIFTY) confirmation
+# ---------------------------------------------------------------------------
+
+def index_position(
+    candles: pd.DataFrame,
+    cfg: SLHuntingIndicatorConfig | None = None,
+) -> dict[str, Any]:
+    """Classify one index's current position vs its own pivot and key levels.
+
+    Returns a compact read used by `cross_index_signal`: where the last price sits
+    relative to the day pivot, the nearest support/resistance among {pivot, prev-day
+    H/L, today H/L, prev close, nearest psych}, whether it is *at* support/resistance
+    (within a small band), and whether it has recently broken the pivot up/down.
+    Heuristic but deterministic — the agent applies the nuance.
+    """
+    cfg = cfg or SLHuntingIndicatorConfig()
+    pl = pivot_and_levels(candles, cfg)
+    if not pl.get("available"):
+        return {"available": False}
+    df = prepare_candles(candles)
+    last = float(pl["last_price"])
+    band = max(cfg.cross_index_band_pct / 100.0 * last, 1e-6)
+    pivot = pl.get("pivot")
+    prev = pl.get("previous_day_ohlc") or {}
+
+    levels: list[tuple[str, float]] = []
+    if pivot is not None:
+        levels.append(("pivot", float(pivot)))
+    # Stable levels only (pivot, prev-day OHLC, nearest psych). Today's H/L are
+    # excluded — they sit right next to price and would make "at a level" trivial.
+    for name, val in (
+        ("prev_high", prev.get("high")), ("prev_low", prev.get("low")),
+        ("prev_close", pl.get("previous_close")),
+    ):
+        if val is not None:
+            levels.append((name, float(val)))
+    psych = pl.get("psych_levels") or []
+    if psych:
+        levels.append(("psych", float(min(psych, key=lambda p: abs(p - last)))))
+
+    # A level at/below price is potential support; strictly above is resistance.
+    supports = [(n, v) for n, v in levels if v <= last]
+    resistances = [(n, v) for n, v in levels if v > last]
+    nearest_support = max(supports, key=lambda nv: nv[1]) if supports else None
+    nearest_resistance = min(resistances, key=lambda nv: nv[1]) if resistances else None
+    at_support = bool(nearest_support and (last - nearest_support[1]) <= band)
+    at_resistance = bool(nearest_resistance and (nearest_resistance[1] - last) <= band)
+
+    if pivot is None:
+        vs_pivot = "unknown"
+    elif abs(last - pivot) <= band:
+        vs_pivot = "at"
+    else:
+        vs_pivot = "above" if last > pivot else "below"
+
+    broke_pivot_down = broke_pivot_up = False
+    if pivot is not None and len(df) >= 2:
+        recent = df.tail(6)
+        if last < pivot - band and float(recent["high"].max()) >= pivot:
+            broke_pivot_down = True
+        if last > pivot + band and float(recent["low"].min()) <= pivot:
+            broke_pivot_up = True
+
+    return {
+        "available": True,
+        "last": round(last, 2),
+        "pivot": round(pivot, 2) if pivot is not None else None,
+        "vs_pivot": vs_pivot,
+        "at_support": at_support,
+        "at_resistance": at_resistance,
+        "nearest_support": {"name": nearest_support[0], "price": round(nearest_support[1], 2)} if nearest_support else None,
+        "nearest_resistance": {"name": nearest_resistance[0], "price": round(nearest_resistance[1], 2)} if nearest_resistance else None,
+        "broke_pivot_down": broke_pivot_down,
+        "broke_pivot_up": broke_pivot_up,
+    }
+
+
+def cross_index_signal(
+    nifty_df: pd.DataFrame,
+    bnf_df: pd.DataFrame | None,
+    cfg: SLHuntingIndicatorConfig | None = None,
+) -> dict[str, Any]:
+    """Compare NIFTY vs BankNIFTY and emit the doc's NF/BNF alignment verdict.
+
+    Faithful to the method's NF/BNF rules (advisory):
+    - both at support   -> bias DOWN (operator likely breaks the support / SL-hunt)
+    - both breakdown     -> bias UP   (the breakdown reverses)
+    - both at resistance -> bias UP;  both breakup -> bias DOWN
+    - one breaks, the other holds -> the break likely FAILS; bias toward the holder
+    - opposite sides of pivot -> treat pivot as a normal level; WAIT for alignment
+    Returns {"available": false, ...} when BankNIFTY data is missing.
+    """
+    cfg = cfg or SLHuntingIndicatorConfig()
+    n = index_position(nifty_df, cfg)
+    b = index_position(bnf_df, cfg) if bnf_df is not None else {"available": False}
+    if not (n.get("available") and b.get("available")):
+        return {"available": False, "reason": "BankNIFTY data unavailable; judge on NIFTY alone (be more conservative)."}
+
+    alignment, bias, reason = "neutral", "none", ""
+    if n["broke_pivot_down"] and b["broke_pivot_down"]:
+        alignment, bias = "both_breakdown", "up"
+        reason = "Both indices broke down through pivot -> breakdown reverses; bias UP."
+    elif n["broke_pivot_up"] and b["broke_pivot_up"]:
+        alignment, bias = "both_breakup", "down"
+        reason = "Both indices broke up through pivot -> breakup reverses; bias DOWN."
+    elif n["at_support"] and b["at_support"]:
+        alignment, bias = "both_at_support", "down"
+        reason = "Both indices at support -> support likely fails; bias DOWN."
+    elif n["at_resistance"] and b["at_resistance"]:
+        alignment, bias = "both_at_resistance", "up"
+        reason = "Both indices at resistance -> continuation up; bias UP."
+    elif (n["broke_pivot_down"] != b["broke_pivot_down"]) and (n["at_support"] or b["at_support"]):
+        holder = "BankNIFTY" if n["broke_pivot_down"] else "NIFTY"
+        alignment, bias = "divergence_breakdown", "up"
+        reason = f"One index broke down while {holder} held support -> breakdown likely fails; bias UP toward the holder."
+    elif n["vs_pivot"] in ("above", "below") and b["vs_pivot"] in ("above", "below") and n["vs_pivot"] != b["vs_pivot"]:
+        alignment, bias = "opposite_sides_of_pivot", "wait"
+        reason = "Indices are on opposite sides of their pivots -> treat pivot as a normal level and WAIT for alignment."
+    elif n["vs_pivot"] == b["vs_pivot"] == "above":
+        alignment, bias = "both_above_pivot", "up_context"
+        reason = "Both above pivot -> buyers' market on both; bullish context."
+    elif n["vs_pivot"] == b["vs_pivot"] == "below":
+        alignment, bias = "both_below_pivot", "down_context"
+        reason = "Both below pivot -> sellers' market on both; bearish context."
+
+    return {
+        "available": True,
+        "alignment": alignment,
+        "bias": bias,
+        "reason": reason,
+        "nifty": n,
+        "bank_nifty": b,
+        "note": "Advisory: weigh with the NIFTY setup. 'wait' = require alignment; if this disagrees with your NIFTY read, prefer HOLD.",
     }

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_indicators.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_indicators.py
@@ -1,0 +1,498 @@
+"""Deterministic price-action detectors for the SL Hunting AI Agent.
+
+Beginner note (why this file exists)
+------------------------------------
+The Claude agent should reason about *facts*, not eyeball a candle dump. So this
+module computes the SL-Hunting method's building blocks deterministically from a
+plain OHLC candle table:
+
+- `pivot_and_levels(...)`  → day pivot, previous-day OHLC, today O/H/L, first-candle
+                             hi/lo, nearby psychological levels, previous close.
+- `fibo_levels(...)`       → 50/61/78 retracement + 161/261 extension of the most
+                             recent significant swing, and where price sits.
+- `candle_patterns(...)`   → reversal patterns (hammer/doji, engulfing, inside-bar,
+                             reversal-bar, star) on recent candles, each tagged with
+                             whether a CONFIRMATION candle has already printed.
+- `market_structure(...)`  → swing points, trend, fast/slow read, trendline points,
+                             W/M and double top/bottom.
+
+Everything here is a pure function of (candles, config) — no randomness, no network
+— so the agent's per-bar decisions are reproducible and cacheable. The functions
+return plain JSON-serialisable dicts/lists so the MCP tools in `tools.py` can wrap
+them directly.
+
+Input contract: a pandas DataFrame with columns ``open, high, low, close`` (and
+optionally ``volume``) plus a ``timestamp`` column OR a DatetimeIndex, ordered
+oldest → newest. Helper `prepare_candles` normalises this.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+# Fibonacci ratios used by the method (retracements + extensions).
+_RETRACEMENTS = (0.5, 0.618, 0.786)
+_EXTENSIONS = (1.272, 1.618, 2.618)
+
+
+@dataclass(frozen=True)
+class SLHuntingIndicatorConfig:
+    """All tunable detector settings in one beginner-friendly place.
+
+    Defaults are chosen for 5-minute NIFTY candles (the agent's default derived
+    timeframe) but work for 1-minute too. The agent does the final judgement, so
+    these only need to surface useful, deterministic facts — not be perfect.
+    """
+
+    # Candle anatomy thresholds (fractions of the candle's full range).
+    doji_body_max_ratio: float = 0.10          # body <= 10% of range → doji
+    long_wick_min_ratio: float = 0.55          # one wick >= 55% of range → long-wick
+    full_body_min_ratio: float = 0.55          # body >= 55% of range → "full body" (confirmation)
+    # How many of the most recent COMPLETED candles to scan for patterns.
+    pattern_lookback: int = 12
+    # Engulfing tolerance (fraction) when comparing bodies.
+    engulf_tolerance: float = 0.0
+    # Inside-bar: child range must be within parent range (no tolerance by default).
+    # Swing detection: a pivot needs this many lower/higher bars on each side.
+    swing_left: int = 2
+    swing_right: int = 2
+    swing_lookback: int = 120                  # bars to scan for swings / fibo
+    # Two swings count as a "double"/equal level if within this fraction.
+    double_tolerance_pct: float = 0.25
+    # Psychological levels: nearest round numbers. NIFTY ≈ 25000, so 50/100-point
+    # steps are the meaningful psych grid; we surface the nearby ones.
+    psych_step: float = 100.0
+    psych_window: int = 3                       # how many psych levels each side of price
+    # "Fast vs slow": compare the average body of the latest third of the window to
+    # the prior portion; ratio above/below these flags acceleration/deceleration.
+    speed_window: int = 20
+
+
+# ---------------------------------------------------------------------------
+# Frame preparation
+# ---------------------------------------------------------------------------
+
+def prepare_candles(candles: pd.DataFrame) -> pd.DataFrame:
+    """Return a clean, time-sorted OHLC frame with a ``timestamp`` column.
+
+    Accepts a ``timestamp`` column or a DatetimeIndex; coerces OHLC to float;
+    drops rows with missing OHLC; sorts oldest → newest; resets the index.
+    """
+    if candles is None or len(candles) == 0:
+        return pd.DataFrame(columns=["timestamp", "open", "high", "low", "close", "volume"])
+
+    df = candles.copy()
+    if "timestamp" not in df.columns:
+        # Fall back to the index if it looks like a datetime.
+        df = df.reset_index()
+        # After reset_index the datetime index becomes a column; find it.
+        for cand in ("timestamp", "index", "date", "datetime", "Datetime", "Date"):
+            if cand in df.columns:
+                df = df.rename(columns={cand: "timestamp"})
+                break
+    if "timestamp" not in df.columns:
+        raise ValueError("prepare_candles: need a 'timestamp' column or a DatetimeIndex.")
+
+    df["timestamp"] = pd.to_datetime(df["timestamp"], errors="coerce")
+    for col in ("open", "high", "low", "close"):
+        if col not in df.columns:
+            raise ValueError(f"prepare_candles: missing required column '{col}'.")
+        df[col] = pd.to_numeric(df[col], errors="coerce")
+    if "volume" not in df.columns:
+        df["volume"] = 0.0
+    df["volume"] = pd.to_numeric(df["volume"], errors="coerce").fillna(0.0)
+
+    df = df.dropna(subset=["timestamp", "open", "high", "low", "close"])
+    df = df.sort_values("timestamp").reset_index(drop=True)
+    return df[["timestamp", "open", "high", "low", "close", "volume"]]
+
+
+# ---------------------------------------------------------------------------
+# Candle anatomy helpers
+# ---------------------------------------------------------------------------
+
+def _anatomy(row: pd.Series, cfg: SLHuntingIndicatorConfig) -> dict[str, Any]:
+    """Describe one candle: body, wicks, and simple shape flags."""
+    o, h, l, c = float(row.open), float(row.high), float(row.low), float(row.close)
+    rng = max(h - l, 1e-9)
+    body = abs(c - o)
+    upper = h - max(o, c)
+    lower = min(o, c) - l
+    is_bull = c > o
+    return {
+        "open": round(o, 2),
+        "high": round(h, 2),
+        "low": round(l, 2),
+        "close": round(c, 2),
+        "range": round(rng, 2),
+        "body": round(body, 2),
+        "upper_wick": round(upper, 2),
+        "lower_wick": round(lower, 2),
+        "is_bull": bool(is_bull),
+        "is_bear": bool(c < o),
+        "is_doji": bool(body <= cfg.doji_body_max_ratio * rng),
+        "is_full_body": bool(body >= cfg.full_body_min_ratio * rng),
+        "is_hammer": bool(lower >= cfg.long_wick_min_ratio * rng and upper <= 0.25 * rng),
+        "is_shooting_star": bool(upper >= cfg.long_wick_min_ratio * rng and lower <= 0.25 * rng),
+        "is_long_wick": bool(max(upper, lower) >= cfg.long_wick_min_ratio * rng),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Pivot, OHLC and key levels
+# ---------------------------------------------------------------------------
+
+def pivot_and_levels(
+    candles: pd.DataFrame,
+    cfg: SLHuntingIndicatorConfig | None = None,
+) -> dict[str, Any]:
+    """Compute the day pivot, previous-day OHLC, today's levels and psych levels.
+
+    Splits the intraday frame by calendar date: the latest date is "today", the
+    date before it is the "previous day". Pivot = (prevHigh + prevLow + prevClose)/3.
+    Psychological levels are the round numbers (``psych_step`` grid) nearest the
+    current price. Distances are reported in points and percent so the agent can
+    judge "near a level".
+    """
+    cfg = cfg or SLHuntingIndicatorConfig()
+    df = prepare_candles(candles)
+    if df.empty:
+        return {"available": False, "reason": "no candles"}
+
+    df = df.assign(_date=df["timestamp"].dt.date)
+    dates = list(dict.fromkeys(df["_date"].tolist()))  # unique, order-preserving
+    today = dates[-1]
+    today_df = df[df["_date"] == today]
+    last_price = float(today_df["close"].iloc[-1])
+
+    prev_day: dict[str, Any] | None = None
+    pivot: float | None = None
+    if len(dates) >= 2:
+        prev = dates[-2]
+        prev_df = df[df["_date"] == prev]
+        ph, pl, pc, po = (
+            float(prev_df["high"].max()),
+            float(prev_df["low"].min()),
+            float(prev_df["close"].iloc[-1]),
+            float(prev_df["open"].iloc[0]),
+        )
+        prev_day = {"open": round(po, 2), "high": round(ph, 2), "low": round(pl, 2), "close": round(pc, 2)}
+        pivot = round((ph + pl + pc) / 3.0, 2)
+
+    first = today_df.iloc[0]
+    today_levels = {
+        "open": round(float(today_df["open"].iloc[0]), 2),
+        "high": round(float(today_df["high"].max()), 2),
+        "low": round(float(today_df["low"].min()), 2),
+        "last": round(last_price, 2),
+        "first_candle_high": round(float(first.high), 2),
+        "first_candle_low": round(float(first.low), 2),
+        "first_candle_time": str(first.timestamp),
+    }
+
+    # Psychological round-number levels around current price.
+    step = cfg.psych_step
+    base = round(last_price / step) * step
+    psych = sorted(
+        {round(base + k * step, 2) for k in range(-cfg.psych_window, cfg.psych_window + 1)}
+    )
+
+    def _dist(level: float | None) -> dict[str, Any] | None:
+        if level is None:
+            return None
+        pts = round(last_price - level, 2)
+        return {"level": round(level, 2), "points_away": pts, "pct_away": round(100.0 * pts / max(level, 1e-9), 3)}
+
+    return {
+        "available": True,
+        "last_price": round(last_price, 2),
+        "pivot": pivot,
+        "previous_day_ohlc": prev_day,
+        "previous_close": prev_day["close"] if prev_day else None,
+        "today": today_levels,
+        "psych_levels": psych,
+        "psych_step": step,
+        "distance_to": {
+            "pivot": _dist(pivot),
+            "previous_close": _dist(prev_day["close"]) if prev_day else None,
+            "previous_high": _dist(prev_day["high"]) if prev_day else None,
+            "previous_low": _dist(prev_day["low"]) if prev_day else None,
+            "today_open": _dist(today_levels["open"]),
+            "nearest_psych": _dist(min(psych, key=lambda p: abs(p - last_price))) if psych else None,
+        },
+        "note": "Above pivot = buyers' market; below = sellers'. A WICK at a level = trap/reversal; a clean BREAK = continuation.",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Swings (used by fibo + structure)
+# ---------------------------------------------------------------------------
+
+def _swings(df: pd.DataFrame, cfg: SLHuntingIndicatorConfig) -> list[dict[str, Any]]:
+    """Return fractal swing highs/lows in the recent window (oldest → newest)."""
+    window = df.tail(cfg.swing_lookback).reset_index(drop=True)
+    n = len(window)
+    left, right = cfg.swing_left, cfg.swing_right
+    swings: list[dict[str, Any]] = []
+    for i in range(left, n - right):
+        hi = float(window.high.iloc[i])
+        lo = float(window.low.iloc[i])
+        is_high = all(hi >= float(window.high.iloc[j]) for j in range(i - left, i + right + 1) if j != i)
+        is_low = all(lo <= float(window.low.iloc[j]) for j in range(i - left, i + right + 1) if j != i)
+        if is_high:
+            swings.append({"kind": "high", "price": round(hi, 2), "time": str(window.timestamp.iloc[i]), "bars_ago": n - 1 - i})
+        elif is_low:
+            swings.append({"kind": "low", "price": round(lo, 2), "time": str(window.timestamp.iloc[i]), "bars_ago": n - 1 - i})
+    return swings
+
+
+# ---------------------------------------------------------------------------
+# Fibonacci
+# ---------------------------------------------------------------------------
+
+def fibo_levels(
+    candles: pd.DataFrame,
+    cfg: SLHuntingIndicatorConfig | None = None,
+) -> dict[str, Any]:
+    """Compute fibo retracement/extension off the most recent significant swing.
+
+    Uses the latest swing high and latest swing low in the window to define the
+    impulse (direction = whichever of the two is more recent is the END of the
+    move). Reports 50/61/78 retracements, 161/261 extensions, and where the
+    current price sits relative to them.
+    """
+    cfg = cfg or SLHuntingIndicatorConfig()
+    df = prepare_candles(candles)
+    if len(df) < (cfg.swing_left + cfg.swing_right + 2):
+        return {"available": False, "reason": "not enough candles"}
+
+    swings = _swings(df, cfg)
+    highs = [s for s in swings if s["kind"] == "high"]
+    lows = [s for s in swings if s["kind"] == "low"]
+    if not highs or not lows:
+        return {"available": False, "reason": "no clear swing high/low"}
+
+    last_high = min(highs, key=lambda s: s["bars_ago"])
+    last_low = min(lows, key=lambda s: s["bars_ago"])
+    hi, lo = last_high["price"], last_low["price"]
+    if hi <= lo:
+        return {"available": False, "reason": "degenerate swing"}
+
+    # Direction: if the high is more recent than the low → up-swing (low→high), so
+    # retracements pull DOWN from the high. Else down-swing (high→low), retraces UP.
+    up_swing = last_high["bars_ago"] <= last_low["bars_ago"]
+    span = hi - lo
+    last_price = round(float(df["close"].iloc[-1]), 2)
+
+    # Truncate (not round) so the labels read the method's vocabulary exactly:
+    # 0.618 -> "61%", 0.786 -> "78%", 1.618 -> "161%", 2.618 -> "261%".
+    retr: dict[str, float] = {}
+    for r in _RETRACEMENTS:
+        level = hi - span * r if up_swing else lo + span * r
+        retr[f"{int(r * 100)}%"] = round(level, 2)
+    ext: dict[str, float] = {}
+    for e in _EXTENSIONS:
+        level = lo + span * e if up_swing else hi - span * e
+        ext[f"{int(e * 100)}%"] = round(level, 2)
+
+    # Which retracement band is price nearest to right now?
+    nearest = min(retr.items(), key=lambda kv: abs(kv[1] - last_price))
+    return {
+        "available": True,
+        "swing_direction": "up" if up_swing else "down",
+        "swing_high": hi,
+        "swing_low": lo,
+        "last_price": last_price,
+        "retracements": retr,
+        "extensions": ext,
+        "nearest_retracement": {"level_name": nearest[0], "price": nearest[1], "points_away": round(last_price - nearest[1], 2)},
+        "note": "Only 50/61/78 are valid reversal zones (need pattern + confirmation); 161/261 are targets. 78% is the deepest valid zone.",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Candlestick patterns + confirmation
+# ---------------------------------------------------------------------------
+
+def _confirmation(
+    df: pd.DataFrame, pattern_idx: int, direction: str, pattern_high: float, pattern_low: float,
+    cfg: SLHuntingIndicatorConfig,
+) -> dict[str, Any]:
+    """Check whether any candle after `pattern_idx` confirms the pattern.
+
+    A bullish confirmation = a later full-body candle that closes ABOVE the
+    pattern's high; bearish = closes BELOW the pattern's low. Returns the first
+    such candle, plus a `trap` flag if a later candle's wick poked back through the
+    pattern (the doc's invalidation rule).
+    """
+    n = len(df)
+    for j in range(pattern_idx + 1, n):
+        a = _anatomy(df.iloc[j], cfg)
+        if direction == "bullish" and a["close"] > pattern_high and a["is_full_body"] and a["is_bull"]:
+            return {"confirmed": True, "bars_after": j - pattern_idx, "close": a["close"], "time": str(df.timestamp.iloc[j])}
+        if direction == "bearish" and a["close"] < pattern_low and a["is_full_body"] and a["is_bear"]:
+            return {"confirmed": True, "bars_after": j - pattern_idx, "close": a["close"], "time": str(df.timestamp.iloc[j])}
+    # No confirmation yet — flag a trap if price poked back through after a wick test.
+    return {"confirmed": False, "bars_after": None, "close": None, "time": None}
+
+
+def candle_patterns(
+    candles: pd.DataFrame,
+    cfg: SLHuntingIndicatorConfig | None = None,
+) -> dict[str, Any]:
+    """Detect reversal patterns on recent completed candles, each with confirmation.
+
+    Scans the last `pattern_lookback` candles for: hammer / shooting-star / doji
+    (long-wick), bullish/bearish engulfing, inside-bar (harami), reversal-bar, and
+    morning/evening star. Each detection carries its implied direction, the
+    pattern's high/low (for the stop), and whether a confirmation candle has
+    already printed beyond it (the method's mandatory rule).
+    """
+    cfg = cfg or SLHuntingIndicatorConfig()
+    df = prepare_candles(candles)
+    n = len(df)
+    if n < 3:
+        return {"available": False, "reason": "not enough candles"}
+
+    start = max(2, n - cfg.pattern_lookback)
+    found: list[dict[str, Any]] = []
+
+    for i in range(start, n):
+        cur = _anatomy(df.iloc[i], cfg)
+        prev = _anatomy(df.iloc[i - 1], cfg)
+        prev2 = _anatomy(df.iloc[i - 2], cfg)
+        bars_ago = n - 1 - i
+        p_high, p_low = cur["high"], cur["low"]
+
+        def _add(ptype: str, direction: str, hi: float, lo: float) -> None:
+            conf = _confirmation(df, i, direction, hi, lo, cfg)
+            found.append({
+                "type": ptype,
+                "direction": direction,
+                "bars_ago": bars_ago,
+                "time": str(df.timestamp.iloc[i]),
+                "pattern_high": round(hi, 2),
+                "pattern_low": round(lo, 2),
+                **conf,
+            })
+
+        # Hammer / shooting star (long-wick single candle) — direction set by where
+        # the confirmation closes, so we record BOTH potential directions' levels but
+        # bias by wick side.
+        if cur["is_hammer"]:
+            _add("hammer", "bullish", p_high, p_low)
+        if cur["is_shooting_star"]:
+            _add("shooting_star", "bearish", p_high, p_low)
+        if cur["is_doji"] and not cur["is_hammer"] and not cur["is_shooting_star"]:
+            # A doji at a level can go either way; record as neutral-ish via both checks.
+            _add("doji", "bullish", p_high, p_low)
+            _add("doji", "bearish", p_high, p_low)
+
+        # Engulfing (2-candle). Body engulf; note whether wicks are covered too.
+        if cur["body"] > 0 and prev["body"] > 0:
+            bull_engulf = cur["is_bull"] and prev["is_bear"] and cur["close"] >= prev["open"] and cur["open"] <= prev["close"]
+            bear_engulf = cur["is_bear"] and prev["is_bull"] and cur["close"] <= prev["open"] and cur["open"] >= prev["close"]
+            if bull_engulf:
+                _add("bullish_engulfing", "bullish", max(cur["high"], prev["high"]), min(cur["low"], prev["low"]))
+            if bear_engulf:
+                _add("bearish_engulfing", "bearish", max(cur["high"], prev["high"]), min(cur["low"], prev["low"]))
+
+        # Inside bar / harami (child range within parent range).
+        if cur["high"] <= prev["high"] and cur["low"] >= prev["low"]:
+            # Direction = breakout of the mother candle; record both edges.
+            _add("inside_bar", "bullish", prev["high"], prev["low"])
+            _add("inside_bar", "bearish", prev["high"], prev["low"])
+
+        # Morning / evening star (3-candle).
+        small_middle = prev["body"] <= 0.5 * max(prev2["body"], 1e-9)
+        if prev2["is_bear"] and small_middle and cur["is_bull"] and cur["close"] > (prev2["open"] + prev2["close"]) / 2:
+            _add("morning_star", "bullish", max(cur["high"], prev["high"], prev2["high"]), min(cur["low"], prev["low"], prev2["low"]))
+        if prev2["is_bull"] and small_middle and cur["is_bear"] and cur["close"] < (prev2["open"] + prev2["close"]) / 2:
+            _add("evening_star", "bearish", max(cur["high"], prev["high"], prev2["high"]), min(cur["low"], prev["low"], prev2["low"]))
+
+    confirmed = [p for p in found if p.get("confirmed")]
+    return {
+        "available": True,
+        "latest_candle": _anatomy(df.iloc[-1], cfg),
+        "patterns": found[-cfg.pattern_lookback:],
+        "confirmed_patterns": confirmed[-5:],
+        "note": "A tradeable setup needs a pattern AT a level AND a confirmation candle that already closed beyond it. No confirmation = no trade.",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Market structure
+# ---------------------------------------------------------------------------
+
+def market_structure(
+    candles: pd.DataFrame,
+    cfg: SLHuntingIndicatorConfig | None = None,
+) -> dict[str, Any]:
+    """Report swings, trend, fast/slow read, trendline points, W/M and doubles."""
+    cfg = cfg or SLHuntingIndicatorConfig()
+    df = prepare_candles(candles)
+    if len(df) < (cfg.swing_left + cfg.swing_right + 3):
+        return {"available": False, "reason": "not enough candles"}
+
+    swings = _swings(df, cfg)
+    highs = [s for s in swings if s["kind"] == "high"]
+    lows = [s for s in swings if s["kind"] == "low"]
+
+    # Trend from the last two highs and last two lows.
+    trend = "sideways"
+    if len(highs) >= 2 and len(lows) >= 2:
+        hh = highs[-1]["price"] > highs[-2]["price"]
+        hl = lows[-1]["price"] > lows[-2]["price"]
+        lh = highs[-1]["price"] < highs[-2]["price"]
+        ll = lows[-1]["price"] < lows[-2]["price"]
+        if hh and hl:
+            trend = "uptrend"
+        elif lh and ll:
+            trend = "downtrend"
+
+    # Fast vs slow: average body of the most recent third vs the prior portion.
+    win = df.tail(cfg.speed_window)
+    if len(win) >= 6:
+        bodies = (win["close"] - win["open"]).abs().to_numpy()
+        third = max(2, len(bodies) // 3)
+        recent_avg = float(np.mean(bodies[-third:]))
+        prior_avg = float(np.mean(bodies[:-third])) if len(bodies) > third else recent_avg
+        ratio = recent_avg / max(prior_avg, 1e-9)
+        speed = "accelerating" if ratio > 1.3 else "decelerating" if ratio < 0.7 else "steady"
+    else:
+        speed = "unknown"
+
+    # Double top / bottom: last two highs (or lows) within tolerance.
+    def _double(points: list[dict[str, Any]]) -> dict[str, Any] | None:
+        if len(points) < 2:
+            return None
+        a, b = points[-2]["price"], points[-1]["price"]
+        if abs(a - b) <= cfg.double_tolerance_pct / 100.0 * max(a, b):
+            return {"price": round((a + b) / 2, 2), "points": [points[-2], points[-1]]}
+        return None
+
+    double_top = _double(highs)
+    double_bottom = _double(lows)
+
+    # Trendline points: the last few same-kind swings define an ascending/descending
+    # line; we surface them so the agent can apply the "3rd point / break" rule.
+    asc_line = lows[-4:] if len(lows) >= 2 else []
+    desc_line = highs[-4:] if len(highs) >= 2 else []
+
+    return {
+        "available": True,
+        "trend": trend,
+        "speed": speed,
+        "recent_swings": swings[-8:],
+        "last_swing_high": highs[-1] if highs else None,
+        "last_swing_low": lows[-1] if lows else None,
+        "ascending_trendline_points": asc_line,
+        "descending_trendline_points": desc_line,
+        "double_top": double_top,
+        "double_bottom": double_bottom,
+        "note": "Trade a trendline only on the 3rd touch or a confirmed break (4th+). For W/M, trade the activation after the neckline break, not the breakout itself.",
+    }

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
@@ -178,6 +178,9 @@ RISK DISCIPLINE
 - Keep the underlying (spot) stop TIGHT: aim for ~10-15 NIFTY points beyond the
   pattern. If the required stop is larger than that, either wait for a pullback
   entry that tightens it, or SKIP the trade (HOLD).
+- Position size is computed AUTOMATICALLY to risk ~Rs.2500 per trade from your stop
+  distance — you do NOT choose lots. A tighter stop just means more lots for the
+  same rupee risk, so set an honest, tight stop; never widen it to "get size".
 - Require a worthwhile target: at least ~1:2 reward:risk to the next clear level
   (swing / pivot / fibo / psych). If the nearest opposing level is too close, the
   target is too small — HOLD.
@@ -186,6 +189,36 @@ RISK DISCIPLINE
   level in your favour. Otherwise HOLD and let it run.
 - One position at a time. Never add to or reverse a position in a single decision —
   EXIT first; a fresh entry is a later decision.
+"""
+
+
+# ---------------------------------------------------------------------------
+# BankNIFTY (BNF) cross-confirmation
+# ---------------------------------------------------------------------------
+
+BNF_CROSS_CONFIRMATION = """\
+CROSS-INDEX CONFIRMATION (NIFTY vs BankNIFTY) — advisory
+-------------------------------------------------------
+The method cross-checks BankNIFTY (BNF) against NIFTY. Use the `cross_index` tool
+(it returns an `alignment` and a `bias`) and `bank_nifty` for BNF's own levels.
+This is ADVISORY: it strengthens or weakens a NIFTY setup; it is NOT a hard gate.
+When BankNIFTY data is unavailable, judge on NIFTY alone (a bit more conservative).
+
+The rules (note the SL-hunting inversion — "taking"/holding a level = continuation,
+a clean BREAK of it = reversal):
+- BOTH indices at SUPPORT → bias DOWN (the shared support likely fails / SL-hunt).
+- BOTH break DOWN through pivot/support → bias UP (the breakdown reverses).
+- BOTH at RESISTANCE → bias UP (continuation); BOTH break UP → bias DOWN.
+- DIVERGENCE — one index breaks a level while the other HOLDS it: the break tends
+  to FAIL; bias toward the holder (e.g. NIFTY breaks down but BNF holds support →
+  NIFTY's breakdown likely fails → look UP).
+- OPPOSITE SIDES of pivot (one above, one below) → treat the pivot as a normal
+  level and WAIT until both align before trading it.
+- BNF psych levels attract within ~100 points (NIFTY ~50). BankNIFTY is the larger,
+  faster index, so its break/hold of a round level often leads.
+
+How to use it: if `cross_index` AGREES with your NIFTY setup, take it with more
+confidence; if it says "wait" or DISAGREES with your direction, prefer HOLD.
 """
 
 
@@ -209,6 +242,10 @@ deciding:
   double top/bottom.
 - `position_state`   → your current open position (direction, entry, stop, target,
   unrealised P&L) or "flat".
+- `bank_nifty`       → BankNIFTY's OWN pivot/levels, structure and recent patterns,
+  for cross-confirmation. Reports available:false when BankNIFTY data is missing.
+- `cross_index`      → the NIFTY-vs-BankNIFTY alignment verdict (see CROSS-INDEX
+  CONFIRMATION). Reports available:false when BankNIFTY data is missing.
 
 To ACT, you have exactly ONE order tool (named `place_paper_order` or
 `place_live_order` — whichever you were given; you cannot choose the venue, the
@@ -217,9 +254,10 @@ your stop & target (on the underlying). It returns whether the order was accepte
 or rejected (e.g. already in a position). If you decide to do nothing, do NOT call
 the order tool — just report HOLD.
 
-NIFTY-ONLY: the original method cross-checks Bank Nifty (BNF). BNF data is NOT
-available to you here, so do not rely on BNF confirmation — judge on NIFTY alone
-and be slightly more conservative because that cross-check is missing.
+CROSS-INDEX (NF/BNF): call `cross_index` (and `bank_nifty` for detail). If they
+report available:false, BankNIFTY data is missing — judge on NIFTY alone and be a
+bit more conservative because that cross-check isn't available. If available, weigh
+the verdict per CROSS-INDEX CONFIRMATION below (it is advisory, not a hard gate).
 """
 
 
@@ -290,6 +328,7 @@ def build_system_prompt() -> str:
         PATTERNS_AND_CONFIRMATION,
         FIBO,
         STRUCTURE,
+        BNF_CROSS_CONFIRMATION,
         RISK,
         TOOL_GUIDE,
         DECISION_RULES,

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
@@ -1,0 +1,298 @@
+"""Externalized SL-Hunting knowledge for the SL Hunting AI Agent.
+
+Why this module exists (beginner note)
+--------------------------------------
+A Claude agent's "skill" is just the expertise we hand it in its system prompt:
+the rules of the method, how to confirm a setup, and how to use its tools. The
+user asked for the agent's knowledge to be **externalized** into a dedicated,
+versioned module so it is easy to read, extend, and review as prose — editing the
+agent's "brain" should mean editing text here, not touching Python logic.
+
+So this module holds the SL-Hunting method (distilled from `sl_hunting_doc.md`)
+as small, composable string constants plus one `build_system_prompt()` that
+stitches them into the final system prompt. The strict JSON output contract lives
+in `FINAL_OUTPUT_INSTRUCTION` (kept separate so the agent appends it last, exactly
+like the Streamlit Scanner App's technical agent does).
+
+The matching machine-readable schema (the Pydantic `SLHuntingDecision`) and the
+actual tool wiring live next door in `sl_hunting_agent.py` and `tools.py`.
+
+This mirrors the house pattern in `../Streamlit Scanner App/backend/technical/knowledge.py`.
+"""
+
+from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# Role and analytical stance
+# ---------------------------------------------------------------------------
+
+ROLE = """\
+You are an expert intraday price-action trader of the NIFTY index, trading via
+ATM index options. You practise the "SL Hunting" method: the market is run by
+operators who deliberately move price to hunt the stop-losses (SLs) of unprepared
+retail traders, so you trade WITH the operator and AGAINST the crowd. You are
+PATIENT and CONSERVATIVE — most candles are noise. Your default action is HOLD.
+You take a trade ONLY when a real setup at a real level is confirmed by a
+candlestick pattern AND a following confirmation candle, with an acceptable
+stop-loss and a worthwhile target. A missed trade costs nothing; a forced trade
+on a weak setup is how retail loses.
+
+You trade BOTH directions, always by BUYING an option:
+- ENTER_LONG  → you expect the NIFTY underlying to go UP   (the system buys an ATM CALL).
+- ENTER_SHORT → you expect the NIFTY underlying to go DOWN (the system buys an ATM PUT).
+Your stop and target are levels on the NIFTY UNDERLYING (spot), not on the option.
+"""
+
+
+# ---------------------------------------------------------------------------
+# The core psychology of the method
+# ---------------------------------------------------------------------------
+
+PSYCHOLOGY = """\
+CORE PSYCHOLOGY (the "why" behind every setup)
+----------------------------------------------
+- Price action starts and ends at Support/Resistance (S/R) levels. New price
+  action begins after the old one expires at a level.
+- The market hunts the SLs of major turning points. At a turning point all SLs are
+  gone, so expect a pullback after it.
+- Fast move one way, then a SLOW move the other way = the operator creating SLs on
+  the slow side. The slow-side reversal is the SL-hunt; trade it, do not chase the
+  fast trend blindly.
+- A long-wicked candle (hammer/doji/pin) marks where money/SLs are parked — the
+  longer the wick, the more SLs. These mark targets and reversal zones.
+- Act OPPOSITE to the obvious retail read: after a gap down retail expects more
+  downside, so look up first; after a break everyone trades the break, so look for
+  the failure/reversal.
+- Most money is made in a sideways-to-trending market. In a pure fast trend you
+  rarely get a clean entry — wait.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Levels: pivot, OHLC, psych levels, the opening
+# ---------------------------------------------------------------------------
+
+LEVELS_AND_PIVOT = """\
+LEVELS — pivot, previous-day OHLC, psych levels, the opening
+-----------------------------------------------------------
+Use the `pivot_and_levels` tool. It gives you the day's pivot, the previous day's
+OHLC, today's open/high/low and the first-candle high/low, nearby psychological
+(round-number) levels, and the previous close ("closing point").
+
+- Pivot = (prevHigh + prevLow + prevClose) / 3. Above pivot is a BUYERS' market
+  (bias long); below pivot is a SELLERS' market (bias short). The pivot is the
+  STRONGEST S/R: it can give exact support/resistance, and "activation" works
+  there — but a candlestick + confirmation must form. The first time price reaches
+  the pivot it may take direct support/resistance; after that treat it as a normal
+  level.
+- A clean BREAK of a level (not a wick) means continuation: break support → down;
+  reclaim/hold resistance → up. A WICK or an immediately-returning candle at a
+  level = a TRAP = reversal.
+- The "closing point" (yesterday's close) attracts price (both sides' SLs sit
+  there). A psych level attracts price within ~50 NIFTY points.
+- Do NOT trade the first candle. The first candle's high/low are trap levels; the
+  target is often the opposite side of the first candle.
+- Opening playbook (5-min has higher accuracy): wait for price to reach the pivot,
+  let a candle touch it, and trade only the confirmed break of the small opening
+  range. If price opens far from the pivot, the pivot can be the first target.
+"""
+
+
+# ---------------------------------------------------------------------------
+# The candlestick + confirmation rule (the heart of the method)
+# ---------------------------------------------------------------------------
+
+PATTERNS_AND_CONFIRMATION = """\
+CANDLESTICK PATTERN + CONFIRMATION (mandatory for every entry)
+-------------------------------------------------------------
+Use the `candle_patterns` tool. The non-negotiable rule: a setup needs a reversal
+PATTERN at a level AND a following CONFIRMATION candle. Never anticipate — the
+confirmation must have ALREADY printed.
+
+- Confirmation candle = a full-body candle that closes BEYOND the pattern:
+  for a bullish setup it closes above the pattern's high; for bearish, below the
+  pattern's low. The stop sits just beyond the pattern (NOT beyond the confirmation
+  candle).
+- Hammer / long-wick / doji: direction is decided by where the full-body
+  confirmation candle closes (above the high → long; below the low → short). Color
+  of the wicked candle itself does NOT matter.
+- Engulfing: needs a later confirmation candle after the two-candle engulf; market
+  goes in the last engulfing candle's color direction. COLOR MATTERS.
+- Inside bar / harami: direction is the breakout of the mother candle; confirmation
+  must close beyond the mother candle's range. COLOR MATTERS.
+- Reversal bar (two candles of similar length at an S/R level): direction is the
+  second candle's; still needs a confirmation candle.
+- Invalidation: if the confirmation candle's wick pokes back through the pattern,
+  it is a trap — no trade. A pattern formed "in between" (not AT the level) is not
+  tradeable; the pattern must form at the very top/bottom of the level.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Fibonacci
+# ---------------------------------------------------------------------------
+
+FIBO = """\
+FIBONACCI (50 / 61 / 78 retracement; 161 / 261 extension)
+---------------------------------------------------------
+Use the `fibo_levels` tool. Only 50%, 61% and 78% retracement levels matter for
+entries; 161% and 261% are extension TARGETS.
+- After a move, the market retraces to a fibo level and may reverse there — but
+  only WITH a candlestick pattern + confirmation at that level.
+- 78% is the deepest valid reversal zone (often coincides with an FVG); a clean
+  break of the 100% level means SLs are exhausted and a reversal is likely.
+- If the impulse move is fast and the retracement is slow, favour continuation in
+  the impulse direction.
+- For targets in untested territory, the 161% / 261% extensions guide where price
+  may reverse.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Structure: trendlines, W/M, double tops/bottoms
+# ---------------------------------------------------------------------------
+
+STRUCTURE = """\
+MARKET STRUCTURE — trendlines, W/M, double top/bottom
+-----------------------------------------------------
+Use the `market_structure` tool for swings, trend, trendline points, and
+double-top/bottom / W-M detection.
+- Trendline: trade only the 3rd touch (in trend direction); from the 4th point on,
+  trade only the trendline BREAK (with pattern + confirmation). Up-leg = fast;
+  pullback = slow with wicks.
+- W / M patterns: do NOT trade the neckline breakout (it can fail). Trade the
+  ACTIVATION below/above the neckline after the break — i.e. the failure-and-go.
+- Double top → target/reversal down after the break; double bottom → up after the
+  break. A trendline/neckline break that has NOT first trapped the opposite SLs
+  tends to fail.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Risk discipline
+# ---------------------------------------------------------------------------
+
+RISK = """\
+RISK DISCIPLINE
+---------------
+- Keep the underlying (spot) stop TIGHT: aim for ~10-15 NIFTY points beyond the
+  pattern. If the required stop is larger than that, either wait for a pullback
+  entry that tightens it, or SKIP the trade (HOLD).
+- Require a worthwhile target: at least ~1:2 reward:risk to the next clear level
+  (swing / pivot / fibo / psych). If the nearest opposing level is too close, the
+  target is too small — HOLD.
+- When already in a position, EXIT on: target reached, stop hit, an OPPOSING
+  pattern + confirmation forming against you, or the move going slow/stalling at a
+  level in your favour. Otherwise HOLD and let it run.
+- One position at a time. Never add to or reverse a position in a single decision —
+  EXIT first; a fresh entry is a later decision.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Tool-usage guide
+# ---------------------------------------------------------------------------
+
+TOOL_GUIDE = """\
+YOUR TOOLS (call them — do not guess from raw numbers)
+-----------------------------------------------------
+You receive a compact recent-candle snapshot for orientation, but the precise
+facts come from these read-only tools. Call the ones you need, once each, before
+deciding:
+- `pivot_and_levels` → pivot, prev-day OHLC, today O/H/L, first-candle hi/lo,
+  psych levels, closing point, and price's distance to each.
+- `candle_patterns`  → reversal patterns on recent completed candles and whether a
+  confirmation candle has already closed beyond them.
+- `fibo_levels`      → 50/61/78 retracement and 161/261 extension of recent swings,
+  and where price sits relative to them.
+- `market_structure` → swings, trend (fast/slow), trendline points, W/M and
+  double top/bottom.
+- `position_state`   → your current open position (direction, entry, stop, target,
+  unrealised P&L) or "flat".
+
+To ACT, you have exactly ONE order tool (named `place_paper_order` or
+`place_live_order` — whichever you were given; you cannot choose the venue, the
+configuration decides it). Call it with action ENTER_LONG / ENTER_SHORT / EXIT and
+your stop & target (on the underlying). It returns whether the order was accepted
+or rejected (e.g. already in a position). If you decide to do nothing, do NOT call
+the order tool — just report HOLD.
+
+NIFTY-ONLY: the original method cross-checks Bank Nifty (BNF). BNF data is NOT
+available to you here, so do not rely on BNF confirmation — judge on NIFTY alone
+and be slightly more conservative because that cross-check is missing.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Decision discipline
+# ---------------------------------------------------------------------------
+
+DECISION_RULES = """\
+DECISION DISCIPLINE
+-------------------
+1. First call `position_state`.
+2. If FLAT: enter ONLY if (a) price is AT a real level (pivot / OHLC / fibo / psych
+   / structure), (b) a reversal pattern + confirmation candle has ALREADY printed
+   in your direction, (c) the stop is tight, and (d) the target is worthwhile.
+   Otherwise HOLD. Never trade the first candle of the day.
+3. If IN A POSITION: EXIT per the RISK rules, else HOLD.
+4. Use the order tool to act, then emit the final JSON describing what you did
+   (or HOLD). The configuration — not you — decides paper vs live and the broker.
+5. When unsure, HOLD. Patience is the edge.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Strict JSON output contract (appended LAST to the system prompt)
+# ---------------------------------------------------------------------------
+
+# Beginner note: the Claude Agent SDK has no `with_structured_output` equivalent,
+# so we steer the model to emit ONE JSON object as its final message and validate
+# it ourselves with Pydantic. The literal phrase "FINAL OUTPUT FORMAT" is relied
+# upon by tests as a marker that this contract is present in the system prompt.
+FINAL_OUTPUT_INSTRUCTION = """\
+
+============================================================
+FINAL OUTPUT FORMAT (STRICT)
+============================================================
+
+After you have acted (or decided to do nothing), your FINAL message must be a
+SINGLE JSON object and NOTHING else — no prose before or after it, and no markdown
+code fences. It records what you decided. The object must contain exactly these
+keys:
+
+- "action": one of "ENTER_LONG", "ENTER_SHORT", "EXIT", "HOLD"
+- "stop": number — the underlying stop level for an entry; 0 for EXIT/HOLD
+- "target": number — the underlying target level for an entry; 0 for EXIT/HOLD
+- "confidence": integer 0-10 (10 = textbook setup, all conditions met)
+- "setup": string — short name of the setup you acted on (e.g.
+  "pivot_support_hammer", "fibo_61_reversal", "wm_neckline_activation",
+  "double_bottom_break"), or "none" for HOLD
+- "reasoning": string — 2-4 sentences: the level, the pattern + confirmation, the
+  stop/target logic, and why now (or why you held)
+- "model_used": string
+
+Emit ONLY this JSON object as your final answer."""
+
+
+def build_system_prompt() -> str:
+    """Compose the full SL-Hunting system prompt from the sections above.
+
+    Returns the agent's "knowledge" portion (role + psychology + level/pattern/
+    fibo/structure rules + risk + tool guide + decision rules). The caller appends
+    `FINAL_OUTPUT_INSTRUCTION` to lock the strict JSON output contract, mirroring
+    how the Streamlit Scanner App's technical agent assembles its prompt.
+    """
+    sections = [
+        ROLE,
+        PSYCHOLOGY,
+        LEVELS_AND_PIVOT,
+        PATTERNS_AND_CONFIRMATION,
+        FIBO,
+        STRUCTURE,
+        RISK,
+        TOOL_GUIDE,
+        DECISION_RULES,
+    ]
+    # A blank line between sections keeps the prompt readable for the model.
+    return "\n\n".join(section.strip() for section in sections)

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_runner.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_runner.py
@@ -99,16 +99,21 @@ def _synthetic_bnf(nifty_1m: pd.DataFrame, scale: float = 2.2, seed: int = 11) -
 
 
 def resample_1m_to_n(candles: pd.DataFrame, minutes: int) -> pd.DataFrame:
-    """Resample 1-minute OHLC up to `minutes`-minute candles.
+    """Resample 1-minute OHLC up to `minutes`-minute candles, keeping ONLY complete bars.
 
-    Uses left-closed, left-labelled bins — the NSE intraday convention (the 09:15
-    bar covers 09:15-09:19), matching the master's `resample_ohlc_from_1m`.
+    Uses left-closed, left-labelled bins — the NSE intraday convention (the 09:15 bar
+    covers 09:15-09:19) — and drops any bucket that did not receive all `minutes`
+    source 1-minute rows (e.g. a 09:15-09:17 tail in a CSV), exactly like the master's
+    `resample_ohlc_from_1m`. This stops the agent from ever deciding on a partial bar.
     """
     if minutes <= 1:
         return prepare_candles(candles)
     df = prepare_candles(candles).set_index("timestamp")
+    rule = f"{minutes}min"
     agg = {"open": "first", "high": "max", "low": "min", "close": "last", "volume": "sum"}
-    out = df.resample(f"{minutes}min", label="left", closed="left").agg(agg).dropna(subset=["open"])
+    out = df.resample(rule, label="left", closed="left").agg(agg).dropna(subset=["open"])
+    counts = df["close"].resample(rule, label="left", closed="left").count()
+    out = out[counts.reindex(out.index) == minutes]
     return out.reset_index()
 
 

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_runner.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_runner.py
@@ -1,0 +1,216 @@
+"""Standalone PAPER runner for the SL Hunting AI Agent.
+
+What this is (beginner note)
+----------------------------
+A self-contained harness to validate the agent on real (or synthetic) NIFTY data
+WITHOUT touching the live multithreaded master. It loads 1-minute OHLC, resamples
+to the agent's decision timeframe, then replays the session bar by bar: on each
+completed bar it lets the agent decide (paper execution via `StandaloneExecutor`),
+auto-fills paper stop/target hits, and prints a session summary.
+
+Modes
+-----
+- ``--synthetic``  : generate a random-walk session (no data file, no SDK needed).
+- ``--fake``       : drive the agent with a built-in always-HOLD runner (zero cost,
+                     no Claude CLI) — use this to smoke-test the whole pipeline.
+- default          : use the real Claude Agent SDK (needs ``pip install
+                     claude-agent-sdk`` and a one-time ``claude`` CLI login;
+                     keep ``ANTHROPIC_API_KEY`` UNSET for subscription billing).
+
+Examples
+--------
+    # zero-cost pipeline smoke test (no data, no SDK):
+    python sl_hunting_runner.py --synthetic --fake
+
+    # replay a real 1-min CSV with the live agent, capped to 30 decisions:
+    python sl_hunting_runner.py --csv "../../Backtest Outputs/nifty_1m.csv" --max-bars 30
+
+This runner is PAPER-ONLY by design. Real-money trading goes through the master
+front-test worker (one shared, lock-guarded broker session) — see the folder
+README.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+
+# Running this file directly puts its folder on sys.path[0], so these bare imports
+# resolve. (The folder name has spaces, so it can't be a normal package.)
+from sl_hunting_agent import AgentRunResult, SLHuntingAgent
+from sl_hunting_executor import StandaloneExecutor
+from sl_hunting_indicators import prepare_candles
+
+logger = logging.getLogger("sl_hunting_runner")
+
+
+# ---------------------------------------------------------------------------
+# Data loading / preparation
+# ---------------------------------------------------------------------------
+
+def _load_csv(path: str) -> pd.DataFrame:
+    df = pd.read_csv(path)
+    # Be forgiving about the timestamp column name.
+    rename = {}
+    for cand in ("datetime", "date", "Datetime", "Date", "time", "Time"):
+        if cand in df.columns and "timestamp" not in df.columns:
+            rename[cand] = "timestamp"
+    if rename:
+        df = df.rename(columns=rename)
+    return prepare_candles(df)
+
+
+def _synthetic_session(bars_1m: int = 375, seed: int = 7, start_price: float = 25000.0) -> pd.DataFrame:
+    """Generate one trading day of synthetic 1-minute candles (random walk)."""
+    rng = np.random.default_rng(seed)
+    steps = rng.normal(0, 4.0, size=bars_1m).cumsum()
+    closes = start_price + steps
+    ts = pd.date_range(start="2026-06-26 09:15", periods=bars_1m, freq="1min")
+    opens = np.concatenate([[start_price], closes[:-1]])
+    highs = np.maximum(opens, closes) + rng.uniform(0, 6, size=bars_1m)
+    lows = np.minimum(opens, closes) - rng.uniform(0, 6, size=bars_1m)
+    return pd.DataFrame(
+        {"timestamp": ts, "open": opens, "high": highs, "low": lows, "close": closes, "volume": 0}
+    )
+
+
+def resample_1m_to_n(candles: pd.DataFrame, minutes: int) -> pd.DataFrame:
+    """Resample 1-minute OHLC up to `minutes`-minute candles.
+
+    Uses left-closed, left-labelled bins — the NSE intraday convention (the 09:15
+    bar covers 09:15-09:19), matching the master's `resample_ohlc_from_1m`.
+    """
+    if minutes <= 1:
+        return prepare_candles(candles)
+    df = prepare_candles(candles).set_index("timestamp")
+    agg = {"open": "first", "high": "max", "low": "min", "close": "last", "volume": "sum"}
+    out = df.resample(f"{minutes}min", label="left", closed="left").agg(agg).dropna(subset=["open"])
+    return out.reset_index()
+
+
+# ---------------------------------------------------------------------------
+# Paper position management between agent decisions
+# ---------------------------------------------------------------------------
+
+def _manage_open_position(ex: StandaloneExecutor, bar: pd.Series) -> None:
+    """Auto-fill a paper stop/target hit using the current bar's high/low."""
+    if not ex.pos.active:
+        return
+    high, low = float(bar.high), float(bar.low)
+    if ex.pos.direction == "LONG":
+        if ex.pos.stop and low <= ex.pos.stop:
+            ex.exit("stop_hit", price=ex.pos.stop)
+        elif ex.pos.target and high >= ex.pos.target:
+            ex.exit("target_hit", price=ex.pos.target)
+    else:  # SHORT
+        if ex.pos.stop and high >= ex.pos.stop:
+            ex.exit("stop_hit", price=ex.pos.stop)
+        elif ex.pos.target and low <= ex.pos.target:
+            ex.exit("target_hit", price=ex.pos.target)
+
+
+class _AlwaysHoldRunner:
+    """A built-in fake runner (for --fake): no SDK, no cost, always HOLD."""
+
+    async def __call__(self, prompt, *, system_prompt, model, max_turns, tool_context=None):
+        import json
+        text = json.dumps(
+            {"action": "HOLD", "stop": 0, "target": 0, "confidence": 0,
+             "setup": "none", "reasoning": "Fake runner: pipeline smoke test.", "model_used": model}
+        )
+        return AgentRunResult(text=text, cost_usd=0.0)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def _env(name: str, default: str) -> str:
+    val = os.getenv(name, "")
+    return val.strip() if val and val.strip() else default
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+
+    parser = argparse.ArgumentParser(description="Standalone PAPER runner for the SL Hunting AI Agent.")
+    src = parser.add_mutually_exclusive_group()
+    src.add_argument("--csv", help="Path to a 1-minute OHLC CSV (timestamp,open,high,low,close[,volume]).")
+    src.add_argument("--synthetic", action="store_true", help="Use a generated random-walk session.")
+    parser.add_argument("--timeframe", type=int, default=int(_env("SL_HUNTING_DERIVED_TIMEFRAME_MINUTES", "5")),
+                        help="Decision timeframe in minutes (resampled from 1-min).")
+    parser.add_argument("--model", default=_env("SL_HUNTING_MODEL", "claude-opus-4-8"), help="Claude model id.")
+    parser.add_argument("--fast", action="store_true", help="Disable extended thinking (lower latency).")
+    parser.add_argument("--fake", action="store_true", help="Use the built-in always-HOLD runner (no SDK/cost).")
+    parser.add_argument("--warmup", type=int, default=30, help="Min completed bars before the first decision.")
+    parser.add_argument("--max-bars", type=int, default=0, help="Cap the number of decisions (0 = all).")
+    parser.add_argument("--lots", type=int, default=int(_env("SL_HUNTING_LOTS", "1")))
+    parser.add_argument("--lot-size", type=int, default=int(_env("NIFTY_LOT_SIZE", "75")))
+    args = parser.parse_args(argv)
+
+    # 1. Load data.
+    if args.csv:
+        candles_1m = _load_csv(args.csv)
+        logger.info("Loaded %d 1-min candles from %s", len(candles_1m), args.csv)
+    else:
+        candles_1m = _synthetic_session()
+        logger.info("Using synthetic session (%d 1-min candles).", len(candles_1m))
+        if not args.synthetic and not args.fake:
+            logger.warning("No --csv given; defaulting to a synthetic session. Pass --csv for real data.")
+
+    bars = resample_1m_to_n(candles_1m, args.timeframe)
+    if len(bars) <= args.warmup + 1:
+        logger.error("Not enough %d-min bars (%d) for warmup=%d.", args.timeframe, len(bars), args.warmup)
+        return 2
+    logger.info("Resampled to %d %d-min bars.", len(bars), args.timeframe)
+
+    # 2. Build the agent (fake runner for --fake; real Claude Agent SDK otherwise).
+    runner = _AlwaysHoldRunner() if args.fake else None
+    agent = SLHuntingAgent(model=args.model, runner=runner, fast_mode=args.fast)
+    ex = StandaloneExecutor(lots=args.lots, lot_size=args.lot_size)
+
+    # 3. Replay bar by bar.
+    decisions = 0
+    n = len(bars)
+    for i in range(args.warmup, n):
+        bar = bars.iloc[i]
+        _manage_open_position(ex, bar)  # fill paper stop/target from this bar first
+        window = bars.iloc[: i + 1]
+        decision = agent.decide(window, ex, live_active=False, broker=None)
+        decisions += 1
+        if decision.action != "HOLD":
+            logger.info(
+                "[%s] %s (conf=%d, setup=%s) stop=%s target=%s :: %s",
+                str(bar.timestamp)[:19], decision.action, decision.confidence,
+                decision.setup, decision.stop, decision.target, decision.reasoning,
+            )
+        if args.max_bars and decisions >= args.max_bars:
+            logger.info("Reached --max-bars=%d; stopping.", args.max_bars)
+            break
+
+    # 4. Close any open position at the last price and summarise.
+    if ex.pos.active:
+        ex.exit("session_end", price=float(bars.iloc[min(i, n - 1)].close))
+
+    trades = ex.closed_trades
+    total = round(sum(t["pnl_proxy"] for t in trades), 2)
+    wins = sum(1 for t in trades if t["pnl_proxy"] > 0)
+    logger.info("=" * 60)
+    logger.info("Session complete: %d decisions, %d paper trades.", decisions, len(trades))
+    if trades:
+        logger.info("Total P&L proxy: %.2f | wins %d/%d (%.0f%%)", total, wins, len(trades), 100.0 * wins / len(trades))
+        for t in trades:
+            logger.info("  %s %s->%s (%+.2f pts, %+.2f) [%s]", t["direction"], t["entry"], t["exit"], t["points"], t["pnl_proxy"], t["exit_reason"])
+    else:
+        logger.info("No trades taken (agent held throughout).")
+    logger.info("NOTE: P&L proxy is on the NIFTY underlying, not option premium - validates decisions, not pricing.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_runner.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_runner.py
@@ -79,6 +79,25 @@ def _synthetic_session(bars_1m: int = 375, seed: int = 7, start_price: float = 2
     )
 
 
+def _synthetic_bnf(nifty_1m: pd.DataFrame, scale: float = 2.2, seed: int = 11) -> pd.DataFrame:
+    """Derive a correlated synthetic BankNIFTY 1-min series from the NIFTY one.
+
+    BankNIFTY trades at roughly `scale`x NIFTY and moves together with it, so we
+    scale the NIFTY closes and add small idiosyncratic noise. Same timestamps, so
+    the two align bar-for-bar. Used only by --synthetic to exercise cross-index.
+    """
+    nifty_1m = prepare_candles(nifty_1m)
+    rng = np.random.default_rng(seed)
+    n = len(nifty_1m)
+    closes = nifty_1m["close"].to_numpy() * scale + rng.normal(0, 12, size=n)
+    opens = np.concatenate([[closes[0]], closes[:-1]])
+    highs = np.maximum(opens, closes) + rng.uniform(0, 15, size=n)
+    lows = np.minimum(opens, closes) - rng.uniform(0, 15, size=n)
+    return pd.DataFrame(
+        {"timestamp": nifty_1m["timestamp"].to_numpy(), "open": opens, "high": highs, "low": lows, "close": closes, "volume": 0}
+    )
+
+
 def resample_1m_to_n(candles: pd.DataFrame, minutes: int) -> pd.DataFrame:
     """Resample 1-minute OHLC up to `minutes`-minute candles.
 
@@ -140,8 +159,9 @@ def main(argv: list[str] | None = None) -> int:
 
     parser = argparse.ArgumentParser(description="Standalone PAPER runner for the SL Hunting AI Agent.")
     src = parser.add_mutually_exclusive_group()
-    src.add_argument("--csv", help="Path to a 1-minute OHLC CSV (timestamp,open,high,low,close[,volume]).")
+    src.add_argument("--csv", help="Path to a 1-minute NIFTY OHLC CSV (timestamp,open,high,low,close[,volume]).")
     src.add_argument("--synthetic", action="store_true", help="Use a generated random-walk session.")
+    parser.add_argument("--bnf-csv", help="Optional 1-minute BankNIFTY OHLC CSV for cross-confirmation (paired with --csv).")
     parser.add_argument("--timeframe", type=int, default=int(_env("SL_HUNTING_DERIVED_TIMEFRAME_MINUTES", "5")),
                         help="Decision timeframe in minutes (resampled from 1-min).")
     parser.add_argument("--model", default=_env("SL_HUNTING_MODEL", "claude-opus-4-8"), help="Claude model id.")
@@ -169,6 +189,18 @@ def main(argv: list[str] | None = None) -> int:
         return 2
     logger.info("Resampled to %d %d-min bars.", len(bars), args.timeframe)
 
+    # 1b. Optional BankNIFTY (cross-confirmation). A real --bnf-csv when given;
+    # a correlated synthetic series in synthetic mode; otherwise None (NIFTY-only).
+    bnf_bars = None
+    if args.bnf_csv:
+        bnf_bars = resample_1m_to_n(_load_csv(args.bnf_csv), args.timeframe)
+        logger.info("Loaded BankNIFTY for cross-confirmation from %s.", args.bnf_csv)
+    elif not args.csv:
+        bnf_bars = resample_1m_to_n(_synthetic_bnf(candles_1m), args.timeframe)
+        logger.info("Using synthetic BankNIFTY for cross-confirmation.")
+    else:
+        logger.info("No --bnf-csv: running NIFTY-only (cross-index will report unavailable).")
+
     # 2. Build the agent (fake runner for --fake; real Claude Agent SDK otherwise).
     runner = _AlwaysHoldRunner() if args.fake else None
     agent = SLHuntingAgent(model=args.model, runner=runner, fast_mode=args.fast)
@@ -181,7 +213,12 @@ def main(argv: list[str] | None = None) -> int:
         bar = bars.iloc[i]
         _manage_open_position(ex, bar)  # fill paper stop/target from this bar first
         window = bars.iloc[: i + 1]
-        decision = agent.decide(window, ex, live_active=False, broker=None)
+        bnf_window = None
+        if bnf_bars is not None:
+            bnf_window = bnf_bars[bnf_bars["timestamp"] <= bar.timestamp]
+            if bnf_window.empty:
+                bnf_window = None
+        decision = agent.decide(window, ex, bnf_candles=bnf_window, live_active=False, broker=None)
         decisions += 1
         if decision.action != "HOLD":
             logger.info(

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_tools.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_tools.py
@@ -1,0 +1,192 @@
+"""In-process MCP tool server for the SL Hunting AI Agent.
+
+Why the agent gets tools (beginner note)
+----------------------------------------
+Instead of pre-chewing every fact into the prompt, the Claude agent is given
+*tools* it calls to fetch precise, deterministic facts about the current NIFTY
+chart, plus ONE tool to act:
+
+Read-only context tools (no arguments — each closes over the per-call context):
+- ``pivot_and_levels`` → day pivot, prev-day OHLC, today O/H/L, first-candle hi/lo,
+                         psych levels, previous close, and distances.
+- ``fibo_levels``      → 50/61/78 retracement + 161/261 extension of the latest swing.
+- ``candle_patterns``  → reversal patterns on recent candles + confirmation status.
+- ``market_structure`` → swings, trend, fast/slow, trendline points, W/M, doubles.
+- ``position_state``   → the current open position (or flat).
+
+Action tool (exactly ONE, named by the environment):
+- ``place_paper_order`` / ``place_kotak_order`` / ``place_shoonya_order`` — only the
+  one the configuration selected is registered (see `executor.execution_tool_name`),
+  so the agent can never choose paper-vs-real or the broker.
+
+This mirrors the house pattern in
+`../Streamlit Scanner App/backend/technical/tools.py`: the SDK is imported lazily
+inside `build_sl_hunting_mcp_server` (so this module imports without the SDK), tool
+results are wrapped as ``{"content": [{"type": "text", "text": json}]}``, and tool
+names are namespaced ``mcp__<server>__<tool>``.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+import pandas as pd
+
+from sl_hunting_indicators import (
+    SLHuntingIndicatorConfig,
+    candle_patterns,
+    fibo_levels,
+    market_structure,
+    pivot_and_levels,
+    prepare_candles,
+)
+from sl_hunting_executor import TradeExecutor, execution_tool_name
+
+SERVER_NAME = "slhunting"
+
+# Read-only context tools are always present; the action tool's name is decided at
+# build time by the environment, so it is appended in `build_sl_hunting_mcp_server`.
+CONTEXT_TOOL_NAMES = [
+    f"mcp__{SERVER_NAME}__pivot_and_levels",
+    f"mcp__{SERVER_NAME}__fibo_levels",
+    f"mcp__{SERVER_NAME}__candle_patterns",
+    f"mcp__{SERVER_NAME}__market_structure",
+    f"mcp__{SERVER_NAME}__position_state",
+]
+
+
+@dataclass
+class SLHuntingToolContext:
+    """Everything the tools need for ONE per-bar decision about NIFTY.
+
+    Built fresh for each `decide(...)` call so concurrent workers never share
+    mutable state. Holds the prepared candle window, the detector config, the
+    injected executor, and the environment's venue selection (live + broker) used
+    only to NAME the single action tool.
+    """
+
+    candles: pd.DataFrame
+    cfg: SLHuntingIndicatorConfig
+    executor: TradeExecutor
+    live_active: bool = False
+    broker: str | None = None
+    last_price: float = field(default=0.0)
+
+    @classmethod
+    def build(
+        cls,
+        candles: pd.DataFrame,
+        executor: TradeExecutor,
+        *,
+        cfg: SLHuntingIndicatorConfig | None = None,
+        live_active: bool = False,
+        broker: str | None = None,
+    ) -> "SLHuntingToolContext":
+        cfg = cfg or SLHuntingIndicatorConfig()
+        prepared = prepare_candles(candles)
+        last_price = float(prepared["close"].iloc[-1]) if not prepared.empty else 0.0
+        return cls(
+            candles=prepared,
+            cfg=cfg,
+            executor=executor,
+            live_active=bool(live_active),
+            broker=broker,
+            last_price=last_price,
+        )
+
+    # --- tool payload builders (plain functions; easy to unit test) ---------
+
+    def pivot_and_levels_payload(self) -> dict[str, Any]:
+        return pivot_and_levels(self.candles, self.cfg)
+
+    def fibo_levels_payload(self) -> dict[str, Any]:
+        return fibo_levels(self.candles, self.cfg)
+
+    def candle_patterns_payload(self) -> dict[str, Any]:
+        return candle_patterns(self.candles, self.cfg)
+
+    def market_structure_payload(self) -> dict[str, Any]:
+        return market_structure(self.candles, self.cfg)
+
+    def position_state_payload(self) -> dict[str, Any]:
+        return self.executor.snapshot()
+
+    def action_tool_name(self) -> str:
+        return execution_tool_name(self.live_active, self.broker)
+
+    def do_order(self, action: str, stop: float, target: float, reason: str) -> dict[str, Any]:
+        """Route an agent order through the injected executor (single source of truth)."""
+        action = (action or "").strip().upper()
+        if action == "ENTER_LONG":
+            return self.executor.enter("LONG", float(stop or 0.0), float(target or 0.0), reason, self.last_price)
+        if action == "ENTER_SHORT":
+            return self.executor.enter("SHORT", float(stop or 0.0), float(target or 0.0), reason, self.last_price)
+        if action == "EXIT":
+            return self.executor.exit(reason, self.last_price)
+        return {"accepted": False, "reason": f"unknown action {action!r}; expected ENTER_LONG, ENTER_SHORT or EXIT"}
+
+
+def _as_tool_text(payload: dict[str, Any]) -> dict[str, Any]:
+    """Wrap a payload dict in the MCP tool-result envelope the SDK expects."""
+    return {"content": [{"type": "text", "text": json.dumps(payload, default=str)}]}
+
+
+def build_sl_hunting_mcp_server(context: SLHuntingToolContext):
+    """Build the in-process MCP server: 5 read-only tools + 1 env-named order tool.
+
+    Returns ``(mcp_servers, allowed_tool_names)`` ready for `ClaudeAgentOptions`.
+    Imports the Claude Agent SDK lazily so importing this module never requires it
+    (mirrors the Scanner app's `build_technical_mcp_server`).
+    """
+    from claude_agent_sdk import create_sdk_mcp_server, tool  # type: ignore[import-not-found, unused-ignore]
+
+    @tool("pivot_and_levels", "Day pivot, previous-day OHLC, today's O/H/L, first-candle hi/lo, psych levels and the previous close, with distances from current price.", {})
+    async def _pivot(_args: dict[str, Any]) -> dict[str, Any]:
+        return _as_tool_text(context.pivot_and_levels_payload())
+
+    @tool("fibo_levels", "Fibonacci 50/61/78 retracement and 161/261 extension levels of the most recent significant swing, and where price sits relative to them.", {})
+    async def _fibo(_args: dict[str, Any]) -> dict[str, Any]:
+        return _as_tool_text(context.fibo_levels_payload())
+
+    @tool("candle_patterns", "Reversal candlestick patterns (hammer/doji, engulfing, inside-bar, reversal-bar, star) on recent candles, each tagged with whether a confirmation candle has already printed.", {})
+    async def _patterns(_args: dict[str, Any]) -> dict[str, Any]:
+        return _as_tool_text(context.candle_patterns_payload())
+
+    @tool("market_structure", "Swing points, trend, fast/slow read, trendline points, and W/M / double top-bottom detection.", {})
+    async def _structure(_args: dict[str, Any]) -> dict[str, Any]:
+        return _as_tool_text(context.market_structure_payload())
+
+    @tool("position_state", "Your current open position (direction, entry, stop, target, unrealised P&L) or 'flat'.", {})
+    async def _position(_args: dict[str, Any]) -> dict[str, Any]:
+        return _as_tool_text(context.position_state_payload())
+
+    order_name = context.action_tool_name()
+    venue = "PAPER" if order_name == "place_paper_order" else ("KOTAK (LIVE)" if order_name == "place_kotak_order" else "SHOONYA (LIVE)")
+
+    @tool(
+        order_name,
+        f"Place an SL-Hunting order on NIFTY ATM options via the {venue} venue (the "
+        "configuration chose this venue; you cannot change it). action is ENTER_LONG "
+        "(buy CALL), ENTER_SHORT (buy PUT) or EXIT. stop and target are NIFTY "
+        "UNDERLYING price levels (required for entries; ignored for EXIT). reason is "
+        "a one-line justification. Returns whether the order was accepted or rejected.",
+        {"action": str, "stop": float, "target": float, "reason": str},
+    )
+    async def _order(args: dict[str, Any]) -> dict[str, Any]:
+        result = context.do_order(
+            args.get("action", ""),
+            args.get("stop", 0.0),
+            args.get("target", 0.0),
+            args.get("reason", ""),
+        )
+        return _as_tool_text(result)
+
+    server = create_sdk_mcp_server(
+        name=SERVER_NAME,
+        version="1.0.0",
+        tools=[_pivot, _fibo, _patterns, _structure, _position, _order],
+    )
+    allowed = list(CONTEXT_TOOL_NAMES) + [f"mcp__{SERVER_NAME}__{order_name}"]
+    return {SERVER_NAME: server}, allowed

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_tools.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_tools.py
@@ -13,6 +13,8 @@ Read-only context tools (no arguments — each closes over the per-call context)
 - ``candle_patterns``  → reversal patterns on recent candles + confirmation status.
 - ``market_structure`` → swings, trend, fast/slow, trendline points, W/M, doubles.
 - ``position_state``   → the current open position (or flat).
+- ``bank_nifty``       → BankNIFTY's own pivot/levels/structure/patterns (advisory).
+- ``cross_index``      → NIFTY-vs-BankNIFTY alignment verdict (NF/BNF rules).
 
 Action tool (exactly ONE, named by the environment):
 - ``place_paper_order`` / ``place_kotak_order`` / ``place_shoonya_order`` — only the
@@ -37,6 +39,7 @@ import pandas as pd
 from sl_hunting_indicators import (
     SLHuntingIndicatorConfig,
     candle_patterns,
+    cross_index_signal,
     fibo_levels,
     market_structure,
     pivot_and_levels,
@@ -54,6 +57,8 @@ CONTEXT_TOOL_NAMES = [
     f"mcp__{SERVER_NAME}__candle_patterns",
     f"mcp__{SERVER_NAME}__market_structure",
     f"mcp__{SERVER_NAME}__position_state",
+    f"mcp__{SERVER_NAME}__bank_nifty",
+    f"mcp__{SERVER_NAME}__cross_index",
 ]
 
 
@@ -73,6 +78,7 @@ class SLHuntingToolContext:
     live_active: bool = False
     broker: str | None = None
     last_price: float = field(default=0.0)
+    bnf_candles: pd.DataFrame | None = None
 
     @classmethod
     def build(
@@ -83,10 +89,17 @@ class SLHuntingToolContext:
         cfg: SLHuntingIndicatorConfig | None = None,
         live_active: bool = False,
         broker: str | None = None,
+        bnf_candles: pd.DataFrame | None = None,
     ) -> "SLHuntingToolContext":
         cfg = cfg or SLHuntingIndicatorConfig()
         prepared = prepare_candles(candles)
         last_price = float(prepared["close"].iloc[-1]) if not prepared.empty else 0.0
+        # BankNIFTY is optional (advisory cross-confirmation); prepare it if given.
+        prepared_bnf = None
+        if bnf_candles is not None:
+            prepared_bnf = prepare_candles(bnf_candles)
+            if prepared_bnf.empty:
+                prepared_bnf = None
         return cls(
             candles=prepared,
             cfg=cfg,
@@ -94,6 +107,7 @@ class SLHuntingToolContext:
             live_active=bool(live_active),
             broker=broker,
             last_price=last_price,
+            bnf_candles=prepared_bnf,
         )
 
     # --- tool payload builders (plain functions; easy to unit test) ---------
@@ -112,6 +126,21 @@ class SLHuntingToolContext:
 
     def position_state_payload(self) -> dict[str, Any]:
         return self.executor.snapshot()
+
+    def bank_nifty_payload(self) -> dict[str, Any]:
+        """BankNIFTY's own pivot/levels, structure and recent patterns (advisory)."""
+        if self.bnf_candles is None or self.bnf_candles.empty:
+            return {"available": False, "reason": "BankNIFTY data unavailable; judge on NIFTY alone."}
+        return {
+            "available": True,
+            "pivot_and_levels": pivot_and_levels(self.bnf_candles, self.cfg),
+            "market_structure": market_structure(self.bnf_candles, self.cfg),
+            "candle_patterns": candle_patterns(self.bnf_candles, self.cfg),
+        }
+
+    def cross_index_payload(self) -> dict[str, Any]:
+        """NIFTY-vs-BankNIFTY alignment verdict (the doc's NF/BNF rules)."""
+        return cross_index_signal(self.candles, self.bnf_candles, self.cfg)
 
     def action_tool_name(self) -> str:
         return execution_tool_name(self.live_active, self.broker)
@@ -162,6 +191,14 @@ def build_sl_hunting_mcp_server(context: SLHuntingToolContext):
     async def _position(_args: dict[str, Any]) -> dict[str, Any]:
         return _as_tool_text(context.position_state_payload())
 
+    @tool("bank_nifty", "BankNIFTY's OWN pivot/levels, market structure and recent candle patterns (for cross-confirmation). Returns available:false when BankNIFTY data is unavailable.", {})
+    async def _bank_nifty(_args: dict[str, Any]) -> dict[str, Any]:
+        return _as_tool_text(context.bank_nifty_payload())
+
+    @tool("cross_index", "NIFTY-vs-BankNIFTY alignment verdict per the NF/BNF rules (both at support -> bias down; both breakdown -> bias up; one fails -> the holder wins; opposite sides of pivot -> wait). Advisory. available:false when BankNIFTY data is unavailable.", {})
+    async def _cross_index(_args: dict[str, Any]) -> dict[str, Any]:
+        return _as_tool_text(context.cross_index_payload())
+
     order_name = context.action_tool_name()
     venue = "PAPER" if order_name == "place_paper_order" else ("KOTAK (LIVE)" if order_name == "place_kotak_order" else "SHOONYA (LIVE)")
 
@@ -186,7 +223,7 @@ def build_sl_hunting_mcp_server(context: SLHuntingToolContext):
     server = create_sdk_mcp_server(
         name=SERVER_NAME,
         version="1.0.0",
-        tools=[_pivot, _fibo, _patterns, _structure, _position, _order],
+        tools=[_pivot, _fibo, _patterns, _structure, _position, _bank_nifty, _cross_index, _order],
     )
     allowed = list(CONTEXT_TOOL_NAMES) + [f"mcp__{SERVER_NAME}__{order_name}"]
     return {SERVER_NAME: server}, allowed

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_agent.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_agent.py
@@ -1,0 +1,204 @@
+"""Agent + executor + tool-context tests (no SDK / CLI / network).
+
+The agentic loop is driven by an injected ``_FakeRunner`` so these tests never
+spawn the Claude CLI — mirroring the Streamlit Scanner App's testing seam.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pandas as pd
+
+from sl_hunting_agent import AgentRunResult, SLHuntingAgent, SLHuntingDecision
+from sl_hunting_executor import (
+    MasterWorkerExecutor,
+    StandaloneExecutor,
+    execution_tool_name,
+)
+from sl_hunting_tools import SLHuntingToolContext
+
+
+def _candles(n=30, start_price=25000.0):
+    ts = pd.date_range(start="2026-06-26 09:15", periods=n, freq="5min")
+    closes = [start_price + i for i in range(n)]
+    rows = []
+    prev = closes[0]
+    for c in closes:
+        rows.append((prev, max(prev, c) + 2, min(prev, c) - 2, c))
+        prev = c
+    return pd.DataFrame(
+        {
+            "timestamp": ts,
+            "open": [r[0] for r in rows],
+            "high": [r[1] for r in rows],
+            "low": [r[2] for r in rows],
+            "close": [r[3] for r in rows],
+            "volume": [100] * n,
+        }
+    )
+
+
+class _FakeRunner:
+    """Stand-in for the Claude Agent SDK runner; returns canned final text."""
+
+    def __init__(self, text: str, *, cost_usd: float | None = 0.01):
+        self.text = text
+        self.cost_usd = cost_usd
+        self.calls = 0
+        self.last_model = None
+
+    async def __call__(self, prompt, *, system_prompt, model, max_turns, tool_context=None):
+        self.calls += 1
+        self.last_model = model
+        return AgentRunResult(text=self.text, cost_usd=self.cost_usd)
+
+
+# --------------------------------------------------------------------------
+# execution_tool_name — the env "picks one of three tools" mapping
+# --------------------------------------------------------------------------
+
+def test_execution_tool_name_mapping():
+    assert execution_tool_name(False, None) == "place_paper_order"
+    assert execution_tool_name(False, "KOTAK") == "place_paper_order"
+    assert execution_tool_name(True, "KOTAK") == "place_kotak_order"
+    assert execution_tool_name(True, "shoonya") == "place_shoonya_order"
+    # Unknown broker fails closed to paper.
+    assert execution_tool_name(True, "ZERODHA") == "place_paper_order"
+
+
+# --------------------------------------------------------------------------
+# StandaloneExecutor guards + P&L proxy
+# --------------------------------------------------------------------------
+
+def test_standalone_executor_enter_exit_and_guards():
+    ex = StandaloneExecutor(lots=1, lot_size=75)
+    assert ex.exit("flat", price=25000)["accepted"] is False  # cannot exit when flat
+
+    r = ex.enter("LONG", stop=24950, target=25100, reason="test", price=25000)
+    assert r["accepted"] is True
+    assert ex.snapshot()["in_position"] is True
+
+    # cannot enter again while in a position
+    assert ex.enter("SHORT", 25050, 24900, "again", 25000)["accepted"] is False
+
+    out = ex.exit("target", price=25075)
+    assert out["accepted"] is True
+    assert out["points"] == 75.0
+    assert out["pnl_proxy"] == 75.0 * 75
+    assert ex.snapshot()["in_position"] is False
+    assert len(ex.closed_trades) == 1
+
+
+def test_standalone_executor_rejects_bad_direction():
+    ex = StandaloneExecutor()
+    assert ex.enter("SIDEWAYS", 1, 2, "x", 100)["accepted"] is False
+
+
+# --------------------------------------------------------------------------
+# Tool context routes orders through the executor
+# --------------------------------------------------------------------------
+
+def test_tool_context_do_order_routes_to_executor():
+    ex = StandaloneExecutor()
+    ctx = SLHuntingToolContext.build(_candles(), ex, live_active=False, broker=None)
+    assert ctx.action_tool_name() == "place_paper_order"
+
+    res = ctx.do_order("ENTER_LONG", stop=24990, target=25080, reason="pivot bounce")
+    assert res["accepted"] is True
+    assert ex.snapshot()["in_position"] is True
+    assert ex.pos.direction == "LONG"
+
+    # context tool payloads are JSON-serialisable dicts
+    assert ctx.pivot_and_levels_payload()["available"] is True
+    assert ctx.position_state_payload()["in_position"] is True
+
+
+# --------------------------------------------------------------------------
+# Agent.decide with the fake runner
+# --------------------------------------------------------------------------
+
+def test_agent_decide_parses_canned_json_and_stamps_model():
+    canned = json.dumps(
+        {
+            "action": "HOLD",
+            "stop": 0,
+            "target": 0,
+            "confidence": 3,
+            "setup": "none",
+            "reasoning": "No confirmed setup at a level; waiting.",
+            "model_used": "ignored-will-be-overwritten",
+        }
+    )
+    agent = SLHuntingAgent(model="test-model", runner=_FakeRunner(canned))
+    decision = agent.decide(_candles(), StandaloneExecutor())
+    assert isinstance(decision, SLHuntingDecision)
+    assert decision.action == "HOLD"
+    assert decision.confidence == 3
+    assert decision.model_used == "test-model"  # stamped by the agent
+
+
+def test_agent_decide_holds_on_malformed_output():
+    agent = SLHuntingAgent(model="test-model", runner=_FakeRunner("this is not json"), attempts=2)
+    decision = agent.decide(_candles(), StandaloneExecutor())
+    assert decision.action == "HOLD"
+    assert decision.setup == "agent_error"
+
+
+def test_agent_decide_on_empty_candles_holds():
+    agent = SLHuntingAgent(model="test-model", runner=_FakeRunner("{}"))
+    empty = pd.DataFrame(columns=["timestamp", "open", "high", "low", "close"])
+    decision = agent.decide(empty, StandaloneExecutor())
+    assert decision.action == "HOLD"
+    assert decision.setup == "no_data"
+
+
+# --------------------------------------------------------------------------
+# MasterWorkerExecutor duck-types the worker
+# --------------------------------------------------------------------------
+
+class _FakePos:
+    def __init__(self):
+        self.active = False
+        self.direction = ""
+        self.entry_underlying = 0.0
+        self.stop_underlying = 0.0
+        self.target_underlying = 0.0
+
+
+class _FakeWorker:
+    def __init__(self):
+        self.pos = _FakePos()
+        self.entries = []
+
+    def enter_position(self, direction, entry_underlying, stop_underlying=0.0, target_underlying=0.0):
+        self.entries.append((direction, entry_underlying, stop_underlying, target_underlying))
+        self.pos.active = True
+        self.pos.direction = direction
+        self.pos.entry_underlying = entry_underlying
+        self.pos.stop_underlying = stop_underlying
+        self.pos.target_underlying = target_underlying
+        return True
+
+    def exit_position(self, reason):
+        self.pos = _FakePos()
+
+    def _get_open_position_pnl(self):
+        return 123.0
+
+
+def test_master_worker_executor_delegates():
+    w = _FakeWorker()
+    ex = MasterWorkerExecutor(w)
+    assert ex.snapshot() == {"in_position": False}
+
+    r = ex.enter("LONG", stop=24950, target=25100, reason="x", price=25000)
+    assert r["accepted"] is True
+    assert w.entries == [("LONG", 25000.0, 24950.0, 25100.0)]
+    snap = ex.snapshot()
+    assert snap["in_position"] is True and snap["unrealized_pnl"] == 123.0
+
+    # cannot enter again while in a position
+    assert ex.enter("SHORT", 1, 2, "y", 25000)["accepted"] is False
+    assert ex.exit("done", price=25050)["accepted"] is True
+    assert ex.snapshot()["in_position"] is False

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_agent.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_agent.py
@@ -139,7 +139,7 @@ def test_agent_decide_parses_canned_json_and_stamps_model():
 
 
 def test_agent_decide_holds_on_malformed_output():
-    agent = SLHuntingAgent(model="test-model", runner=_FakeRunner("this is not json"), attempts=2)
+    agent = SLHuntingAgent(model="test-model", runner=_FakeRunner("this is not json"))
     decision = agent.decide(_candles(), StandaloneExecutor())
     assert decision.action == "HOLD"
     assert decision.setup == "agent_error"

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_indicators.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_indicators.py
@@ -1,0 +1,111 @@
+"""Tests for the deterministic SL-Hunting detectors."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from sl_hunting_indicators import (
+    SLHuntingIndicatorConfig,
+    candle_patterns,
+    fibo_levels,
+    market_structure,
+    pivot_and_levels,
+    prepare_candles,
+)
+
+
+def _ohlc(rows, start="2026-06-26 09:15"):
+    """Build an OHLC frame from (o,h,l,c) tuples at 5-min steps."""
+    ts = pd.date_range(start=start, periods=len(rows), freq="5min")
+    return pd.DataFrame(
+        {
+            "timestamp": ts,
+            "open": [r[0] for r in rows],
+            "high": [r[1] for r in rows],
+            "low": [r[2] for r in rows],
+            "close": [r[3] for r in rows],
+            "volume": [100] * len(rows),
+        }
+    )
+
+
+def _closes_to_ohlc(closes, start="2026-06-26 09:15"):
+    rows = []
+    prev = closes[0]
+    for c in closes:
+        o = prev
+        hi = max(o, c) + 1.0
+        lo = min(o, c) - 1.0
+        rows.append((o, hi, lo, c))
+        prev = c
+    return _ohlc(rows, start=start)
+
+
+def test_prepare_candles_accepts_datetime_index():
+    df = _ohlc([(100, 101, 99, 100)]).set_index("timestamp")
+    prepared = prepare_candles(df)
+    assert "timestamp" in prepared.columns
+    assert len(prepared) == 1
+
+
+def test_pivot_uses_previous_day_ohlc():
+    # Previous day (2026-06-25): high 110, low 90, close 100 -> pivot = 100.0
+    prev = _ohlc(
+        [(95, 110, 90, 100), (100, 105, 98, 100)],
+        start="2026-06-25 09:15",
+    )
+    today = _ohlc([(101, 103, 100, 102)], start="2026-06-26 09:15")
+    df = pd.concat([prev, today], ignore_index=True)
+
+    result = pivot_and_levels(df)
+    assert result["available"] is True
+    assert result["pivot"] == round((110 + 90 + 100) / 3.0, 2)
+    assert result["previous_day_ohlc"] == {"open": 95.0, "high": 110.0, "low": 90.0, "close": 100.0}
+    assert result["today"]["first_candle_high"] == 103.0
+    assert result["previous_close"] == 100.0
+
+
+def test_fibo_levels_available_with_swings():
+    closes = (
+        list(range(100, 116))      # up to ~115
+        + list(range(115, 105, -1))  # pull back to ~106
+        + list(range(106, 122))    # up to ~121
+        + list(range(121, 112, -1))  # pull back
+    )
+    df = _closes_to_ohlc([float(c) for c in closes])
+    result = fibo_levels(df)
+    assert result["available"] is True
+    assert set(result["retracements"]) == {"50%", "61%", "78%"}
+    assert result["swing_direction"] in ("up", "down")
+
+
+def test_candle_patterns_detects_confirmed_bullish_engulfing():
+    rows = [
+        (100, 101, 99, 100.0),   # filler
+        (100, 101, 99, 100.0),   # filler
+        (100, 101, 95, 96.0),    # bearish (engulf target)
+        (95, 103, 94, 102.0),    # bullish engulfing of the prior body
+        (103, 109, 102.5, 108.0),  # full-body bullish confirmation closing above pattern high
+    ]
+    df = _ohlc(rows)
+    result = candle_patterns(df)
+    assert result["available"] is True
+    kinds = {p["type"] for p in result["patterns"]}
+    assert "bullish_engulfing" in kinds
+    confirmed = [p for p in result["confirmed_patterns"] if p["type"] == "bullish_engulfing"]
+    assert confirmed and confirmed[0]["confirmed"] is True
+
+
+def test_market_structure_reports_trend_and_speed():
+    closes = [float(c) for c in (list(range(100, 130)) )]
+    df = _closes_to_ohlc(closes)
+    result = market_structure(df)
+    assert result["available"] is True
+    assert result["trend"] in ("uptrend", "downtrend", "sideways")
+    assert result["speed"] in ("accelerating", "decelerating", "steady", "unknown")
+
+
+def test_empty_frame_is_handled():
+    empty = pd.DataFrame(columns=["timestamp", "open", "high", "low", "close"])
+    assert pivot_and_levels(empty)["available"] is False
+    assert fibo_levels(empty)["available"] is False

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_runner.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_runner.py
@@ -33,6 +33,13 @@ def test_resample_1m_to_5m_aggregates_ohlc():
     assert set(["timestamp", "open", "high", "low", "close"]).issubset(out.columns)
 
 
+def test_resample_drops_incomplete_tail_bucket():
+    # 12 one-minute bars -> two COMPLETE 5-min bars (09:15, 09:20); the 09:25 bucket
+    # has only 2 of 5 rows and must be dropped (matches the master's resampler).
+    out = resample_1m_to_n(_one_min(n=12), 5)
+    assert len(out) == 2
+
+
 def test_manage_open_position_fills_long_target_and_stop():
     ex = StandaloneExecutor()
     ex.enter("LONG", stop=24950, target=25100, reason="t", price=25000)

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_runner.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_runner.py
@@ -1,0 +1,58 @@
+"""Tests for the standalone runner's non-trivial helpers."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from sl_hunting_executor import StandaloneExecutor
+from sl_hunting_runner import _manage_open_position, resample_1m_to_n
+
+
+def _one_min(n=20, start_price=25000.0):
+    ts = pd.date_range(start="2026-06-26 09:15", periods=n, freq="1min")
+    closes = [start_price + i for i in range(n)]
+    return pd.DataFrame(
+        {
+            "timestamp": ts,
+            "open": closes,
+            "high": [c + 1 for c in closes],
+            "low": [c - 1 for c in closes],
+            "close": closes,
+            "volume": [10] * n,
+        }
+    )
+
+
+def test_resample_1m_to_5m_aggregates_ohlc():
+    df = _one_min(n=20)
+    out = resample_1m_to_n(df, 5)
+    # 20 one-minute bars → 4 five-minute bars.
+    assert len(out) == 4
+    # First 5-min bar's high should be the max of its constituent 1-min highs.
+    assert out.iloc[0]["high"] == df.iloc[:5]["high"].max()
+    assert set(["timestamp", "open", "high", "low", "close"]).issubset(out.columns)
+
+
+def test_manage_open_position_fills_long_target_and_stop():
+    ex = StandaloneExecutor()
+    ex.enter("LONG", stop=24950, target=25100, reason="t", price=25000)
+    # A bar whose high reaches the target fills the target.
+    bar = pd.Series({"high": 25120.0, "low": 25010.0})
+    _manage_open_position(ex, bar)
+    assert ex.snapshot()["in_position"] is False
+    assert ex.closed_trades[-1]["exit_reason"] == "target_hit"
+
+    ex2 = StandaloneExecutor()
+    ex2.enter("LONG", stop=24950, target=25100, reason="t", price=25000)
+    bar2 = pd.Series({"high": 25010.0, "low": 24940.0})  # low breaches stop
+    _manage_open_position(ex2, bar2)
+    assert ex2.snapshot()["in_position"] is False
+    assert ex2.closed_trades[-1]["exit_reason"] == "stop_hit"
+
+
+def test_manage_open_position_fills_short():
+    ex = StandaloneExecutor()
+    ex.enter("SHORT", stop=25050, target=24900, reason="t", price=25000)
+    bar = pd.Series({"high": 25010.0, "low": 24880.0})  # low reaches target
+    _manage_open_position(ex, bar)
+    assert ex.closed_trades[-1]["exit_reason"] == "target_hit"

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
@@ -64,3 +64,12 @@ def test_system_prompt_has_final_output_marker():
     # The method's core rules should be present in the agent's "brain".
     assert "pivot" in prompt.lower()
     assert "confirmation" in prompt.lower()
+
+
+def test_system_prompt_has_v2_markers():
+    """v2: BankNIFTY cross-confirmation section + the dynamic-sizing note are present."""
+    prompt = build_system_prompt()
+    assert "CROSS-INDEX CONFIRMATION" in prompt
+    assert "bank_nifty" in prompt and "cross_index" in prompt
+    # The agent is told sizing is automatic at ~Rs.2500 risk (it does not pick lots).
+    assert "2500" in prompt

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
@@ -1,0 +1,66 @@
+"""Strict-schema tests for the SLHuntingDecision output contract."""
+
+from __future__ import annotations
+
+import pytest
+
+from sl_hunting_agent import SLHuntingDecision
+from sl_hunting_knowledge import FINAL_OUTPUT_INSTRUCTION, build_system_prompt
+
+
+def _valid_payload(**overrides):
+    payload = {
+        "action": "ENTER_LONG",
+        "stop": 24950.0,
+        "target": 25100.0,
+        "confidence": 7,
+        "setup": "pivot_support_hammer",
+        "reasoning": "Hammer at pivot with bullish confirmation; tight stop, clear target.",
+        "model_used": "claude-opus-4-8",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_valid_decision_parses():
+    decision = SLHuntingDecision.model_validate(_valid_payload())
+    assert decision.action == "ENTER_LONG"
+    assert decision.confidence == 7
+
+
+def test_confidence_out_of_range_is_rejected():
+    with pytest.raises(Exception):
+        SLHuntingDecision.model_validate(_valid_payload(confidence=11))
+    with pytest.raises(Exception):
+        SLHuntingDecision.model_validate(_valid_payload(confidence=-1))
+
+
+def test_strict_rejects_unknown_fields_and_coercion():
+    # extra field forbidden
+    with pytest.raises(Exception):
+        SLHuntingDecision.model_validate(_valid_payload(unexpected="x"))
+    # strict mode: a string is not coerced to int for confidence
+    with pytest.raises(Exception):
+        SLHuntingDecision.model_validate(_valid_payload(confidence="7"))
+
+
+def test_invalid_action_rejected():
+    with pytest.raises(Exception):
+        SLHuntingDecision.model_validate(_valid_payload(action="BUY"))
+
+
+def test_json_schema_omits_min_max_on_confidence():
+    """Regression guard: Claude rejects minimum/maximum on integer types."""
+    schema = SLHuntingDecision.model_json_schema()
+    conf = schema["properties"]["confidence"]
+    assert conf["type"] == "integer"
+    assert "minimum" not in conf
+    assert "maximum" not in conf
+
+
+def test_system_prompt_has_final_output_marker():
+    prompt = build_system_prompt() + FINAL_OUTPUT_INSTRUCTION
+    assert "FINAL OUTPUT FORMAT" in prompt
+    # The method's core rules should be present in the agent's "brain".
+    assert "pivot" in prompt.lower()
+    assert "confirmation" in prompt.lower()

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_v2.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_v2.py
@@ -1,0 +1,131 @@
+"""v2 tests: BankNIFTY cross-confirmation + dynamic (Rs.2500) position sizing."""
+
+from __future__ import annotations
+
+import json
+
+import pandas as pd
+
+from sl_hunting_agent import AgentRunResult, SLHuntingAgent
+from sl_hunting_executor import StandaloneExecutor, risk_based_lots
+from sl_hunting_indicators import cross_index_signal
+from sl_hunting_tools import SLHuntingToolContext
+
+
+def _two_day(prev_high, prev_low, prev_close, today_closes):
+    """Build a 2-day 5-min OHLC frame (prev day sets H/L/C; today is a close path)."""
+    prev_rows = [
+        (prev_low, prev_high, prev_low, prev_high),
+        (prev_high, prev_high, prev_low, prev_close),
+    ]
+    today_rows = []
+    p = prev_close
+    for c in today_closes:
+        today_rows.append((p, max(p, c) + 1, min(p, c) - 1, c))
+        p = c
+    rows = prev_rows + today_rows
+    ts = list(pd.date_range("2026-06-25 09:15", periods=len(prev_rows), freq="5min")) + \
+        list(pd.date_range("2026-06-26 09:15", periods=len(today_rows), freq="5min"))
+    return pd.DataFrame({
+        "timestamp": ts,
+        "open": [r[0] for r in rows], "high": [r[1] for r in rows],
+        "low": [r[2] for r in rows], "close": [r[3] for r in rows],
+        "volume": [100] * len(rows),
+    })
+
+
+# Both indices sitting on support (last just above prev-day low; pivot above).
+_NIFTY_AT_SUPPORT = _two_day(25100, 24900, 25000, [24960, 24950, 24940, 24930, 24920, 24910, 24905, 24902])
+_BNF_AT_SUPPORT = _two_day(55100, 54900, 55000, [54960, 54950, 54940, 54930, 54920, 54910, 54905, 54902])
+# Both indices broke down through pivot (rose above pivot, then closed clearly below
+# it — BankNIFTY needs a larger drop since its 0.15% "at-level" band is ~2x NIFTY's).
+_NIFTY_BREAKDOWN = _two_day(25100, 24900, 25000, [25010, 25030, 25020, 24990, 24970, 24950, 24940])
+_BNF_BREAKDOWN = _two_day(55100, 54900, 55000, [55010, 55030, 55020, 54980, 54940, 54900, 54870])
+
+
+# --------------------------------------------------------------------------
+# cross_index_signal
+# --------------------------------------------------------------------------
+
+def test_cross_index_unavailable_without_bnf():
+    out = cross_index_signal(_NIFTY_AT_SUPPORT, None)
+    assert out["available"] is False
+    assert "NIFTY alone" in out["reason"]
+
+
+def test_cross_index_both_at_support_biases_down():
+    out = cross_index_signal(_NIFTY_AT_SUPPORT, _BNF_AT_SUPPORT)
+    assert out["available"] is True
+    assert out["nifty"]["at_support"] is True and out["bank_nifty"]["at_support"] is True
+    assert out["alignment"] == "both_at_support"
+    assert out["bias"] == "down"
+
+
+def test_cross_index_both_breakdown_biases_up():
+    out = cross_index_signal(_NIFTY_BREAKDOWN, _BNF_BREAKDOWN)
+    assert out["available"] is True
+    assert out["nifty"]["broke_pivot_down"] is True and out["bank_nifty"]["broke_pivot_down"] is True
+    assert out["alignment"] == "both_breakdown"
+    assert out["bias"] == "up"
+
+
+# --------------------------------------------------------------------------
+# bank_nifty / cross_index tool payloads via the context
+# --------------------------------------------------------------------------
+
+def test_tool_payloads_available_with_bnf_and_unavailable_without():
+    with_bnf = SLHuntingToolContext.build(_NIFTY_AT_SUPPORT, StandaloneExecutor(), bnf_candles=_BNF_AT_SUPPORT)
+    assert with_bnf.bank_nifty_payload()["available"] is True
+    assert with_bnf.cross_index_payload()["available"] is True
+
+    no_bnf = SLHuntingToolContext.build(_NIFTY_AT_SUPPORT, StandaloneExecutor(), bnf_candles=None)
+    assert no_bnf.bank_nifty_payload()["available"] is False
+    assert no_bnf.cross_index_payload()["available"] is False
+
+
+# --------------------------------------------------------------------------
+# decide() passes bnf_candles through (fake runner)
+# --------------------------------------------------------------------------
+
+class _FakeRunner:
+    def __init__(self, text):
+        self.text = text
+
+    async def __call__(self, prompt, *, system_prompt, model, max_turns, tool_context=None):
+        return AgentRunResult(text=self.text, cost_usd=0.0)
+
+
+def test_decide_accepts_bnf_candles():
+    canned = json.dumps({"action": "HOLD", "stop": 0, "target": 0, "confidence": 2,
+                         "setup": "none", "reasoning": "waiting", "model_used": "x"})
+    agent = SLHuntingAgent(model="test-model", runner=_FakeRunner(canned))
+    decision = agent.decide(_NIFTY_AT_SUPPORT, StandaloneExecutor(), bnf_candles=_BNF_AT_SUPPORT)
+    assert decision.action == "HOLD"
+    assert decision.model_used == "test-model"
+
+
+# --------------------------------------------------------------------------
+# Dynamic position sizing (~Rs.2500 risk per trade)
+# --------------------------------------------------------------------------
+
+def test_risk_based_lots_targets_budget():
+    # 15-pt stop, lot 75 -> risk/lot 1125; ceil(2500/1125)=3.
+    assert risk_based_lots(25000, 24985, 75, 2500) == 3
+    # 40-pt stop -> risk/lot 3000; ceil(2500/3000)=1 (never zero).
+    assert risk_based_lots(25000, 24960, 75, 2500) == 1
+    # 10-pt stop -> risk/lot 750; ceil(2500/750)=4.
+    assert risk_based_lots(25000, 24990, 75, 2500) == 4
+
+
+def test_risk_based_lots_falls_back_on_zero_distance():
+    assert risk_based_lots(25000, 25000, 75, 2500, fallback_lots=2) == 2
+
+
+def test_standalone_executor_sizes_dynamically():
+    ex = StandaloneExecutor(lot_size=75, risk_budget=2500)
+    r = ex.enter("LONG", stop=24985, target=25060, reason="t", price=25000)
+    assert r["accepted"] is True
+    assert r["lots"] == 3 and r["quantity"] == 3 * 75
+    out = ex.exit("target", price=25020)  # +20 pts
+    assert out["lots"] == 3
+    assert out["pnl_proxy"] == 20 * 3 * 75

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_v2.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_v2.py
@@ -7,7 +7,7 @@ import json
 import pandas as pd
 
 from sl_hunting_agent import AgentRunResult, SLHuntingAgent
-from sl_hunting_executor import StandaloneExecutor, risk_based_lots
+from sl_hunting_executor import StandaloneExecutor, risk_based_lots, stop_or_target_hit
 from sl_hunting_indicators import cross_index_signal
 from sl_hunting_tools import SLHuntingToolContext
 
@@ -119,6 +119,19 @@ def test_risk_based_lots_targets_budget():
 
 def test_risk_based_lots_falls_back_on_zero_distance():
     assert risk_based_lots(25000, 25000, 75, 2500, fallback_lots=2) == 2
+
+
+def test_stop_or_target_hit():
+    # LONG: spot at/below stop -> AI_STOP; at/above target -> AI_TARGET.
+    assert stop_or_target_hit("LONG", 24985, 25080, 24980) == "AI_STOP"
+    assert stop_or_target_hit("LONG", 24985, 25080, 25090) == "AI_TARGET"
+    assert stop_or_target_hit("LONG", 24985, 25080, 25000) is None
+    # SHORT: spot at/above stop -> AI_STOP; at/below target -> AI_TARGET.
+    assert stop_or_target_hit("SHORT", 25050, 24900, 25060) == "AI_STOP"
+    assert stop_or_target_hit("SHORT", 25050, 24900, 24890) == "AI_TARGET"
+    assert stop_or_target_hit("SHORT", 25050, 24900, 25000) is None
+    # Zero levels mean "not set" -> never trigger.
+    assert stop_or_target_hit("LONG", 0, 0, 1) is None
 
 
 def test_standalone_executor_sizes_dynamically():

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,10 @@ requests
 #   scikit-learn
 # Optional faster indicators (the signal generators fall back to pandas if absent):
 #   TA-Lib
+# SL Hunting AI Agent (optional, LLM-driven strategy under "Signal Generators/
+# SL Hunting AI Agent/") — only needed when SL_HUNTING_ENABLED=true. The Claude
+# Agent SDK runs on your Claude subscription (bundled Claude CLI login; keep
+# ANTHROPIC_API_KEY UNSET). pydantic validates the agent's JSON decisions. Both
+# are lazily imported, so the master and its test suite run fine without them:
+#   claude-agent-sdk
+#   pydantic


### PR DESCRIPTION
## What & why

Adds a new **opt-in, LLM-driven** NIFTY index-options strategy under
`Signal Generators/SL Hunting AI Agent/`. Instead of a deterministic signal
engine, a **Claude agent** (`claude-agent-sdk`) trades the discretionary
*"SL Hunting"* price-action method — pivot retests, previous-day OHLC, Fibonacci
50/61/78 reversals, the mandatory *candlestick pattern + confirmation candle*
rule, trendline 3rd-point/break logic, W/M patterns, the gap playbook, and the
core psychology of trading **opposite to where retail stop-losses sit**.

An LLM "brain" fits this judgment-heavy, multi-signal method where a
deterministic engine struggles. The implementation mirrors the in-house agent
pattern from the sibling **Streamlit Scanner App** repo: `claude-agent-sdk` on
the Claude subscription (no API key), in-process MCP tool servers, an injectable
`runner=` testing seam, a Windows-safe async→sync bridge, and strict Pydantic
output validation.

## How it works

Once per **completed 5-min bar** (configurable), the agent calls read-only
context tools (`pivot_and_levels`, `candle_patterns` with confirmation status,
`fibo_levels`, `market_structure`, `position_state`), and — only if a confirmed
setup at a real level with a tight stop and worthwhile target is present — calls
its **single order tool** to act. `ENTER_LONG` buys an ATM CALL; `ENTER_SHORT`
buys an ATM PUT. Its final message is a strict `SLHuntingDecision` JSON object.

## Changes

**New folder `Signal Generators/SL Hunting AI Agent/`**
- `sl_hunting_doc.md` — verbatim source methodology (ground truth)
- `sl_hunting_knowledge.py` — `build_system_prompt()` + strict-JSON contract
- `sl_hunting_indicators.py` — deterministic detectors (pivot/levels, fibo, candlestick patterns + confirmation, structure)
- `sl_hunting_tools.py` — 5 read-only MCP tools + 1 env-selected order tool
- `sl_hunting_executor.py` — `StandaloneExecutor` (paper) + `MasterWorkerExecutor`
- `sl_hunting_ai_validation.py` — `StrictAIModel` + `parse_with_retry`
- `sl_hunting_agent.py` — `SLHuntingAgent` + `SLHuntingDecision`
- `sl_hunting_runner.py` — standalone PAPER harness (synthetic/CSV)
- `tests/` (4 files, 23 tests) + `README.md` + `conftest.py`

**Master integration (`Nifty Multi Strategy Front Test - Master File.py`)**
- `SLHuntingAIWorker(AtmSingleLegStrategyWorker)` — calls the agent once per new
  completed bar, acting through the worker's own `enter_position`/`exit_position`
- Guarded optional import (fail-soft, like the broker layer), roster wiring gated
  by `SL_HUNTING_ENABLED`, and a `STRATEGY_ENV_PREFIX["SL Hunting AI"]` entry

**Config & docs**
- `Dependencies/env.example` — `SL_HUNTING_*` block
- `requirements.txt` — optional `claude-agent-sdk` + `pydantic`
- Synced master header docstring and `CLAUDE.md`

## Safety (live-money)

- **Paper by default.** Real orders only when `LIVE_TRADING_ENABLED` **and**
  `SL_HUNTING_LIVE_TRADING` are both true; the live broker is the existing
  `LIVE_BROKER`. Live orders go through the one shared, lock-guarded broker
  session (max-loss, square-off, Telegram all apply).
- The agent is handed exactly **one** env-selected order tool, so it can never
  pick paper-vs-real or the broker.
- `claude-agent-sdk` / `pydantic` are **lazily imported** — a missing dep just
  disables this one worker. The agent **never raises** into the trading loop
  (returns `HOLD` on any failure).

## Scope

NIFTY-only for v1 — BankNIFTY is not in the master's live data store; BNF
cross-confirmation is a documented future enhancement.

## Verification

- ✅ 23 new folder tests pass (`pytest`)
- ✅ Master `unittest` suite (133 tests) green **with and without** the new deps
- ✅ Master loads the worker when `SL_HUNTING_ENABLED=true` (no SDK needed at import)
- ✅ Standalone pipeline runs end-to-end (`--synthetic --fake`)
- ⚠️ A **real Claude decision was not run** here — `claude-agent-sdk` isn't
  installed in this environment. To validate live behavior:
  `pip install claude-agent-sdk pydantic` + `claude login`, then
  `python sl_hunting_runner.py --csv <nifty_1m.csv> --max-bars 20`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
