### PR TITLE
[codex] Add Flattrade Pi live broker support

### DIFF
--- a/Dependencies/Flattrade API/diagnose_flattrade_symbol.py
+++ b/Dependencies/Flattrade API/diagnose_flattrade_symbol.py
@@ -10,6 +10,11 @@ used by live execution, prints the exact contract row, and checks the shared
 resolver.  It does not place an order unless ``--place-order`` is supplied and
 the operator then types exactly ``YES``.  The real-money path buys one lot and
 immediately sells it to flatten.
+
+The normal read-only flow has four visible checkpoints: authenticate, download
+the official contract list, select one exact row, and ask the production resolver
+for the same symbol. A mismatch is reported before the optional order prompt, so
+the diagnostic tests the same boundary that live strategies depend upon.
 """
 
 from __future__ import annotations
@@ -29,7 +34,12 @@ UNDERLYING = "NIFTY"
 
 
 def build_parser() -> argparse.ArgumentParser:
-    """Build the small broker-specific parser used directly and through algo.py."""
+    """Build the parser used directly and through ``algo.py diagnose``.
+
+    ``algo.py`` consumes only ``--broker flattrade`` and forwards every remaining
+    argument unchanged, so this parser remains the single source of truth for the
+    broker-specific option type, strike, expiry, quantity, and real-order switch.
+    """
     parser = argparse.ArgumentParser(
         description=(
             "Validate a Flattrade NIFTY option symbol. Read-only unless "
@@ -95,6 +105,21 @@ def select_contract(
     When no expiry is supplied, the nearest non-expired contract containing the
     requested strike is chosen.  Filtering the strike before choosing the date
     avoids selecting an expiry that does not list that particular contract.
+
+    Args:
+        client: Logged-in FlattradeExecutionClient with ``_scrip_df`` preloaded.
+        underlying: Index name (the CLI currently fixes this to NIFTY).
+        option_type: ``CE`` or ``PE``.
+        strike: Whole-number option strike.
+        requested_expiry: Exact date, or ``None`` to choose the nearest future row.
+        today: Injectable clock used by deterministic unit tests.
+
+    Returns:
+        ``(expiry_date, trading_symbol, lot_size)`` from one official CSV row.
+
+    Raises:
+        ValueError: The master is unavailable, no exact row exists, or lot size is
+            invalid. It never guesses a symbol or quantity.
     """
     frame = getattr(client, "_scrip_df", None)
     if frame is None or frame.empty:
@@ -133,7 +158,13 @@ def select_contract(
 
 
 def place_round_trip_test_order(client: Any, symbol: str, quantity: int) -> bool:
-    """Place a confirmation-gated REAL BUY then SELL; return True only if flat."""
+    """Place a confirmation-gated REAL BUY then SELL; return True only if flat.
+
+    This is deliberately separate from ``main`` so tests can prove that anything
+    except uppercase ``YES`` sends zero orders. If entry or exit confirmation is
+    ambiguous, the message assumes a live position *may* exist and directs the
+    operator to Flattrade; silence would be unsafe in a real-money diagnostic.
+    """
     print("\n" + "=" * 72)
     print("REAL ROUND-TRIP TEST ORDER on Flattrade")
     print(
@@ -191,7 +222,13 @@ def place_round_trip_test_order(client: Any, symbol: str, quantity: int) -> bool
 
 
 def main(argv: list[str] | None = None) -> int:
-    """Run the safe symbol diagnostic and optional confirmation-gated order."""
+    """Run the safe symbol diagnostic and optional confirmation-gated order.
+
+    Return codes follow normal CLI convention: 0 success, 1 operational failure
+    (login/resolution/order), and 2 invalid command-line input.
+    """
+    # Parse and validate all local input before login. Typos should never open a
+    # browser or touch the broker API.
     args = build_parser().parse_args(argv)
     if args.qty is not None and args.qty <= 0:
         print("--qty must be a positive integer.", file=sys.stderr)
@@ -208,6 +245,8 @@ def main(argv: list[str] | None = None) -> int:
     )
     client = fe.flattrade_execution_client
     try:
+        # ``preload_scrip_master`` authenticates first, then downloads once. The
+        # production resolver below reuses the already-normalized in-memory table.
         print("Logging in to Flattrade and loading the official NFO index master...")
         if not client.preload_scrip_master():
             print("Could not log in / load the Flattrade scrip master.")
@@ -239,6 +278,8 @@ def main(argv: list[str] | None = None) -> int:
             print("Resolver did not reproduce the exact official CSV symbol.")
             return 1
 
+        # Read-only is the default. Reaching the order helper requires both the
+        # explicit flag here and its second, typed-YES confirmation inside.
         if not args.place_order:
             print("\nRead-only diagnostic complete. No order was placed.")
             return 0
@@ -248,6 +289,8 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Flattrade diagnostic failed: {exc}", file=sys.stderr)
         return 1
     finally:
+        # Also runs on parse/resolution/order exceptions. Flattrade has no remote
+        # logout endpoint, so this clears the local token/session/cache state.
         client.logout()
 
 

--- a/Dependencies/Flattrade API/diagnose_flattrade_symbol.py
+++ b/Dependencies/Flattrade API/diagnose_flattrade_symbol.py
@@ -1,0 +1,255 @@
+"""Read-only Flattrade NIFTY option diagnostic with an opt-in REAL test order.
+
+Examples from the repository root::
+
+    python "Dependencies/Flattrade API/diagnose_flattrade_symbol.py" CE 24150
+    python "Dependencies/Flattrade API/diagnose_flattrade_symbol.py" PE 24000 14JUL26
+
+The script logs in, downloads the same official index-derivative scrip master
+used by live execution, prints the exact contract row, and checks the shared
+resolver.  It does not place an order unless ``--place-order`` is supplied and
+the operator then types exactly ``YES``.  The real-money path buys one lot and
+immediately sells it to flatten.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import flattrade_execution as fe  # noqa: E402 - sibling import for standalone use
+
+
+UNDERLYING = "NIFTY"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the small broker-specific parser used directly and through algo.py."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Validate a Flattrade NIFTY option symbol. Read-only unless "
+            "--place-order is supplied and YES is typed."
+        )
+    )
+    parser.add_argument(
+        "option_type",
+        nargs="?",
+        default="CE",
+        choices=("CE", "PE"),
+        type=str.upper,
+        help="Option type (default: CE).",
+    )
+    parser.add_argument(
+        "strike",
+        nargs="?",
+        default=23950,
+        type=int,
+        help="NIFTY strike (default: 23950).",
+    )
+    parser.add_argument(
+        "expiry",
+        nargs="?",
+        help="Optional expiry as DDMMMYY, for example 14JUL26.",
+    )
+    parser.add_argument(
+        "--place-order",
+        action="store_true",
+        help="After another YES prompt, place a REAL BUY then SELL round trip.",
+    )
+    parser.add_argument(
+        "--qty",
+        type=int,
+        help="Override the official contract Lotsize used for the REAL test.",
+    )
+    return parser
+
+
+def _parse_expiry(raw: str | None) -> dt.date | None:
+    """Parse the optional DDMMMYY CLI expiry with a friendly error."""
+    if not raw:
+        return None
+    try:
+        return dt.datetime.strptime(raw.upper().strip(), "%d%b%y").date()
+    except ValueError as exc:
+        raise ValueError(
+            f"Could not parse expiry {raw!r}; expected DDMMMYY like 14JUL26."
+        ) from exc
+
+
+def select_contract(
+    client: Any,
+    *,
+    underlying: str,
+    option_type: str,
+    strike: int,
+    requested_expiry: dt.date | None,
+    today: dt.date | None = None,
+) -> tuple[dt.date, str, int]:
+    """Select one exact CSV row and return expiry, trading symbol, and lot size.
+
+    When no expiry is supplied, the nearest non-expired contract containing the
+    requested strike is chosen.  Filtering the strike before choosing the date
+    avoids selecting an expiry that does not list that particular contract.
+    """
+    frame = getattr(client, "_scrip_df", None)
+    if frame is None or frame.empty:
+        raise ValueError("Flattrade NFO scrip master is not loaded.")
+    underlying_u = str(underlying).upper().strip()
+    option_u = str(option_type).upper().strip()
+    strike_i = round(float(strike))
+    matches = frame[
+        (frame["_symbol_u"] == underlying_u)
+        & (frame["_option_u"] == option_u)
+        & (frame["_strike_f"].round().astype(int) == strike_i)
+    ].copy()
+    if requested_expiry is not None:
+        matches = matches[matches["_expiry_date"] == requested_expiry]
+    else:
+        today = today or dt.date.today()
+        matches = matches[matches["_expiry_date"] >= today]
+        if not matches.empty:
+            nearest = min(matches["_expiry_date"])
+            matches = matches[matches["_expiry_date"] == nearest]
+    if matches.empty:
+        expiry_text = requested_expiry.isoformat() if requested_expiry else "nearest future"
+        raise ValueError(
+            f"No Flattrade {underlying_u} {option_u} strike {strike_i} "
+            f"contract found for {expiry_text} expiry."
+        )
+    row = matches.sort_values(["_expiry_date", "_trading_symbol"]).iloc[0]
+    lot_size = int(row["_lotsize_i"])
+    if lot_size <= 0:
+        raise ValueError("Resolved Flattrade contract has no valid Lotsize.")
+    return (
+        row["_expiry_date"],
+        str(row["_trading_symbol"]).strip(),
+        lot_size,
+    )
+
+
+def place_round_trip_test_order(client: Any, symbol: str, quantity: int) -> bool:
+    """Place a confirmation-gated REAL BUY then SELL; return True only if flat."""
+    print("\n" + "=" * 72)
+    print("REAL ROUND-TRIP TEST ORDER on Flattrade")
+    print(
+        f"  BUY {quantity} {symbol} (product=INTRADAY), then auto SELL "
+        f"{quantity} to flatten."
+    )
+    print("  THIS PLACES REAL ORDERS WITH REAL MONEY.")
+    try:
+        confirmation = input(
+            "  Type exactly YES to proceed (anything else aborts): "
+        ).strip()
+    except (EOFError, OSError):
+        confirmation = ""
+    if confirmation != "YES":
+        print("  Aborted (no confirmation).")
+        return False
+
+    print(f"  Placing BUY {quantity} {symbol} ...")
+    try:
+        entry = client.place_market_order(
+            symbol=symbol,
+            side="BUY",
+            quantity=quantity,
+            product_type="INTRADAY",
+        )
+    except Exception as exc:
+        print(f"  ENTRY NOT CONFIRMED: {exc}")
+        print(
+            f"  !! A LIVE long position in {symbol} (qty={quantity}) MAY BE OPEN. "
+            "CHECK FLATTRADE BEFORE RETRYING OR PLACING ANOTHER ORDER."
+        )
+        return False
+    print(f"  ENTRY filled. OrderId={client.extract_order_id(entry)}")
+
+    print(f"  Squaring off: SELL {quantity} {symbol} ...")
+    try:
+        exit_order = client.place_market_order(
+            symbol=symbol,
+            side="SELL",
+            quantity=quantity,
+            product_type="INTRADAY",
+        )
+    except Exception as exc:
+        print(f"  !! EXIT FAILED: {exc}")
+        print(
+            f"  !! A LIVE long position in {symbol} (qty={quantity}) MAY BE OPEN. "
+            "CHECK FLATTRADE AND SQUARE IT OFF MANUALLY NOW."
+        )
+        return False
+    print(
+        f"  EXIT filled. OrderId={client.extract_order_id(exit_order)} "
+        "-> flat. Round-trip OK."
+    )
+    return True
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the safe symbol diagnostic and optional confirmation-gated order."""
+    args = build_parser().parse_args(argv)
+    if args.qty is not None and args.qty <= 0:
+        print("--qty must be a positive integer.", file=sys.stderr)
+        return 2
+    try:
+        requested_expiry = _parse_expiry(args.expiry)
+    except ValueError as exc:
+        print(exc, file=sys.stderr)
+        return 2
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s | %(levelname)s | %(message)s",
+    )
+    client = fe.flattrade_execution_client
+    try:
+        print("Logging in to Flattrade and loading the official NFO index master...")
+        if not client.preload_scrip_master():
+            print("Could not log in / load the Flattrade scrip master.")
+            return 1
+
+        expiry, csv_symbol, lot_size = select_contract(
+            client,
+            underlying=UNDERLYING,
+            option_type=args.option_type,
+            strike=args.strike,
+            requested_expiry=requested_expiry,
+        )
+        resolved = client.resolve_option_symbol(
+            UNDERLYING,
+            expiry,
+            args.option_type,
+            args.strike,
+        )
+        print(f"\nContract master rows: {len(client._scrip_df)}")
+        print(f"Selected expiry : {expiry:%d%b%y}")
+        print(f"Trading symbol  : {csv_symbol}")
+        print(f"Official lot    : {lot_size}")
+        print(
+            "Resolver result : "
+            f"resolve_option_symbol({UNDERLYING}, {expiry}, "
+            f"{args.option_type}, {args.strike}) -> {resolved!r}"
+        )
+        if not resolved or resolved != csv_symbol:
+            print("Resolver did not reproduce the exact official CSV symbol.")
+            return 1
+
+        if not args.place_order:
+            print("\nRead-only diagnostic complete. No order was placed.")
+            return 0
+        quantity = args.qty if args.qty is not None else lot_size
+        return 0 if place_round_trip_test_order(client, resolved, quantity) else 1
+    except Exception as exc:
+        print(f"Flattrade diagnostic failed: {exc}", file=sys.stderr)
+        return 1
+    finally:
+        client.logout()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Dependencies/Flattrade API/flattrade_execution.py
+++ b/Dependencies/Flattrade API/flattrade_execution.py
@@ -19,6 +19,27 @@ Safety rules followed here:
 
 Flattrade Pi v2 currently documents no logout endpoint.  ``logout()`` therefore
 closes the local HTTP session and erases the in-memory token.
+
+Beginner's mental model — one live order travels through this file as follows:
+
+1. ``ensure_logged_in()`` obtains or validates today's access token.
+2. ``preload_scrip_master()`` downloads Flattrade's list of real NFO contracts.
+3. ``resolve_option_symbol()`` converts strategy details such as
+   NIFTY/14-JUL-2026/CE/24150 into Flattrade's exact trading symbol.
+4. ``place_market_order()`` translates friendly values such as BUY and INTRADAY
+   into Flattrade's short API codes, then submits the order.
+5. ``_confirm_fill()`` checks order history; an acknowledgement alone is never
+   treated as proof that money changed hands.
+
+Small glossary:
+
+* ``jData`` is the JSON request object Flattrade expects inside the POST body.
+* ``jKey`` is today's access token. It is sensitive and is never logged here.
+* A *scrip master* is the broker's contract catalogue: symbol, expiry, strike,
+  option type, token, and lot size for every listed instrument.
+* ``norenordno`` is Flattrade's order number, used to query fill status later.
+* *Market protection* limits how far a market order may chase a rapidly moving
+  price; the default value comes from Flattrade's official Postman example.
 """
 
 from __future__ import annotations
@@ -125,15 +146,25 @@ class _RollingWindowRateLimiter:
         self._lock = threading.Lock()
 
     def acquire(self) -> None:
-        """Reserve one request slot or raise before a long/stale wait."""
+        """Reserve one request slot or raise before a long/stale wait.
+
+        The deque stores only timestamps from the last minute. We separately
+        count its last one-second slice because Flattrade publishes both limits.
+        A short wait is acceptable; a long wait would make a trading decision
+        stale, so it raises *before* any broker request is sent.
+        """
         started = self._clock()
         with self._lock:
             while True:
                 now = self._clock()
+                # Discard calls that are older than the longest (60-second)
+                # window. Keeping the deque small also makes each check cheap.
                 minute_cutoff = now - 60.0
                 while self._timestamps and self._timestamps[0] <= minute_cutoff:
                     self._timestamps.popleft()
 
+                # The minute deque includes the one-second window, so select its
+                # recent tail instead of maintaining a second source of truth.
                 recent_second = [
                     stamp for stamp in self._timestamps if stamp > now - 1.0
                 ]
@@ -141,6 +172,8 @@ class _RollingWindowRateLimiter:
                 minute_full = len(self._timestamps) >= self.per_minute
 
                 if not second_full and not minute_full:
+                    # Reserving the timestamp before returning prevents two
+                    # strategy threads from claiming the same final slot.
                     self._timestamps.append(now)
                     return
 
@@ -165,7 +198,13 @@ class _RollingWindowRateLimiter:
 
 
 class FlattradeExecutionClient:
-    """One lazily authenticated, lock-guarded Flattrade execution session."""
+    """One lazily authenticated, lock-guarded Flattrade execution session.
+
+    The master creates many strategy threads but imports one singleton from the
+    bottom of this module. All those threads therefore share one HTTP session,
+    one token, one contract cache, and one pair of rate-limit counters. ``RLock``
+    makes nested helper calls safe without allowing simultaneous session writes.
+    """
 
     def __init__(self) -> None:
         self.client: requests.Session | None = None
@@ -198,14 +237,31 @@ class FlattradeExecutionClient:
         return self.client
 
     def ensure_logged_in(self) -> bool:
-        """Return True only when a validated Flattrade daily token is available."""
+        """Return True only when a validated Flattrade daily token is available.
+
+        This method is intentionally safe to call before every operation. The
+        normal fast path only checks in-memory state; the interactive browser
+        flow runs once when the session has not yet been established.
+        """
         with self._lock:
             if self.is_logged_in and self._access_token and self.client is not None:
                 return True
             return self._login_locked()
 
     def _login_locked(self) -> bool:
-        """Validate an env token or perform Flattrade's browser request-code flow."""
+        """Validate an env token or perform Flattrade's browser request-code flow.
+
+        Authentication order is deliberate:
+
+        1. Require the client id used by all later ``jData`` payloads.
+        2. Prefer a manually supplied daily token, but verify it with UserDetails.
+        3. If absent/expired, open the official authorization page.
+        4. Hash API key + request code + API secret exactly as Flattrade documents.
+        5. Exchange that digest for a token and verify the resulting session.
+
+        Returns ``False`` instead of raising so startup can force every strategy
+        back to paper mode. Secrets, request codes, and tokens are never logged.
+        """
         self.is_logged_in = False
         self._client_id = _env_str("FLATTRADE_CLIENT_ID")
         if not self._client_id:
@@ -327,7 +383,23 @@ class FlattradeExecutionClient:
         *,
         is_order: bool = False,
     ) -> Any:
-        """POST one documented ``jData``/``jKey`` request with limits and timeout."""
+        """POST one documented ``jData``/``jKey`` request with limits and timeout.
+
+        Args:
+            endpoint: Final Pi endpoint name, such as ``UserDetails``.
+            payload: Plain Python dictionary that becomes compact JSON in jData.
+            is_order: Also consume the stricter order budget for write endpoints.
+
+        Returns:
+            The decoded JSON object/list supplied by Flattrade.
+
+        Raises:
+            RuntimeError: No token, rate budget, or valid JSON is available.
+            requests.RequestException: The network or HTTP status failed.
+
+        ``urlencode`` matters even though jData itself is JSON: it protects symbols
+        containing characters such as ``&`` from corrupting the outer POST body.
+        """
         if not self._access_token:
             raise RuntimeError("Flattrade has no validated access token.")
         self._api_limiter.acquire()
@@ -356,7 +428,12 @@ class FlattradeExecutionClient:
                 ) from exc
 
     def preload_scrip_master(self) -> bool:
-        """Log in and cache Flattrade's official NSE index-derivative CSV."""
+        """Log in and cache Flattrade's official NSE index-derivative CSV.
+
+        The master calls this once before worker threads start. Returning ``False``
+        makes startup disable live trading instead of discovering a missing or
+        malformed contract catalogue during the first real order.
+        """
         if not self.ensure_logged_in():
             return False
         with self._lock:
@@ -387,7 +464,16 @@ class FlattradeExecutionClient:
 
     @staticmethod
     def _prepare_scrip_master(raw: pd.DataFrame) -> pd.DataFrame:
-        """Validate official CSV columns and add normalized lookup fields."""
+        """Validate official CSV columns and add normalized lookup fields.
+
+        Human-facing CSV values vary in case and type (for example, strike may be
+        text ``"24150.00"``). Columns prefixed with ``_`` are internal, normalized
+        forms used for reliable comparisons; the original broker columns remain
+        available to the diagnostic for display and lot-size inspection.
+
+        Raises:
+            ValueError: Required columns or usable NFO rows are missing.
+        """
         required = {
             "Exchange",
             "Lotsize",
@@ -432,7 +518,19 @@ class FlattradeExecutionClient:
         strike: Any,
         exchange_segment: str = "NFO",
     ) -> str:
-        """Return the exact Flattrade ``Tradingsymbol`` or ``""`` on a miss."""
+        """Return the exact Flattrade ``Tradingsymbol`` or ``""`` on a miss.
+
+        Args:
+            underlying: Index name, currently ``NIFTY`` from the master runner.
+            expiry: Date-like option expiry supplied by the Dhan contract lookup.
+            option_type: ``CE`` for calls or ``PE`` for puts.
+            strike: Human-scale strike such as 24150 (not a paise multiplier).
+            exchange_segment: Must be ``NFO`` for this index-options helper.
+
+        Resolution is exact rather than pattern-based: the requested expiry,
+        strike, and option type must all occur in Flattrade's downloaded catalogue.
+        Returning an empty string makes the caller skip the real order safely.
+        """
         underlying_u = str(underlying).upper().strip()
         option_u = str(option_type).upper().strip()
         exchange_u = str(exchange_segment).upper().strip() or "NFO"
@@ -494,7 +592,26 @@ class FlattradeExecutionClient:
         exchange_segment: str = "NFO",
         product_type: str = "INTRADAY",
     ) -> dict[str, Any]:
-        """Place one MKT order and return only after the full fill is confirmed."""
+        """Place one MKT order and return only after the full fill is confirmed.
+
+        Args:
+            symbol: Exact Flattrade trading symbol returned by the resolver.
+            side: Friendly ``BUY`` or ``SELL`` value used by every broker helper.
+            quantity: Number of option units, normally a whole-number lot multiple.
+            exchange_segment: ``NFO``; other exchanges fail closed in this helper.
+            product_type: ``INTRADAY`` (Flattrade ``I``) or ``NORMAL`` (``M``).
+
+        Returns:
+            Flattrade's successful PlaceOrder acknowledgement dictionary.
+
+        Raises:
+            ValueError: A caller supplied an unsupported order value.
+            RuntimeError: Login, acknowledgement, rejection, or fill failed.
+            TimeoutError: The broker did not confirm the complete fill in time.
+
+        Important: ``stat=Ok`` only means the broker accepted the request. The
+        method still polls SingleOrdHist before reporting success to the strategy.
+        """
         side_u = str(side).upper().strip()
         product_u = str(product_type).upper().strip()
         exchange_u = str(exchange_segment).upper().strip() or "NFO"
@@ -577,7 +694,12 @@ class FlattradeExecutionClient:
         return (None, 0, 0, str(reason))
 
     def _confirm_fill(self, order_id: str, want_qty: int) -> None:
-        """Poll SingleOrdHist until fully filled, rejected, or timed out."""
+        """Poll SingleOrdHist until fully filled, rejected, or timed out.
+
+        ``COMPLETE`` must include at least the requested filled quantity. A partial
+        completion, rejection, cancellation, or timeout raises with the order id
+        so operators can locate the possibly open order in Flattrade immediately.
+        """
         deadline = time.monotonic() + _FILL_TIMEOUT_SECONDS
         last_state = None
         while time.monotonic() < deadline:
@@ -624,7 +746,12 @@ class FlattradeExecutionClient:
         return ""
 
     def logout(self) -> dict[str, Any]:
-        """Close the local session and erase sensitive in-memory state."""
+        """Close the local session and erase sensitive in-memory state.
+
+        Flattrade Pi v2 exposes no documented remote logout call. Closing requests'
+        connection pool, clearing the token/account fields, contract cache, and
+        rate histories is therefore the complete local logout operation.
+        """
         with self._lock:
             if self.client is not None:
                 try:

--- a/Dependencies/Flattrade API/flattrade_execution.py
+++ b/Dependencies/Flattrade API/flattrade_execution.py
@@ -1,0 +1,647 @@
+"""
+Thread-safe Flattrade Pi v2 execution client for the multi-strategy runner.
+
+The master runner deliberately knows almost nothing about broker APIs.  It asks
+each broker helper to log in, preload a contract master, resolve one NIFTY option
+and place a confirmed market order.  This module implements that same small
+surface for Flattrade using only its documented REST endpoints and ``requests``.
+
+Safety rules followed here:
+
+* Importing this module never logs in, opens a browser, or sends an order.
+* A supplied daily access token is verified through ``UserDetails`` before use.
+* Without a token, the operator completes Flattrade's browser authorization and
+  pastes the short-lived request code; the API secret never leaves this process.
+* Every HTTP call has an explicit timeout and every API/order call is rate-limited.
+* ``place_market_order`` returns only after ``SingleOrdHist`` confirms the whole
+  quantity filled.  Any ambiguity raises so the runner's existing fail-safe path
+  can take over rather than pretending a real order succeeded.
+
+Flattrade Pi v2 currently documents no logout endpoint.  ``logout()`` therefore
+closes the local HTTP session and erases the in-memory token.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import logging
+import os
+import threading
+import time
+import webbrowser
+from collections import deque
+from pathlib import Path
+from typing import Any, Callable
+from urllib.parse import urlencode
+
+import pandas as pd
+import requests
+
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv(
+        dotenv_path=Path(__file__).resolve().parent.parent / ".env",
+        override=False,
+    )
+except Exception:
+    # ``python-dotenv`` is a core dependency, but keeping import-time behaviour
+    # harmless means paper trading can still start and report a clear login error.
+    pass
+
+
+log = logging.getLogger(__name__)
+
+_BASE_URL = "https://piconnect.flattrade.in/PiConnectAPI"
+_AUTH_URL = "https://auth.flattrade.in/?app_key={api_key}"
+_TOKEN_URL = "https://authapi.flattrade.in/trade/apitoken"
+_NFO_INDEX_MASTER_URL = (
+    "https://flattrade.s3.ap-south-1.amazonaws.com/"
+    "scripmaster/Nfo_Index_Derivatives.csv"
+)
+
+_API_TIMEOUT_SECONDS = 30
+_SCRIP_MASTER_TIMEOUT_SECONDS = 120
+_FILL_TIMEOUT_SECONDS = 8.0
+_FILL_POLL_INTERVAL = 0.5
+_MAX_RATE_LIMIT_WAIT_SECONDS = 2.0
+
+_PRODUCT_MAP = {"INTRADAY": "I", "NORMAL": "M"}
+_SIDE_MAP = {"BUY": "B", "SELL": "S"}
+_TERMINAL_FAILURE_STATES = {"rejected", "cancelled", "canceled"}
+
+
+def _env_str(name: str, default: str = "") -> str:
+    """Read one environment value and remove accidental wrapping quotes."""
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    value = str(raw).strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        value = value[1:-1].strip()
+    return value or default
+
+
+def _env_non_negative_int(name: str, default: int) -> int:
+    """Read a non-negative integer setting, falling back safely on bad input."""
+    raw = _env_str(name, str(default))
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        log.warning("Invalid %s=%r; using %s.", name, raw, default)
+        return default
+    if value < 0:
+        log.warning("Invalid %s=%r; using %s.", name, raw, default)
+        return default
+    return value
+
+
+class _RollingWindowRateLimiter:
+    """Enforce per-second and per-minute request budgets across worker threads.
+
+    Short bursts wait for a slot.  A wait longer than ``max_wait_seconds`` raises
+    before the HTTP request is sent; a stale live order is more dangerous than a
+    clear failure that activates the runner's paper fallback.
+    """
+
+    def __init__(
+        self,
+        per_second: int,
+        per_minute: int,
+        max_wait_seconds: float,
+        clock: Callable[[], float] = time.monotonic,
+        sleeper: Callable[[float], None] = time.sleep,
+        label: str = "API",
+    ) -> None:
+        self.per_second = int(per_second)
+        self.per_minute = int(per_minute)
+        self.max_wait_seconds = float(max_wait_seconds)
+        self._clock = clock
+        self._sleep = sleeper
+        self.label = label
+        self._timestamps: deque[float] = deque()
+        self._lock = threading.Lock()
+
+    def acquire(self) -> None:
+        """Reserve one request slot or raise before a long/stale wait."""
+        started = self._clock()
+        with self._lock:
+            while True:
+                now = self._clock()
+                minute_cutoff = now - 60.0
+                while self._timestamps and self._timestamps[0] <= minute_cutoff:
+                    self._timestamps.popleft()
+
+                recent_second = [
+                    stamp for stamp in self._timestamps if stamp > now - 1.0
+                ]
+                second_full = len(recent_second) >= self.per_second
+                minute_full = len(self._timestamps) >= self.per_minute
+
+                if not second_full and not minute_full:
+                    self._timestamps.append(now)
+                    return
+
+                waits = []
+                if second_full:
+                    waits.append(1.0 - (now - recent_second[0]))
+                if minute_full:
+                    waits.append(60.0 - (now - self._timestamps[0]))
+                wait_seconds = max(0.0, max(waits))
+                elapsed = now - started
+                if elapsed + wait_seconds > self.max_wait_seconds:
+                    raise RuntimeError(
+                        f"Flattrade {self.label} rate limit exhausted; "
+                        f"safe slot needs {wait_seconds:.2f}s"
+                    )
+                self._sleep(wait_seconds)
+
+    def reset(self) -> None:
+        """Forget local request history after a session is explicitly closed."""
+        with self._lock:
+            self._timestamps.clear()
+
+
+class FlattradeExecutionClient:
+    """One lazily authenticated, lock-guarded Flattrade execution session."""
+
+    def __init__(self) -> None:
+        self.client: requests.Session | None = None
+        self.is_logged_in = False
+        self._lock = threading.RLock()
+        self._access_token = ""
+        self._client_id = ""
+        self._account_id = ""
+        self._scrip_df: pd.DataFrame | None = None
+        self._symbol_cache: dict[tuple, str] = {}
+        # Flattrade documents 40/s + 200/min for general API calls and the
+        # stricter 10/s + 40/min budget for order APIs.
+        self._api_limiter = _RollingWindowRateLimiter(
+            40,
+            200,
+            _MAX_RATE_LIMIT_WAIT_SECONDS,
+            label="API",
+        )
+        self._order_limiter = _RollingWindowRateLimiter(
+            10,
+            40,
+            _MAX_RATE_LIMIT_WAIT_SECONDS,
+            label="order API",
+        )
+
+    def _ensure_session_locked(self) -> requests.Session:
+        """Create the shared HTTP session on first use; caller holds ``_lock``."""
+        if self.client is None:
+            self.client = requests.Session()
+        return self.client
+
+    def ensure_logged_in(self) -> bool:
+        """Return True only when a validated Flattrade daily token is available."""
+        with self._lock:
+            if self.is_logged_in and self._access_token and self.client is not None:
+                return True
+            return self._login_locked()
+
+    def _login_locked(self) -> bool:
+        """Validate an env token or perform Flattrade's browser request-code flow."""
+        self.is_logged_in = False
+        self._client_id = _env_str("FLATTRADE_CLIENT_ID")
+        if not self._client_id:
+            log.error("Flattrade login disabled: FLATTRADE_CLIENT_ID is blank.")
+            return False
+
+        self._ensure_session_locked()
+        supplied_token = _env_str("FLATTRADE_ACCESS_TOKEN")
+        if supplied_token:
+            self._access_token = supplied_token
+            if self._validate_session_locked():
+                self.is_logged_in = True
+                log.info("Flattrade supplied access token validated successfully.")
+                return True
+            log.warning(
+                "FLATTRADE_ACCESS_TOKEN was rejected or expired; starting browser authorization."
+            )
+            self._access_token = ""
+
+        api_key = _env_str("FLATTRADE_API_KEY")
+        raw_secret = _env_str("FLATTRADE_API_SECRET")
+        missing = [
+            name
+            for name, value in (
+                ("FLATTRADE_API_KEY", api_key),
+                ("FLATTRADE_API_SECRET", raw_secret),
+            )
+            if not value
+        ]
+        if missing:
+            log.error(
+                "Flattrade login disabled: missing %s.", ", ".join(missing)
+            )
+            return False
+
+        authorization_url = _AUTH_URL.format(api_key=api_key)
+        log.warning(
+            "Opening Flattrade authorization. Complete login in the browser, then paste the request_code."
+        )
+        try:
+            webbrowser.open(authorization_url)
+        except Exception as exc:
+            # A browser-launch problem is recoverable: the operator can open the
+            # logged URL manually and still paste the request code.
+            log.warning("Could not open the Flattrade browser automatically: %s", exc)
+        try:
+            request_code = input("Flattrade request_code: ").strip()
+        except (EOFError, OSError):
+            request_code = ""
+        if not request_code:
+            log.error("Flattrade login aborted: no request_code supplied.")
+            return False
+
+        digest = hashlib.sha256(
+            f"{api_key}{request_code}{raw_secret}".encode("utf-8")
+        ).hexdigest()
+        try:
+            response = self.client.post(
+                _TOKEN_URL,
+                json={
+                    "api_key": api_key,
+                    "request_code": request_code,
+                    "api_secret": digest,
+                },
+                timeout=_API_TIMEOUT_SECONDS,
+            )
+            response.raise_for_status()
+            payload = response.json()
+        except Exception as exc:
+            log.error("Flattrade token exchange failed: %s", exc)
+            return False
+
+        if not isinstance(payload, dict) or str(payload.get("status", "")).lower() != "ok":
+            message = payload.get("emsg", "unknown error") if isinstance(payload, dict) else "malformed response"
+            log.error("Flattrade token exchange rejected: %s", message)
+            return False
+        token = str(payload.get("token") or "").strip()
+        returned_client = str(payload.get("client") or "").strip()
+        if not token:
+            log.error("Flattrade token exchange returned no access token.")
+            return False
+        if returned_client and returned_client.upper() != self._client_id.upper():
+            log.error("Flattrade token belongs to a different client id; login rejected.")
+            return False
+
+        self._access_token = token
+        if not self._validate_session_locked():
+            self._access_token = ""
+            log.error("Flattrade issued a token, but UserDetails validation failed.")
+            return False
+        self.is_logged_in = True
+        log.info("Flattrade execution client login successful.")
+        return True
+
+    def _validate_session_locked(self) -> bool:
+        """Validate the current token and remember Flattrade's account id."""
+        try:
+            payload = self._post_api("UserDetails", {"uid": self._client_id})
+        except Exception as exc:
+            log.error("Flattrade UserDetails validation failed: %s", exc)
+            return False
+        if not isinstance(payload, dict) or str(payload.get("stat", "")).lower() != "ok":
+            message = payload.get("emsg", "invalid session") if isinstance(payload, dict) else "malformed response"
+            log.error("Flattrade session validation rejected: %s", message)
+            return False
+        enabled_exchanges = {
+            str(value).upper() for value in (payload.get("exarr") or [])
+        }
+        if enabled_exchanges and "NFO" not in enabled_exchanges:
+            log.error("Flattrade account does not report NFO access; live trading disabled.")
+            return False
+        self._account_id = str(payload.get("actid") or self._client_id).strip()
+        return bool(self._account_id)
+
+    def _post_api(
+        self,
+        endpoint: str,
+        payload: dict[str, Any],
+        *,
+        is_order: bool = False,
+    ) -> Any:
+        """POST one documented ``jData``/``jKey`` request with limits and timeout."""
+        if not self._access_token:
+            raise RuntimeError("Flattrade has no validated access token.")
+        self._api_limiter.acquire()
+        if is_order:
+            self._order_limiter.acquire()
+        with self._lock:
+            session = self._ensure_session_locked()
+            body = urlencode(
+                {
+                    "jData": json.dumps(payload, separators=(",", ":")),
+                    "jKey": self._access_token,
+                }
+            )
+            response = session.post(
+                f"{_BASE_URL}/{endpoint}",
+                data=body,
+                headers={"Content-Type": "application/json"},
+                timeout=_API_TIMEOUT_SECONDS,
+            )
+            response.raise_for_status()
+            try:
+                return response.json()
+            except Exception as exc:
+                raise RuntimeError(
+                    f"Flattrade {endpoint} returned malformed JSON"
+                ) from exc
+
+    def preload_scrip_master(self) -> bool:
+        """Log in and cache Flattrade's official NSE index-derivative CSV."""
+        if not self.ensure_logged_in():
+            return False
+        with self._lock:
+            return self._ensure_scrip_master_locked()
+
+    def _ensure_scrip_master_locked(self) -> bool:
+        """Download and normalize the contract master once; caller holds ``_lock``."""
+        if self._scrip_df is not None:
+            return not self._scrip_df.empty
+        try:
+            session = self._ensure_session_locked()
+            response = session.get(
+                _NFO_INDEX_MASTER_URL,
+                timeout=_SCRIP_MASTER_TIMEOUT_SECONDS,
+            )
+            response.raise_for_status()
+            raw = pd.read_csv(io.StringIO(response.text))
+            self._scrip_df = self._prepare_scrip_master(raw)
+            log.info(
+                "Flattrade NFO index scrip master loaded (%d rows).",
+                len(self._scrip_df),
+            )
+            return True
+        except Exception as exc:
+            self._scrip_df = None
+            log.error("Flattrade NFO scrip master download/parse failed: %s", exc)
+            return False
+
+    @staticmethod
+    def _prepare_scrip_master(raw: pd.DataFrame) -> pd.DataFrame:
+        """Validate official CSV columns and add normalized lookup fields."""
+        required = {
+            "Exchange",
+            "Lotsize",
+            "Symbol",
+            "Tradingsymbol",
+            "Expiry",
+            "Strike",
+            "Optiontype",
+        }
+        missing = sorted(required.difference(raw.columns))
+        if missing:
+            raise ValueError(
+                "Flattrade scrip master missing columns: " + ", ".join(missing)
+            )
+        frame = raw.copy()
+        frame["_exchange_u"] = frame["Exchange"].astype(str).str.strip().str.upper()
+        frame["_symbol_u"] = frame["Symbol"].astype(str).str.strip().str.upper()
+        frame["_trading_symbol"] = frame["Tradingsymbol"].astype(str).str.strip()
+        frame["_option_u"] = frame["Optiontype"].astype(str).str.strip().str.upper()
+        frame["_expiry_date"] = pd.to_datetime(
+            frame["Expiry"], format="%d-%b-%Y", errors="coerce"
+        ).dt.date
+        frame["_strike_f"] = pd.to_numeric(frame["Strike"], errors="coerce")
+        frame["_lotsize_i"] = pd.to_numeric(
+            frame["Lotsize"], errors="coerce"
+        ).fillna(0).astype(int)
+        frame = frame[
+            (frame["_exchange_u"] == "NFO")
+            & frame["_expiry_date"].notna()
+            & frame["_strike_f"].notna()
+            & frame["_trading_symbol"].ne("")
+        ].copy()
+        if frame.empty:
+            raise ValueError("Flattrade scrip master contains no usable NFO rows.")
+        return frame
+
+    def resolve_option_symbol(
+        self,
+        underlying: str,
+        expiry: Any,
+        option_type: str,
+        strike: Any,
+        exchange_segment: str = "NFO",
+    ) -> str:
+        """Return the exact Flattrade ``Tradingsymbol`` or ``""`` on a miss."""
+        underlying_u = str(underlying).upper().strip()
+        option_u = str(option_type).upper().strip()
+        exchange_u = str(exchange_segment).upper().strip() or "NFO"
+        if option_u not in {"CE", "PE"} or exchange_u != "NFO":
+            log.warning(
+                "Flattrade resolve skipped: unsupported option/exchange %r/%r.",
+                option_type,
+                exchange_segment,
+            )
+            return ""
+        try:
+            expiry_date = pd.Timestamp(expiry).date()
+            strike_i = round(float(strike))
+        except Exception:
+            log.warning(
+                "Flattrade resolve skipped: invalid expiry/strike %r/%r.",
+                expiry,
+                strike,
+            )
+            return ""
+        cache_key = (underlying_u, expiry_date, option_u, strike_i)
+        with self._lock:
+            cached = self._symbol_cache.get(cache_key)
+            if cached:
+                return cached
+        if not self.ensure_logged_in():
+            return ""
+        with self._lock:
+            cached = self._symbol_cache.get(cache_key)
+            if cached:
+                return cached
+            if not self._ensure_scrip_master_locked():
+                return ""
+            frame = self._scrip_df
+            matches = frame[
+                (frame["_symbol_u"] == underlying_u)
+                & (frame["_option_u"] == option_u)
+                & (frame["_expiry_date"] == expiry_date)
+                & (frame["_strike_f"].round().astype(int) == strike_i)
+            ]
+            if matches.empty:
+                log.warning(
+                    "Flattrade symbol NOT resolved: %s/%s/%s/strike %s.",
+                    underlying_u,
+                    option_u,
+                    expiry_date,
+                    strike_i,
+                )
+                return ""
+            symbol = str(matches.iloc[0]["_trading_symbol"]).strip()
+            self._symbol_cache[cache_key] = symbol
+            return symbol
+
+    def place_market_order(
+        self,
+        symbol: str,
+        side: str,
+        quantity: int,
+        exchange_segment: str = "NFO",
+        product_type: str = "INTRADAY",
+    ) -> dict[str, Any]:
+        """Place one MKT order and return only after the full fill is confirmed."""
+        side_u = str(side).upper().strip()
+        product_u = str(product_type).upper().strip()
+        exchange_u = str(exchange_segment).upper().strip() or "NFO"
+        symbol_s = str(symbol).strip()
+        try:
+            quantity_i = int(quantity)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"Invalid quantity: {quantity!r}") from exc
+        if side_u not in _SIDE_MAP:
+            raise ValueError(f"Invalid side: {side!r}")
+        if product_u not in _PRODUCT_MAP:
+            raise ValueError(f"Invalid product_type: {product_type!r}")
+        if exchange_u != "NFO":
+            raise ValueError(f"Invalid exchange_segment: {exchange_segment!r}")
+        if quantity_i <= 0:
+            raise ValueError(f"Invalid quantity: {quantity!r}")
+        if not symbol_s:
+            raise ValueError("Missing trading symbol for order.")
+        if not self.ensure_logged_in():
+            raise RuntimeError("Flattrade login failed; cannot place real order.")
+
+        protection = _env_non_negative_int("FLATTRADE_MARKET_PROTECTION", 5)
+        payload = {
+            "uid": self._client_id,
+            "actid": self._account_id or self._client_id,
+            "exch": exchange_u,
+            "tsym": symbol_s,
+            "qty": str(quantity_i),
+            "prc": "0",
+            "dscqty": "0",
+            "prd": _PRODUCT_MAP[product_u],
+            "trantype": _SIDE_MAP[side_u],
+            "prctyp": "MKT",
+            "ret": "DAY",
+            "ordersource": "API",
+            "mkt_protection": str(protection),
+        }
+        response = self._post_api("PlaceOrder", payload, is_order=True)
+        if not self._is_order_ack(response):
+            raise RuntimeError(f"Flattrade did not acknowledge the order: {response}")
+        order_id = self.extract_order_id(response)
+        self._confirm_fill(order_id, quantity_i)
+        return response
+
+    def _is_order_ack(self, response: Any) -> bool:
+        """True only for ``stat=Ok`` payloads carrying a Noren order number."""
+        return (
+            isinstance(response, dict)
+            and str(response.get("stat", "")).lower() == "ok"
+            and bool(str(response.get("norenordno") or "").strip())
+        )
+
+    def _order_status(self, order_id: str) -> tuple[str | None, int, int, str]:
+        """Return normalized state, filled qty, order qty, and rejection reason."""
+        response = self._post_api(
+            "SingleOrdHist",
+            {"uid": self._client_id, "norenordno": str(order_id)},
+        )
+        rows = response if isinstance(response, list) else [response]
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            if str(row.get("stat", "Ok")).lower() not in {"", "ok"}:
+                continue
+            state = str(row.get("status") or "").strip().lower() or None
+
+            def _as_int(value: Any) -> int:
+                try:
+                    return int(float(value or 0))
+                except (TypeError, ValueError):
+                    return 0
+
+            return (
+                state,
+                _as_int(row.get("fillshares")),
+                _as_int(row.get("qty")),
+                str(row.get("rejreason") or row.get("emsg") or "").strip(),
+            )
+        reason = response.get("emsg", "unrecognised response") if isinstance(response, dict) else "unrecognised response"
+        return (None, 0, 0, str(reason))
+
+    def _confirm_fill(self, order_id: str, want_qty: int) -> None:
+        """Poll SingleOrdHist until fully filled, rejected, or timed out."""
+        deadline = time.monotonic() + _FILL_TIMEOUT_SECONDS
+        last_state = None
+        while time.monotonic() < deadline:
+            state, filled, order_qty, reason = self._order_status(order_id)
+            last_state = state
+            if state == "complete":
+                if filled >= want_qty:
+                    return
+                raise RuntimeError(
+                    f"Flattrade order {order_id} completed only {filled}/{want_qty}"
+                )
+            if state in _TERMINAL_FAILURE_STATES:
+                raise RuntimeError(
+                    f"Flattrade order {order_id} {state}: {reason or 'no reason given'}"
+                )
+            time.sleep(_FILL_POLL_INTERVAL)
+        raise TimeoutError(
+            f"Flattrade order {order_id} not confirmed filled within "
+            f"{_FILL_TIMEOUT_SECONDS:.0f}s (last status: {last_state})"
+        )
+
+    def extract_order_id(self, order_response: Any) -> str:
+        """Recursively find Flattrade's ``norenordno`` in a response payload."""
+        if order_response is None:
+            return ""
+        if isinstance(order_response, dict):
+            for key in ("norenordno", "order_id", "orderId", "id"):
+                value = order_response.get(key)
+                if value:
+                    return str(value).strip()
+            for value in order_response.values():
+                found = self.extract_order_id(value)
+                if found:
+                    return found
+            return ""
+        if isinstance(order_response, list):
+            for value in order_response:
+                found = self.extract_order_id(value)
+                if found:
+                    return found
+            return ""
+        if isinstance(order_response, str):
+            return order_response.strip()
+        return ""
+
+    def logout(self) -> dict[str, Any]:
+        """Close the local session and erase sensitive in-memory state."""
+        with self._lock:
+            if self.client is not None:
+                try:
+                    self.client.close()
+                except Exception as exc:
+                    log.warning("Flattrade local session close failed: %s", exc)
+            self.is_logged_in = False
+            self._access_token = ""
+            self._client_id = ""
+            self._account_id = ""
+            self._symbol_cache.clear()
+            self._scrip_df = None
+            self._api_limiter.reset()
+            self._order_limiter.reset()
+            return {"stat": "Ok", "message": "Flattrade local session cleared"}
+
+
+# The master imports and reuses this one object so all worker threads share the
+# same authenticated session, contract cache, lock, and rate-limit budgets.
+flattrade_execution_client = FlattradeExecutionClient()

--- a/Dependencies/Readme.md
+++ b/Dependencies/Readme.md
@@ -12,27 +12,30 @@ Dependencies/
 ├── Kotak API/           # Kotak Neo live execution
 │   ├── kotak_execution.py        # KotakExecutionClient (shared singleton)
 │   └── diagnose_kotak_symbol.py  # read-only symbol check + optional test order
-└── Shoonya API/         # Shoonya (Finvasia) live execution
-    ├── NorenApi.py               # vendored Finvasia NorenApi client
-    ├── shoonya_execution.py      # ShoonyaExecutionClient (shared singleton)
-    └── diagnose_shoonya_symbol.py# read-only symbol check + optional test order
+├── Shoonya API/         # Shoonya (Finvasia) live execution
+│   ├── NorenApi.py               # vendored Finvasia NorenApi client
+│   ├── shoonya_execution.py      # ShoonyaExecutionClient (shared singleton)
+│   └── diagnose_shoonya_symbol.py# read-only symbol check + optional test order
+└── Flattrade API/       # Flattrade Pi v2 REST live execution
+    ├── flattrade_execution.py      # FlattradeExecutionClient (shared singleton)
+    └── diagnose_flattrade_symbol.py# read-only symbol check + optional test order
 ```
 
 `.env` itself is git-ignored (it holds secrets); `env.example` is the committed template.
-Both execution modules load `.env` from this `Dependencies/` folder.
+All execution modules load `.env` from this `Dependencies/` folder.
 
 ## How live execution works
-The master file loads **both** broker clients (each guarded — a missing SDK just
-disables that broker) and then picks one with `LIVE_BROKER` (`KOTAK` or `SHOONYA`).
-The rest of the runner only touches a single generic `execution_client`, so the two
-brokers are interchangeable. Both clients expose the **same surface**:
+The master file guarded-loads all three broker clients and then picks one with
+`LIVE_BROKER` (`KOTAK`, `SHOONYA`, or `FLATTRADE`). The rest of the runner only
+touches a single generic `execution_client`, so the brokers are interchangeable.
+All clients expose the **same surface**:
 `ensure_logged_in()`, `preload_scrip_master()`, `resolve_option_symbol()`,
 `place_market_order()` (with fill confirmation), `extract_order_id()`, `logout()`,
 and an `is_logged_in` flag.
 
 Safety gates (all in `.env`):
 - `LIVE_TRADING_ENABLED` — global kill-switch (default `false` = everything paper).
-- `LIVE_BROKER` — `KOTAK` or `SHOONYA`. An unrecognised value **fails closed**
+- `LIVE_BROKER` — `KOTAK`, `SHOONYA`, or `FLATTRADE`. An unrecognised value **fails closed**
   (live disabled, paper only) rather than guessing a broker.
 - `<PREFIX>_LIVE_TRADING` — per strategy. A strategy goes live only when the global
   switch **and** its own flag are both true.
@@ -40,8 +43,8 @@ Safety gates (all in `.env`):
   strategy falls back to paper for that trade.
 
 Product/exchange per broker is derived from `LIVE_BROKER`: Kotak uses `nse_fo` +
-`KOTAK_PRODUCT_TYPE`; Shoonya uses `NFO` + `SHOONYA_PRODUCT_TYPE` (INTRADAY → MIS/I,
-NORMAL → NRML/M).
+`KOTAK_PRODUCT_TYPE`; Shoonya uses `NFO` + `SHOONYA_PRODUCT_TYPE`; Flattrade uses
+`NFO` + `FLATTRADE_PRODUCT_TYPE` (INTRADAY → MIS/I, NORMAL → NRML/M).
 
 ## Credentials (in `.env`)
 - **Kotak Neo:** `CONSUMER_KEY`, `MOBILE`, `MPIN`, `UCC`. TOTP is typed at startup
@@ -50,10 +53,15 @@ NORMAL → NRML/M).
   `SHOONYA_API_SECRET`, `SHOONYA_IMEI`, `SHOONYA_TOTP_SECRET` (base32 seed; the TOTP
   is auto-generated via `pyotp`, or you're prompted if blank). The client is vendored
   here; needs `pip install pyotp websocket-client`.
+- **Flattrade:** `FLATTRADE_CLIENT_ID`, `FLATTRADE_API_KEY`, and
+  `FLATTRADE_API_SECRET`. `FLATTRADE_ACCESS_TOKEN` is optional: when blank, startup
+  opens Flattrade authorization and asks for the returned `request_code`. Tokens
+  remain in memory unless you manually paste one into `.env`. Uses core `requests`
+  and `pandas`; no extra SDK is required. Token exchange must originate from the
+  static IP registered against your Flattrade API key.
 
 > Note: Finvasia is decommissioning the legacy Shoonya QuickAuth endpoint (it returns
 > HTTP 502), so Shoonya live login needs the new OAuth API before it works again.
-> Kotak Neo is the working live path today.
 
 ## Diagnostics (read-only, with an optional REAL test order)
 Each broker has a diagnostic that logs in and shows whether a contract resolves to a
@@ -63,4 +71,5 @@ flatten) — it asks you to type `YES` first:
 ```
 python "Dependencies/Kotak API/diagnose_kotak_symbol.py" CE 23950 --place-order
 python "Dependencies/Shoonya API/diagnose_shoonya_symbol.py" CE 23950 26JUN25 --place-order
+python "Dependencies/Flattrade API/diagnose_flattrade_symbol.py" CE 24150 14JUL26 --place-order
 ```

--- a/Dependencies/env.example
+++ b/Dependencies/env.example
@@ -980,15 +980,16 @@ GSHEET_OAUTH_TOKEN_FILE=
 # By default EVERYTHING is paper: LIVE_TRADING_ENABLED=false is the global
 # kill-switch. A strategy places REAL orders only when BOTH this master switch
 # AND that strategy's own <PREFIX>_LIVE_TRADING are true. LIVE_BROKER picks which
-# broker those orders route to (KOTAK or SHOONYA) - both share one code path in
+# broker those orders route to (KOTAK, SHOONYA, or FLATTRADE) - all share one code path in
 # the runner (Dependencies/Kotak API/kotak_execution.py /
-# Dependencies/Shoonya API/shoonya_execution.py). On any order failure the
+# Dependencies/Shoonya API/shoonya_execution.py / Dependencies/Flattrade API/
+# flattrade_execution.py). On any order failure the
 # strategy falls back to paper for that trade.
 
 # ---- Global master kill-switch (must be true for ANY live order) ----
 LIVE_TRADING_ENABLED=false
 
-# ---- Active broker for live orders: KOTAK or SHOONYA ----
+# ---- Active broker for live orders: KOTAK, SHOONYA, or FLATTRADE ----
 LIVE_BROKER=KOTAK
 
 # ---- Kotak Neo credentials (used when LIVE_BROKER=KOTAK) ----
@@ -1015,6 +1016,18 @@ SHOONYA_API_SECRET=
 SHOONYA_IMEI=
 SHOONYA_TOTP_SECRET=
 SHOONYA_PRODUCT_TYPE=INTRADAY
+
+# ---- Flattrade Pi v2 credentials (used when LIVE_BROKER=FLATTRADE) ----
+# The daily access token is optional. When blank, startup opens Flattrade's
+# browser authorization and prompts for the returned request_code; the generated
+# token stays in memory and is never written back to this file. Credential fields
+# intentionally remain blank in this committed template.
+FLATTRADE_CLIENT_ID=
+FLATTRADE_API_KEY=
+FLATTRADE_API_SECRET=
+FLATTRADE_ACCESS_TOKEN=
+FLATTRADE_PRODUCT_TYPE=INTRADAY
+FLATTRADE_MARKET_PROTECTION=5
 
 # ---- Per-strategy live toggles (all default false; flip individually) ----
 # Prefixes match each strategy's existing <PREFIX>_* knobs above.

--- a/Nifty Multi Strategy Front Test - Master File.py
+++ b/Nifty Multi Strategy Front Test - Master File.py
@@ -955,11 +955,10 @@ CPR_ALGO3_LOGIC = load_module(
 )
 
 # -----------------------------------------------------------------------------
-# Live-execution layer (optional) - selectable broker: Kotak Neo or Shoonya.
+# Live-execution layer (optional) - Kotak Neo, Shoonya, or Flattrade.
 # -----------------------------------------------------------------------------
-# This is how real (non-paper) orders reach the broker. Both helpers
-# (Dependencies/Kotak API/kotak_execution.py and Dependencies/Shoonya API/
-# shoonya_execution.py) expose the SAME surface (ensure_logged_in /
+# This is how real (non-paper) orders reach the broker. All three helpers expose
+# the SAME surface (ensure_logged_in /
 # preload_scrip_master / resolve_option_symbol / place_market_order /
 # extract_order_id / logout / is_logged_in), so the runner uses whichever one
 # LIVE_BROKER selects via a single generic `execution_client`. Each import is
@@ -993,30 +992,50 @@ except Exception as _shoonya_import_exc:  # ImportError when SDK folder/deps mis
         _shoonya_import_exc,
     )
 
-# Pick the active broker from .env (default KOTAK). The rest of the runner only
-# touches the generic `execution_client` / LIVE_EXCHANGE_SEGMENT / LIVE_PRODUCT_TYPE
-# below, so the per-broker differences (exchange code, product key) live here only.
-# INTRADAY (MIS/I) = squared off same day; NORMAL (NRML/M) = carried overnight.
-LIVE_BROKER = _env_str("LIVE_BROKER", "KOTAK").upper().strip() or "KOTAK"
-if LIVE_BROKER == "KOTAK":
-    execution_client = kotak_execution_client
-    LIVE_EXCHANGE_SEGMENT = "nse_fo"
-    LIVE_PRODUCT_TYPE = _env_str("KOTAK_PRODUCT_TYPE", "INTRADAY").upper().strip() or "INTRADAY"
-elif LIVE_BROKER == "SHOONYA":
-    execution_client = shoonya_execution_client
-    LIVE_EXCHANGE_SEGMENT = "NFO"
-    LIVE_PRODUCT_TYPE = _env_str("SHOONYA_PRODUCT_TYPE", "INTRADAY").upper().strip() or "INTRADAY"
-else:
-    # Fail CLOSED on an unknown/typo'd broker (e.g. "SHONYA"): leave NO client so
-    # the startup guard forces every strategy to PAPER, and log a loud error. We
-    # must never silently fall back to a different broker for live-money execution.
-    logging.getLogger(LOGGER_NAME).error(
-        "Unknown LIVE_BROKER=%r (expected KOTAK or SHOONYA); live trading DISABLED (paper only).",
-        LIVE_BROKER,
+try:
+    _flattrade_execution_module = load_module(
+        "master_flattrade_execution",
+        Path(__file__).resolve().parent / "Dependencies" / "Flattrade API" / "flattrade_execution.py",
     )
-    execution_client = None
-    LIVE_EXCHANGE_SEGMENT = ""
-    LIVE_PRODUCT_TYPE = "INTRADAY"
+    flattrade_execution_client = _flattrade_execution_module.flattrade_execution_client
+except Exception as _flattrade_import_exc:
+    flattrade_execution_client = None
+    logging.getLogger(LOGGER_NAME).warning(
+        "Flattrade execution layer unavailable (%s); Flattrade live trading disabled.",
+        _flattrade_import_exc,
+    )
+
+
+def _select_execution_client(broker_name: str):
+    """Return client, exchange, and product for one explicit broker selection.
+
+    Keeping this decision in one small function makes the fail-closed behaviour
+    easy to test.  A typo must never route real-money orders to another broker.
+    """
+    broker = str(broker_name).upper().strip()
+    if broker == "KOTAK":
+        product = _env_str("KOTAK_PRODUCT_TYPE", "INTRADAY").upper().strip() or "INTRADAY"
+        return kotak_execution_client, "nse_fo", product
+    if broker == "SHOONYA":
+        product = _env_str("SHOONYA_PRODUCT_TYPE", "INTRADAY").upper().strip() or "INTRADAY"
+        return shoonya_execution_client, "NFO", product
+    if broker == "FLATTRADE":
+        product = _env_str("FLATTRADE_PRODUCT_TYPE", "INTRADAY").upper().strip() or "INTRADAY"
+        return flattrade_execution_client, "NFO", product
+    logging.getLogger(LOGGER_NAME).error(
+        "Unknown LIVE_BROKER=%r (expected KOTAK, SHOONYA, or FLATTRADE); "
+        "live trading DISABLED (paper only).",
+        broker_name,
+    )
+    return None, "", "INTRADAY"
+
+
+# Pick the active broker from .env (default KOTAK). The rest of the runner only
+# touches these three generic values. INTRADAY is same-day; NORMAL is carry-forward.
+LIVE_BROKER = _env_str("LIVE_BROKER", "KOTAK").upper().strip() or "KOTAK"
+execution_client, LIVE_EXCHANGE_SEGMENT, LIVE_PRODUCT_TYPE = _select_execution_client(
+    LIVE_BROKER
+)
 
 # =============================================================================
 # SIGNAL GENERATOR PORTS (ATM single-leg strategies from the TradingBot repo)
@@ -2907,7 +2926,7 @@ class BasePaperStrategyWorker(threading.Thread):
         This is the bridge between "paper" and "real": in paper mode it does
         nothing and just returns True, so the rest of the trade code can call it
         without caring which mode we're in. In live mode it actually places the
-        order via the selected `execution_client` (Kotak or Shoonya). A "leg" is
+        order via the selected `execution_client` (Kotak, Shoonya, or Flattrade). A "leg" is
         one option contract (a spread has two legs).
 
         `leg` is a dict describing the option:
@@ -9827,9 +9846,9 @@ def main() -> None:
         live_count = 0
 
     # Eagerly establish the broker session NOW (at startup) so worker threads never
-    # block on login mid-session (Kotak prompts for a TOTP; Shoonya auto-generates
-    # it). If login/2FA fails here, force every strategy to PAPER rather than
-    # failing one order at a time later.
+    # block on login mid-session (Kotak uses TOTP, Shoonya may auto-generate it,
+    # and Flattrade uses browser authorization). If login fails here, force every
+    # strategy to PAPER rather than failing one order at a time later.
     if live_count > 0 and execution_client is not None:
         logger.warning("Logging in to %s for LIVE trading now.", LIVE_BROKER)
         if not execution_client.ensure_logged_in():

--- a/Nifty Multi Strategy Front Test - Master File.py
+++ b/Nifty Multi Strategy Front Test - Master File.py
@@ -1011,6 +1011,11 @@ def _select_execution_client(broker_name: str):
 
     Keeping this decision in one small function makes the fail-closed behaviour
     easy to test.  A typo must never route real-money orders to another broker.
+
+    Returns:
+        ``(client, exchange_segment, product_type)``. Unknown names deliberately
+        return ``(None, "", "INTRADAY")``; startup sees the missing client and
+        forces every would-be live strategy back to paper mode.
     """
     broker = str(broker_name).upper().strip()
     if broker == "KOTAK":

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Although I own the code, the coding itself was done entirely using GPT-5.4-xhigh
 - The backtest files I used to backtest
 - The signal generators I created to generate signals
 - The main front test file which uses miltithreading to execute all strategies together
-- Live order execution to a real broker — selectable between **Kotak Neo** and **Shoonya (Finvasia)** — gated by a global kill-switch and per-strategy paper/live toggles (everything defaults to paper)
+- Live order execution to a real broker — selectable among **Kotak Neo**, **Shoonya (Finvasia)**, and **Flattrade Pi v2** — gated by a global kill-switch and per-strategy paper/live toggles (everything defaults to paper)
 - Live Telegram alerts: the front-test master file can post every entry/exit (option instrument, lot size, entry/exit price, and P&L) to a Telegram group/channel
 - An **optional, opt-in LLM trading agent** — the "SL Hunting AI Agent" — a Claude agent that trades a discretionary price-action method on NIFTY options; off by default, paper unless explicitly enabled, and fail-soft (see Recent additions)
 
@@ -22,7 +22,7 @@ Although I own the code, the coding itself was done entirely using GPT-5.4-xhigh
 - **Optional LLM trading agent — the "SL Hunting AI Agent" (opt-in 27th worker).** A Claude agent (via the [`claude-agent-sdk`](https://pypi.org/project/claude-agent-sdk/) on your Claude subscription — **no API key**) trades the discretionary *SL Hunting* price-action method on NIFTY ATM options. Once per completed 1-min bar (the method's native timeframe) it reads the NIFTY chart (with **BankNIFTY cross-confirmation**) and — only on a confirmed setup at a real level — acts through the SAME tested `enter_position`/`exit_position` path as every other worker, with dynamic **~₹2,500 risk-per-trade** position sizing (it does not pick lots). It **stops opening new positions after noon** (`SL_HUNTING_NO_NEW_ENTRY_HOUR`, default 12:00) — *not* a square-off: open positions, their stops/targets, and the 15:15 square-off are unaffected. It is **off by default** (`SL_HUNTING_ENABLED`), trades **paper** unless both `LIVE_TRADING_ENABLED` and `SL_HUNTING_LIVE_TRADING` are set, and is **fail-soft** — any agent/SDK error becomes a safe HOLD (never an exception into the trading loop), and its extra deps are lazily imported so a missing dep just disables this one worker. It can also **learn from its own trades**: a per-trade journal feeds an off-loop reflection *coach* that proposes lessons, which the operator human-gates into the prompt (paper-first, off by default). Needs `pip install claude-agent-sdk pydantic` and a one-time `claude setup-token` (keep `ANTHROPIC_API_KEY` **UNSET** so it bills your Claude plan, not per-token API). Full details — knowledge, tools, safety model, the learning loop — are in `Signal Generators/SL Hunting AI Agent/README.md`. This is the optional **27th** worker.
 - **CPR Algo 3 (multi-instrument) is now wired into the front test.** A new `CPRAlgo3StrategyWorker` runs the "CPR basic setup" strategy, which watches THREE charts at once — the NIFTY spot plus a ~ITM CE and a ~ITM PE of the current-week expiry — and only fires when VWAP and the CPR band align across all three (RSI/ARSI on spot). The two ITM options are **observation only**: a signal still BUYS the ATM CE/PE of the next-next expiry through the same tested path as the other directional workers, so it shares CPR's risk knobs (tunable via `CPR_ALGO3_*` in `.env`, including `CPR_ALGO3_ITM_OFFSET`). It fetches the two option 1-min OHLC feeds on demand and drives its own spot target/stop exit. This brings the runner to **26 workers**. (The standalone Algo 3 signal generator + its unit tests live under `Signal Generators/CPR Strategy/`.)
 - **Code-quality pass.** Added a `requirements.txt`; gave every Shoonya broker HTTP call a timeout (a hung call could otherwise stall a worker thread and the shared broker lock); removed hardcoded credentials from the vendored Shoonya client; routed the execution layer's status/errors through `logging` instead of `print()`; and ported the master test suite into the repo (`test_nifty_multi_strategy_master.py` — see Tests below).
-- **Live broker execution is now broker-selectable (Kotak Neo or Shoonya).** The front-test master can place REAL orders, not just paper. `LIVE_BROKER` (in `.env`) picks the broker — `KOTAK` or `SHOONYA` — and the runner routes every real order through one generic `execution_client` to whichever is selected. It is gated by two switches: the global `LIVE_TRADING_ENABLED` kill-switch AND each strategy's own `<PREFIX>_LIVE_TRADING` flag — a strategy goes live only when both are true, and an unrecognised `LIVE_BROKER` fails closed (live disabled, paper only). The per-broker code lives under `Dependencies/Kotak API/` and `Dependencies/Shoonya API/`, each with its execution client plus a read-only diagnostic that can optionally place a confirmation-gated round-trip test order (`--place-order`). Both brokers share one surface (login, symbol resolution, market order with fill confirmation), and any order failure falls back to paper for that trade. Everything defaults to paper. (Note: Shoonya's legacy QuickAuth endpoint is being decommissioned by Finvasia, so Kotak Neo is the working live path today.)
+- **Live broker execution is broker-selectable (Kotak Neo, Shoonya, or Flattrade).** `LIVE_BROKER` picks `KOTAK`, `SHOONYA`, or `FLATTRADE`, and every real order goes through one generic `execution_client`. The global `LIVE_TRADING_ENABLED` kill-switch and each strategy's `<PREFIX>_LIVE_TRADING` flag must both be true; unknown broker names fail closed to paper. Each broker folder contains an execution client and a read-only diagnostic with an optional, typed-`YES`, round-trip test order. Flattrade uses its official Pi v2 browser-token flow, exact NFO index scrip master, documented request limits, market-order protection, and `SingleOrdHist` fill confirmation. Everything still defaults to paper. (Shoonya's legacy QuickAuth endpoint is being decommissioned by Finvasia.)
 - **End-of-day P&L is now written to a Google Sheet.** When all workers exit on a clean end of day, the master parses the run's log for each strategy's realised P&L and writes it into a tracker sheet — one row per strategy, one column per calendar day — overwriting today's cell and backfilling any blank earlier-this-month cells from the (append-mode) log. Auth is OAuth user-token via `gspread`; configure `GSHEET_ID` + an OAuth client in `.env` (see Setup). It's a safe no-op when unconfigured, so it never disturbs shutdown.
 - **13 TradingBot signal-generator ports added — the front test now runs 24 workers.** Thirteen more ATM single-leg strategies were ported into `Signal Generators/` (SMA Crossover, Bollinger Bands, Keltner Squeeze, Mean Reversion Z-Score, ML Ensemble, Multi-Timeframe, Opening Range Breakout, Parabolic SAR, RSI Divergence, RSI Reversal, Stochastic, Supertrend, Volatility Breakout), all sharing `misc_strategy_common.py` (TA-Lib-first indicator helpers). They're wired into the master via one shared factory as `AtmSingleLegStrategyWorker`s — the same family as Renko/Goldmine/CPR — and each is fully tunable from `.env` by its own prefix (e.g. `SMA_CROSSOVER_*`, `KELTNER_SQUEEZE_*`). This brings the runner to **24 workers** (21 ATM single-leg + 2 Hedged Puts + 1 Delta-0.2). ML Ensemble needs `scikit-learn`.
 - **CPR (Central Pivot Range) strategy is now live in the front test.** It runs as an ATM single-leg worker (`CPRStrategyWorker`) alongside the other strategies: the master file feeds it 1-min OHLC, the CPR logic resamples to complete 5-min candles internally, and a LONG/SHORT signal buys the ATM CE/PE of the next-next expiry. Tunable via `CPR_*` knobs in the `.env` (lots, max-loss, poll, 09:25-15:15 window). (This brought the master file to nine workers at the time; see the latest addition at the top of this list for the current total.)
@@ -42,7 +42,8 @@ You might have to adjust the import addresses from which the files are to be imp
     ├── env.example                                    # copy to Dependencies/.env and fill in
     ├── dhan_token_setup.py                            # one-time DhanHQ OAuth token setup
     ├── Kotak API/                                     # kotak_execution.py + diagnose_kotak_symbol.py
-    └── Shoonya API/                                   # NorenApi.py + shoonya_execution.py + diagnose_shoonya_symbol.py
+    ├── Shoonya API/                                   # NorenApi.py + shoonya_execution.py + diagnose_shoonya_symbol.py
+    └── Flattrade API/                                 # flattrade_execution.py + diagnose_flattrade_symbol.py
 ```
 Each subfolder has its own `Readme.md` with the details.
 
@@ -52,7 +53,7 @@ Each subfolder has its own `Readme.md` with the details.
    ```
    pip install -r requirements.txt
    ```
-   That covers the core (data fetch, backtests, runner). For live trading also install your broker's client — see the commented "Live trading (optional)" section in `requirements.txt`: Kotak Neo (`neo_api_client`) and/or Shoonya (`pyotp` + `websocket-client`; the NorenApi client itself is vendored in `Dependencies/Shoonya API/`).
+   That covers the core (data fetch, backtests, runner). For live trading also install your broker's client — see the commented "Live trading (optional)" section in `requirements.txt`: Kotak Neo (`neo_api_client`) and/or Shoonya (`pyotp` + `websocket-client`; the NorenApi client itself is vendored). Flattrade uses the core `requests` and `pandas` dependencies, so it needs no extra SDK.
 3. Configure credentials. Copy `Dependencies/env.example` to `Dependencies/.env` and fill it in (`.env` is git-ignored). Set your Dhan credentials there, then run the one-time token setup:
    ```
    python "Dependencies/dhan_token_setup.py"
@@ -77,13 +78,14 @@ Each subfolder has its own `Readme.md` with the details.
 6. (Optional) Live broker execution. Everything is paper by default. To place REAL orders, set in `Dependencies/.env`:
    ```
    LIVE_TRADING_ENABLED=true        # global kill-switch (default false)
-   LIVE_BROKER=KOTAK                # KOTAK or SHOONYA
+   LIVE_BROKER=KOTAK                # KOTAK, SHOONYA, or FLATTRADE
    RENKO_LIVE_TRADING=true          # flip the specific strategies you want live
    ```
-   Then fill the selected broker's credential block (Kotak: `CONSUMER_KEY`/`MOBILE`/`MPIN`/`UCC`; Shoonya: `SHOONYA_USERID`/`SHOONYA_PASSWORD`/`SHOONYA_VENDOR_CODE`/`SHOONYA_API_SECRET`/`SHOONYA_IMEI`/`SHOONYA_TOTP_SECRET`). A strategy trades live only when `LIVE_TRADING_ENABLED` **and** its own `<PREFIX>_LIVE_TRADING` are both true; any order failure falls back to paper for that trade. Check connectivity first with the read-only diagnostics — they can place a confirmation-gated round-trip (buy + auto square-off) test order via `--place-order`:
+   Then fill the selected broker's credential block. Flattrade needs `FLATTRADE_CLIENT_ID`, `FLATTRADE_API_KEY`, and `FLATTRADE_API_SECRET`; its optional `FLATTRADE_ACCESS_TOKEN` is validated when supplied, otherwise startup opens browser authorization and asks for the returned `request_code`. A strategy trades live only when `LIVE_TRADING_ENABLED` **and** its own `<PREFIX>_LIVE_TRADING` are both true; any order failure falls back to paper for that trade. Check connectivity first with the read-only diagnostics — they can place a confirmation-gated round-trip (buy + auto square-off) test order via `--place-order`:
    ```
    python "Dependencies/Kotak API/diagnose_kotak_symbol.py" CE 23950 --place-order
    python "Dependencies/Shoonya API/diagnose_shoonya_symbol.py" CE 23950 26JUN25 --place-order
+   python "Dependencies/Flattrade API/diagnose_flattrade_symbol.py" CE 24150 14JUL26 --place-order
    ```
 
 # Command-line interface
@@ -95,7 +97,7 @@ Each subfolder has its own `Readme.md` with the details.
 | `backtest --strategy {renko,ema,heikin,cpr,profit-shooter,goldmine,money-machine}` | Backtest one strategy against a CSV | `python algo.py backtest --strategy renko --data "Backtest Outputs/nifty_renko_futures_5y_1min_data.csv"` |
 | `run` | Start the front-test master (paper by default; live per `.env`) | `python algo.py run` |
 | `setup-token` | One-time DhanHQ token setup (writes `.env`) | `python algo.py setup-token` |
-| `diagnose --broker {kotak,shoonya}` | Read-only broker/symbol check (add `--place-order` for a test order) | `python algo.py diagnose --broker kotak CE 23950` |
+| `diagnose --broker {kotak,shoonya,flattrade}` | Read-only broker/symbol check (add `--place-order` for a test order) | `python algo.py diagnose --broker flattrade CE 24150 14JUL26` |
 
 Run `python algo.py --help`, or `python algo.py <command> --help`, for the details.
 
@@ -113,7 +115,7 @@ The front-test master has a unittest suite — env toggles, broker paper/live ro
 ```
 python -m unittest test_nifty_multi_strategy_master
 ```
-133 tests; the broker/SDK-specific cases skip automatically when those optional deps aren't installed. (The CPR, Subhamoy, and SL Hunting AI Agent signal generators have their own tests under `Signal Generators/`.)
+157 tests; broker/SDK-specific cases skip automatically when optional dependencies are absent, and all Flattrade HTTP/browser/order behaviour is mocked. (The CPR, Subhamoy, and SL Hunting AI Agent signal generators have their own tests under `Signal Generators/`.)
 
 # License
 Released under the MIT License — see [LICENSE](LICENSE).

--- a/algo.py
+++ b/algo.py
@@ -91,7 +91,9 @@ BACKTEST_SCRIPTS = {
     "money-machine": "My Backtest Files (For Reference)/Subhamoy Strategies/Nifty Money Machine Strategy Backtest.py",
 }
 
-# `diagnose --broker <key>`
+# `diagnose --broker <key>`. argparse builds its allowed --broker choices from
+# these keys automatically; each value is the script that receives the remaining
+# CE/PE, strike, expiry, and --place-order arguments unchanged.
 BROKER_DIAGNOSTICS = {
     "flattrade": "Dependencies/Flattrade API/diagnose_flattrade_symbol.py",
     "kotak": "Dependencies/Kotak API/diagnose_kotak_symbol.py",

--- a/algo.py
+++ b/algo.py
@@ -45,6 +45,7 @@ The commands:
                place a confirmation-gated round-trip TEST order with --place-order).
       python algo.py diagnose --broker kotak CE 23950
       python algo.py diagnose --broker shoonya CE 23950 26JUN25 --place-order
+      python algo.py diagnose --broker flattrade CE 24150 14JUL26
 
 Tips:
   - `python algo.py --help` lists the commands; `python algo.py <command> --help`
@@ -92,6 +93,7 @@ BACKTEST_SCRIPTS = {
 
 # `diagnose --broker <key>`
 BROKER_DIAGNOSTICS = {
+    "flattrade": "Dependencies/Flattrade API/diagnose_flattrade_symbol.py",
     "kotak": "Dependencies/Kotak API/diagnose_kotak_symbol.py",
     "shoonya": "Dependencies/Shoonya API/diagnose_shoonya_symbol.py",
 }

--- a/test_nifty_multi_strategy_master.py
+++ b/test_nifty_multi_strategy_master.py
@@ -1,5 +1,7 @@
 import unittest
 import importlib.util
+import hashlib
+import json
 import tempfile
 import threading
 from pathlib import Path
@@ -8,6 +10,7 @@ import pandas as pd
 from unittest.mock import MagicMock, patch
 import os
 import sys
+from urllib.parse import parse_qs
 
 # =============================================================================
 # DYNAMIC MODULE IMPORT
@@ -33,6 +36,39 @@ with patch.dict(os.environ, {"DHAN_CLIENT_CODE": "test", "DHAN_TOKEN_ID": "test"
             spec.loader.exec_module(master_file)
         except Exception as e:
             print(f"Failed to load master_file for testing: {e}")
+
+
+# The Flattrade helper is loaded separately so its low-level REST behaviour can
+# be tested without starting the master runner or making any network requests.
+flattrade_file_path = Path(__file__).parent / "Dependencies" / "Flattrade API" / "flattrade_execution.py"
+flattrade_module = None
+if flattrade_file_path.is_file():
+    flattrade_spec = importlib.util.spec_from_file_location(
+        "flattrade_execution_under_test", flattrade_file_path
+    )
+    flattrade_module = importlib.util.module_from_spec(flattrade_spec)
+    sys.modules["flattrade_execution_under_test"] = flattrade_module
+    flattrade_spec.loader.exec_module(flattrade_module)
+
+flattrade_diagnostic_path = (
+    Path(__file__).parent
+    / "Dependencies"
+    / "Flattrade API"
+    / "diagnose_flattrade_symbol.py"
+)
+flattrade_diagnostic_module = None
+if flattrade_diagnostic_path.is_file():
+    flattrade_diagnostic_spec = importlib.util.spec_from_file_location(
+        "diagnose_flattrade_symbol_under_test", flattrade_diagnostic_path
+    )
+    flattrade_diagnostic_module = importlib.util.module_from_spec(
+        flattrade_diagnostic_spec
+    )
+    sys.modules["diagnose_flattrade_symbol_under_test"] = flattrade_diagnostic_module
+    # The diagnostic imports its sibling module by name, just like a standalone
+    # invocation. Temporarily expose the already-loaded, network-free test copy.
+    with patch.dict(sys.modules, {"flattrade_execution": flattrade_module}):
+        flattrade_diagnostic_spec.loader.exec_module(flattrade_diagnostic_module)
 
 
 # =============================================================================
@@ -1884,6 +1920,496 @@ class TestShoonyaSymbolResolution(unittest.TestCase):
         c._symbol_set = {"NIFTY25JUN26C23000"}  # wanted strike absent
         self.assertEqual(
             c.resolve_option_symbol("NIFTY", date(2026, 6, 25), "CE", 22500), ""
+        )
+
+
+class _FakeHttpResponse:
+    """Small requests.Response stand-in used by the offline Flattrade tests."""
+
+    def __init__(self, payload, text=""):
+        self._payload = payload
+        self.text = text
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+class _FakeClock:
+    """Controllable monotonic clock so rate-limit tests never really sleep."""
+
+    def __init__(self):
+        self.now = 0.0
+        self.sleeps = []
+
+    def monotonic(self):
+        return self.now
+
+    def sleep(self, seconds):
+        self.sleeps.append(seconds)
+        self.now += seconds
+
+
+class TestFlattradeAuthentication(unittest.TestCase):
+    """Flattrade login must validate a token or perform the documented code exchange."""
+
+    def setUp(self):
+        self.assertIsNotNone(
+            flattrade_module,
+            "Dependencies/Flattrade API/flattrade_execution.py has not been implemented",
+        )
+        self.client = flattrade_module.FlattradeExecutionClient()
+        self.session = MagicMock()
+        self.client.client = self.session
+
+    def test_existing_access_token_is_validated_with_user_details(self):
+        self.session.post.return_value = _FakeHttpResponse(
+            {"stat": "Ok", "actid": "FT123", "exarr": ["NFO"]}
+        )
+        env = {
+            "FLATTRADE_CLIENT_ID": "FT123",
+            "FLATTRADE_ACCESS_TOKEN": "daily-token",
+            "FLATTRADE_API_KEY": "",
+            "FLATTRADE_API_SECRET": "",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            self.assertTrue(self.client.ensure_logged_in())
+
+        self.assertTrue(self.client.is_logged_in)
+        self.assertEqual(self.client._access_token, "daily-token")
+        _, kwargs = self.session.post.call_args
+        self.assertEqual(kwargs["timeout"], flattrade_module._API_TIMEOUT_SECONDS)
+        posted = parse_qs(kwargs["data"])
+        self.assertEqual(json.loads(posted["jData"][0]), {"uid": "FT123"})
+        self.assertEqual(posted["jKey"], ["daily-token"])
+        self.assertEqual(kwargs["headers"], {"Content-Type": "application/json"})
+
+    def test_browser_request_code_is_hashed_exchanged_and_validated(self):
+        self.session.post.side_effect = [
+            _FakeHttpResponse({"status": "Ok", "token": "issued-token", "client": "FT123"}),
+            _FakeHttpResponse({"stat": "Ok", "actid": "FT123", "exarr": ["NFO"]}),
+        ]
+        env = {
+            "FLATTRADE_CLIENT_ID": "FT123",
+            "FLATTRADE_ACCESS_TOKEN": "",
+            "FLATTRADE_API_KEY": "public-key",
+            "FLATTRADE_API_SECRET": "raw-secret",
+        }
+        with patch.dict(os.environ, env, clear=False), \
+             patch.object(flattrade_module.webbrowser, "open", return_value=True) as open_browser, \
+             patch("builtins.input", return_value="request-code"):
+            self.assertTrue(self.client.ensure_logged_in())
+
+        expected_hash = hashlib.sha256(
+            b"public-keyrequest-coderaw-secret"
+        ).hexdigest()
+        open_browser.assert_called_once_with(
+            "https://auth.flattrade.in/?app_key=public-key"
+        )
+        token_call = self.session.post.call_args_list[0]
+        self.assertEqual(token_call.args[0], flattrade_module._TOKEN_URL)
+        self.assertEqual(
+            token_call.kwargs["json"],
+            {
+                "api_key": "public-key",
+                "request_code": "request-code",
+                "api_secret": expected_hash,
+            },
+        )
+        self.assertEqual(self.client._access_token, "issued-token")
+
+    def test_missing_credentials_fail_closed_without_network(self):
+        env = {
+            "FLATTRADE_CLIENT_ID": "",
+            "FLATTRADE_ACCESS_TOKEN": "",
+            "FLATTRADE_API_KEY": "",
+            "FLATTRADE_API_SECRET": "",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            self.assertFalse(self.client.ensure_logged_in())
+        self.session.post.assert_not_called()
+
+    def test_failed_exchange_logs_no_secret_or_request_code(self):
+        self.session.post.return_value = _FakeHttpResponse(
+            {"status": "Not_Ok", "emsg": "invalid input"}
+        )
+        env = {
+            "FLATTRADE_CLIENT_ID": "FT123",
+            "FLATTRADE_ACCESS_TOKEN": "",
+            "FLATTRADE_API_KEY": "public-key",
+            "FLATTRADE_API_SECRET": "raw-secret",
+        }
+        with patch.dict(os.environ, env, clear=False), \
+             patch.object(flattrade_module.webbrowser, "open", return_value=True), \
+             patch("builtins.input", return_value="request-code"), \
+             self.assertLogs(flattrade_module.log, level="ERROR") as captured:
+            self.assertFalse(self.client.ensure_logged_in())
+        joined = "\n".join(captured.output)
+        self.assertNotIn("raw-secret", joined)
+        self.assertNotIn("request-code", joined)
+
+
+class TestFlattradeRateLimits(unittest.TestCase):
+    """The client must wait for short bursts and fail before stale minute waits."""
+
+    def setUp(self):
+        self.assertIsNotNone(flattrade_module)
+
+    def test_short_per_second_limit_waits_for_a_slot(self):
+        clock = _FakeClock()
+        limiter = flattrade_module._RollingWindowRateLimiter(
+            per_second=2,
+            per_minute=10,
+            max_wait_seconds=2.0,
+            clock=clock.monotonic,
+            sleeper=clock.sleep,
+            label="test",
+        )
+        limiter.acquire()
+        limiter.acquire()
+        limiter.acquire()
+        self.assertTrue(clock.sleeps)
+        self.assertGreaterEqual(clock.now, 1.0)
+
+    def test_exhausted_minute_limit_raises_before_http_request(self):
+        clock = _FakeClock()
+        limiter = flattrade_module._RollingWindowRateLimiter(
+            per_second=10,
+            per_minute=2,
+            max_wait_seconds=0.0,
+            clock=clock.monotonic,
+            sleeper=clock.sleep,
+            label="test",
+        )
+        limiter.acquire()
+        limiter.acquire()
+
+        client = flattrade_module.FlattradeExecutionClient()
+        client.client = MagicMock()
+        client._access_token = "token"
+        client._client_id = "FT123"
+        client._api_limiter = limiter
+        with self.assertRaises(RuntimeError):
+            client._post_api("UserDetails", {"uid": "FT123"})
+        client.client.post.assert_not_called()
+
+
+class TestFlattradeSymbolResolution(unittest.TestCase):
+    """Option resolution must use exact rows from Flattrade's official CSV schema."""
+
+    def setUp(self):
+        self.assertIsNotNone(flattrade_module)
+        self.client = flattrade_module.FlattradeExecutionClient()
+        raw = pd.DataFrame(
+            [
+                {
+                    "Exchange": "NFO",
+                    "Token": "51377",
+                    "Lotsize": "65",
+                    "Symbol": "NIFTY",
+                    "Tradingsymbol": "NIFTY14JUL26C24150",
+                    "Instrument": "OPTIDX",
+                    "Expiry": "14-JUL-2026",
+                    "Strike": "24150.00",
+                    "Optiontype": "CE",
+                }
+            ]
+        )
+        self.client._scrip_df = self.client._prepare_scrip_master(raw)
+
+    def test_exact_contract_resolves_and_is_cached(self):
+        with patch.object(self.client, "ensure_logged_in", return_value=True):
+            symbol = self.client.resolve_option_symbol(
+                "NIFTY", date(2026, 7, 14), "CE", 24150
+            )
+            self.client._scrip_df = pd.DataFrame()
+            cached = self.client.resolve_option_symbol(
+                "NIFTY", date(2026, 7, 14), "CE", 24150
+            )
+        self.assertEqual(symbol, "NIFTY14JUL26C24150")
+        self.assertEqual(cached, symbol)
+
+    def test_nonexistent_contract_returns_empty(self):
+        with patch.object(self.client, "ensure_logged_in", return_value=True):
+            self.assertEqual(
+                self.client.resolve_option_symbol(
+                    "NIFTY", date(2026, 7, 14), "PE", 24150
+                ),
+                "",
+            )
+
+    def test_malformed_master_is_rejected(self):
+        with self.assertRaises(ValueError):
+            self.client._prepare_scrip_master(pd.DataFrame({"Symbol": ["NIFTY"]}))
+
+
+class TestFlattradeOrders(unittest.TestCase):
+    """Market orders must use Flattrade mappings and confirm the complete fill."""
+
+    def setUp(self):
+        self.assertIsNotNone(flattrade_module)
+        self.client = flattrade_module.FlattradeExecutionClient()
+        self.client._client_id = "FT123"
+        self.client._account_id = "FT123"
+        self.client._access_token = "token"
+        self.client.is_logged_in = True
+
+    def test_market_order_payload_uses_documented_codes(self):
+        ack = {"stat": "Ok", "norenordno": "260703000001"}
+        with patch.dict(os.environ, {"FLATTRADE_MARKET_PROTECTION": "5"}), \
+             patch.object(self.client, "ensure_logged_in", return_value=True), \
+             patch.object(self.client, "_post_api", return_value=ack) as post_api, \
+             patch.object(self.client, "_confirm_fill") as confirm:
+            result = self.client.place_market_order(
+                symbol="NIFTY14JUL26C24150",
+                side="BUY",
+                quantity=65,
+                exchange_segment="NFO",
+                product_type="INTRADAY",
+            )
+
+        self.assertEqual(result, ack)
+        endpoint, payload = post_api.call_args.args
+        self.assertEqual(endpoint, "PlaceOrder")
+        self.assertEqual(
+            payload,
+            {
+                "uid": "FT123",
+                "actid": "FT123",
+                "exch": "NFO",
+                "tsym": "NIFTY14JUL26C24150",
+                "qty": "65",
+                "prc": "0",
+                "dscqty": "0",
+                "prd": "I",
+                "trantype": "B",
+                "prctyp": "MKT",
+                "ret": "DAY",
+                "ordersource": "API",
+                "mkt_protection": "5",
+            },
+        )
+        self.assertTrue(post_api.call_args.kwargs["is_order"])
+        confirm.assert_called_once_with("260703000001", 65)
+
+    def test_invalid_order_inputs_raise_before_submission(self):
+        with patch.object(self.client, "_post_api") as post_api:
+            for kwargs in (
+                {"symbol": "X", "side": "HOLD", "quantity": 65},
+                {"symbol": "X", "side": "BUY", "quantity": 0},
+                {
+                    "symbol": "X",
+                    "side": "BUY",
+                    "quantity": 65,
+                    "exchange_segment": "NSE",
+                },
+                {
+                    "symbol": "X",
+                    "side": "BUY",
+                    "quantity": 65,
+                    "product_type": "DELIVERY",
+                },
+            ):
+                with self.assertRaises(ValueError):
+                    self.client.place_market_order(**kwargs)
+        post_api.assert_not_called()
+
+    def test_acknowledgement_requires_ok_and_order_id(self):
+        self.assertTrue(
+            self.client._is_order_ack({"stat": "Ok", "norenordno": "ORD1"})
+        )
+        for bad in (
+            {"stat": "Not_Ok", "norenordno": "ORD1"},
+            {"stat": "Ok"},
+            {"norenordno": "ORD1"},
+            None,
+        ):
+            self.assertFalse(self.client._is_order_ack(bad))
+
+    def test_order_status_parses_single_order_history(self):
+        history = [
+            {
+                "stat": "Ok",
+                "status": "COMPLETE",
+                "fillshares": "65",
+                "qty": "65",
+                "rejreason": "",
+            }
+        ]
+        with patch.object(self.client, "_post_api", return_value=history):
+            self.assertEqual(
+                self.client._order_status("ORD1"),
+                ("complete", 65, 65, ""),
+            )
+
+    def test_fill_confirmation_handles_complete_rejected_and_timeout(self):
+        with patch.object(
+            self.client, "_order_status", return_value=("complete", 65, 65, "")
+        ):
+            self.client._confirm_fill("ORD1", 65)
+
+        with patch.object(
+            self.client,
+            "_order_status",
+            return_value=("rejected", 0, 65, "RMS: margin"),
+        ), self.assertRaises(RuntimeError):
+            self.client._confirm_fill("ORD2", 65)
+
+        with patch.object(
+            self.client, "_order_status", return_value=("open", 0, 65, "")
+        ), patch.object(flattrade_module, "_FILL_TIMEOUT_SECONDS", 0.02), \
+             patch.object(flattrade_module, "_FILL_POLL_INTERVAL", 0.005), \
+             self.assertRaises(TimeoutError):
+            self.client._confirm_fill("ORD3", 65)
+
+    def test_recursive_order_id_extraction_and_local_logout(self):
+        self.assertEqual(
+            self.client.extract_order_id({"data": [{"norenordno": "ORD9"}]}),
+            "ORD9",
+        )
+        self.client.client = MagicMock()
+        response = self.client.logout()
+        self.assertEqual(response["stat"], "Ok")
+        self.assertFalse(self.client.is_logged_in)
+        self.assertEqual(self.client._access_token, "")
+        self.client.client.close.assert_called_once()
+
+
+class TestFlattradeDiagnostic(unittest.TestCase):
+    """The diagnostic is read-only unless the operator explicitly confirms."""
+
+    def setUp(self):
+        self.assertIsNotNone(
+            flattrade_diagnostic_module,
+            "diagnose_flattrade_symbol.py has not been implemented",
+        )
+        raw = pd.DataFrame(
+            [
+                {
+                    "Exchange": "NFO",
+                    "Token": "1",
+                    "Lotsize": "65",
+                    "Symbol": "NIFTY",
+                    "Tradingsymbol": "NIFTY14JUL26C24150",
+                    "Instrument": "OPTIDX",
+                    "Expiry": "14-JUL-2026",
+                    "Strike": "24150.00",
+                    "Optiontype": "CE",
+                },
+                {
+                    "Exchange": "NFO",
+                    "Token": "2",
+                    "Lotsize": "65",
+                    "Symbol": "NIFTY",
+                    "Tradingsymbol": "NIFTY21JUL26C24150",
+                    "Instrument": "OPTIDX",
+                    "Expiry": "21-JUL-2026",
+                    "Strike": "24150.00",
+                    "Optiontype": "CE",
+                },
+            ]
+        )
+        self.client = flattrade_module.FlattradeExecutionClient()
+        self.client._scrip_df = self.client._prepare_scrip_master(raw)
+
+    def test_nearest_matching_expiry_and_lot_size_are_selected(self):
+        expiry, symbol, lot_size = flattrade_diagnostic_module.select_contract(
+            self.client,
+            underlying="NIFTY",
+            option_type="CE",
+            strike=24150,
+            requested_expiry=None,
+            today=date(2026, 7, 3),
+        )
+        self.assertEqual(expiry, date(2026, 7, 14))
+        self.assertEqual(symbol, "NIFTY14JUL26C24150")
+        self.assertEqual(lot_size, 65)
+
+    def test_explicit_expiry_selects_exact_contract(self):
+        expiry, symbol, lot_size = flattrade_diagnostic_module.select_contract(
+            self.client,
+            underlying="NIFTY",
+            option_type="CE",
+            strike=24150,
+            requested_expiry=date(2026, 7, 21),
+            today=date(2026, 7, 3),
+        )
+        self.assertEqual((expiry, symbol, lot_size), (
+            date(2026, 7, 21), "NIFTY21JUL26C24150", 65
+        ))
+
+    def test_round_trip_aborts_without_exact_yes(self):
+        fake_client = MagicMock()
+        with patch("builtins.input", return_value="yes"):
+            placed = flattrade_diagnostic_module.place_round_trip_test_order(
+                fake_client, "NIFTY14JUL26C24150", 65
+            )
+        self.assertFalse(placed)
+        fake_client.place_market_order.assert_not_called()
+
+    def test_round_trip_buys_then_sells_after_confirmation(self):
+        fake_client = MagicMock()
+        fake_client.place_market_order.side_effect = [
+            {"stat": "Ok", "norenordno": "BUY1"},
+            {"stat": "Ok", "norenordno": "SELL1"},
+        ]
+        fake_client.extract_order_id.side_effect = ["BUY1", "SELL1"]
+        with patch("builtins.input", return_value="YES"):
+            placed = flattrade_diagnostic_module.place_round_trip_test_order(
+                fake_client, "NIFTY14JUL26C24150", 65
+            )
+        self.assertTrue(placed)
+        self.assertEqual(
+            [call.kwargs["side"] for call in fake_client.place_market_order.call_args_list],
+            ["BUY", "SELL"],
+        )
+
+    def test_unconfirmed_entry_warns_that_a_live_position_may_exist(self):
+        fake_client = MagicMock()
+        fake_client.place_market_order.side_effect = TimeoutError("fill unknown")
+        with patch("builtins.input", return_value="YES"), \
+             patch("builtins.print") as printed:
+            placed = flattrade_diagnostic_module.place_round_trip_test_order(
+                fake_client, "NIFTY14JUL26C24150", 65
+            )
+        self.assertFalse(placed)
+        output = "\n".join(" ".join(map(str, call.args)) for call in printed.call_args_list)
+        self.assertIn("MAY BE OPEN", output)
+
+
+class TestFlattradeMasterIntegration(unittest.TestCase):
+    """The master and friendly CLI must expose Flattrade without network access."""
+
+    def test_master_guarded_loads_flattrade_singleton(self):
+        self.assertIsNotNone(
+            getattr(master_file, "flattrade_execution_client", None)
+        )
+
+    def test_master_selector_uses_flattrade_nfo_product_settings(self):
+        self.assertTrue(hasattr(master_file, "_select_execution_client"))
+        with patch.dict(
+            os.environ, {"FLATTRADE_PRODUCT_TYPE": "NORMAL"}, clear=False
+        ):
+            client, exchange, product = master_file._select_execution_client(
+                "FLATTRADE"
+            )
+        self.assertIs(client, master_file.flattrade_execution_client)
+        self.assertEqual((exchange, product), ("NFO", "NORMAL"))
+
+    def test_master_selector_fails_closed_for_unknown_broker(self):
+        self.assertTrue(hasattr(master_file, "_select_execution_client"))
+        with self.assertLogs(master_file.logging.getLogger(master_file.LOGGER_NAME), level="ERROR"):
+            selected = master_file._select_execution_client("FLAT-TYPO")
+        self.assertEqual(selected, (None, "", "INTRADAY"))
+
+    def test_algo_cli_maps_flattrade_diagnostic(self):
+        import algo
+
+        self.assertEqual(
+            algo.BROKER_DIAGNOSTICS.get("flattrade"),
+            "Dependencies/Flattrade API/diagnose_flattrade_symbol.py",
         )
 
 


### PR DESCRIPTION
## Summary

- add a thread-safe Flattrade Pi v2 REST execution client with daily token validation/browser fallback, official NFO contract resolution, documented rate limits, market protection, and fill confirmation
- add a read-only-by-default Flattrade diagnostic with dynamic official lot sizing and a typed-YES real-money round trip
- wire `LIVE_BROKER=FLATTRADE` into the master runner and unified CLI, with blank credential placeholders and updated documentation

## Safety

- paper trading remains the default and unknown brokers still fail closed
- every Flattrade HTTP call has an explicit timeout
- generated access tokens remain in memory and are never written to `.env`
- automated tests never authenticate or place real orders

## Validation

- `python -m unittest test_nifty_multi_strategy_master` — 157 passed
- `python -m compileall "Dependencies/Flattrade API" algo.py "Nifty Multi Strategy Front Test - Master File.py"`
- `ruff check "Dependencies/Flattrade API/flattrade_execution.py" "Dependencies/Flattrade API/diagnose_flattrade_symbol.py" algo.py test_nifty_multi_strategy_master.py`
- diagnostic and unified CLI help smoke tests
- `git diff --check`
- read-only parse of the live official Flattrade NFO index scrip master — 11,039 rows

## References

- https://pi.flattrade.in/docs
- https://flattrade.s3.ap-south-1.amazonaws.com/pidoc/collections/Piconnect.postman_collection.zip

Co-authored-by: Codex <noreply@anthropic.com>