### PR TITLE
Gitignore Google Sheets OAuth credential files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ Dependencies/gsheet_oauth_*.json
 # Generated outputs (downloaded OHLC data, backtest results, logs)
 Backtest Outputs/
 *.log
+# DhanHQ instrument master dump (regenerated daily by the runner; auto-swept)
+Dependencies/all_instrument*.csv
 
 # IDE / OS
 .vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ env/
 .env.*
 # Shoonya/Noren session token, if ever written to disk (broker session secret)
 shoonyakey.txt
+# Google Sheets OAuth client + cached token (credentials for the EOD P&L export)
+Dependencies/gsheet_oauth_*.json
 
 # Generated outputs (downloaded OHLC data, backtest results, logs)
 Backtest Outputs/


### PR DESCRIPTION
## What & why

`Dependencies/gsheet_oauth_client.json` and `Dependencies/gsheet_oauth_token.json` are the
Google Sheets OAuth **client secret + cached user token** used by the end-of-day P&L export.
They were sitting **untracked but not ignored**, so a stray `git add -A` could have committed
live credentials. This adds them to `.gitignore` (glob `Dependencies/gsheet_oauth_*.json`,
under the existing "Environment / secrets" section).

The files were never tracked, so no history scrub is needed — this just prevents a future
accidental commit.

## Verification
- `git check-ignore Dependencies/gsheet_oauth_client.json Dependencies/gsheet_oauth_token.json`
  now reports both as ignored.
- `git status` no longer lists them as untracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
