### PR TITLE
Fix SL Hunting fast-mode crash: ThinkingConfigDisabled() -> KeyError 'type'

### DIFF
--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_agent.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_agent.py
@@ -181,6 +181,26 @@ def _mentions_usage_limit(*texts: str | None) -> bool:
     return any(k in blob for k in ("usage limit", "rate limit", "429", "quota"))
 
 
+def _disabled_thinking_config(sdk_module: Any) -> dict[str, Any] | None:
+    """Build the SDK ``thinking`` option that DISABLES extended thinking (fast mode).
+
+    Returns ``{"type": "disabled"}`` (via the SDK's ``ThinkingConfigDisabled`` type),
+    or ``None`` when the installed SDK is too old to expose that type (the caller then
+    warns and falls back to the default thinking).
+
+    Why this helper exists: ``ThinkingConfigDisabled`` is a *TypedDict*, so a bare
+    ``ThinkingConfigDisabled()`` evaluates to an empty ``{}`` with NO ``"type"`` key.
+    The SDK's ``_build_command`` reads ``thinking["type"]`` unconditionally, so that
+    empty dict makes it raise ``KeyError: 'type'`` before the CLI is ever launched --
+    i.e. `SL_HUNTING_FAST_MODE=true` crashed the agent. The fix is to build the dict
+    WITH its required ``type="disabled"`` field.
+    """
+    thinking_disabled = getattr(sdk_module, "ThinkingConfigDisabled", None)
+    if thinking_disabled is None:
+        return None
+    return thinking_disabled(type="disabled")
+
+
 # ---------------------------------------------------------------------------
 # Agent
 # ---------------------------------------------------------------------------
@@ -293,7 +313,6 @@ class SLHuntingAgent:
                 "UNSET so it bills your plan, not per-token API usage."
             ) from exc
 
-        ThinkingConfigDisabled = getattr(claude_sdk, "ThinkingConfigDisabled", None)
         mcp_servers, allowed_tools = build_sl_hunting_mcp_server(tool_context)
 
         options_kwargs: dict[str, Any] = {
@@ -307,10 +326,12 @@ class SLHuntingAgent:
             "permission_mode": "dontAsk",
             "setting_sources": [],
         }
-        if self._fast_mode and ThinkingConfigDisabled is not None:
-            options_kwargs["thinking"] = ThinkingConfigDisabled()
-        elif self._fast_mode:
-            logger.warning("SL Hunting fast mode requested but ThinkingConfigDisabled is unavailable; using default thinking.")
+        if self._fast_mode:
+            thinking_cfg = _disabled_thinking_config(claude_sdk)
+            if thinking_cfg is not None:
+                options_kwargs["thinking"] = thinking_cfg
+            else:
+                logger.warning("SL Hunting fast mode requested but ThinkingConfigDisabled is unavailable; using default thinking.")
         options = ClaudeAgentOptions(**options_kwargs)
 
         final_text = ""

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_coach.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_coach.py
@@ -31,6 +31,7 @@ from typing import Any
 
 from pydantic import ValidationError
 
+from sl_hunting_agent import _disabled_thinking_config
 from sl_hunting_ai_validation import parse_with_retry
 from sl_hunting_lessons import (
     CoachOutput,
@@ -151,7 +152,6 @@ class CoachAgent:
                 "sign in once with the Claude CLI (keep ANTHROPIC_API_KEY UNSET)."
             ) from exc
 
-        ThinkingConfigDisabled = getattr(claude_sdk, "ThinkingConfigDisabled", None)
         options_kwargs: dict[str, Any] = {
             "model": model,
             "system_prompt": system_prompt,
@@ -159,8 +159,14 @@ class CoachAgent:
             "permission_mode": "dontAsk",
             "setting_sources": [],
         }
-        if self._fast_mode and ThinkingConfigDisabled is not None:
-            options_kwargs["thinking"] = ThinkingConfigDisabled()
+        if self._fast_mode:
+            # Shared helper builds {"type": "disabled"}; a bare ThinkingConfigDisabled()
+            # is {} and would KeyError in the SDK's _build_command (see the helper docstring).
+            thinking_cfg = _disabled_thinking_config(claude_sdk)
+            if thinking_cfg is not None:
+                options_kwargs["thinking"] = thinking_cfg
+            else:
+                logger.warning("SL Hunting coach fast mode requested but ThinkingConfigDisabled is unavailable; using default thinking.")
         options = ClaudeAgentOptions(**options_kwargs)
 
         final_text = ""

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_agent.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_agent.py
@@ -218,6 +218,37 @@ def test_agent_decide_logs_actionable_auth_error(caplog):
 
 
 # --------------------------------------------------------------------------
+# Fast mode ("disable extended thinking") must build a VALID thinking config.
+# Regression: ThinkingConfigDisabled is a TypedDict, so a bare ThinkingConfigDisabled()
+# is {} (no "type" key). Passing that to the SDK makes _build_command raise
+# `KeyError: 'type'` on `thinking["type"]` -- i.e. fast mode never worked.
+# --------------------------------------------------------------------------
+
+def test_disabled_thinking_config_carries_type_key():
+    import pytest
+
+    sdk = pytest.importorskip("claude_agent_sdk")
+    from sl_hunting_agent import _disabled_thinking_config
+
+    cfg = _disabled_thinking_config(sdk)
+    assert cfg is not None
+    # The SDK does `thinking["type"]`; a config without it KeyErrors in _build_command.
+    assert cfg["type"] == "disabled"
+
+    # Guard against regressing to the bare call: ThinkingConfigDisabled() is the {} trap.
+    assert dict(sdk.ThinkingConfigDisabled()) == {}
+
+
+def test_disabled_thinking_config_none_when_sdk_lacks_it():
+    from sl_hunting_agent import _disabled_thinking_config
+
+    class _OldSdk:  # too old to expose ThinkingConfigDisabled -> caller warns, no thinking
+        pass
+
+    assert _disabled_thinking_config(_OldSdk()) is None
+
+
+# --------------------------------------------------------------------------
 # MasterWorkerExecutor duck-types the worker
 # --------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
With `SL_HUNTING_FAST_MODE=true` the SL Hunting AI agent crashed every 1-min bar with `KeyError: 'type'` from inside `claude-agent-sdk` (`subprocess_cli._build_command`), so it just **HELD all day** and never traded.

## Root cause
`ThinkingConfigDisabled` is a **TypedDict**, so the bare call `ThinkingConfigDisabled()` evaluates to an empty `{}` with **no `"type"` key**. The SDK's `_build_command` reads `thinking["type"]` unconditionally when assembling the CLI args → `KeyError` before the CLI is even launched. Fast mode had therefore **never worked** — the unit tests missed it because they inject a fake runner that bypasses the real-SDK option-building in `_default_run`.

## Fix
Build the config **with** its required field: `ThinkingConfigDisabled(type="disabled")` → the SDK emits `--thinking disabled`. Extracted into a shared, documented helper `_disabled_thinking_config(sdk)` used by **both** the trading agent and the reflection coach (`sl_hunting_coach.py` carried the identical latent bug under `--fast`).

## Verification
- **New regression tests** — the helper yields `{"type":"disabled"}`; also pins the bare-call `{}` trap so nobody regresses it.
- **Offline end-to-end repro against the SDK** — the OLD value reproduces `KeyError('type')` at the exact `_build_command` line from the traceback; the FIXED value builds the command cleanly (`--thinking disabled`).
- Folder suite **55 passed** (was 53); master suite **133 OK**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
