### PR TITLE
SL Hunting v3c: gap-up opening drive + trap-density test (knowledge-only)

### DIFF
--- a/Dependencies/env.example
+++ b/Dependencies/env.example
@@ -1081,8 +1081,11 @@ SL_HUNTING_RISK_BUDGET=2500
 # ~3 full stop-outs at ~Rs.2,500/trade -- so several trades can run before it trips.
 SL_HUNTING_STARTING_CAPITAL=600000.0
 SL_HUNTING_DAILY_MAX_LOSS_PCT=0.0125
+# NOTE: the v3c OPENING DRIVE knowledge (gap-up continuation in the first ~15 min)
+# only ever fires if the worker is awake for the open -- set MINUTE=15 for that;
+# at the shared default of 25 the agent wakes too late to ever use that branch.
 SL_HUNTING_TRADING_START_HOUR=9
-SL_HUNTING_TRADING_START_MINUTE=25
+SL_HUNTING_TRADING_START_MINUTE=15
 SL_HUNTING_SQUARE_OFF_HOUR=15
 SL_HUNTING_SQUARE_OFF_MINUTE=15
 # Stop opening NEW positions at/after this time (default 12:00). This is NOT a

--- a/Signal Generators/SL Hunting AI Agent/README.md
+++ b/Signal Generators/SL Hunting AI Agent/README.md
@@ -167,6 +167,21 @@ about execution changes. The video audio is Hindi and raw transcripts weren't re
 so the rules were distilled via YouTube's built-in "Ask"/Gemini summaries (a secondary AI
 summary, recorded with provenance in `sl_hunting_doc.md` and operator-reviewable).
 
+## Gap-up opening drive (v3c)
+Knowledge-only drop from the 2026-07-02 live session (`WhfVxV0h5bo`) reviewed the same day
+against the agent's decision log and journal — this time from the **verbatim Hindi
+auto-transcript** (YouTube transcript panel), not an AI summary. The trader went LONG with a
+small gap-up ~1 minute after open ("nobody is trapped on a mild gap-up, so there is no
+SL-hunt — go WITH the market"); the agent, awake only from 09:25 and pattern-gated, took
+three shorts instead. Changes: a **TRAP-DENSITY TEST** before every fade and a
+**first-trade-WITH-the-gap** rule in `RETAIL_POSITIONING`; a new **`OPENING_DRIVE`** section —
+the one scoped exception to the pattern+confirmation rule (with-gap LONG only, first ~15 min,
+strict no-major-rejection conditions, honest wide stop with risk-budget sizing); cross-index
+cautions (stale early verdicts; an opposing verdict means HOLD); and an expiry-day-as-fuel
+note. Full analysis + provenance in the v3c addendum of `sl_hunting_doc.md`. The operator
+separately moved the worker's start to 09:15 via `SL_HUNTING_TRADING_START_*` in `.env`
+(config, not code).
+
 ## Decision log
 The agent decides once per completed bar, but the worker only *logs* the bars where it
 acts — so a HOLD leaves just a `decision cost` line with no record of **what** it decided or

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -356,3 +356,76 @@ its preview lists method topics (e.g. "how to predict Monday's direction when re
 "regain confidence after a big loss", "60% profit booking") — a potential net-new "weekend / Friday-exit
 → Monday-open" refinement — but the answers are paywalled, so nothing is added from it. (If the operator
 shares those notes, the Friday→Monday concept can be folded into `RETAIL_POSITIONING` the same way.)
+
+---
+
+## Video addendum — live gap-up session + same-day journal review (v3c)
+
+> Source: "Live Bank Nifty Option Trading" (`WhfVxV0h5bo`), the 2026-07-02 live session,
+> reviewed the same day against the agent's own decision log and trade journal. Unlike v3a
+> (Ask/Gemini summaries), this one was distilled from the **verbatim Hindi auto-transcript**
+> captured via YouTube's transcript panel — primary-source provenance. Timestamps in
+> parentheses are video time (session opens at 0:06 ≈ 09:15 IST).
+
+**The trade (what the agent was benchmarked against):**
+- Market opens gap-up; "no big rejection, only small green-to-red candles" (0:06–0:17).
+- LONG (call-side) basket built ~1 minute after open: BankNifty 1170 qty (0:24), Sensex
+  900 qty (0:43), NIFTY 1365 qty (0:53) — triple-index, with-gap.
+- Reasoning (1:08–2:27): the market moved up but with NO BIG momentum, so few traders
+  could have bought; whatever few longs exist have SLs below the closing price —
+  unreachable without a major rejection. "We can't target those buyers directly. Had it
+  opened flat or gap-down we would hunt them; but on a gap-up we should go WITH the
+  market" → call-side trade. NIFTY's 24,000 round level was the same read (3:18–3:25).
+- Risk framing (3:03–3:18): the danger is a rejection that drags price back to the round
+  number — that's where the loss limit would be crossed. No big rejection = stay.
+- Catalyst (3:52): "today Sensex has expiry — overall positive momentum is possible."
+- Booked ~9 minutes in when momentum arrived across Sensex + NIFTY and BankNifty printed
+  2-3 strong candles (5:59–6:49).
+- Discipline riffs: don't make 2-3 trades in 5-10 minutes; give the market time after a
+  trade (4:09–4:49); put effort into the trade that's working (7:06–7:21); "greed has a
+  limit" — book, don't sit (8:32–8:40).
+
+**Same-day journal/decisions review (2026-07-02; 149 decisions, 3 trades, all SHORT):**
+- **T1** 09:28 `psych_round_number_bearish_engulfing_fade`, -19.0 pts (-1.11R): faded a
+  ~60-pt gap-grind 13 minutes in by declaring "late breakout longs trapped" — exactly the
+  read the video refutes (small momentum = nobody trapped). The agent's own 09:26 HOLD had
+  said "classic gap-up momentum, no reason to fade blindly"; two bars later it faded on
+  the first confirmed bearish pattern. → the TRAP-DENSITY TEST now in `RETAIL_POSITIONING`.
+- **T2** 09:46 `double_top_doji_confirmation_reversal`, +42.35 pts (+3.04R): the CORRECT
+  fade — a ~170-pt run to 24159 trapped real breakout buyers at a double top. Validates
+  the same test from the winning side (extended run → real trapped SLs → hunt works).
+- **T3** 10:33 `shooting_star_evening_star_fib_rejection`, -16.55 pts (-1.15R): entered
+  SHORT while `cross_index` read "both_at_resistance → bias UP" — the knowledge already
+  said "disagrees → prefer HOLD" and was overridden. → the two cautions appended to
+  `BNF_CROSS_CONFIRMATION`. (T1's cross read, "both_at_support → bias down" during a
+  gap-up rally, was the opposite failure: a stale yesterday-levels verdict — same fix.)
+- A valid with-gap LONG trigger existed inside the agent's own rules — its 09:33 exit
+  reasoning cites a bullish doji (09:26) confirmed above 24117.85 at 09:31 — and was
+  never taken. → the GAP-UP FIRST-TRADE bullet in `RETAIL_POSITIONING`.
+
+**Why the agent could not capture the video's trade (root causes):**
+1. It was asleep: the worker's `trading_start` used the shared 09:25 default
+   (`_signal_gen_ops`), so its first decision landed 09:26:16 vs the video's ~09:16 entry.
+   The operator has since set the start to 09:15 via the existing
+   `SL_HUNTING_TRADING_START_HOUR/MINUTE` knobs in `.env` — a config change, not code.
+2. Even awake, the method had no opening-drive entry: every entry required a reversal
+   pattern + confirmation at a level, and the first candle was untradeable — the video's
+   trade is a positioning/context trade, structurally outside those rules.
+3. No trap-density notion — see T1 vs T2 above.
+4. Cross-index verdicts nudged/allowed the wrong side — see T3/T1 above.
+
+**Knowledge changes made for v3c (all prose, no logic):**
+- `RETAIL_POSITIONING`: TRAP-DENSITY TEST + GAP-UP MORNING → FIRST TRADE WITH THE GAP
+  (incl. "a stopped-out fade on a gap-up morning is evidence of gap-and-go — don't re-fade").
+- New `OPENING_DRIVE` section: the ONE scoped exception to pattern+confirmation — with-gap
+  LONG only, first ~15 minutes, clear gap-up above prev close + round number, entry only
+  after the first 1-min candle closes, no full-body green-to-red rejection, behavioural
+  confirmation substitutes, stop below first-candle/opening-range low (size auto-shrinks
+  via the risk budget), exit immediately on a major rejection, book on weakness. No
+  gap-down mirror (flat/gap-down stays a hunt-UP trap per the existing read).
+- `ROLE`, `LEVELS_AND_PIVOT`, `DECISION_RULES`: the blanket "pattern only / never the
+  first candle" statements now carry the scoped OPENING DRIVE exception (never DURING the
+  forming first candle; from its close onward, only under ALL its conditions).
+- `BNF_CROSS_CONFIRMATION`: two cautions (stale early verdicts vs the opening-gap context;
+  an opposing verdict is a real vote → HOLD unless textbook).
+- `BNF_SPECIFIC`: expiry-day index = extra fuel for with-gap momentum on a gap morning.

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
@@ -34,8 +34,9 @@ retail traders, so you trade WITH the operator and AGAINST the crowd. You are
 PATIENT and CONSERVATIVE — most candles are noise. Your default action is HOLD.
 You take a trade ONLY when a real setup at a real level is confirmed by a
 candlestick pattern AND a following confirmation candle, with an acceptable
-stop-loss and a worthwhile target. A missed trade costs nothing; a forced trade
-on a weak setup is how retail loses.
+stop-loss and a worthwhile target (sole exception: the OPENING DRIVE gap-up
+continuation, which has its own strict conditions — see that section). A missed
+trade costs nothing; a forced trade on a weak setup is how retail loses.
 
 You trade BOTH directions, always by BUYING an option:
 - ENTER_LONG  → you expect the NIFTY underlying to go UP   (the system buys an ATM CALL).
@@ -98,9 +99,67 @@ retail's stop-losses sit so you can trade where the operator will hunt them.
   if price has ALREADY moved sharply, retail is likely trapped and chasing → a fade /
   SL-hunt is in play; if the market has been STAGNANT (retail hasn't participated
   yet), the momentum candle may be the START of the real move → don't fade it.
+- TRAP-DENSITY TEST (run it before EVERY counter-trend fade): name exactly WHO is
+  trapped and HOW they got trapped. A fade / SL-hunt needs a fast, EXTENDED move that
+  visibly trapped latecomers — as a rough guide, a run of ~100+ NIFTY points (or a
+  parabolic push through a round number) BEFORE the reversal pattern. A modest gap-up
+  that then grinds up a few tens of points has trapped NOBODY: with no trapped SLs
+  there is no hunt, and the with-trend continuation IS the trade. A bearish pattern
+  at a psych level is NOT, by itself, a short on a gap-up morning.
+- GAP-UP MORNING → FIRST TRADE WITH THE GAP: on a gap-up open holding above the round
+  number / opening range with no major rejection (no full-body green-to-red reversal
+  candle), prefer the day's FIRST trade WITH the gap — ENTER_LONG on a bullish
+  pattern + confirmation at a shallow pullback/hold (or the OPENING DRIVE branch
+  below). If a fade gets stopped out on such a morning, the stop-out is itself
+  EVIDENCE of gap-and-go: do NOT re-fade the next bearish pattern; look for the
+  with-trend long, and fade again only once an extended run has actually trapped
+  buyers (see the trap-density test).
 
 This refines the gap playbook in LEVELS and the OPPOSITE-to-retail rule in PSYCHOLOGY:
 the gap tells you whether retail is trapped (fade / hunt) or absent (follow).
+"""
+
+
+# ---------------------------------------------------------------------------
+# The opening-drive gap-up continuation (v3c)
+# ---------------------------------------------------------------------------
+
+# Distilled from a live triple-index session (see the v3c addendum in
+# `sl_hunting_doc.md`). This is the ONE deliberately scoped exception to the
+# pattern+confirmation rule; everywhere else that rule stays mandatory.
+OPENING_DRIVE = """\
+OPENING DRIVE — gap-up continuation (scoped exception, first ~15 minutes only)
+------------------------------------------------------------------------------
+The one setup that does NOT wait for a reversal pattern: riding a clean gap-up
+open WITH the market. The logic is pure positioning: a gap-up leaves retail
+un-positioned, and whatever few longs exist have their SLs below the previous
+close — unreachable without a major rejection. Nobody is trapped, so there is
+NO SL-hunt available; the with-gap continuation IS the trade.
+
+Conditions (ALL must hold — otherwise this branch simply does not apply):
+- First ~15 minutes of the session only, and ONLY as ENTER_LONG on a clear
+  GAP-UP (open above the previous close AND holding above/at a round number).
+  There is NO gap-down mirror: a flat/gap-down open is a trap to hunt UPWARD on
+  confirmation (see READING RETAIL POSITIONING) — never an opening-drive short.
+- Enter at the earliest AFTER the first 1-min candle CLOSES, never during it.
+- No MAJOR rejection so far: no full-body green-to-red reversal candle since the
+  open. Small red / green-to-red ticks are acceptable noise; a full-bodied
+  rejection candle kills this branch for the day.
+- Behavioural confirmation substitutes for the candle rule HERE ONLY: price
+  holding above the open / round number without aggressive selling is the
+  confirmation. Everywhere else the pattern + confirmation rule is mandatory.
+
+Risk handling for this branch:
+- Stop = below the first-candle low / opening-range low. This stop may be wider
+  than the usual 10-15 point guide — that is acceptable here because position
+  size is auto-computed from the stop distance (~Rs.2500 risk); set the honest
+  stop, never a cosmetic tight one.
+- Premise-invalidation: a major rejection candle, or price falling back to the
+  round number / opening range, means the drive has failed — EXIT immediately,
+  do not wait for the stop.
+- Target: ride the momentum and book on WEAKNESS (momentum failure, the leading
+  index stalling, an opposing reversal forming) rather than a fixed number. An
+  index whose EXPIRY falls today adds fuel to the drive (see BANK NIFTY notes).
 """
 
 
@@ -129,8 +188,11 @@ OHLC, today's open/high/low and the first-candle high/low, nearby psychological
   the closing point (or a short lets price reclaim it), the premise has failed —
   exit. A psych level attracts price within ~50 NIFTY points; round numbers act
   as magnets and breakout levels (more strongly on the larger indices).
-- Do NOT trade the first candle. The first candle's high/low are trap levels; the
-  target is often the opposite side of the first candle.
+- Do NOT trade DURING the forming first candle. The first candle's high/low are
+  trap levels; the target is often the opposite side of the first candle. The ONLY
+  entry allowed from the first candle's close onward without a reversal pattern is
+  the OPENING DRIVE gap-up continuation (see that section); every other setup still
+  waits for pattern + confirmation.
 - Opening playbook (5-min has higher accuracy): wait for price to reach the pivot,
   let a candle touch it, and trade only the confirmed break of the small opening
   range. If price opens far from the pivot, the pivot can be the first target.
@@ -274,6 +336,14 @@ a clean BREAK of it = reversal):
 
 How to use it: if `cross_index` AGREES with your NIFTY setup, take it with more
 confidence; if it says "wait" or DISAGREES with your direction, prefer HOLD.
+
+Two cautions from live review:
+- SANITY-CHECK the mechanical verdict against the OPENING-GAP context. Early on a
+  clear gap-and-go morning, an alignment built from yesterday's levels (e.g. "both
+  at support → bias down" while both indices are rallying AWAY from those levels)
+  is stale — weight READING RETAIL POSITIONING first in the opening hour.
+- A verdict that directly OPPOSES your intended direction is a real vote against
+  the trade, not a footnote: HOLD unless the setup is genuinely textbook.
 """
 
 
@@ -302,6 +372,8 @@ you size or place the NIFTY trade. Advisory, not a hard gate.
   treat that as an exit / avoid signal for the shared direction.
 - Give priority to the index whose EXPIRY falls that day (e.g. Sensex or NIFTY on
   its expiry): expiry concentrates the action and accelerates option time-decay.
+  On a gap-up morning the expiring index is read as extra FUEL for directional
+  momentum — further support for with-gap continuation over counter-trend fades.
 - Round-number levels weigh MORE on BankNIFTY because of its larger point range
   (the round "...500" / "...000" levels): they are prime trap / breakout magnets
   where breakout-buyers get trapped — exactly the spots the operator hunts. (For
@@ -359,7 +431,9 @@ DECISION DISCIPLINE
 2. If FLAT: enter ONLY if (a) price is AT a real level (pivot / OHLC / fibo / psych
    / structure), (b) a reversal pattern + confirmation candle has ALREADY printed
    in your direction, (c) the stop is tight, and (d) the target is worthwhile.
-   Otherwise HOLD. Never trade the first candle of the day.
+   Otherwise HOLD. Never trade during the forming first candle of the day; the one
+   exception to (b) is the OPENING DRIVE gap-up continuation (its own section),
+   valid only from the first candle's close and only under ALL its conditions.
 3. If IN A POSITION: EXIT per the RISK rules, else HOLD.
 4. Use the order tool to act, then emit the final JSON describing what you did
    (or HOLD). The configuration — not you — decides paper vs live and the broker.
@@ -415,6 +489,7 @@ def build_system_prompt() -> str:
         ROLE,
         PSYCHOLOGY,
         RETAIL_POSITIONING,
+        OPENING_DRIVE,
         LEVELS_AND_PIVOT,
         PATTERNS_AND_CONFIRMATION,
         FIBO,


### PR DESCRIPTION
## Summary

Knowledge-only drop (v3c) for the SL Hunting AI Agent from a same-day review of the 2 Jul
Intraday Hunter live trade (`WhfVxV0h5bo`, verbatim Hindi auto-transcript) against the agent's
own decision log and trade journal. **No Python logic changes.**

**The gap:** IH went LONG with a mild gap-up ~1 minute after open — a small gap-up traps nobody,
so there is no SL-hunt available; the with-gap continuation IS the trade (Sensex expiry cited as
momentum fuel). The agent took three SHORTS on the same morning (-19 / +42.35 / -16.55 pts).

**Why the agent missed it:** asleep until 09:25 (shared trading-start default; operator has
since set 09:15 in `.env`); no opening-drive entry existed in the method; no trap-density
notion; cross-index verdicts misused.

**Changes:** TRAP-DENSITY TEST + first-trade-WITH-the-gap in `RETAIL_POSITIONING`; new
`OPENING_DRIVE` section — the one scoped exception to the pattern+confirmation rule (with-gap
LONG only, first ~15 min, entry only after the first 1-min candle closes, dead on any full-body
rejection, honest wide stop with risk-budget sizing); `ROLE`/`LEVELS`/`DECISION_RULES` amended
so their blanket rules can't suppress it; cross-index cautions; expiry-day-as-fuel note; v3c
addendum in `sl_hunting_doc.md`; README section; `env.example` start-minute note.

**Verified:** 55/55 SL Hunting tests, master suite exit 0, prompt markers + section order.

*(v3d — the 2-week verbatim video sweep — was committed after this PR merged and ships in the
follow-up PR together with the codebase review and quality CI.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
