### PR TITLE
SL Hunting v3d sweep, whole-codebase review + fixes, quality CI, PR#34 reconciliation

### DIFF
--- a/.github/workflows/quality-and-security.yml
+++ b/.github/workflows/quality-and-security.yml
@@ -1,0 +1,76 @@
+name: Quality and security
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+# Least privilege: this workflow only reads the repo (checkout + run tools), so
+# the GITHUB_TOKEN is pinned to read-only instead of inheriting broader defaults.
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Python ${{ matrix.python-version }} quality checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        # 3.13 is the operator's live runtime; 3.12 catches accidental use of
+        # newer-only syntax before an interpreter downgrade would reveal it.
+        python-version: ["3.12", "3.13"]
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt -r requirements-dev.txt
+
+      - name: Validate pre-commit configuration
+        run: python -m pre_commit validate-config .pre-commit-config.yaml
+
+      - name: Run the master unittest suite
+        # Loads the spaced-name master file via importlib with dhanhq mocked --
+        # this suite is the correctness gate for the runner itself.
+        run: python -m unittest test_nifty_multi_strategy_master
+
+      - name: Run the pytest suites
+        # Signal-generator + SL Hunting agent + broker-helper tests. SDK-gated
+        # cases skip cleanly when an optional dependency is absent.
+        run: python -m pytest "Signal Generators" "Dependencies" -q
+
+      - name: Compile every Python file
+        # The master runner and most strategy files have SPACES in their names,
+        # so they cannot be mypy modules -- byte-compiling them (plus the test
+        # suites above) is their syntax/consistency gate.
+        run: python -m compileall -q . -x "(__pycache__|Backtest Outputs|\.git)"
+
+      - name: Run Ruff static checks
+        run: python -m ruff check .
+
+      - name: Run mypy type checks
+        # Scope and strictness live in pyproject.toml ([tool.mypy]): every
+        # identifier-named module is checked; expanding to tests is a follow-up.
+        run: python -m mypy
+
+      - name: Run Bandit security checks
+        # B101 (asserts), B105 (false positives on token-URL/dict-key strings)
+        # and B110 (documented best-effort fallbacks) are skipped; vendored and
+        # reference-only code is excluded. Coverage gating is a deliberate
+        # follow-up (measuring the importlib-loaded master needs its own work).
+        run: >
+          python -m bandit -r . -q
+          -x "./Backtest Outputs,./My Backtest Files (For Reference),./Dependencies/Shoonya API/NorenApi.py"
+          --skip B101,B105,B110

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+# Local commit-time checks (mirrors the Streamlit Scanner App policy).
+#
+# Install once with:  pre-commit install
+# Run on demand with: pre-commit run --all-files
+#
+# Policy: hooks here only CHECK, never rewrite files. Auto-fixers are run
+# deliberately (`ruff check --fix`) so a commit never changes content the
+# author didn't review. CI remains the authoritative gate; these hooks just
+# catch the obvious failures before a push.
+
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Keep this rev aligned with the ruff pin in requirements-dev.txt.
+    rev: v0.15.1
+    hooks:
+      - id: ruff
+        name: ruff check (no fixes)
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-merge-conflict
+      - id: check-yaml
+      - id: check-added-large-files
+        args: ["--maxkb=1024"]
+      - id: debug-statements

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,9 @@
-# CLAUDE.md — My-Algo-Trading-Code
+# AGENTS.md — My-Algo-Trading-Code
 
-> **Before doing any work in this repo**, invoke the **`anthropic-skills:using-superpowers`** skill (it
-> surfaces any other relevant skills) and the **`anthropic-skills:karpathy-guidelines`** skill, then
-> follow them: simplicity first, surgical changes, surface tradeoffs, and verify before claiming done.
-> This is live-money trading code — bias toward caution.
+> Working principles for ANY coding agent in this repo: simplicity first, surgical changes,
+> surface tradeoffs, and verify before claiming done. This is live-money trading code — bias
+> toward caution. (Claude Code additionally loads its skills per `CLAUDE.md`; both files must
+> be kept factually in sync.)
 
 ## What this project is
 A NIFTY index-options, multi-strategy trading system. The flow is: **fetch** 1-minute OHLC history from
@@ -71,12 +71,10 @@ Backtest Outputs/                                  # generated CSVs/logs (gitign
   `LIVE_TRADING_ENABLED` **and** that strategy's `<PREFIX>_LIVE_TRADING` are both true. `LIVE_BROKER`
   (`KOTAK` | `SHOONYA`) selects the broker; an unknown value **fails closed** (live disabled, paper only).
   Any order failure falls back to paper for that trade. Every broker HTTP call must have a timeout.
-- **Broker layer:** the Kotak, Shoonya and Flattrade clients expose the SAME surface —
-  `ensure_logged_in`, `preload_scrip_master`, `resolve_option_symbol`, `place_market_order`,
-  `extract_order_id`, `logout`, `is_logged_in` — so the runner only ever touches the generic
-  `execution_client`. The Shoonya `NorenApi` client is vendored under `Dependencies/Shoonya API/`.
-  Flattrade is DIAGNOSTICS-ONLY so far (`algo.py diagnose --broker flattrade`); wiring it into
-  `LIVE_BROKER` is a separate, deliberate step.
+- **Broker layer:** the Kotak and Shoonya clients expose the SAME surface — `ensure_logged_in`,
+  `preload_scrip_master`, `resolve_option_symbol`, `place_market_order`, `extract_order_id`, `logout`,
+  `is_logged_in` — so the runner only ever touches the generic `execution_client`. The Shoonya `NorenApi`
+  client is vendored under `Dependencies/Shoonya API/`.
 - **Code style:** detailed, beginner-friendly module + function docstrings and plain-English inline
   comments — match the existing density. Type hints where practical. `snake_case` functions/modules,
   `PascalCase` classes, `UPPER_SNAKE` constants and env keys. In library code use a module
@@ -88,10 +86,10 @@ Backtest Outputs/                                  # generated CSVs/logs (gitign
 - **Tests:** `python -m unittest test_nifty_multi_strategy_master` (loads the master via `importlib`,
   mocks `dhanhq`; broker/SDK-specific cases skip when those deps are absent). Signal-generator tests live
   under `Signal Generators/`.
-- **Quality gates (run before pushing; CI enforces on Python 3.12 + 3.13):** the two test suites plus
-  `python -m ruff check .`, `python -m mypy` (scoped in `pyproject.toml` — the spaced-name master is
-  covered by `compileall` + tests instead), `python -m compileall -q .`, and `python -m bandit` per the
-  CI workflow. Dev tools install via `pip install -r requirements-dev.txt`.
 - **Dependencies:** `pip install -r requirements.txt`; optional broker/ML extras are documented (commented) inside it.
-- **Git / PRs:** branch off `main`; open PRs into `main` with `gh`; end commit messages with the
-  `Co-Authored-By: Claude <noreply@anthropic.com>` trailer. `.env`, `Backtest Outputs/`, and `*.log` stay gitignored.
+- **Git / PRs:** branch off `main`; open PRs into `main` with `gh`; end commit messages with a
+  `Co-Authored-By:` trailer identifying the agent that produced the change. `.env`,
+  `Backtest Outputs/`, and `*.log` stay gitignored.
+- **Quality gates (run locally before pushing):** `python -m unittest test_nifty_multi_strategy_master`,
+  `python -m pytest "Signal Generators" -q`, `python -m ruff check .`, `python -m mypy`,
+  `python -m compileall -q .` — CI enforces the same set on Python 3.12 + 3.13.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,8 +55,8 @@ Dependencies/
   dhan_token_setup.py                              # one-time DhanHQ OAuth token setup
   Kotak API/     -> kotak_execution.py, diagnose_kotak_symbol.py
   Shoonya API/   -> NorenApi.py (vendored client), shoonya_execution.py, diagnose_shoonya_symbol.py
-  Flattrade API/ -> flattrade_execution.py, diagnose_flattrade_symbol.py (diagnostics only —
-                    NOT yet selectable via LIVE_BROKER)
+  Flattrade API/ -> flattrade_execution.py, diagnose_flattrade_symbol.py,
+                    test_flattrade_execution.py
 pyproject.toml                                     # ruff + mypy quality-gate configuration
 .github/workflows/quality-and-security.yml         # CI: tests + compileall + ruff + mypy + bandit
 Backtest Outputs/                                  # generated CSVs/logs (gitignored)
@@ -69,7 +69,8 @@ Backtest Outputs/                                  # generated CSVs/logs (gitign
   name→prefix map is `STRATEGY_ENV_PREFIX`. **Never commit secrets** — `env.example` holds blank placeholders.
 - **Live-trading safety (critical):** paper by default. A strategy trades live ONLY when the global
   `LIVE_TRADING_ENABLED` **and** that strategy's `<PREFIX>_LIVE_TRADING` are both true. `LIVE_BROKER`
-  (`KOTAK` | `SHOONYA`) selects the broker; an unknown value **fails closed** (live disabled, paper only).
+  (`KOTAK` | `SHOONYA` | `FLATTRADE`) selects the broker; an unknown value **fails closed** (live
+  disabled, paper only).
   Any order failure falls back to paper for that trade. Every broker HTTP call must have a timeout.
 - **Broker layer:** the Kotak and Shoonya clients expose the SAME surface — `ensure_logged_in`,
   `preload_scrip_master`, `resolve_option_symbol`, `place_market_order`, `extract_order_id`, `logout`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,8 +55,8 @@ Dependencies/
   dhan_token_setup.py                              # one-time DhanHQ OAuth token setup
   Kotak API/     -> kotak_execution.py, diagnose_kotak_symbol.py
   Shoonya API/   -> NorenApi.py (vendored client), shoonya_execution.py, diagnose_shoonya_symbol.py
-  Flattrade API/ -> flattrade_execution.py, diagnose_flattrade_symbol.py (diagnostics only —
-                    NOT yet selectable via LIVE_BROKER)
+  Flattrade API/ -> flattrade_execution.py, diagnose_flattrade_symbol.py,
+                    test_flattrade_execution.py
 pyproject.toml                                     # ruff + mypy quality-gate configuration
 .github/workflows/quality-and-security.yml         # CI: tests + compileall + ruff + mypy + bandit
 Backtest Outputs/                                  # generated CSVs/logs (gitignored)
@@ -69,14 +69,16 @@ Backtest Outputs/                                  # generated CSVs/logs (gitign
   name→prefix map is `STRATEGY_ENV_PREFIX`. **Never commit secrets** — `env.example` holds blank placeholders.
 - **Live-trading safety (critical):** paper by default. A strategy trades live ONLY when the global
   `LIVE_TRADING_ENABLED` **and** that strategy's `<PREFIX>_LIVE_TRADING` are both true. `LIVE_BROKER`
-  (`KOTAK` | `SHOONYA`) selects the broker; an unknown value **fails closed** (live disabled, paper only).
+  (`KOTAK` | `SHOONYA` | `FLATTRADE`) selects the broker; an unknown value **fails closed** (live
+  disabled, paper only).
   Any order failure falls back to paper for that trade. Every broker HTTP call must have a timeout.
 - **Broker layer:** the Kotak, Shoonya and Flattrade clients expose the SAME surface —
   `ensure_logged_in`, `preload_scrip_master`, `resolve_option_symbol`, `place_market_order`,
   `extract_order_id`, `logout`, `is_logged_in` — so the runner only ever touches the generic
   `execution_client`. The Shoonya `NorenApi` client is vendored under `Dependencies/Shoonya API/`.
-  Flattrade is DIAGNOSTICS-ONLY so far (`algo.py diagnose --broker flattrade`); wiring it into
-  `LIVE_BROKER` is a separate, deliberate step.
+  Before first routing live orders through Flattrade, validate the symbol/order path once with
+  `python algo.py diagnose --broker flattrade CE <strike>` (its jData wire format is newer than
+  the battle-tested Kotak/Shoonya paths).
 - **Code style:** detailed, beginner-friendly module + function docstrings and plain-English inline
   comments — match the existing density. Type hints where practical. `snake_case` functions/modules,
   `PascalCase` classes, `UPPER_SNAKE` constants and env keys. In library code use a module

--- a/Data Extractors/Banknifty 1m 5Y Data Fetch Dhan.py
+++ b/Data Extractors/Banknifty 1m 5Y Data Fetch Dhan.py
@@ -20,7 +20,6 @@ import os
 
 from index_1m_5y_data_fetch_dhan_common import IndexFetchDefaults, run_index_fetcher
 
-
 # Anchor the default output to <repo_root>/Backtest Outputs/ so the CSV
 # always lands in the repo's shared output folder regardless of the cwd
 # the script is launched from. `__file__` is at <repo>/Data Extractors/...

--- a/Data Extractors/Finnifty 1m 5Y Data Fetch Dhan.py
+++ b/Data Extractors/Finnifty 1m 5Y Data Fetch Dhan.py
@@ -20,7 +20,6 @@ import os
 
 from index_1m_5y_data_fetch_dhan_common import IndexFetchDefaults, run_index_fetcher
 
-
 # Anchor the default output to <repo_root>/Backtest Outputs/ so the CSV
 # always lands in the repo's shared output folder regardless of the cwd
 # the script is launched from. `__file__` is at <repo>/Data Extractors/...

--- a/Data Extractors/Nifty 1m 5Y Data Fetch Dhan.py
+++ b/Data Extractors/Nifty 1m 5Y Data Fetch Dhan.py
@@ -24,7 +24,6 @@ import os
 
 from index_1m_5y_data_fetch_dhan_common import IndexFetchDefaults, run_index_fetcher
 
-
 # Anchor the default output to <repo_root>/Backtest Outputs/ so the CSV
 # always lands in the repo's shared output folder regardless of the cwd
 # the script is launched from. `__file__` is at <repo>/Data Extractors/...

--- a/Data Extractors/index_1m_5y_data_fetch_dhan_common.py
+++ b/Data Extractors/index_1m_5y_data_fetch_dhan_common.py
@@ -48,8 +48,13 @@ class IndexFetchDefaults:
     instrument_type: str = "INDEX"
     interval: int = 1
     lookback: str = "5y"
-    default_client_id: str = "1102601655"
-    default_access_token: str = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJkaGFuIiwicGFydG5lcklkIjoiIiwiZXhwIjoxNzc2NzAwOTY5LCJpYXQiOjE3NzY2MTQ1NjksInRva2VuQ29uc3VtZXJUeXBlIjoiU0VMRiIsIndlYmhvb2tVcmwiOiIiLCJkaGFuQ2xpZW50SWQiOiIxMTAyNjAxNjU1In0.Ivic07sLx-lbLd1LYtcwNkNGJk5XOtN7LBfGeeEH5jNrLevrRADofSI3DL4OABo0svY68k0mFeX8GWDQk6Ofcw"
+    # SECURITY: never hardcode credentials here. Resolution order is CLI flag ->
+    # environment variable (DHAN_CLIENT_CODE / DHAN_TOKEN_ID, e.g. from
+    # Dependencies/.env) -> these blanks. A real client id + access token used
+    # to live in these defaults; they were removed (and remain in old git
+    # history, so treat that token as burned).
+    default_client_id: str = ""
+    default_access_token: str = ""
 
 
 def parse_args(defaults: IndexFetchDefaults):
@@ -200,9 +205,7 @@ def normalize_response_data(data) -> pd.DataFrame:
         return pd.DataFrame()
 
     try:
-        if isinstance(data, list):
-            df = pd.DataFrame(data)
-        elif isinstance(data, dict):
+        if isinstance(data, (list, dict)):
             df = pd.DataFrame(data)
         else:
             return pd.DataFrame()

--- a/Dependencies/Flattrade API/diagnose_flattrade_symbol.py
+++ b/Dependencies/Flattrade API/diagnose_flattrade_symbol.py
@@ -27,8 +27,7 @@ from pathlib import Path
 from typing import Any
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-import flattrade_execution as fe  # noqa: E402 - sibling import for standalone use
-
+import flattrade_execution as fe
 
 UNDERLYING = "NIFTY"
 
@@ -265,7 +264,8 @@ def main(argv: list[str] | None = None) -> int:
             args.option_type,
             args.strike,
         )
-        print(f"\nContract master rows: {len(client._scrip_df)}")
+        master_rows = 0 if client._scrip_df is None else len(client._scrip_df)
+        print(f"\nContract master rows: {master_rows}")
         print(f"Selected expiry : {expiry:%d%b%y}")
         print(f"Trading symbol  : {csv_symbol}")
         print(f"Official lot    : {lot_size}")

--- a/Dependencies/Flattrade API/flattrade_execution.py
+++ b/Dependencies/Flattrade API/flattrade_execution.py
@@ -53,8 +53,9 @@ import threading
 import time
 import webbrowser
 from collections import deque
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 from urllib.parse import urlencode
 
 import pandas as pd
@@ -316,10 +317,10 @@ class FlattradeExecutionClient:
             return False
 
         digest = hashlib.sha256(
-            f"{api_key}{request_code}{raw_secret}".encode("utf-8")
+            f"{api_key}{request_code}{raw_secret}".encode()
         ).hexdigest()
         try:
-            response = self.client.post(
+            response = self._ensure_session_locked().post(
                 _TOKEN_URL,
                 json={
                     "api_key": api_key,
@@ -565,6 +566,8 @@ class FlattradeExecutionClient:
             if not self._ensure_scrip_master_locked():
                 return ""
             frame = self._scrip_df
+            if frame is None:
+                return ""
             matches = frame[
                 (frame["_symbol_u"] == underlying_u)
                 & (frame["_option_u"] == option_u)
@@ -690,7 +693,10 @@ class FlattradeExecutionClient:
                 _as_int(row.get("qty")),
                 str(row.get("rejreason") or row.get("emsg") or "").strip(),
             )
-        reason = response.get("emsg", "unrecognised response") if isinstance(response, dict) else "unrecognised response"
+        reason = (
+            response.get("emsg", "unrecognised response")
+            if isinstance(response, dict) else "unrecognised response"
+        )
         return (None, 0, 0, str(reason))
 
     def _confirm_fill(self, order_id: str, want_qty: int) -> None:
@@ -703,7 +709,7 @@ class FlattradeExecutionClient:
         deadline = time.monotonic() + _FILL_TIMEOUT_SECONDS
         last_state = None
         while time.monotonic() < deadline:
-            state, filled, order_qty, reason = self._order_status(order_id)
+            state, filled, _order_qty, reason = self._order_status(order_id)
             last_state = state
             if state == "complete":
                 if filled >= want_qty:

--- a/Dependencies/Flattrade API/test_flattrade_execution.py
+++ b/Dependencies/Flattrade API/test_flattrade_execution.py
@@ -1,0 +1,171 @@
+"""Unit tests for the pure logic in the Flattrade broker helpers.
+
+Everything here runs offline: no login, no HTTP, no orders. The tests cover the
+pieces a live session depends on but that do not need a live session to verify —
+the rate limiter's budget math, scrip-master normalization, exact contract
+selection, order-status parsing, and order-id extraction.
+
+Run from the repository root::
+
+    python -m pytest "Dependencies/Flattrade API" -q
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import diagnose_flattrade_symbol as diag
+import flattrade_execution as fe
+
+# ---------------------------------------------------------------------------
+# Rate limiter
+# ---------------------------------------------------------------------------
+
+class _FakeClock:
+    """Deterministic clock + sleeper so the limiter tests never really wait."""
+
+    def __init__(self) -> None:
+        self.now = 0.0
+        self.slept: list[float] = []
+
+    def clock(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.slept.append(seconds)
+        self.now += max(seconds, 0.0)
+
+
+def _limiter(per_second: int, per_minute: int, max_wait: float, fake: _FakeClock):
+    return fe._RollingWindowRateLimiter(
+        per_second, per_minute, max_wait, clock=fake.clock, sleeper=fake.sleep
+    )
+
+
+def test_rate_limiter_grants_within_budget_without_sleeping():
+    fake = _FakeClock()
+    limiter = _limiter(2, 10, max_wait=1.0, fake=fake)
+    limiter.acquire()
+    fake.now += 0.1
+    limiter.acquire()
+    assert fake.slept == []
+
+
+def test_rate_limiter_sleeps_for_the_per_second_window():
+    fake = _FakeClock()
+    limiter = _limiter(1, 10, max_wait=2.0, fake=fake)
+    limiter.acquire()
+    limiter.acquire()  # second call must wait out the 1-second window
+    assert fake.slept and fake.slept[0] == pytest.approx(1.0)
+
+
+def test_rate_limiter_raises_instead_of_waiting_past_max():
+    fake = _FakeClock()
+    limiter = _limiter(1, 1, max_wait=0.5, fake=fake)
+    limiter.acquire()
+    with pytest.raises(RuntimeError):
+        limiter.acquire()  # a 60s minute-window wait exceeds max_wait=0.5s
+
+
+# ---------------------------------------------------------------------------
+# Scrip-master normalization + contract selection
+# ---------------------------------------------------------------------------
+
+def _raw_master() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "Exchange": ["NFO", "NFO", "NSE", "NFO"],
+            "Lotsize": [75, 75, 1, "75"],
+            "Symbol": ["NIFTY", "NIFTY", "NIFTY", "nifty"],
+            "Tradingsymbol": ["NIFTY14JUL26C24150", "NIFTY14JUL26P24150", "NIFTY-EQ", "NIFTY21JUL26C24150"],
+            "Expiry": ["14-Jul-2026", "14-Jul-2026", "", "21-Jul-2026"],
+            "Strike": ["24150.00", 24150, "", 24150],
+            "Optiontype": ["CE", "PE", "", "ce"],
+        }
+    )
+
+
+def test_prepare_scrip_master_normalizes_and_filters_to_nfo():
+    frame = fe.FlattradeExecutionClient._prepare_scrip_master(_raw_master())
+    assert len(frame) == 3  # the NSE equity row is dropped
+    assert set(frame["_option_u"]) == {"CE", "PE"}
+    assert all(frame["_lotsize_i"] == 75)
+
+
+def test_prepare_scrip_master_raises_on_missing_columns():
+    with pytest.raises(ValueError):
+        fe.FlattradeExecutionClient._prepare_scrip_master(pd.DataFrame({"Exchange": ["NFO"]}))
+
+
+def test_select_contract_picks_nearest_future_expiry_for_strike():
+    client = fe.FlattradeExecutionClient()
+    client._scrip_df = fe.FlattradeExecutionClient._prepare_scrip_master(_raw_master())
+    expiry, symbol, lot = diag.select_contract(
+        client,
+        underlying="NIFTY",
+        option_type="CE",
+        strike=24150,
+        requested_expiry=None,
+        today=pd.Timestamp("2026-07-10").date(),
+    )
+    assert (str(expiry), symbol, lot) == ("2026-07-14", "NIFTY14JUL26C24150", 75)
+
+
+def test_select_contract_raises_when_no_exact_row_exists():
+    client = fe.FlattradeExecutionClient()
+    client._scrip_df = fe.FlattradeExecutionClient._prepare_scrip_master(_raw_master())
+    with pytest.raises(ValueError):
+        diag.select_contract(
+            client,
+            underlying="NIFTY",
+            option_type="CE",
+            strike=99999,
+            requested_expiry=None,
+            today=pd.Timestamp("2026-07-10").date(),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Order acknowledgement / status parsing / order-id extraction
+# ---------------------------------------------------------------------------
+
+def test_is_order_ack_requires_ok_and_order_number():
+    client = fe.FlattradeExecutionClient()
+    assert client._is_order_ack({"stat": "Ok", "norenordno": "123"})
+    assert not client._is_order_ack({"stat": "Ok"})
+    assert not client._is_order_ack({"stat": "Not_Ok", "norenordno": "123"})
+    assert not client._is_order_ack("Ok")
+
+
+def test_order_status_parses_the_latest_ok_row(monkeypatch):
+    client = fe.FlattradeExecutionClient()
+    monkeypatch.setattr(
+        client,
+        "_post_api",
+        lambda *a, **k: [{"stat": "Ok", "status": "COMPLETE", "fillshares": "75", "qty": "75"}],
+    )
+    state, filled, qty, reason = client._order_status("ORD1")
+    assert (state, filled, qty, reason) == ("complete", 75, 75, "")
+
+
+def test_order_status_surfaces_rejection_reason(monkeypatch):
+    client = fe.FlattradeExecutionClient()
+    monkeypatch.setattr(
+        client,
+        "_post_api",
+        lambda *a, **k: [{"stat": "Ok", "status": "REJECTED", "rejreason": "RMS limit"}],
+    )
+    state, _filled, _qty, reason = client._order_status("ORD1")
+    assert state == "rejected" and reason == "RMS limit"
+
+
+def test_extract_order_id_searches_nested_payloads():
+    client = fe.FlattradeExecutionClient()
+    assert client.extract_order_id({"norenordno": " 42 "}) == "42"
+    assert client.extract_order_id({"data": [{"order_id": "77"}]}) == "77"
+    assert client.extract_order_id(None) == ""

--- a/Dependencies/Kotak API/diagnose_kotak_symbol.py
+++ b/Dependencies/Kotak API/diagnose_kotak_symbol.py
@@ -81,6 +81,9 @@ def main():
         return
 
     df = client._scrip_df
+    if df is None:
+        print("Scrip master is unexpectedly empty after preload.")
+        return
     print(f"\nScrip master rows: {len(df)}")
     base = df[(df["_sym_u"] == UNDERLYING) & (df["_opt_u"] == OPT)]
     print(f"{UNDERLYING} {OPT} rows: {len(base)}")

--- a/Dependencies/Kotak API/kotak_execution.py
+++ b/Dependencies/Kotak API/kotak_execution.py
@@ -64,7 +64,7 @@ import sys
 import threading
 import time
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any
 
 import pandas as pd
 import requests
@@ -138,27 +138,20 @@ class KotakExecutionClient:
 
     def __init__(self) -> None:
         # The live Kotak SDK object. Stays None until we successfully log in.
-        self.client: Optional[NeoAPI] = None
+        self.client: NeoAPI | None = None
         # Simple flag so we don't re-login every call once we're authenticated.
         self.is_logged_in = False
         # The "one thread at a time" gate for login + orders + scrip lookups.
         self._lock = threading.Lock()
-        # Remember Kotak symbols we've already looked up, so we don't search the
-        # scrip master again for the same contract. Key = (underlying, expiry as
-        # "DDMMMYYYY", "CE"/"PE", strike-as-int) -> Kotak pTrdSymbol string.
-        self._symbol_cache: Dict[tuple, str] = {}
-        # The full NSE F&O contract list (a pandas table). We download it ONCE and
-        # reuse it for every symbol lookup. It stays None until first loaded.
-        self._scrip_df: Optional["pd.DataFrame"] = None
         # Cache of resolved Kotak symbols, keyed by
         # (underlying, expiry "DDMMMYYYY", option_type, int_strike). search_scrip
         # downloads the whole NFO scrip-master CSV per call, so caching per
         # contract keeps real trading cheap (one lookup per option per day).
-        self._symbol_cache: Dict[tuple, str] = {}
+        self._symbol_cache: dict[tuple, str] = {}
         # The full NSE F&O scrip master, downloaded once per process and reused
         # for every symbol lookup (the SDK's search_scrip re-downloads it on
         # EVERY call, which is far too slow for a live multi-strategy runner).
-        self._scrip_df: Optional["pd.DataFrame"] = None
+        self._scrip_df: pd.DataFrame | None = None
 
     # ------------------------------------------------------------------
     # Authentication
@@ -340,6 +333,9 @@ class KotakExecutionClient:
         """
         if self._scrip_df is not None:
             return True  # already downloaded earlier in this run
+        if self.client is None:
+            log.warning("Kotak scrip master unavailable: not logged in yet.")
+            return False
         # Step 1: ask Kotak for the download URL of the F&O contract CSV.
         try:
             url = self.client.scrip_master(exchange_segment="nse_fo")
@@ -409,7 +405,7 @@ class KotakExecutionClient:
         except Exception:
             log.warning(f"Kotak resolve skipped (expiry not a date): expiry={expiry!r} type={type(expiry).__name__}")
             return ""
-        int_strike = int(round(float(strike)))
+        int_strike = round(float(strike))
         cache_key = (underlying, expiry_str, option_type, int_strike)
 
         # Fast path: have we already resolved this exact contract today?
@@ -466,6 +462,9 @@ class KotakExecutionClient:
         WHICH part didn't match (wrong expiry vs wrong strike). Debug aid only.
         """
         df = self._scrip_df
+        if df is None:
+            log.warning("Kotak symbol NOT resolved (scrip master not loaded).")
+            return
         base = df[(df["_sym_u"] == underlying) & (df["_opt_u"] == option_type)]
         exp_match = base[base["_expiry_str"] == expiry_str]
         log.warning(f"Kotak symbol NOT resolved: {underlying}/{option_type}/{expiry_str}/strike {int_strike} "
@@ -490,7 +489,7 @@ class KotakExecutionClient:
         quantity: int,
         exchange_segment: str = "nse_fo",
         product_type: str = "INTRADAY",
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """
         Place ONE market order (buy or sell at the current price) on Kotak.
 
@@ -676,7 +675,7 @@ class KotakExecutionClient:
     # ------------------------------------------------------------------
     # Teardown
     # ------------------------------------------------------------------
-    def logout(self) -> Dict[str, Any]:
+    def logout(self) -> dict[str, Any]:
         """Close the Kotak session cleanly at shutdown (safe to call if never logged in)."""
         with self._lock:
             if self.client is None:

--- a/Dependencies/Shoonya API/shoonya_execution.py
+++ b/Dependencies/Shoonya API/shoonya_execution.py
@@ -54,13 +54,13 @@ How the master file uses this module:
 3. `logout()` is called during graceful shutdown.
 """
 
+import logging
 import os
 import sys
-import logging
 import threading
 import time
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any
 
 import pandas as pd
 
@@ -134,7 +134,7 @@ class ShoonyaExecutionClient:
 
     def __init__(self) -> None:
         # The live Shoonya SDK object. Stays None until we successfully log in.
-        self.client: Optional[NorenApi] = None
+        self.client: NorenApi | None = None
         # Simple flag so we don't re-login every call once we're authenticated.
         self.is_logged_in = False
         # The "one thread at a time" gate for login + orders + symbol lookups.
@@ -142,10 +142,10 @@ class ShoonyaExecutionClient:
         # Remember symbols we've already resolved, so we don't rebuild/re-validate
         # for the same contract. Key = (underlying, expiry "DDMMMYY", "CE"/"PE",
         # strike-as-int) -> Shoonya tsym string.
-        self._symbol_cache: Dict[tuple, str] = {}
+        self._symbol_cache: dict[tuple, str] = {}
         # The set of valid NFO trading symbols (uppercased), downloaded once and
         # reused for validation. Stays None until first loaded.
-        self._symbol_set: Optional[set] = None
+        self._symbol_set: set | None = None
 
     # ------------------------------------------------------------------
     # Authentication
@@ -362,7 +362,7 @@ class ShoonyaExecutionClient:
             log.warning(f"Shoonya resolve skipped (expiry not a date): expiry={expiry!r} "
                   f"type={type(expiry).__name__}")
             return ""
-        int_strike = int(round(float(strike)))
+        int_strike = round(float(strike))
         cache_key = (underlying, expiry_str, option_type, int_strike)
 
         # Fast path: have we already resolved this exact contract today?
@@ -412,7 +412,7 @@ class ShoonyaExecutionClient:
         quantity: int,
         exchange_segment: str = "NFO",
         product_type: str = "INTRADAY",
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """
         Place ONE market order (buy or sell at the current price) on Shoonya.
 
@@ -587,7 +587,7 @@ class ShoonyaExecutionClient:
     # ------------------------------------------------------------------
     # Teardown
     # ------------------------------------------------------------------
-    def logout(self) -> Dict[str, Any]:
+    def logout(self) -> dict[str, Any]:
         """Close the Shoonya session cleanly at shutdown (safe to call if never logged in)."""
         with self._lock:
             if self.client is None:

--- a/Dependencies/dhan_token_setup.py
+++ b/Dependencies/dhan_token_setup.py
@@ -376,7 +376,8 @@ def main() -> None:
         # Surface a friendly identifier from the profile response so the
         # user knows their request landed on the right account.
         if isinstance(profile, dict):
-            data = profile.get("data") if isinstance(profile.get("data"), dict) else profile
+            maybe_data = profile.get("data")
+            data = maybe_data if isinstance(maybe_data, dict) else profile
             client_id_back = data.get("dhanClientId") or data.get("clientId") or "?"
             print(f"OK: token validated. Client ID returned by DhanHQ = {client_id_back}")
 

--- a/Dependencies/env.example
+++ b/Dependencies/env.example
@@ -1094,6 +1094,19 @@ SL_HUNTING_RISK_BUDGET=2500
 # ~3 full stop-outs at ~Rs.2,500/trade -- so several trades can run before it trips.
 SL_HUNTING_STARTING_CAPITAL=600000.0
 SL_HUNTING_DAILY_MAX_LOSS_PCT=0.0125
+# --- Flattrade (Pi v2) broker credentials -------------------------------------
+# Used ONLY by Dependencies/Flattrade API/ (the diagnose script and the
+# execution client). NOT yet selectable via LIVE_BROKER -- the master runner
+# still fails closed to paper for any LIVE_BROKER other than KOTAK/SHOONYA.
+# FLATTRADE_ACCESS_TOKEN is the optional daily token; without it the client
+# opens Flattrade's browser authorization and asks for the request code.
+FLATTRADE_CLIENT_ID=
+FLATTRADE_API_KEY=
+FLATTRADE_API_SECRET=
+FLATTRADE_ACCESS_TOKEN=
+# Market-protection percentage for MKT orders (Flattrade's Postman default).
+FLATTRADE_MARKET_PROTECTION=5
+
 # NOTE: the v3c OPENING DRIVE knowledge (gap-up continuation in the first ~15 min)
 # only ever fires if the worker is awake for the open -- set MINUTE=15 for that;
 # at the shared default of 25 the agent wakes too late to ever use that branch.

--- a/Dependencies/env.example
+++ b/Dependencies/env.example
@@ -1094,19 +1094,6 @@ SL_HUNTING_RISK_BUDGET=2500
 # ~3 full stop-outs at ~Rs.2,500/trade -- so several trades can run before it trips.
 SL_HUNTING_STARTING_CAPITAL=600000.0
 SL_HUNTING_DAILY_MAX_LOSS_PCT=0.0125
-# --- Flattrade (Pi v2) broker credentials -------------------------------------
-# Used ONLY by Dependencies/Flattrade API/ (the diagnose script and the
-# execution client). NOT yet selectable via LIVE_BROKER -- the master runner
-# still fails closed to paper for any LIVE_BROKER other than KOTAK/SHOONYA.
-# FLATTRADE_ACCESS_TOKEN is the optional daily token; without it the client
-# opens Flattrade's browser authorization and asks for the request code.
-FLATTRADE_CLIENT_ID=
-FLATTRADE_API_KEY=
-FLATTRADE_API_SECRET=
-FLATTRADE_ACCESS_TOKEN=
-# Market-protection percentage for MKT orders (Flattrade's Postman default).
-FLATTRADE_MARKET_PROTECTION=5
-
 # NOTE: the v3c OPENING DRIVE knowledge (gap-up continuation in the first ~15 min)
 # only ever fires if the worker is awake for the open -- set MINUTE=15 for that;
 # at the shared default of 25 the agent wakes too late to ever use that branch.

--- a/My Backtest Files (For Reference)/Nifty CPR Strategy Backtest.py
+++ b/My Backtest Files (For Reference)/Nifty CPR Strategy Backtest.py
@@ -43,7 +43,6 @@ from cpr_strategy_logic import (
     prepare_cpr_ohlc_input,
 )
 
-
 OUTPUT_DIR = ROOT_DIR / "Backtest Outputs"
 
 DEFAULT_DATA_PATHS = {

--- a/My Backtest Files (For Reference)/Nifty EMA Trend Strategy Backtest.py
+++ b/My Backtest Files (For Reference)/Nifty EMA Trend Strategy Backtest.py
@@ -55,7 +55,6 @@ from ema_trend_strategy_logic import (
     build_ema_trend_with_indicators,
 )
 
-
 # -----------------------------
 # User configuration
 # -----------------------------

--- a/My Backtest Files (For Reference)/Nifty Heiken Ashi Futures 5Y Backtest.py
+++ b/My Backtest Files (For Reference)/Nifty Heiken Ashi Futures 5Y Backtest.py
@@ -20,7 +20,6 @@ import numpy as np
 import pandas as pd
 from backtesting import Backtest, Strategy
 
-
 # Anchor everything to the repo root (parent of `My Backtest Files (For
 # Reference)/`) so paths resolve regardless of cwd. `__file__` lives at
 # <repo>/My Backtest Files (For Reference)/..., so dirname(dirname(__file__))

--- a/My Backtest Files (For Reference)/Nifty Renko Strategy Backtest.py
+++ b/My Backtest Files (For Reference)/Nifty Renko Strategy Backtest.py
@@ -49,7 +49,6 @@ from renko_strategy_logic_9_21 import (
     build_renko_with_indicators,
 )
 
-
 # -----------------------------
 # User configuration
 # -----------------------------

--- a/My Backtest Files (For Reference)/Subhamoy Strategies/Nifty Goldmine Strategy Backtest.py
+++ b/My Backtest Files (For Reference)/Subhamoy Strategies/Nifty Goldmine Strategy Backtest.py
@@ -21,7 +21,6 @@ import numpy as np
 import pandas as pd
 from backtesting import Backtest, Strategy
 
-
 SCRIPT_DIR = Path(__file__).resolve().parent
 ROOT_DIR = SCRIPT_DIR.parents[1]
 SIGNAL_GENERATOR_DIR = ROOT_DIR / "Signal Generators" / "Subhamoy Strategies"
@@ -55,7 +54,6 @@ from subhamoy_backtest_common import (
     save_outputs,
     setup_logging,
 )
-
 
 STRATEGY_CONFIG = GoldmineStrategyConfig(
     sma_fast_period=env_int("GOLDMINE_SMA_FAST_PERIOD", 20),
@@ -207,10 +205,9 @@ class NiftyGoldmineStrategyBacktest(Strategy):
         if active_trade is not None:
             # Attach stop-loss and take-profit to the framework trade only after
             # the entry fill is known. That keeps target = actual entry +/- 2 ATR.
-            if direction == "LONG" and stop < actual_entry < target:
-                active_trade.sl = stop
-                active_trade.tp = target
-            elif direction == "SHORT" and target < actual_entry < stop:
+            if (direction == "LONG" and stop < actual_entry < target) or (
+                direction == "SHORT" and target < actual_entry < stop
+            ):
                 active_trade.sl = stop
                 active_trade.tp = target
             else:

--- a/My Backtest Files (For Reference)/Subhamoy Strategies/Nifty Money Machine Strategy Backtest.py
+++ b/My Backtest Files (For Reference)/Subhamoy Strategies/Nifty Money Machine Strategy Backtest.py
@@ -20,7 +20,6 @@ import numpy as np
 import pandas as pd
 from backtesting import Backtest, Strategy
 
-
 SCRIPT_DIR = Path(__file__).resolve().parent
 ROOT_DIR = SCRIPT_DIR.parents[1]
 SIGNAL_GENERATOR_DIR = ROOT_DIR / "Signal Generators" / "Subhamoy Strategies"
@@ -54,7 +53,6 @@ from subhamoy_backtest_common import (
     save_outputs,
     setup_logging,
 )
-
 
 STRATEGY_CONFIG = MoneyMachineStrategyConfig(
     sma_fast_period=env_int("MONEY_MACHINE_SMA_FAST_PERIOD", 20),
@@ -198,10 +196,9 @@ class NiftyMoneyMachineStrategyBacktest(Strategy):
         if active_trade is not None:
             # Attach the protective stop and profit target only after entry
             # exists. backtesting.py then handles intrabar touches from here.
-            if direction == "LONG" and stop < actual_entry < target:
-                active_trade.sl = stop
-                active_trade.tp = target
-            elif direction == "SHORT" and target < actual_entry < stop:
+            if (direction == "LONG" and stop < actual_entry < target) or (
+                direction == "SHORT" and target < actual_entry < stop
+            ):
                 active_trade.sl = stop
                 active_trade.tp = target
             else:

--- a/My Backtest Files (For Reference)/Subhamoy Strategies/subhamoy_backtest_common.py
+++ b/My Backtest Files (For Reference)/Subhamoy Strategies/subhamoy_backtest_common.py
@@ -19,7 +19,6 @@ from typing import Any
 
 import pandas as pd
 
-
 ROOT_DIR = Path(__file__).resolve().parents[2]
 SIGNAL_GENERATOR_DIR = ROOT_DIR / "Signal Generators" / "Subhamoy Strategies"
 if str(SIGNAL_GENERATOR_DIR) not in sys.path:
@@ -29,7 +28,6 @@ if str(SIGNAL_GENERATOR_DIR) not in sys.path:
     sys.path.insert(0, str(SIGNAL_GENERATOR_DIR))
 
 from subhamoy_strategy_common import normalize_ohlc_frame, validate_five_minute_spacing
-
 
 OUTPUT_DIR = ROOT_DIR / "Backtest Outputs"
 

--- a/My Backtest Files (For Reference)/profit_shooter_backtest.py
+++ b/My Backtest Files (For Reference)/profit_shooter_backtest.py
@@ -32,12 +32,12 @@ Important modeling note:
 """
 
 import argparse
+import contextlib
 import logging
 import os
 import sys
 from dataclasses import dataclass
 from datetime import time as dt_time
-from typing import Optional
 
 import numpy as np
 import pandas as pd
@@ -62,7 +62,6 @@ from profit_shooter_strategy_logic import (
     ProfitShooterSignalEngine,
     build_profit_shooter_with_indicators,
 )
-
 
 # -----------------------------
 # User configuration
@@ -348,7 +347,7 @@ class ProfitShooterFuturesStrategy(Strategy):
         self.close_request_reason = ""
 
         # Pending next-candle breakout order state.
-        self.pending_entry: Optional[PendingEntryOrder] = None
+        self.pending_entry: PendingEntryOrder | None = None
 
         # Diagnostic counters.
         self.signal_count = 0
@@ -391,10 +390,8 @@ class ProfitShooterFuturesStrategy(Strategy):
             return
 
         if cancel_order:
-            try:
+            with contextlib.suppress(Exception):
                 self.pending_entry.order.cancel()
-            except Exception:
-                pass
             self.pending_entry_cancel_count += 1
 
         self.pending_entry = None

--- a/Nifty Multi Strategy Front Test - Master File.py
+++ b/Nifty Multi Strategy Front Test - Master File.py
@@ -203,17 +203,19 @@ import re
 import sys
 import threading
 from dataclasses import dataclass
-from datetime import date, datetime, time as dt_time, timedelta
+from datetime import date, datetime, timedelta
+from datetime import time as dt_time
 from pathlib import Path
-from typing import Optional
 
 # --- Third-party imports -----------------------------------------------------
 import pandas as pd
+
 # `requests` is only used by the end-of-day instrument-master refresh helper at
 # the bottom of this file. We keep it next to `pandas` rather than lazy-loading
 # it inside the helper because the rest of the repo (e.g. the swing strategy
 # data fetcher) already depends on `requests`, so it is guaranteed to be present.
 import requests
+
 # `DhanContext` wraps (client_id, access_token) so the rest of the SDK can
 # share one authenticated session. `DhanLogin` is the auth helper class we
 # use only for `user_profile(...)` startup validation -- the OAuth dance
@@ -1445,8 +1447,8 @@ class MarketSnapshot:
 
     timeframe: str
     frame: pd.DataFrame
-    source_candle_ts: Optional[pd.Timestamp]
-    candle_signature: Optional[tuple]
+    source_candle_ts: pd.Timestamp | None
+    candle_signature: tuple | None
     fetched_at: datetime
 
 
@@ -1489,7 +1491,7 @@ class PaperPosition:
     option_exchange_segment: str = ""
     option_right: str = ""
     option_strike: float = 0.0
-    option_expiry: Optional[date] = None
+    option_expiry: date | None = None
     option_lot_size: int = 0
 
 
@@ -1516,7 +1518,7 @@ class HedgedPaperPosition:
 
     # Snapshot at entry, used for logging / audit / SL-target anchoring.
     entry_underlying: float = 0.0
-    entry_timestamp: Optional[datetime] = None
+    entry_timestamp: datetime | None = None
 
     # -- Main leg (SELL PE for bullish, SELL CE for bearish) ----------------
     main_symbol: str = ""
@@ -1525,7 +1527,7 @@ class HedgedPaperPosition:
     main_exchange_segment: str = ""
     main_right: str = ""
     main_strike: float = 0.0
-    main_expiry: Optional[date] = None
+    main_expiry: date | None = None
     main_lot_size: int = 0
     main_quantity: int = 0
     main_entry_price: float = 0.0
@@ -1538,7 +1540,7 @@ class HedgedPaperPosition:
     hedge_exchange_segment: str = ""
     hedge_right: str = ""
     hedge_strike: float = 0.0
-    hedge_expiry: Optional[date] = None
+    hedge_expiry: date | None = None
     hedge_lot_size: int = 0
     hedge_quantity: int = 0
     hedge_entry_price: float = 0.0
@@ -1577,7 +1579,7 @@ class OptionSubscription:
     trading_symbol: str
     right: str
     strike: float
-    expiry: Optional[date]
+    expiry: date | None
 
 
 # =============================================================================
@@ -1629,7 +1631,7 @@ class SharedMarketDataStore:
             self._snapshots[str(timeframe)] = snapshot
         return snapshot
 
-    def get(self, timeframe: str) -> Optional[MarketSnapshot]:
+    def get(self, timeframe: str) -> MarketSnapshot | None:
         """
         Return a fresh `MarketSnapshot` whose `frame` is a pandas copy.
 
@@ -1734,7 +1736,7 @@ def _to_int_safe(value, default=0) -> int:
         return default
 
 
-def _first_existing_col(df: pd.DataFrame, names) -> Optional[str]:
+def _first_existing_col(df: pd.DataFrame, names) -> str | None:
     """
     Case-insensitively look up the first column from `names` that exists in
     `df`. Used for instrument-master parsing where column names can vary
@@ -1844,7 +1846,7 @@ def normalize_dhan_intraday_response(resp) -> pd.DataFrame:
     return out
 
 
-def build_last_row_signature(frame: pd.DataFrame) -> Optional[tuple]:
+def build_last_row_signature(frame: pd.DataFrame) -> tuple | None:
     """
     Fingerprint the latest row of an OHLC table.
 
@@ -2167,8 +2169,8 @@ class OptionsContractResolver:
         self.underlying = str(underlying).upper().strip()
         self.instrument_master_glob = instrument_master_glob
         self.log = log
-        self._option_chain_cache: Optional[pd.DataFrame] = None
-        self._cache_date: Optional[date] = None
+        self._option_chain_cache: pd.DataFrame | None = None
+        self._cache_date: date | None = None
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -2410,7 +2412,7 @@ class OptionsContractResolver:
         spot_price: float,
         right: str,
         otm_steps: int = 1,
-        expiry: Optional[date] = None,
+        expiry: date | None = None,
     ) -> dict:
         """
         Resolve an OUT-OF-THE-MONEY option row, `otm_steps` strikes from ATM.
@@ -2507,7 +2509,7 @@ class OptionsContractResolver:
         puts: pd.DataFrame,
         ltp_map: dict[tuple[str, int], float],
         target_premium: float,
-        exclude_security_ids: Optional[set[int]] = None,
+        exclude_security_ids: set[int] | None = None,
     ) -> dict:
         """
         From a PE-rows DataFrame and a (segment, sec_id) -> LTP map, return
@@ -2579,7 +2581,7 @@ class OptionsContractResolver:
         calls: pd.DataFrame,
         ltp_map: dict[tuple[str, int], float],
         target_premium: float,
-        exclude_security_ids: Optional[set[int]] = None,
+        exclude_security_ids: set[int] | None = None,
     ) -> dict:
         """
         Mirror of `pick_put_by_target_premium` for CE rows.
@@ -2634,7 +2636,7 @@ class OptionsContractResolver:
         expiry: date,
         strike: float,
         right: str,
-    ) -> Optional[dict]:
+    ) -> dict | None:
         """
         Return the option-chain row for an exact (expiry, strike, right) tuple.
 
@@ -2754,8 +2756,8 @@ class CentralMarketDataFetcher(threading.Thread):
         self.stop_event = stop_event
         self.broker = broker
         self.log = logging.getLogger(f"{LOGGER_NAME}.fetcher")
-        self.last_logged_candle_ts: dict[str, Optional[pd.Timestamp]] = {}
-        self.last_logged_index_ltp: Optional[float] = None
+        self.last_logged_candle_ts: dict[str, pd.Timestamp | None] = {}
+        self.last_logged_index_ltp: float | None = None
 
     def fetch_ohlc(self, timeframe: str) -> pd.DataFrame:
         """Fetch 1-min NIFTY spot OHLC. Higher TFs are derived per-worker."""
@@ -4606,15 +4608,15 @@ class OpeningStrikePCRVWAPATRWorker(AtmSingleLegStrategyWorker):
         # mid-session reset).
         # Shape: {strike_float: {"ce": ce_oi_float, "pe": pe_oi_float}}.
         self._oi_baseline: dict[float, dict[str, float]] = {}
-        self._oi_baseline_captured_at: Optional[datetime] = None
+        self._oi_baseline_captured_at: datetime | None = None
 
         # `self._last_option_chain_fetch_at` is a simple "remember the
         # last time we called the option_chain API" timestamp. Combined
         # with `_last_oi_change_frame` (the cached result), it lets us
         # avoid hammering the rate-limited endpoint when the run loop
         # ticks faster than OPENING_STRIKE_OPTION_CHAIN_REFRESH_SECONDS.
-        self._last_option_chain_fetch_at: Optional[datetime] = None
-        self._last_oi_change_frame: Optional[pd.DataFrame] = None
+        self._last_option_chain_fetch_at: datetime | None = None
+        self._last_oi_change_frame: pd.DataFrame | None = None
 
         # `self._high_water_R` tracks the BEST reward this trade has
         # touched so far, measured in "R units" (1R = OPENING_STRIKE_
@@ -4799,12 +4801,11 @@ class OpeningStrikePCRVWAPATRWorker(AtmSingleLegStrategyWorker):
 
             # Only keep strikes that have BOTH CE and PE OI reported,
             # and where at least one side has non-zero OI.
-            if "ce_oi" in record and "pe_oi" in record:
-                if record["ce_oi"] > 0 or record["pe_oi"] > 0:
-                    out[strike] = record
+            if "ce_oi" in record and "pe_oi" in record and (record["ce_oi"] > 0 or record["pe_oi"] > 0):
+                out[strike] = record
         return out
 
-    def _build_option_chain_oi_change(self) -> Optional[pd.DataFrame]:
+    def _build_option_chain_oi_change(self) -> pd.DataFrame | None:
         """
         Produce the per-strike OI-change DataFrame the signal engine
         expects. Columns:
@@ -4908,7 +4909,7 @@ class OpeningStrikePCRVWAPATRWorker(AtmSingleLegStrategyWorker):
                 baseline = self._oi_baseline[strike]
             rows.append(
                 {
-                    "strike": int(round(strike)),
+                    "strike": round(float(strike)),
                     "call_oi_change": float(meta.get("ce_oi", 0.0) - baseline.get("ce", 0.0)),
                     "put_oi_change": float(meta.get("pe_oi", 0.0) - baseline.get("pe", 0.0)),
                 }
@@ -5261,8 +5262,8 @@ class CPRAlgo3StrategyWorker(AtmSingleLegStrategyWorker):
         super().__init__(store, stop_event, broker)
         self.config = CPR_ALGO3_CONFIG
         # Observation legs, chosen once per session by `_ensure_observation_strikes`.
-        self.itm_ce: Optional[dict] = None
-        self.itm_pe: Optional[dict] = None
+        self.itm_ce: dict | None = None
+        self.itm_pe: dict | None = None
         self.observation_expiry = None
         self.signal_count = 0
         self.entry_submit_count = 0
@@ -5384,14 +5385,10 @@ class CPRAlgo3StrategyWorker(AtmSingleLegStrategyWorker):
         )
         if decision.signal_triggered:
             self.signal_count += 1
-        if decision.action == "ENTER_LONG":
+        if decision.action in ("ENTER_LONG", "ENTER_SHORT"):
+            direction = "LONG" if decision.action == "ENTER_LONG" else "SHORT"
             if self.enter_position(
-                "LONG", decision.entry_underlying, decision.stop_underlying, decision.target_underlying
-            ):
-                self.entry_submit_count += 1
-        elif decision.action == "ENTER_SHORT":
-            if self.enter_position(
-                "SHORT", decision.entry_underlying, decision.stop_underlying, decision.target_underlying
+                direction, decision.entry_underlying, decision.stop_underlying, decision.target_underlying
             ):
                 self.entry_submit_count += 1
 
@@ -5448,7 +5445,7 @@ class SupertrendBullishWorker(BasePaperStrategyWorker):
         self.pos = HedgedPaperPosition()
         # Wall-clock time of the most recent paper-trade exit. The cool-off
         # gate compares (now - last_exit) against POST_EXIT_COOLDOWN_MINUTES.
-        self.last_exit_datetime: Optional[datetime] = None
+        self.last_exit_datetime: datetime | None = None
         self.post_exit_cooldown = timedelta(minutes=POST_EXIT_COOLDOWN_MINUTES)
         self.signal_count = 0
         self.entry_submit_count = 0
@@ -5536,7 +5533,7 @@ class SupertrendBullishWorker(BasePaperStrategyWorker):
     # ------------------------------------------------------------------
     # Hedged entry (PE legs - strike selection lives HERE per the user's hint)
     # ------------------------------------------------------------------
-    def _pick_hedged_puts(self, spot_price: float) -> Optional[tuple[dict, dict, date]]:
+    def _pick_hedged_puts(self, spot_price: float) -> tuple[dict, dict, date] | None:
         """
         Pick the main (SELL ~Rs.160) and hedge (BUY ~Rs.10) PE legs for the
         CURRENT-WEEK expiry.
@@ -6038,9 +6035,7 @@ class DonchianBearishWorker(BasePaperStrategyWorker):
         """True between BEARISH_TRADING_START_*:* and BEARISH_ENTRY_CUTOFF_*:*."""
         if is_before_time(self.trading_start_hour, self.trading_start_minute):
             return False
-        if is_after_time(BEARISH_ENTRY_CUTOFF_HOUR, BEARISH_ENTRY_CUTOFF_MINUTE):
-            return False
-        return True
+        return not is_after_time(BEARISH_ENTRY_CUTOFF_HOUR, BEARISH_ENTRY_CUTOFF_MINUTE)
 
     def process_strategy_frame(self, strategy_frame: pd.DataFrame) -> None:
         """
@@ -6091,7 +6086,7 @@ class DonchianBearishWorker(BasePaperStrategyWorker):
     # ------------------------------------------------------------------
     # Hedged entry (CE legs - strike selection lives HERE per the user's hint)
     # ------------------------------------------------------------------
-    def _pick_hedged_calls(self, spot_price: float) -> Optional[tuple[dict, dict, date]]:
+    def _pick_hedged_calls(self, spot_price: float) -> tuple[dict, dict, date] | None:
         """
         Pick the main (SELL ~Rs.160) and hedge (BUY ~Rs.10) CE legs for the
         CURRENT-WEEK expiry. Mirror of `_pick_hedged_puts` with PE swapped
@@ -6734,10 +6729,10 @@ class Delta20HedgedSpreadWorker(BasePaperStrategyWorker):
         # Wall-clock time of the most recent capture attempt. We use this
         # to enforce a backoff between retries so we do not spam DhanHQ's
         # `/optionchain` endpoint when something is wrong.
-        self.last_capture_attempt_at: Optional[datetime] = None
+        self.last_capture_attempt_at: datetime | None = None
         self.capture_backoff = timedelta(seconds=DELTA20_CAPTURE_RETRY_SECONDS)
         # The expiry we captured against. Stored only for log clarity.
-        self.reference_expiry: Optional[date] = None
+        self.reference_expiry: date | None = None
 
         # ----- Per-side metadata snapshot at 09:20 ----------------------
         # Each *_meta is a dict with keys:
@@ -6749,10 +6744,10 @@ class Delta20HedgedSpreadWorker(BasePaperStrategyWorker):
         # All four are subscribed with the central fetcher at capture
         # time, so their LTPs stay fresh in the shared store throughout
         # the session without us needing to make extra broker calls.
-        self.ce_monitor_meta: Optional[dict] = None
-        self.ce_hedge_meta: Optional[dict] = None
-        self.pe_monitor_meta: Optional[dict] = None
-        self.pe_hedge_meta: Optional[dict] = None
+        self.ce_monitor_meta: dict | None = None
+        self.ce_hedge_meta: dict | None = None
+        self.pe_monitor_meta: dict | None = None
+        self.pe_hedge_meta: dict | None = None
         # The "reference" premium = the monitor leg's LTP at 09:20. This
         # is the yardstick: entries fire on a 5% drop below it; exits
         # fire on a 3x rise above it. The deltas are stored only for
@@ -7285,7 +7280,7 @@ class Delta20HedgedSpreadWorker(BasePaperStrategyWorker):
         parsed_chain: dict,
         target_delta: float,
         right: str,
-    ) -> Optional[tuple[float, dict]]:
+    ) -> tuple[float, dict] | None:
         """
         Return (strike, leg_dict) whose delta is closest to `target_delta`.
 
@@ -7983,8 +7978,8 @@ class LongStrangleWorker(BasePaperStrategyWorker):
         # The exact contract last held on each leg (normalized 7-key dict), so a
         # re-entry re-buys the SAME strike rather than re-deriving OTM1 from a
         # since-moved spot.
-        self.ce_last_contract: Optional[dict] = None
-        self.pe_last_contract: Optional[dict] = None
+        self.ce_last_contract: dict | None = None
+        self.pe_last_contract: dict | None = None
 
         # Telemetry for the end-of-day summary line.
         self.entry_submit_count = 0
@@ -8830,7 +8825,7 @@ if SL_HUNTING_AVAILABLE:
     SL_HUNTING_LESSONS_ENABLED = _env_bool("SL_HUNTING_LESSONS_ENABLED", False)
     SL_HUNTING_LESSONS_PATH = _env_str("SL_HUNTING_LESSONS_PATH", str(SL_HUNTING_DIR / "lessons.json"))
 
-    class SLHuntingAIWorker(AtmSingleLegStrategyWorker):  # noqa: F811 - optional definition
+    class SLHuntingAIWorker(AtmSingleLegStrategyWorker):
         """ATM single-leg worker whose entries/exits come from the SL Hunting agent."""
 
         strategy_name = "SL Hunting AI"
@@ -8851,8 +8846,8 @@ if SL_HUNTING_AVAILABLE:
         # manual "no fresh trades after noon" rule. This does NOT square off open
         # positions -- only the existing square_off_* gate (15:15) force-closes; exits
         # (stop/target, AI exit, max-loss) keep working. See process_strategy_frame.
-        no_new_entry_hour = _env_int("SL_HUNTING_NO_NEW_ENTRY_HOUR", 12)
-        no_new_entry_minute = _env_int("SL_HUNTING_NO_NEW_ENTRY_MINUTE", 0)
+        no_new_entry_hour = _env_int("SL_HUNTING_NO_NEW_ENTRY_HOUR", 10)
+        no_new_entry_minute = _env_int("SL_HUNTING_NO_NEW_ENTRY_MINUTE", 30)
 
         def __init__(self, store, stop_event, broker):
             super().__init__(store, stop_event, broker)
@@ -9220,7 +9215,7 @@ def format_trade_message(event: dict) -> str:
     if quantity is not None:
         size_line = f"Qty: <b>{quantity}</b>"
         if lots is not None and lot_size:
-            size_line += f" ({lots} lot(s) × {lot_size})"
+            size_line += f" ({lots} lot(s) x {lot_size})"
         elif lot_size:
             size_line += f" (lot size {lot_size})"
         lines.append(size_line)
@@ -9260,7 +9255,7 @@ class TelegramMessageWorker(threading.Thread):
 
     def __init__(
         self,
-        event_queue: "queue.Queue",
+        event_queue: queue.Queue,
         stop_event: threading.Event,
         bot_token: str,
         chat_id: str,
@@ -9490,7 +9485,7 @@ def _parse_eod_pnl_by_day(log_path) -> dict:
         if not Path(log_path).exists():
             return result
         # errors="replace" stops one stray non-UTF-8 byte from aborting the parse.
-        with open(log_path, "r", encoding="utf-8", errors="replace") as handle:
+        with open(log_path, encoding="utf-8", errors="replace") as handle:
             for line in handle:
                 # Cheap pre-filter: skip everything that isn't a P&L summary line
                 # before doing the costlier split/regex work below.

--- a/Signal Generators/CPR Strategy/Nifty CPR Algo 1 Signal Generator.py
+++ b/Signal Generators/CPR Strategy/Nifty CPR Algo 1 Signal Generator.py
@@ -12,10 +12,7 @@ sync.
 
 from __future__ import annotations
 
-from typing import Optional
-
 import pandas as pd
-
 from cpr_strategy_logic import (
     CPRDecision,
     CPRPositionContext,
@@ -27,7 +24,7 @@ from cpr_strategy_logic import (
 class NiftyCPRAlgo1SignalGenerator(CPRSignalGenerator):
     """CPR Algo 1 only: narrow/medium CPR trend entries."""
 
-    def __init__(self, config: Optional[CPRStrategyConfig] = None) -> None:
+    def __init__(self, config: CPRStrategyConfig | None = None) -> None:
         # `enabled_algorithms=("ALGO1",)` means the shared engine ignores
         # sideways zones and RSI-divergence reversal entries.
         super().__init__(config=config, enabled_algorithms=("ALGO1",))
@@ -35,7 +32,7 @@ class NiftyCPRAlgo1SignalGenerator(CPRSignalGenerator):
 
 def generate_nifty_cpr_algo1_signals(
     data: pd.DataFrame,
-    config: Optional[CPRStrategyConfig] = None,
+    config: CPRStrategyConfig | None = None,
 ) -> pd.DataFrame:
     """Return full-history Algo 1 signals."""
     return NiftyCPRAlgo1SignalGenerator(config=config).generate(data)
@@ -43,8 +40,8 @@ def generate_nifty_cpr_algo1_signals(
 
 def get_latest_nifty_cpr_algo1_signal(
     data: pd.DataFrame,
-    config: Optional[CPRStrategyConfig] = None,
-    position: Optional[CPRPositionContext] = None,
+    config: CPRStrategyConfig | None = None,
+    position: CPRPositionContext | None = None,
 ) -> CPRDecision:
     """Return only the newest Algo 1 decision."""
     return NiftyCPRAlgo1SignalGenerator(config=config).latest_signal(data, position=position)

--- a/Signal Generators/CPR Strategy/Nifty CPR Algo 2 Signal Generator.py
+++ b/Signal Generators/CPR Strategy/Nifty CPR Algo 2 Signal Generator.py
@@ -11,10 +11,7 @@ so the behavior is repeatable in both backtests and future live/front tests.
 
 from __future__ import annotations
 
-from typing import Optional
-
 import pandas as pd
-
 from cpr_strategy_logic import (
     CPRDecision,
     CPRPositionContext,
@@ -26,13 +23,13 @@ from cpr_strategy_logic import (
 class NiftyCPRAlgo2SignalGenerator(CPRSignalGenerator):
     """CPR Algo 2 only: sideways zones plus RSI divergence reversals."""
 
-    def __init__(self, config: Optional[CPRStrategyConfig] = None) -> None:
+    def __init__(self, config: CPRStrategyConfig | None = None) -> None:
         super().__init__(config=config, enabled_algorithms=("ALGO2_ZONE", "RSI_DIVERGENCE"))
 
 
 def generate_nifty_cpr_algo2_signals(
     data: pd.DataFrame,
-    config: Optional[CPRStrategyConfig] = None,
+    config: CPRStrategyConfig | None = None,
 ) -> pd.DataFrame:
     """Return full-history Algo 2 signals."""
     return NiftyCPRAlgo2SignalGenerator(config=config).generate(data)
@@ -40,8 +37,8 @@ def generate_nifty_cpr_algo2_signals(
 
 def get_latest_nifty_cpr_algo2_signal(
     data: pd.DataFrame,
-    config: Optional[CPRStrategyConfig] = None,
-    position: Optional[CPRPositionContext] = None,
+    config: CPRStrategyConfig | None = None,
+    position: CPRPositionContext | None = None,
 ) -> CPRDecision:
     """Return only the newest Algo 2 decision."""
     return NiftyCPRAlgo2SignalGenerator(config=config).latest_signal(data, position=position)

--- a/Signal Generators/CPR Strategy/Nifty CPR Algo 3 Signal Generator.py
+++ b/Signal Generators/CPR Strategy/Nifty CPR Algo 3 Signal Generator.py
@@ -50,10 +50,8 @@ needs synchronized 1-minute OHLC for the chosen ITM CE & PE (a separate follow-u
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Optional
 
 import pandas as pd
-
 from cpr_strategy_logic import (
     CPRDecision,
     CPRPositionContext,
@@ -107,7 +105,7 @@ def _next_level(row: pd.Series, reference: float, direction: str) -> float:
 class NiftyCPRAlgo3SignalGenerator:
     """Multi-instrument CPR Algo 3 generator (spot + ITM CE + ITM PE)."""
 
-    def __init__(self, config: Optional[CPRAlgo3Config] = None) -> None:
+    def __init__(self, config: CPRAlgo3Config | None = None) -> None:
         self.config = config or CPRAlgo3Config()
 
     def _enrich(self, frame: pd.DataFrame) -> pd.DataFrame:
@@ -189,7 +187,7 @@ class NiftyCPRAlgo3SignalGenerator:
         spot: pd.DataFrame,
         ce: pd.DataFrame,
         pe: pd.DataFrame,
-        position: Optional[CPRPositionContext] = None,  # accepted for API parity; entries only
+        position: CPRPositionContext | None = None,  # accepted for API parity; entries only
     ) -> CPRDecision:
         """Return only the newest Algo 3 decision (the last shared candle)."""
         s, c, p, common = self._aligned(spot, ce, pe)
@@ -204,7 +202,7 @@ def generate_nifty_cpr_algo3_signals(
     spot: pd.DataFrame,
     ce: pd.DataFrame,
     pe: pd.DataFrame,
-    config: Optional[CPRAlgo3Config] = None,
+    config: CPRAlgo3Config | None = None,
 ) -> pd.DataFrame:
     """Full-history Algo 3 signals across the candles the three charts share."""
     return NiftyCPRAlgo3SignalGenerator(config=config).generate(spot, ce, pe)
@@ -214,8 +212,8 @@ def get_latest_nifty_cpr_algo3_signal(
     spot: pd.DataFrame,
     ce: pd.DataFrame,
     pe: pd.DataFrame,
-    config: Optional[CPRAlgo3Config] = None,
-    position: Optional[CPRPositionContext] = None,
+    config: CPRAlgo3Config | None = None,
+    position: CPRPositionContext | None = None,
 ) -> CPRDecision:
     """Only the newest Algo 3 decision."""
     return NiftyCPRAlgo3SignalGenerator(config=config).latest_signal(spot, ce, pe, position=position)

--- a/Signal Generators/CPR Strategy/Nifty CPR Combined Signal Generator.py
+++ b/Signal Generators/CPR Strategy/Nifty CPR Combined Signal Generator.py
@@ -19,10 +19,7 @@ this file as its own generator - see `Nifty CPR Algo 3 Signal Generator.py`.
 
 from __future__ import annotations
 
-from typing import Optional
-
 import pandas as pd
-
 from cpr_strategy_logic import (
     CPRDecision,
     CPRPositionContext,
@@ -36,7 +33,7 @@ from cpr_strategy_logic import (
 class NiftyCPRCombinedSignalGenerator(CPRSignalGenerator):
     """Full CPR PDF strategy wrapper."""
 
-    def __init__(self, config: Optional[CPRStrategyConfig] = None) -> None:
+    def __init__(self, config: CPRStrategyConfig | None = None) -> None:
         super().__init__(
             config=config,
             enabled_algorithms=("ALGO1", "ALGO2_ZONE", "RSI_DIVERGENCE"),
@@ -45,7 +42,7 @@ class NiftyCPRCombinedSignalGenerator(CPRSignalGenerator):
 
 def generate_nifty_cpr_combined_signals(
     data: pd.DataFrame,
-    config: Optional[CPRStrategyConfig] = None,
+    config: CPRStrategyConfig | None = None,
 ) -> pd.DataFrame:
     """Return full-history combined CPR signals."""
     return generate_cpr_signals(
@@ -57,8 +54,8 @@ def generate_nifty_cpr_combined_signals(
 
 def get_latest_nifty_cpr_combined_signal(
     data: pd.DataFrame,
-    config: Optional[CPRStrategyConfig] = None,
-    position: Optional[CPRPositionContext] = None,
+    config: CPRStrategyConfig | None = None,
+    position: CPRPositionContext | None = None,
 ) -> CPRDecision:
     """Return only the newest combined CPR decision."""
     return get_latest_cpr_signal(

--- a/Signal Generators/CPR Strategy/cpr_strategy_logic.py
+++ b/Signal Generators/CPR Strategy/cpr_strategy_logic.py
@@ -14,16 +14,19 @@ future front-test use the same repeatable rules.
 
 from __future__ import annotations
 
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
-from typing import Any, Iterable, Optional, Sequence
+from typing import Any
 
 import numpy as np
 import pandas as pd
 
 try:
-    import talib  # type: ignore
+    import talib
 except ImportError:  # pragma: no cover - fallback path is used when TA-Lib is absent
-    talib = None
+    # The assignment error only exists where TA-Lib (with stubs) is installed;
+    # on stub-less machines the ignore is unused, hence the dual code.
+    talib = None  # type: ignore[assignment, unused-ignore]
 
 
 OHLC_COLUMNS = ["open", "high", "low", "close"]
@@ -119,7 +122,7 @@ class CPRDecision:
     debug: dict[str, Any] = field(default_factory=dict)
 
 
-def _find_first_col(frame: pd.DataFrame, names: Iterable[str]) -> Optional[str]:
+def _find_first_col(frame: pd.DataFrame, names: Iterable[str]) -> str | None:
     """Find a column name case-insensitively."""
     col_map = {str(column).strip().lower(): column for column in frame.columns}
     for name in names:
@@ -241,7 +244,7 @@ def _ema(values: pd.Series, period: int) -> pd.Series:
     """Calculate EMA with TA-Lib when available, otherwise pandas."""
     if talib is not None:
         return pd.Series(
-            talib.EMA(values.to_numpy(dtype=float), timeperiod=int(period)),  # type: ignore[union-attr]
+            talib.EMA(values.to_numpy(dtype=float), timeperiod=int(period)),
             index=values.index,
         )
     return values.ewm(span=int(period), adjust=False, min_periods=int(period)).mean()
@@ -251,7 +254,7 @@ def _rsi(close: pd.Series, period: int) -> pd.Series:
     """Calculate Wilder-style RSI."""
     if talib is not None:
         return pd.Series(
-            talib.RSI(close.to_numpy(dtype=float), timeperiod=int(period)),  # type: ignore[union-attr]
+            talib.RSI(close.to_numpy(dtype=float), timeperiod=int(period)),
             index=close.index,
         )
 
@@ -304,8 +307,8 @@ def _add_daily_cpr(frame: pd.DataFrame) -> pd.DataFrame:
     result["s3"] = low - 2.0 * (high - pivot)
     result["s4"] = result["s3"] - (high - low)
     result["cpr_width"] = [
-        classify_daily_cpr_width(h, l, c)
-        for h, l, c in zip(result["prev_high"], result["prev_low"], result["prev_close"])
+        classify_daily_cpr_width(hi, lo, cl)
+        for hi, lo, cl in zip(result["prev_high"], result["prev_low"], result["prev_close"], strict=False)
     ]
     return result
 
@@ -385,8 +388,8 @@ def _add_swings_and_divergence(frame: pd.DataFrame, config: CPRStrategyConfig) -
     bullish_move_seen = result["bullish_half_pct_move_seen"].to_numpy(dtype=bool)
     bearish_move_seen = result["bearish_half_pct_move_seen"].to_numpy(dtype=bool)
 
-    last_high: Optional[tuple[int, float, float]] = None
-    last_low: Optional[tuple[int, float, float]] = None
+    last_high: tuple[int, float, float] | None = None
+    last_low: tuple[int, float, float] | None = None
     last_confirmed_low_price = np.nan
     last_confirmed_high_price = np.nan
 
@@ -639,7 +642,7 @@ def _add_sideways_zones(frame: pd.DataFrame, config: CPRStrategyConfig) -> pd.Da
 
 def build_cpr_with_indicators(
     ohlc: pd.DataFrame,
-    config: Optional[CPRStrategyConfig] = None,
+    config: CPRStrategyConfig | None = None,
 ) -> pd.DataFrame:
     """
     Normalize OHLC candles and add all CPR strategy indicator/setup columns.
@@ -674,14 +677,14 @@ class CPRSignalEngine:
 
     def __init__(
         self,
-        config: Optional[CPRStrategyConfig] = None,
-        enabled_algorithms: Optional[Sequence[str]] = None,
+        config: CPRStrategyConfig | None = None,
+        enabled_algorithms: Sequence[str] | None = None,
     ) -> None:
         self.config = config or CPRStrategyConfig()
         self.enabled_algorithms = tuple(enabled_algorithms or self.config.enabled_algorithms)
 
     @staticmethod
-    def _hold(reason: str = "", debug: Optional[dict[str, Any]] = None) -> CPRDecision:
+    def _hold(reason: str = "", debug: dict[str, Any] | None = None) -> CPRDecision:
         return CPRDecision(action="HOLD", exit_reason=reason, debug=debug or {})
 
     @staticmethod
@@ -762,7 +765,7 @@ class CPRSignalEngine:
         stop_column: str,
         target_column: str,
         priority: int,
-    ) -> Optional[dict[str, Any]]:
+    ) -> dict[str, Any] | None:
         """Return a normalized entry candidate if the setup is valid."""
         if not bool(row.get(condition, False)):
             return None
@@ -889,7 +892,7 @@ class CPRSignalEngine:
     def evaluate_candle(
         self,
         candles_with_indicators: pd.DataFrame,
-        position: Optional[CPRPositionContext] = None,
+        position: CPRPositionContext | None = None,
     ) -> CPRDecision:
         """Evaluate only the newest candle in an enriched CPR DataFrame."""
         if candles_with_indicators is None or candles_with_indicators.empty:
@@ -941,8 +944,8 @@ class CPRSignalGenerator:
 
     def __init__(
         self,
-        config: Optional[CPRStrategyConfig] = None,
-        enabled_algorithms: Optional[Sequence[str]] = None,
+        config: CPRStrategyConfig | None = None,
+        enabled_algorithms: Sequence[str] | None = None,
     ) -> None:
         self.config = config or CPRStrategyConfig()
         self.engine = CPRSignalEngine(self.config, enabled_algorithms=enabled_algorithms)
@@ -959,7 +962,7 @@ class CPRSignalGenerator:
         stops: list[float] = []
         targets: list[float] = []
         stream: list[int] = []
-        position: Optional[CPRPositionContext] = None
+        position: CPRPositionContext | None = None
 
         for index in range(len(frame)):
             decision = self.engine.evaluate_candle(frame.iloc[: index + 1], position=position)
@@ -1005,7 +1008,7 @@ class CPRSignalGenerator:
     def latest_signal(
         self,
         data: pd.DataFrame,
-        position: Optional[CPRPositionContext] = None,
+        position: CPRPositionContext | None = None,
     ) -> CPRDecision:
         """Return only the newest CPR decision."""
         frame = build_cpr_with_indicators(data, self.config)
@@ -1014,8 +1017,8 @@ class CPRSignalGenerator:
 
 def generate_cpr_signals(
     data: pd.DataFrame,
-    config: Optional[CPRStrategyConfig] = None,
-    enabled_algorithms: Optional[Sequence[str]] = None,
+    config: CPRStrategyConfig | None = None,
+    enabled_algorithms: Sequence[str] | None = None,
 ) -> pd.DataFrame:
     """Functional wrapper for full-history signal generation."""
     return CPRSignalGenerator(config=config, enabled_algorithms=enabled_algorithms).generate(data)
@@ -1023,9 +1026,9 @@ def generate_cpr_signals(
 
 def get_latest_cpr_signal(
     data: pd.DataFrame,
-    config: Optional[CPRStrategyConfig] = None,
-    position: Optional[CPRPositionContext] = None,
-    enabled_algorithms: Optional[Sequence[str]] = None,
+    config: CPRStrategyConfig | None = None,
+    position: CPRPositionContext | None = None,
+    enabled_algorithms: Sequence[str] | None = None,
 ) -> CPRDecision:
     """Functional wrapper for latest-candle signal generation."""
     return CPRSignalGenerator(config=config, enabled_algorithms=enabled_algorithms).latest_signal(
@@ -1035,14 +1038,14 @@ def get_latest_cpr_signal(
 
 
 __all__ = [
-    "CPRStrategyConfig",
-    "CPRPositionContext",
     "CPRDecision",
+    "CPRPositionContext",
     "CPRSignalEngine",
     "CPRSignalGenerator",
+    "CPRStrategyConfig",
     "build_cpr_with_indicators",
     "classify_daily_cpr_width",
-    "prepare_cpr_ohlc_input",
     "generate_cpr_signals",
     "get_latest_cpr_signal",
+    "prepare_cpr_ohlc_input",
 ]

--- a/Signal Generators/CPR Strategy/test_cpr_strategy_signal_generators.py
+++ b/Signal Generators/CPR Strategy/test_cpr_strategy_signal_generators.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 import pandas as pd
 
-
 STRATEGY_DIR = Path(__file__).resolve().parent
 LOGIC_PATH = STRATEGY_DIR / "cpr_strategy_logic.py"
 BACKTEST_PATH = STRATEGY_DIR / "Nifty CPR Strategy Backtest.py"

--- a/Signal Generators/Donchian Signal Generator Bearish.py
+++ b/Signal Generators/Donchian Signal Generator Bearish.py
@@ -129,19 +129,23 @@ point rounding) because they compute the same rolling max/min/average.
 
 from __future__ import annotations
 
+import contextlib
+from collections.abc import Iterable
+
 # --- Standard library imports ------------------------------------------------
 # `dataclass` lets us define small "struct-like" classes without writing the
 # `__init__` boilerplate ourselves.
 from dataclasses import dataclass
+
 # `IntEnum` attaches human-readable names (LONG, SHORT, ...) to small integer
 # flags. The underlying values stay plain integers, so they can be compared
 # against numpy arrays cheaply.
 from enum import IntEnum
-from typing import Iterable, Optional
 
 # --- Third-party imports -----------------------------------------------------
 # numpy is used for fast array math (no Python for-loops over raw numbers).
 import numpy as np
+
 # pandas is the tabular-data library we accept as input and return as output.
 import pandas as pd
 
@@ -170,7 +174,7 @@ except ImportError:  # pragma: no cover - only exercised when TA-Lib missing
 # and cache the outcome. On an ordinary session with TA-Lib installed,
 # pandas_ta is NEVER imported at all.
 pta = None  # populated lazily on first use, never at module load
-_PANDAS_TA_AVAILABLE: Optional[bool] = None  # None = "not probed yet"
+_PANDAS_TA_AVAILABLE: bool | None = None  # None = "not probed yet"
 
 
 def _ensure_pandas_ta() -> bool:
@@ -284,7 +288,7 @@ class BearishDecision:
 # resolve cross-file imports for the helper functions. The duplication is a
 # few dozen lines and pays for itself in decoupling.
 
-def _find_first_col(frame: pd.DataFrame, names: Iterable[str]) -> Optional[str]:
+def _find_first_col(frame: pd.DataFrame, names: Iterable[str]) -> str | None:
     """
     Return the first column in `frame` whose (case-insensitive, trimmed)
     name is in `names`, or None if nothing matches.
@@ -351,12 +355,10 @@ def _prepare_ohlc_frame(data: pd.DataFrame) -> pd.DataFrame:
         # as-is.
         #
         # We used to pass `errors="ignore"` here, but pandas deprecated that
-        # option (FutureWarning on every call). The try/except below gives
+        # option (FutureWarning on every call). The suppress below gives
         # the same behaviour without the warning.
-        try:
+        with contextlib.suppress(ValueError, TypeError):
             out["timestamp"] = pd.to_datetime(out["timestamp"])
-        except (ValueError, TypeError):
-            pass
     # Reset to a clean integer index so `.iloc[-1]`, `.iloc[-2]`, etc. behave
     # predictably regardless of the original index.
     return out.reset_index(drop=True)
@@ -537,7 +539,7 @@ class DonchianBearishSignalGenerator:
     natural bearish counterpart to the bullish file's "sell a put".
     """
 
-    def __init__(self, settings: Optional[DonchianSettings] = None) -> None:
+    def __init__(self, settings: DonchianSettings | None = None) -> None:
         # If the caller does not pass settings, fall back to the default
         # configuration from `DonchianSettings` (length = 20).
         self.settings = settings or DonchianSettings()
@@ -711,7 +713,7 @@ class DonchianBearishSignalGenerator:
 # unless the caller overrides them.
 def generate_donchian_bearish_signals(
     data: pd.DataFrame,
-    settings: Optional[DonchianSettings] = None,
+    settings: DonchianSettings | None = None,
 ) -> pd.DataFrame:
     """Functional alias for `DonchianBearishSignalGenerator(...).generate(data)`."""
     generator = DonchianBearishSignalGenerator(settings=settings)
@@ -720,7 +722,7 @@ def generate_donchian_bearish_signals(
 
 def get_latest_donchian_bearish_signal(
     data: pd.DataFrame,
-    settings: Optional[DonchianSettings] = None,
+    settings: DonchianSettings | None = None,
 ) -> BearishDecision:
     """Functional alias for `DonchianBearishSignalGenerator(...).latest_signal(data)`."""
     generator = DonchianBearishSignalGenerator(settings=settings)
@@ -730,10 +732,10 @@ def get_latest_donchian_bearish_signal(
 # `__all__` controls what `from module import *` exposes. Listing public
 # names here also serves as a quick table-of-contents for readers.
 __all__ = [
-    "Direction",
-    "DonchianSettings",
     "BearishDecision",
+    "Direction",
     "DonchianBearishSignalGenerator",
+    "DonchianSettings",
     "generate_donchian_bearish_signals",
     "get_latest_donchian_bearish_signal",
 ]

--- a/Signal Generators/Nifty Bollinger Bands Signal Generator.py
+++ b/Signal Generators/Nifty Bollinger Bands Signal Generator.py
@@ -35,10 +35,9 @@ This module does not resample - feed it already-prepared OHLC candles.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any
 
 import pandas as pd
-
 from misc_strategy_common import bollinger_bands, finite, normalize_ohlc_frame, require_columns
 
 
@@ -82,7 +81,7 @@ class BollingerBandsDecision:
 
 def build_bollinger_bands_with_indicators(
     ohlc: pd.DataFrame,
-    config: Optional[BollingerBandsConfig] = None,
+    config: BollingerBandsConfig | None = None,
 ) -> pd.DataFrame:
     """Enrich OHLC candles with Bollinger Bands, bounce flags, and risk levels."""
     config = config or BollingerBandsConfig()
@@ -118,7 +117,7 @@ def build_bollinger_bands_with_indicators(
 class BollingerBandsSignalEngine:
     """Decision engine for Bollinger Bands mean-reversion entries and exits."""
 
-    def __init__(self, config: Optional[BollingerBandsConfig] = None) -> None:
+    def __init__(self, config: BollingerBandsConfig | None = None) -> None:
         self.config = config or BollingerBandsConfig()
 
     def minimum_history_bars(self) -> int:
@@ -160,7 +159,7 @@ class BollingerBandsSignalEngine:
     def evaluate_candle(
         self,
         candles_with_indicators: pd.DataFrame,
-        position: Optional[BollingerBandsPositionContext] = None,
+        position: BollingerBandsPositionContext | None = None,
     ) -> BollingerBandsDecision:
         if candles_with_indicators is None or candles_with_indicators.empty:
             return self._hold("No candles supplied.")
@@ -217,7 +216,7 @@ class BollingerBandsSignalEngine:
 class BollingerBandsSignalGenerator:
     """Convenience wrapper for full-history and latest-candle Bollinger signals."""
 
-    def __init__(self, config: Optional[BollingerBandsConfig] = None) -> None:
+    def __init__(self, config: BollingerBandsConfig | None = None) -> None:
         self.config = config or BollingerBandsConfig()
         self.engine = BollingerBandsSignalEngine(self.config)
 
@@ -231,7 +230,7 @@ class BollingerBandsSignalGenerator:
         stops: list[float] = []
         targets: list[float] = []
         stream: list[int] = []
-        position: Optional[BollingerBandsPositionContext] = None
+        position: BollingerBandsPositionContext | None = None
 
         for index in range(len(frame)):
             decision = self.engine.evaluate_candle(frame.iloc[: index + 1], position=position)
@@ -267,7 +266,7 @@ class BollingerBandsSignalGenerator:
     def latest_signal(
         self,
         data: pd.DataFrame,
-        position: Optional[BollingerBandsPositionContext] = None,
+        position: BollingerBandsPositionContext | None = None,
     ) -> BollingerBandsDecision:
         frame = build_bollinger_bands_with_indicators(data, self.config)
         return self.engine.evaluate_candle(frame, position=position)
@@ -275,15 +274,15 @@ class BollingerBandsSignalGenerator:
 
 def generate_bollinger_bands_signals(
     data: pd.DataFrame,
-    config: Optional[BollingerBandsConfig] = None,
+    config: BollingerBandsConfig | None = None,
 ) -> pd.DataFrame:
     return BollingerBandsSignalGenerator(config=config).generate(data)
 
 
 def get_latest_bollinger_bands_signal(
     data: pd.DataFrame,
-    config: Optional[BollingerBandsConfig] = None,
-    position: Optional[BollingerBandsPositionContext] = None,
+    config: BollingerBandsConfig | None = None,
+    position: BollingerBandsPositionContext | None = None,
 ) -> BollingerBandsDecision:
     return BollingerBandsSignalGenerator(config=config).latest_signal(data, position=position)
 
@@ -295,14 +294,14 @@ get_latest_nifty_bollinger_bands_signal = get_latest_bollinger_bands_signal
 
 __all__ = [
     "BollingerBandsConfig",
-    "BollingerBandsPositionContext",
     "BollingerBandsDecision",
-    "build_bollinger_bands_with_indicators",
+    "BollingerBandsPositionContext",
     "BollingerBandsSignalEngine",
     "BollingerBandsSignalGenerator",
-    "generate_bollinger_bands_signals",
-    "get_latest_bollinger_bands_signal",
     "NiftyBollingerBandsSignalGenerator",
+    "build_bollinger_bands_with_indicators",
+    "generate_bollinger_bands_signals",
     "generate_nifty_bollinger_bands_signals",
+    "get_latest_bollinger_bands_signal",
     "get_latest_nifty_bollinger_bands_signal",
 ]

--- a/Signal Generators/Nifty Keltner Squeeze Signal Generator.py
+++ b/Signal Generators/Nifty Keltner Squeeze Signal Generator.py
@@ -31,10 +31,9 @@ This module does not resample - feed it already-prepared OHLC candles.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any
 
 import pandas as pd
-
 from misc_strategy_common import (
     bollinger_bands,
     finite,
@@ -103,7 +102,7 @@ class KeltnerSqueezeDecision:
 
 def build_keltner_squeeze_with_indicators(
     ohlc: pd.DataFrame,
-    config: Optional[KeltnerSqueezeConfig] = None,
+    config: KeltnerSqueezeConfig | None = None,
 ) -> pd.DataFrame:
     """Enrich OHLC candles with BB/KC bands, MACD histogram, squeeze-release flags, and risk levels."""
     config = config or KeltnerSqueezeConfig()
@@ -112,8 +111,8 @@ def build_keltner_squeeze_with_indicators(
         return frame
 
     close = frame["close"].astype(float)
-    bb_upper, bb_mid, bb_lower = bollinger_bands(close, config.bb_period, config.bb_std)
-    kc_upper, kc_mid, kc_lower = keltner_channels(frame, config.kc_period, config.kc_atr_period, config.kc_multiplier)
+    bb_upper, _bb_mid, bb_lower = bollinger_bands(close, config.bb_period, config.bb_std)
+    kc_upper, _kc_mid, kc_lower = keltner_channels(frame, config.kc_period, config.kc_atr_period, config.kc_multiplier)
     _, _, macd_hist = macd(close, config.macd_fast, config.macd_slow, config.macd_signal)
 
     frame["bb_upper"] = bb_upper
@@ -146,7 +145,7 @@ def build_keltner_squeeze_with_indicators(
 class KeltnerSqueezeSignalEngine:
     """Decision engine for Keltner squeeze entries and exits."""
 
-    def __init__(self, config: Optional[KeltnerSqueezeConfig] = None) -> None:
+    def __init__(self, config: KeltnerSqueezeConfig | None = None) -> None:
         self.config = config or KeltnerSqueezeConfig()
 
     def minimum_history_bars(self) -> int:
@@ -192,7 +191,7 @@ class KeltnerSqueezeSignalEngine:
     def evaluate_candle(
         self,
         candles_with_indicators: pd.DataFrame,
-        position: Optional[KeltnerSqueezePositionContext] = None,
+        position: KeltnerSqueezePositionContext | None = None,
     ) -> KeltnerSqueezeDecision:
         if candles_with_indicators is None or candles_with_indicators.empty:
             return self._hold("No candles supplied.")
@@ -249,7 +248,7 @@ class KeltnerSqueezeSignalEngine:
 class KeltnerSqueezeSignalGenerator:
     """Convenience wrapper for full-history and latest-candle squeeze signals."""
 
-    def __init__(self, config: Optional[KeltnerSqueezeConfig] = None) -> None:
+    def __init__(self, config: KeltnerSqueezeConfig | None = None) -> None:
         self.config = config or KeltnerSqueezeConfig()
         self.engine = KeltnerSqueezeSignalEngine(self.config)
 
@@ -263,7 +262,7 @@ class KeltnerSqueezeSignalGenerator:
         stops: list[float] = []
         targets: list[float] = []
         stream: list[int] = []
-        position: Optional[KeltnerSqueezePositionContext] = None
+        position: KeltnerSqueezePositionContext | None = None
 
         for index in range(len(frame)):
             decision = self.engine.evaluate_candle(frame.iloc[: index + 1], position=position)
@@ -299,7 +298,7 @@ class KeltnerSqueezeSignalGenerator:
     def latest_signal(
         self,
         data: pd.DataFrame,
-        position: Optional[KeltnerSqueezePositionContext] = None,
+        position: KeltnerSqueezePositionContext | None = None,
     ) -> KeltnerSqueezeDecision:
         frame = build_keltner_squeeze_with_indicators(data, self.config)
         return self.engine.evaluate_candle(frame, position=position)
@@ -307,15 +306,15 @@ class KeltnerSqueezeSignalGenerator:
 
 def generate_keltner_squeeze_signals(
     data: pd.DataFrame,
-    config: Optional[KeltnerSqueezeConfig] = None,
+    config: KeltnerSqueezeConfig | None = None,
 ) -> pd.DataFrame:
     return KeltnerSqueezeSignalGenerator(config=config).generate(data)
 
 
 def get_latest_keltner_squeeze_signal(
     data: pd.DataFrame,
-    config: Optional[KeltnerSqueezeConfig] = None,
-    position: Optional[KeltnerSqueezePositionContext] = None,
+    config: KeltnerSqueezeConfig | None = None,
+    position: KeltnerSqueezePositionContext | None = None,
 ) -> KeltnerSqueezeDecision:
     return KeltnerSqueezeSignalGenerator(config=config).latest_signal(data, position=position)
 
@@ -327,14 +326,14 @@ get_latest_nifty_keltner_squeeze_signal = get_latest_keltner_squeeze_signal
 
 __all__ = [
     "KeltnerSqueezeConfig",
-    "KeltnerSqueezePositionContext",
     "KeltnerSqueezeDecision",
-    "build_keltner_squeeze_with_indicators",
+    "KeltnerSqueezePositionContext",
     "KeltnerSqueezeSignalEngine",
     "KeltnerSqueezeSignalGenerator",
-    "generate_keltner_squeeze_signals",
-    "get_latest_keltner_squeeze_signal",
     "NiftyKeltnerSqueezeSignalGenerator",
+    "build_keltner_squeeze_with_indicators",
+    "generate_keltner_squeeze_signals",
     "generate_nifty_keltner_squeeze_signals",
+    "get_latest_keltner_squeeze_signal",
     "get_latest_nifty_keltner_squeeze_signal",
 ]

--- a/Signal Generators/Nifty ML Ensemble Signal Generator.py
+++ b/Signal Generators/Nifty ML Ensemble Signal Generator.py
@@ -38,11 +38,10 @@ This module does not resample - feed it already-prepared OHLC candles.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any
 
 import numpy as np
 import pandas as pd
-
 from misc_strategy_common import (
     atr,
     bollinger_bands,
@@ -145,7 +144,7 @@ class MLEnsembleDecision:
 
 def build_ml_ensemble_with_indicators(
     ohlc: pd.DataFrame,
-    config: Optional[MLEnsembleConfig] = None,
+    config: MLEnsembleConfig | None = None,
 ) -> pd.DataFrame:
     """Enrich OHLC candles with the model feature set, the training label, and risk levels."""
     config = config or MLEnsembleConfig()
@@ -206,7 +205,7 @@ def _load_random_forest():
 class MLEnsembleSignalEngine:
     """Stateful decision engine: trains/caches a RandomForest and predicts entries."""
 
-    def __init__(self, config: Optional[MLEnsembleConfig] = None) -> None:
+    def __init__(self, config: MLEnsembleConfig | None = None) -> None:
         self.config = config or MLEnsembleConfig()
         self._rf_class = _load_random_forest()
         self.model = None
@@ -256,7 +255,7 @@ class MLEnsembleSignalEngine:
         # Only rows whose forward outcome is already known by the latest bar are
         # eligible for training -> drop the trailing `forward_bars` rows.
         trainable = frame.iloc[: max(0, n - int(self.config.forward_bars))]
-        trainable = trainable.dropna(subset=FEATURE_COLUMNS + ["ml_target"])
+        trainable = trainable.dropna(subset=[*FEATURE_COLUMNS, "ml_target"])
         if len(trainable) < int(self.config.min_training_rows):
             return
         trainable = trainable.iloc[-int(self.config.training_window):]
@@ -276,7 +275,7 @@ class MLEnsembleSignalEngine:
         model.fit(x, y)
         self.model = model
 
-    def _predict_up_probability(self, current: pd.Series) -> Optional[float]:
+    def _predict_up_probability(self, current: pd.Series) -> float | None:
         if self.model is None:
             return None
         features = [current.get(col) for col in FEATURE_COLUMNS]
@@ -314,7 +313,7 @@ class MLEnsembleSignalEngine:
     def evaluate_candle(
         self,
         candles_with_indicators: pd.DataFrame,
-        position: Optional[MLEnsemblePositionContext] = None,
+        position: MLEnsemblePositionContext | None = None,
     ) -> MLEnsembleDecision:
         if candles_with_indicators is None or candles_with_indicators.empty:
             return self._hold("No candles supplied.")
@@ -324,7 +323,7 @@ class MLEnsembleSignalEngine:
         if position is not None:
             return self._evaluate_exit(current, position)
 
-        require_columns(candles_with_indicators, FEATURE_COLUMNS + ["ml_target"])
+        require_columns(candles_with_indicators, [*FEATURE_COLUMNS, "ml_target"])
         if len(candles_with_indicators) < self.minimum_history_bars():
             return self._hold("Insufficient history.")
 
@@ -371,7 +370,7 @@ class MLEnsembleSignalEngine:
 class MLEnsembleSignalGenerator:
     """Convenience wrapper for full-history and latest-candle ML ensemble signals."""
 
-    def __init__(self, config: Optional[MLEnsembleConfig] = None) -> None:
+    def __init__(self, config: MLEnsembleConfig | None = None) -> None:
         self.config = config or MLEnsembleConfig()
         self.engine = MLEnsembleSignalEngine(self.config)
 
@@ -385,7 +384,7 @@ class MLEnsembleSignalGenerator:
         stops: list[float] = []
         targets: list[float] = []
         stream: list[int] = []
-        position: Optional[MLEnsemblePositionContext] = None
+        position: MLEnsemblePositionContext | None = None
 
         for index in range(len(frame)):
             decision = self.engine.evaluate_candle(frame.iloc[: index + 1], position=position)
@@ -421,7 +420,7 @@ class MLEnsembleSignalGenerator:
     def latest_signal(
         self,
         data: pd.DataFrame,
-        position: Optional[MLEnsemblePositionContext] = None,
+        position: MLEnsemblePositionContext | None = None,
     ) -> MLEnsembleDecision:
         frame = build_ml_ensemble_with_indicators(data, self.config)
         return self.engine.evaluate_candle(frame, position=position)
@@ -429,15 +428,15 @@ class MLEnsembleSignalGenerator:
 
 def generate_ml_ensemble_signals(
     data: pd.DataFrame,
-    config: Optional[MLEnsembleConfig] = None,
+    config: MLEnsembleConfig | None = None,
 ) -> pd.DataFrame:
     return MLEnsembleSignalGenerator(config=config).generate(data)
 
 
 def get_latest_ml_ensemble_signal(
     data: pd.DataFrame,
-    config: Optional[MLEnsembleConfig] = None,
-    position: Optional[MLEnsemblePositionContext] = None,
+    config: MLEnsembleConfig | None = None,
+    position: MLEnsemblePositionContext | None = None,
 ) -> MLEnsembleDecision:
     return MLEnsembleSignalGenerator(config=config).latest_signal(data, position=position)
 
@@ -450,14 +449,14 @@ get_latest_nifty_ml_ensemble_signal = get_latest_ml_ensemble_signal
 __all__ = [
     "FEATURE_COLUMNS",
     "MLEnsembleConfig",
-    "MLEnsemblePositionContext",
     "MLEnsembleDecision",
-    "build_ml_ensemble_with_indicators",
+    "MLEnsemblePositionContext",
     "MLEnsembleSignalEngine",
     "MLEnsembleSignalGenerator",
-    "generate_ml_ensemble_signals",
-    "get_latest_ml_ensemble_signal",
     "NiftyMLEnsembleSignalGenerator",
+    "build_ml_ensemble_with_indicators",
+    "generate_ml_ensemble_signals",
     "generate_nifty_ml_ensemble_signals",
+    "get_latest_ml_ensemble_signal",
     "get_latest_nifty_ml_ensemble_signal",
 ]

--- a/Signal Generators/Nifty Mean Reversion Zscore Signal Generator.py
+++ b/Signal Generators/Nifty Mean Reversion Zscore Signal Generator.py
@@ -32,10 +32,9 @@ This module does not resample - feed it already-prepared OHLC candles.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any
 
 import pandas as pd
-
 from misc_strategy_common import finite, normalize_ohlc_frame, require_columns, rolling_zscore, sma
 
 
@@ -82,7 +81,7 @@ class MeanReversionZscoreDecision:
 
 def build_mean_reversion_zscore_with_indicators(
     ohlc: pd.DataFrame,
-    config: Optional[MeanReversionZscoreConfig] = None,
+    config: MeanReversionZscoreConfig | None = None,
 ) -> pd.DataFrame:
     """Enrich OHLC candles with rolling mean, z-score, cross flags, and risk levels."""
     config = config or MeanReversionZscoreConfig()
@@ -113,7 +112,7 @@ def build_mean_reversion_zscore_with_indicators(
 class MeanReversionZscoreSignalEngine:
     """Decision engine for z-score mean reversion entries and exits."""
 
-    def __init__(self, config: Optional[MeanReversionZscoreConfig] = None) -> None:
+    def __init__(self, config: MeanReversionZscoreConfig | None = None) -> None:
         self.config = config or MeanReversionZscoreConfig()
 
     def minimum_history_bars(self) -> int:
@@ -131,7 +130,9 @@ class MeanReversionZscoreSignalEngine:
     def _direction(direction: str) -> str:
         return str(direction).strip().upper()
 
-    def _evaluate_exit(self, current: pd.Series, position: MeanReversionZscorePositionContext) -> MeanReversionZscoreDecision:
+    def _evaluate_exit(
+        self, current: pd.Series, position: MeanReversionZscorePositionContext
+    ) -> MeanReversionZscoreDecision:
         direction = self._direction(position.direction)
         high = float(current["high"])
         low = float(current["low"])
@@ -162,7 +163,7 @@ class MeanReversionZscoreSignalEngine:
     def evaluate_candle(
         self,
         candles_with_indicators: pd.DataFrame,
-        position: Optional[MeanReversionZscorePositionContext] = None,
+        position: MeanReversionZscorePositionContext | None = None,
     ) -> MeanReversionZscoreDecision:
         if candles_with_indicators is None or candles_with_indicators.empty:
             return self._hold("No candles supplied.")
@@ -219,7 +220,7 @@ class MeanReversionZscoreSignalEngine:
 class MeanReversionZscoreSignalGenerator:
     """Convenience wrapper for full-history and latest-candle z-score signals."""
 
-    def __init__(self, config: Optional[MeanReversionZscoreConfig] = None) -> None:
+    def __init__(self, config: MeanReversionZscoreConfig | None = None) -> None:
         self.config = config or MeanReversionZscoreConfig()
         self.engine = MeanReversionZscoreSignalEngine(self.config)
 
@@ -233,7 +234,7 @@ class MeanReversionZscoreSignalGenerator:
         stops: list[float] = []
         targets: list[float] = []
         stream: list[int] = []
-        position: Optional[MeanReversionZscorePositionContext] = None
+        position: MeanReversionZscorePositionContext | None = None
 
         for index in range(len(frame)):
             decision = self.engine.evaluate_candle(frame.iloc[: index + 1], position=position)
@@ -269,7 +270,7 @@ class MeanReversionZscoreSignalGenerator:
     def latest_signal(
         self,
         data: pd.DataFrame,
-        position: Optional[MeanReversionZscorePositionContext] = None,
+        position: MeanReversionZscorePositionContext | None = None,
     ) -> MeanReversionZscoreDecision:
         frame = build_mean_reversion_zscore_with_indicators(data, self.config)
         return self.engine.evaluate_candle(frame, position=position)
@@ -277,15 +278,15 @@ class MeanReversionZscoreSignalGenerator:
 
 def generate_mean_reversion_zscore_signals(
     data: pd.DataFrame,
-    config: Optional[MeanReversionZscoreConfig] = None,
+    config: MeanReversionZscoreConfig | None = None,
 ) -> pd.DataFrame:
     return MeanReversionZscoreSignalGenerator(config=config).generate(data)
 
 
 def get_latest_mean_reversion_zscore_signal(
     data: pd.DataFrame,
-    config: Optional[MeanReversionZscoreConfig] = None,
-    position: Optional[MeanReversionZscorePositionContext] = None,
+    config: MeanReversionZscoreConfig | None = None,
+    position: MeanReversionZscorePositionContext | None = None,
 ) -> MeanReversionZscoreDecision:
     return MeanReversionZscoreSignalGenerator(config=config).latest_signal(data, position=position)
 
@@ -297,14 +298,14 @@ get_latest_nifty_mean_reversion_zscore_signal = get_latest_mean_reversion_zscore
 
 __all__ = [
     "MeanReversionZscoreConfig",
-    "MeanReversionZscorePositionContext",
     "MeanReversionZscoreDecision",
-    "build_mean_reversion_zscore_with_indicators",
+    "MeanReversionZscorePositionContext",
     "MeanReversionZscoreSignalEngine",
     "MeanReversionZscoreSignalGenerator",
-    "generate_mean_reversion_zscore_signals",
-    "get_latest_mean_reversion_zscore_signal",
     "NiftyMeanReversionZscoreSignalGenerator",
+    "build_mean_reversion_zscore_with_indicators",
+    "generate_mean_reversion_zscore_signals",
     "generate_nifty_mean_reversion_zscore_signals",
+    "get_latest_mean_reversion_zscore_signal",
     "get_latest_nifty_mean_reversion_zscore_signal",
 ]

--- a/Signal Generators/Nifty Multi Timeframe Signal Generator.py
+++ b/Signal Generators/Nifty Multi Timeframe Signal Generator.py
@@ -32,10 +32,9 @@ This module does not resample - feed it already-prepared OHLC candles.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any
 
 import pandas as pd
-
 from misc_strategy_common import ema, finite, normalize_ohlc_frame, require_columns, rsi, sma
 
 
@@ -93,7 +92,7 @@ class MultiTimeframeDecision:
 
 def build_multi_timeframe_with_indicators(
     ohlc: pd.DataFrame,
-    config: Optional[MultiTimeframeConfig] = None,
+    config: MultiTimeframeConfig | None = None,
 ) -> pd.DataFrame:
     """Enrich OHLC candles with trend SMA, EMA crossover flags, RSI, and risk levels."""
     config = config or MultiTimeframeConfig()
@@ -134,7 +133,7 @@ def build_multi_timeframe_with_indicators(
 class MultiTimeframeSignalEngine:
     """Decision engine for multi-timeframe trend entries and exits."""
 
-    def __init__(self, config: Optional[MultiTimeframeConfig] = None) -> None:
+    def __init__(self, config: MultiTimeframeConfig | None = None) -> None:
         self.config = config or MultiTimeframeConfig()
 
     def minimum_history_bars(self) -> int:
@@ -176,7 +175,7 @@ class MultiTimeframeSignalEngine:
     def evaluate_candle(
         self,
         candles_with_indicators: pd.DataFrame,
-        position: Optional[MultiTimeframePositionContext] = None,
+        position: MultiTimeframePositionContext | None = None,
     ) -> MultiTimeframeDecision:
         if candles_with_indicators is None or candles_with_indicators.empty:
             return self._hold("No candles supplied.")
@@ -233,7 +232,7 @@ class MultiTimeframeSignalEngine:
 class MultiTimeframeSignalGenerator:
     """Convenience wrapper for full-history and latest-candle multi-timeframe signals."""
 
-    def __init__(self, config: Optional[MultiTimeframeConfig] = None) -> None:
+    def __init__(self, config: MultiTimeframeConfig | None = None) -> None:
         self.config = config or MultiTimeframeConfig()
         self.engine = MultiTimeframeSignalEngine(self.config)
 
@@ -247,7 +246,7 @@ class MultiTimeframeSignalGenerator:
         stops: list[float] = []
         targets: list[float] = []
         stream: list[int] = []
-        position: Optional[MultiTimeframePositionContext] = None
+        position: MultiTimeframePositionContext | None = None
 
         for index in range(len(frame)):
             decision = self.engine.evaluate_candle(frame.iloc[: index + 1], position=position)
@@ -283,7 +282,7 @@ class MultiTimeframeSignalGenerator:
     def latest_signal(
         self,
         data: pd.DataFrame,
-        position: Optional[MultiTimeframePositionContext] = None,
+        position: MultiTimeframePositionContext | None = None,
     ) -> MultiTimeframeDecision:
         frame = build_multi_timeframe_with_indicators(data, self.config)
         return self.engine.evaluate_candle(frame, position=position)
@@ -291,15 +290,15 @@ class MultiTimeframeSignalGenerator:
 
 def generate_multi_timeframe_signals(
     data: pd.DataFrame,
-    config: Optional[MultiTimeframeConfig] = None,
+    config: MultiTimeframeConfig | None = None,
 ) -> pd.DataFrame:
     return MultiTimeframeSignalGenerator(config=config).generate(data)
 
 
 def get_latest_multi_timeframe_signal(
     data: pd.DataFrame,
-    config: Optional[MultiTimeframeConfig] = None,
-    position: Optional[MultiTimeframePositionContext] = None,
+    config: MultiTimeframeConfig | None = None,
+    position: MultiTimeframePositionContext | None = None,
 ) -> MultiTimeframeDecision:
     return MultiTimeframeSignalGenerator(config=config).latest_signal(data, position=position)
 
@@ -311,14 +310,14 @@ get_latest_nifty_multi_timeframe_signal = get_latest_multi_timeframe_signal
 
 __all__ = [
     "MultiTimeframeConfig",
-    "MultiTimeframePositionContext",
     "MultiTimeframeDecision",
-    "build_multi_timeframe_with_indicators",
+    "MultiTimeframePositionContext",
     "MultiTimeframeSignalEngine",
     "MultiTimeframeSignalGenerator",
-    "generate_multi_timeframe_signals",
-    "get_latest_multi_timeframe_signal",
     "NiftyMultiTimeframeSignalGenerator",
+    "build_multi_timeframe_with_indicators",
+    "generate_multi_timeframe_signals",
     "generate_nifty_multi_timeframe_signals",
+    "get_latest_multi_timeframe_signal",
     "get_latest_nifty_multi_timeframe_signal",
 ]

--- a/Signal Generators/Nifty Opening Range Breakout Signal Generator.py
+++ b/Signal Generators/Nifty Opening Range Breakout Signal Generator.py
@@ -34,10 +34,9 @@ This module does not resample - feed it already-prepared OHLC candles.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any
 
 import pandas as pd
-
 from misc_strategy_common import atr, finite, normalize_ohlc_frame, require_columns
 
 
@@ -82,7 +81,7 @@ class OpeningRangeBreakoutDecision:
 
 def build_opening_range_breakout_with_indicators(
     ohlc: pd.DataFrame,
-    config: Optional[OpeningRangeBreakoutConfig] = None,
+    config: OpeningRangeBreakoutConfig | None = None,
 ) -> pd.DataFrame:
     """Enrich OHLC candles with ATR-scaled opening-range levels and cross flags."""
     config = config or OpeningRangeBreakoutConfig()
@@ -114,7 +113,7 @@ def build_opening_range_breakout_with_indicators(
 class OpeningRangeBreakoutSignalEngine:
     """Decision engine for opening range breakout entries and exits."""
 
-    def __init__(self, config: Optional[OpeningRangeBreakoutConfig] = None) -> None:
+    def __init__(self, config: OpeningRangeBreakoutConfig | None = None) -> None:
         self.config = config or OpeningRangeBreakoutConfig()
 
     def minimum_history_bars(self) -> int:
@@ -132,7 +131,9 @@ class OpeningRangeBreakoutSignalEngine:
     def _direction(direction: str) -> str:
         return str(direction).strip().upper()
 
-    def _evaluate_exit(self, current: pd.Series, position: OpeningRangeBreakoutPositionContext) -> OpeningRangeBreakoutDecision:
+    def _evaluate_exit(
+        self, current: pd.Series, position: OpeningRangeBreakoutPositionContext
+    ) -> OpeningRangeBreakoutDecision:
         direction = self._direction(position.direction)
         high = float(current["high"])
         low = float(current["low"])
@@ -156,7 +157,7 @@ class OpeningRangeBreakoutSignalEngine:
     def evaluate_candle(
         self,
         candles_with_indicators: pd.DataFrame,
-        position: Optional[OpeningRangeBreakoutPositionContext] = None,
+        position: OpeningRangeBreakoutPositionContext | None = None,
     ) -> OpeningRangeBreakoutDecision:
         if candles_with_indicators is None or candles_with_indicators.empty:
             return self._hold("No candles supplied.")
@@ -213,7 +214,7 @@ class OpeningRangeBreakoutSignalEngine:
 class OpeningRangeBreakoutSignalGenerator:
     """Convenience wrapper for full-history and latest-candle ORB signals."""
 
-    def __init__(self, config: Optional[OpeningRangeBreakoutConfig] = None) -> None:
+    def __init__(self, config: OpeningRangeBreakoutConfig | None = None) -> None:
         self.config = config or OpeningRangeBreakoutConfig()
         self.engine = OpeningRangeBreakoutSignalEngine(self.config)
 
@@ -227,7 +228,7 @@ class OpeningRangeBreakoutSignalGenerator:
         stops: list[float] = []
         targets: list[float] = []
         stream: list[int] = []
-        position: Optional[OpeningRangeBreakoutPositionContext] = None
+        position: OpeningRangeBreakoutPositionContext | None = None
 
         for index in range(len(frame)):
             decision = self.engine.evaluate_candle(frame.iloc[: index + 1], position=position)
@@ -263,7 +264,7 @@ class OpeningRangeBreakoutSignalGenerator:
     def latest_signal(
         self,
         data: pd.DataFrame,
-        position: Optional[OpeningRangeBreakoutPositionContext] = None,
+        position: OpeningRangeBreakoutPositionContext | None = None,
     ) -> OpeningRangeBreakoutDecision:
         frame = build_opening_range_breakout_with_indicators(data, self.config)
         return self.engine.evaluate_candle(frame, position=position)
@@ -271,15 +272,15 @@ class OpeningRangeBreakoutSignalGenerator:
 
 def generate_opening_range_breakout_signals(
     data: pd.DataFrame,
-    config: Optional[OpeningRangeBreakoutConfig] = None,
+    config: OpeningRangeBreakoutConfig | None = None,
 ) -> pd.DataFrame:
     return OpeningRangeBreakoutSignalGenerator(config=config).generate(data)
 
 
 def get_latest_opening_range_breakout_signal(
     data: pd.DataFrame,
-    config: Optional[OpeningRangeBreakoutConfig] = None,
-    position: Optional[OpeningRangeBreakoutPositionContext] = None,
+    config: OpeningRangeBreakoutConfig | None = None,
+    position: OpeningRangeBreakoutPositionContext | None = None,
 ) -> OpeningRangeBreakoutDecision:
     return OpeningRangeBreakoutSignalGenerator(config=config).latest_signal(data, position=position)
 
@@ -290,15 +291,15 @@ get_latest_nifty_opening_range_breakout_signal = get_latest_opening_range_breako
 
 
 __all__ = [
+    "NiftyOpeningRangeBreakoutSignalGenerator",
     "OpeningRangeBreakoutConfig",
-    "OpeningRangeBreakoutPositionContext",
     "OpeningRangeBreakoutDecision",
-    "build_opening_range_breakout_with_indicators",
+    "OpeningRangeBreakoutPositionContext",
     "OpeningRangeBreakoutSignalEngine",
     "OpeningRangeBreakoutSignalGenerator",
-    "generate_opening_range_breakout_signals",
-    "get_latest_opening_range_breakout_signal",
-    "NiftyOpeningRangeBreakoutSignalGenerator",
+    "build_opening_range_breakout_with_indicators",
     "generate_nifty_opening_range_breakout_signals",
+    "generate_opening_range_breakout_signals",
     "get_latest_nifty_opening_range_breakout_signal",
+    "get_latest_opening_range_breakout_signal",
 ]

--- a/Signal Generators/Nifty Opening Strike PCR VWAP ATR Signal Generator.py
+++ b/Signal Generators/Nifty Opening Strike PCR VWAP ATR Signal Generator.py
@@ -52,9 +52,10 @@ the opening strike fixed and block duplicate entries when configured to do so.
 Create a new engine, or call `reset_trading_day()`, for a new trading day.
 """
 
-from dataclasses import asdict, dataclass, field
 import math
-from typing import Any, Iterable, Optional
+from collections.abc import Iterable
+from dataclasses import asdict, dataclass, field
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -141,7 +142,7 @@ class NiftyOpeningStrikePCRVWAPATRDecision:
 # =============================================================================
 # SMALL INPUT AND INDICATOR HELPERS
 # =============================================================================
-def _find_first_col(frame: pd.DataFrame, names: Iterable[str]) -> Optional[str]:
+def _find_first_col(frame: pd.DataFrame, names: Iterable[str]) -> str | None:
     """
     Find a column by comparing lower-case, trimmed column names.
 
@@ -269,7 +270,7 @@ def _normalize_option_chain_frame(data: pd.DataFrame) -> pd.DataFrame:
     return grouped
 
 
-def _attach_vwap(frame: pd.DataFrame) -> tuple[pd.DataFrame, Optional[str]]:
+def _attach_vwap(frame: pd.DataFrame) -> tuple[pd.DataFrame, str | None]:
     """Use an existing VWAP column or calculate VWAP from OHLCV."""
 
     result = frame.copy()
@@ -407,9 +408,9 @@ class NiftyOpeningStrikePCRVWAPATRSignalGenerator:
     - `_entry_signal_sent`: used to block duplicate entries when configured.
     """
 
-    def __init__(self, config: Optional[NiftyOpeningStrikePCRVWAPATRConfig] = None):
+    def __init__(self, config: NiftyOpeningStrikePCRVWAPATRConfig | None = None):
         self.config = config or NiftyOpeningStrikePCRVWAPATRConfig()
-        self.starting_strike: Optional[int] = None
+        self.starting_strike: int | None = None
         self._starting_strike_source = ""
         self._entry_signal_sent = False
 
@@ -448,9 +449,9 @@ class NiftyOpeningStrikePCRVWAPATRSignalGenerator:
     def _ensure_starting_strike(
         self,
         ohlc: pd.DataFrame,
-        opening_price: Optional[float],
+        opening_price: float | None,
         debug: dict[str, Any],
-    ) -> Optional[str]:
+    ) -> str | None:
         """Set starting strike once, then keep it fixed."""
 
         if self.starting_strike is not None:
@@ -478,13 +479,13 @@ class NiftyOpeningStrikePCRVWAPATRSignalGenerator:
         self,
         option_chain: pd.DataFrame,
         debug: dict[str, Any],
-    ) -> Optional[str]:
+    ) -> str | None:
         """Calculate PCR-change inputs and store them in debug."""
 
         selected_strikes = self._selected_pcr_strikes()
         debug["selected_pcr_strikes"] = selected_strikes
 
-        available_strikes = set(int(strike) for strike in option_chain["strike"].tolist())
+        available_strikes = {int(strike) for strike in option_chain["strike"].tolist()}
         missing_strikes = [strike for strike in selected_strikes if strike not in available_strikes]
         debug["missing_selected_pcr_strikes"] = missing_strikes
         if missing_strikes:
@@ -552,7 +553,7 @@ class NiftyOpeningStrikePCRVWAPATRSignalGenerator:
         self,
         ohlc: pd.DataFrame,
         option_chain_oi_change: pd.DataFrame,
-        opening_price: Optional[float] = None,
+        opening_price: float | None = None,
     ) -> NiftyOpeningStrikePCRVWAPATRDecision:
         """
         Evaluate the latest supplied OHLC candle and return one decision.
@@ -743,8 +744,8 @@ class NiftyOpeningStrikePCRVWAPATRSignalGenerator:
 def get_latest_nifty_opening_strike_pcr_vwap_atr_signal(
     ohlc: pd.DataFrame,
     option_chain_oi_change: pd.DataFrame,
-    config: Optional[NiftyOpeningStrikePCRVWAPATRConfig] = None,
-    opening_price: Optional[float] = None,
+    config: NiftyOpeningStrikePCRVWAPATRConfig | None = None,
+    opening_price: float | None = None,
 ) -> NiftyOpeningStrikePCRVWAPATRDecision:
     """
     One-shot helper for callers who do not want to instantiate the engine.

--- a/Signal Generators/Nifty Parabolic SAR Signal Generator.py
+++ b/Signal Generators/Nifty Parabolic SAR Signal Generator.py
@@ -32,10 +32,9 @@ This module does not resample - feed it already-prepared OHLC candles.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any
 
 import pandas as pd
-
 from misc_strategy_common import adx, finite, normalize_ohlc_frame, parabolic_sar, require_columns
 
 
@@ -85,7 +84,7 @@ class ParabolicSARDecision:
 
 def build_parabolic_sar_with_indicators(
     ohlc: pd.DataFrame,
-    config: Optional[ParabolicSARConfig] = None,
+    config: ParabolicSARConfig | None = None,
 ) -> pd.DataFrame:
     """Enrich OHLC candles with SAR, SAR direction, ADX, flip flags, and risk levels."""
     config = config or ParabolicSARConfig()
@@ -121,7 +120,7 @@ def build_parabolic_sar_with_indicators(
 class ParabolicSARSignalEngine:
     """Decision engine for Parabolic SAR entries and exits."""
 
-    def __init__(self, config: Optional[ParabolicSARConfig] = None) -> None:
+    def __init__(self, config: ParabolicSARConfig | None = None) -> None:
         self.config = config or ParabolicSARConfig()
 
     def minimum_history_bars(self) -> int:
@@ -170,7 +169,7 @@ class ParabolicSARSignalEngine:
     def evaluate_candle(
         self,
         candles_with_indicators: pd.DataFrame,
-        position: Optional[ParabolicSARPositionContext] = None,
+        position: ParabolicSARPositionContext | None = None,
     ) -> ParabolicSARDecision:
         if candles_with_indicators is None or candles_with_indicators.empty:
             return self._hold("No candles supplied.")
@@ -227,7 +226,7 @@ class ParabolicSARSignalEngine:
 class ParabolicSARSignalGenerator:
     """Convenience wrapper for full-history and latest-candle Parabolic SAR signals."""
 
-    def __init__(self, config: Optional[ParabolicSARConfig] = None) -> None:
+    def __init__(self, config: ParabolicSARConfig | None = None) -> None:
         self.config = config or ParabolicSARConfig()
         self.engine = ParabolicSARSignalEngine(self.config)
 
@@ -241,7 +240,7 @@ class ParabolicSARSignalGenerator:
         stops: list[float] = []
         targets: list[float] = []
         stream: list[int] = []
-        position: Optional[ParabolicSARPositionContext] = None
+        position: ParabolicSARPositionContext | None = None
 
         for index in range(len(frame)):
             decision = self.engine.evaluate_candle(frame.iloc[: index + 1], position=position)
@@ -277,7 +276,7 @@ class ParabolicSARSignalGenerator:
     def latest_signal(
         self,
         data: pd.DataFrame,
-        position: Optional[ParabolicSARPositionContext] = None,
+        position: ParabolicSARPositionContext | None = None,
     ) -> ParabolicSARDecision:
         frame = build_parabolic_sar_with_indicators(data, self.config)
         return self.engine.evaluate_candle(frame, position=position)
@@ -285,15 +284,15 @@ class ParabolicSARSignalGenerator:
 
 def generate_parabolic_sar_signals(
     data: pd.DataFrame,
-    config: Optional[ParabolicSARConfig] = None,
+    config: ParabolicSARConfig | None = None,
 ) -> pd.DataFrame:
     return ParabolicSARSignalGenerator(config=config).generate(data)
 
 
 def get_latest_parabolic_sar_signal(
     data: pd.DataFrame,
-    config: Optional[ParabolicSARConfig] = None,
-    position: Optional[ParabolicSARPositionContext] = None,
+    config: ParabolicSARConfig | None = None,
+    position: ParabolicSARPositionContext | None = None,
 ) -> ParabolicSARDecision:
     return ParabolicSARSignalGenerator(config=config).latest_signal(data, position=position)
 
@@ -304,15 +303,15 @@ get_latest_nifty_parabolic_sar_signal = get_latest_parabolic_sar_signal
 
 
 __all__ = [
+    "NiftyParabolicSARSignalGenerator",
     "ParabolicSARConfig",
-    "ParabolicSARPositionContext",
     "ParabolicSARDecision",
-    "build_parabolic_sar_with_indicators",
+    "ParabolicSARPositionContext",
     "ParabolicSARSignalEngine",
     "ParabolicSARSignalGenerator",
-    "generate_parabolic_sar_signals",
-    "get_latest_parabolic_sar_signal",
-    "NiftyParabolicSARSignalGenerator",
+    "build_parabolic_sar_with_indicators",
     "generate_nifty_parabolic_sar_signals",
+    "generate_parabolic_sar_signals",
     "get_latest_nifty_parabolic_sar_signal",
+    "get_latest_parabolic_sar_signal",
 ]

--- a/Signal Generators/Nifty RSI Divergence Signal Generator.py
+++ b/Signal Generators/Nifty RSI Divergence Signal Generator.py
@@ -38,11 +38,10 @@ This module does not resample - feed it already-prepared OHLC candles.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any
 
 import numpy as np
 import pandas as pd
-
 from misc_strategy_common import (
     find_swing_highs,
     find_swing_lows,
@@ -92,7 +91,7 @@ class RSIDivergenceDecision:
     debug: dict[str, Any] = field(default_factory=dict)  # optional extra diagnostics
 
 
-def _last_two_at_or_before(positions: list[int], limit: int) -> Optional[tuple[int, int]]:
+def _last_two_at_or_before(positions: list[int], limit: int) -> tuple[int, int] | None:
     """Return the last two swing positions that are confirmed by `limit`."""
     eligible = [p for p in positions if p <= limit]
     if len(eligible) < 2:
@@ -102,7 +101,7 @@ def _last_two_at_or_before(positions: list[int], limit: int) -> Optional[tuple[i
 
 def build_rsi_divergence_with_indicators(
     ohlc: pd.DataFrame,
-    config: Optional[RSIDivergenceConfig] = None,
+    config: RSIDivergenceConfig | None = None,
 ) -> pd.DataFrame:
     """Enrich OHLC candles with RSI, divergence flags, and risk levels."""
     config = config or RSIDivergenceConfig()
@@ -176,7 +175,7 @@ def build_rsi_divergence_with_indicators(
 class RSIDivergenceSignalEngine:
     """Decision engine for RSI divergence entries and exits."""
 
-    def __init__(self, config: Optional[RSIDivergenceConfig] = None) -> None:
+    def __init__(self, config: RSIDivergenceConfig | None = None) -> None:
         self.config = config or RSIDivergenceConfig()
 
     def minimum_history_bars(self) -> int:
@@ -218,7 +217,7 @@ class RSIDivergenceSignalEngine:
     def evaluate_candle(
         self,
         candles_with_indicators: pd.DataFrame,
-        position: Optional[RSIDivergencePositionContext] = None,
+        position: RSIDivergencePositionContext | None = None,
     ) -> RSIDivergenceDecision:
         if candles_with_indicators is None or candles_with_indicators.empty:
             return self._hold("No candles supplied.")
@@ -275,7 +274,7 @@ class RSIDivergenceSignalEngine:
 class RSIDivergenceSignalGenerator:
     """Convenience wrapper for full-history and latest-candle RSI divergence signals."""
 
-    def __init__(self, config: Optional[RSIDivergenceConfig] = None) -> None:
+    def __init__(self, config: RSIDivergenceConfig | None = None) -> None:
         self.config = config or RSIDivergenceConfig()
         self.engine = RSIDivergenceSignalEngine(self.config)
 
@@ -289,7 +288,7 @@ class RSIDivergenceSignalGenerator:
         stops: list[float] = []
         targets: list[float] = []
         stream: list[int] = []
-        position: Optional[RSIDivergencePositionContext] = None
+        position: RSIDivergencePositionContext | None = None
 
         for index in range(len(frame)):
             decision = self.engine.evaluate_candle(frame.iloc[: index + 1], position=position)
@@ -325,7 +324,7 @@ class RSIDivergenceSignalGenerator:
     def latest_signal(
         self,
         data: pd.DataFrame,
-        position: Optional[RSIDivergencePositionContext] = None,
+        position: RSIDivergencePositionContext | None = None,
     ) -> RSIDivergenceDecision:
         frame = build_rsi_divergence_with_indicators(data, self.config)
         return self.engine.evaluate_candle(frame, position=position)
@@ -333,15 +332,15 @@ class RSIDivergenceSignalGenerator:
 
 def generate_rsi_divergence_signals(
     data: pd.DataFrame,
-    config: Optional[RSIDivergenceConfig] = None,
+    config: RSIDivergenceConfig | None = None,
 ) -> pd.DataFrame:
     return RSIDivergenceSignalGenerator(config=config).generate(data)
 
 
 def get_latest_rsi_divergence_signal(
     data: pd.DataFrame,
-    config: Optional[RSIDivergenceConfig] = None,
-    position: Optional[RSIDivergencePositionContext] = None,
+    config: RSIDivergenceConfig | None = None,
+    position: RSIDivergencePositionContext | None = None,
 ) -> RSIDivergenceDecision:
     return RSIDivergenceSignalGenerator(config=config).latest_signal(data, position=position)
 
@@ -352,15 +351,15 @@ get_latest_nifty_rsi_divergence_signal = get_latest_rsi_divergence_signal
 
 
 __all__ = [
+    "NiftyRSIDivergenceSignalGenerator",
     "RSIDivergenceConfig",
-    "RSIDivergencePositionContext",
     "RSIDivergenceDecision",
-    "build_rsi_divergence_with_indicators",
+    "RSIDivergencePositionContext",
     "RSIDivergenceSignalEngine",
     "RSIDivergenceSignalGenerator",
-    "generate_rsi_divergence_signals",
-    "get_latest_rsi_divergence_signal",
-    "NiftyRSIDivergenceSignalGenerator",
+    "build_rsi_divergence_with_indicators",
     "generate_nifty_rsi_divergence_signals",
+    "generate_rsi_divergence_signals",
     "get_latest_nifty_rsi_divergence_signal",
+    "get_latest_rsi_divergence_signal",
 ]

--- a/Signal Generators/Nifty RSI Reversal Signal Generator.py
+++ b/Signal Generators/Nifty RSI Reversal Signal Generator.py
@@ -31,10 +31,9 @@ This module does not resample - feed it already-prepared OHLC candles.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any
 
 import pandas as pd
-
 from misc_strategy_common import finite, normalize_ohlc_frame, require_columns, rsi
 
 
@@ -82,7 +81,7 @@ class RSIReversalDecision:
 
 def build_rsi_reversal_with_indicators(
     ohlc: pd.DataFrame,
-    config: Optional[RSIReversalConfig] = None,
+    config: RSIReversalConfig | None = None,
 ) -> pd.DataFrame:
     """Enrich OHLC candles with RSI, oversold/overbought cross flags, and risk levels."""
     config = config or RSIReversalConfig()
@@ -111,7 +110,7 @@ def build_rsi_reversal_with_indicators(
 class RSIReversalSignalEngine:
     """Decision engine for RSI reversal entries and exits."""
 
-    def __init__(self, config: Optional[RSIReversalConfig] = None) -> None:
+    def __init__(self, config: RSIReversalConfig | None = None) -> None:
         self.config = config or RSIReversalConfig()
 
     def minimum_history_bars(self) -> int:
@@ -132,7 +131,7 @@ class RSIReversalSignalEngine:
     def _evaluate_exit(
         self,
         current: pd.Series,
-        prev: Optional[pd.Series],
+        prev: pd.Series | None,
         position: RSIReversalPositionContext,
     ) -> RSIReversalDecision:
         direction = self._direction(position.direction)
@@ -180,7 +179,7 @@ class RSIReversalSignalEngine:
     def evaluate_candle(
         self,
         candles_with_indicators: pd.DataFrame,
-        position: Optional[RSIReversalPositionContext] = None,
+        position: RSIReversalPositionContext | None = None,
     ) -> RSIReversalDecision:
         if candles_with_indicators is None or candles_with_indicators.empty:
             return self._hold("No candles supplied.")
@@ -238,7 +237,7 @@ class RSIReversalSignalEngine:
 class RSIReversalSignalGenerator:
     """Convenience wrapper for full-history and latest-candle RSI reversal signals."""
 
-    def __init__(self, config: Optional[RSIReversalConfig] = None) -> None:
+    def __init__(self, config: RSIReversalConfig | None = None) -> None:
         self.config = config or RSIReversalConfig()
         self.engine = RSIReversalSignalEngine(self.config)
 
@@ -252,7 +251,7 @@ class RSIReversalSignalGenerator:
         stops: list[float] = []
         targets: list[float] = []
         stream: list[int] = []
-        position: Optional[RSIReversalPositionContext] = None
+        position: RSIReversalPositionContext | None = None
 
         for index in range(len(frame)):
             decision = self.engine.evaluate_candle(frame.iloc[: index + 1], position=position)
@@ -288,7 +287,7 @@ class RSIReversalSignalGenerator:
     def latest_signal(
         self,
         data: pd.DataFrame,
-        position: Optional[RSIReversalPositionContext] = None,
+        position: RSIReversalPositionContext | None = None,
     ) -> RSIReversalDecision:
         frame = build_rsi_reversal_with_indicators(data, self.config)
         return self.engine.evaluate_candle(frame, position=position)
@@ -296,15 +295,15 @@ class RSIReversalSignalGenerator:
 
 def generate_rsi_reversal_signals(
     data: pd.DataFrame,
-    config: Optional[RSIReversalConfig] = None,
+    config: RSIReversalConfig | None = None,
 ) -> pd.DataFrame:
     return RSIReversalSignalGenerator(config=config).generate(data)
 
 
 def get_latest_rsi_reversal_signal(
     data: pd.DataFrame,
-    config: Optional[RSIReversalConfig] = None,
-    position: Optional[RSIReversalPositionContext] = None,
+    config: RSIReversalConfig | None = None,
+    position: RSIReversalPositionContext | None = None,
 ) -> RSIReversalDecision:
     return RSIReversalSignalGenerator(config=config).latest_signal(data, position=position)
 
@@ -315,15 +314,15 @@ get_latest_nifty_rsi_reversal_signal = get_latest_rsi_reversal_signal
 
 
 __all__ = [
+    "NiftyRSIReversalSignalGenerator",
     "RSIReversalConfig",
-    "RSIReversalPositionContext",
     "RSIReversalDecision",
-    "build_rsi_reversal_with_indicators",
+    "RSIReversalPositionContext",
     "RSIReversalSignalEngine",
     "RSIReversalSignalGenerator",
-    "generate_rsi_reversal_signals",
-    "get_latest_rsi_reversal_signal",
-    "NiftyRSIReversalSignalGenerator",
+    "build_rsi_reversal_with_indicators",
     "generate_nifty_rsi_reversal_signals",
+    "generate_rsi_reversal_signals",
     "get_latest_nifty_rsi_reversal_signal",
+    "get_latest_rsi_reversal_signal",
 ]

--- a/Signal Generators/Nifty SMA Crossover Signal Generator.py
+++ b/Signal Generators/Nifty SMA Crossover Signal Generator.py
@@ -33,10 +33,9 @@ This module does not resample - feed it already-prepared OHLC candles.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any
 
 import pandas as pd
-
 from misc_strategy_common import finite, normalize_ohlc_frame, require_columns, sma
 
 
@@ -87,7 +86,7 @@ class SMACrossoverDecision:
 
 def build_sma_crossover_with_indicators(
     ohlc: pd.DataFrame,
-    config: Optional[SMACrossoverConfig] = None,
+    config: SMACrossoverConfig | None = None,
 ) -> pd.DataFrame:
     """Enrich OHLC candles with fast/slow SMAs, crossover flags, and risk levels."""
     config = config or SMACrossoverConfig()
@@ -122,7 +121,7 @@ def build_sma_crossover_with_indicators(
 class SMACrossoverSignalEngine:
     """Decision engine for SMA crossover entries and exits."""
 
-    def __init__(self, config: Optional[SMACrossoverConfig] = None) -> None:
+    def __init__(self, config: SMACrossoverConfig | None = None) -> None:
         self.config = config or SMACrossoverConfig()
 
     def minimum_history_bars(self) -> int:
@@ -171,7 +170,7 @@ class SMACrossoverSignalEngine:
     def evaluate_candle(
         self,
         candles_with_indicators: pd.DataFrame,
-        position: Optional[SMACrossoverPositionContext] = None,
+        position: SMACrossoverPositionContext | None = None,
     ) -> SMACrossoverDecision:
         if candles_with_indicators is None or candles_with_indicators.empty:
             return self._hold("No candles supplied.")
@@ -228,7 +227,7 @@ class SMACrossoverSignalEngine:
 class SMACrossoverSignalGenerator:
     """Convenience wrapper for full-history and latest-candle SMA crossover signals."""
 
-    def __init__(self, config: Optional[SMACrossoverConfig] = None) -> None:
+    def __init__(self, config: SMACrossoverConfig | None = None) -> None:
         self.config = config or SMACrossoverConfig()
         self.engine = SMACrossoverSignalEngine(self.config)
 
@@ -242,7 +241,7 @@ class SMACrossoverSignalGenerator:
         stops: list[float] = []
         targets: list[float] = []
         stream: list[int] = []
-        position: Optional[SMACrossoverPositionContext] = None
+        position: SMACrossoverPositionContext | None = None
 
         for index in range(len(frame)):
             decision = self.engine.evaluate_candle(frame.iloc[: index + 1], position=position)
@@ -278,7 +277,7 @@ class SMACrossoverSignalGenerator:
     def latest_signal(
         self,
         data: pd.DataFrame,
-        position: Optional[SMACrossoverPositionContext] = None,
+        position: SMACrossoverPositionContext | None = None,
     ) -> SMACrossoverDecision:
         frame = build_sma_crossover_with_indicators(data, self.config)
         return self.engine.evaluate_candle(frame, position=position)
@@ -286,7 +285,7 @@ class SMACrossoverSignalGenerator:
 
 def generate_sma_crossover_signals(
     data: pd.DataFrame,
-    config: Optional[SMACrossoverConfig] = None,
+    config: SMACrossoverConfig | None = None,
 ) -> pd.DataFrame:
     """Functional wrapper for full-history SMA crossover signals."""
     return SMACrossoverSignalGenerator(config=config).generate(data)
@@ -294,8 +293,8 @@ def generate_sma_crossover_signals(
 
 def get_latest_sma_crossover_signal(
     data: pd.DataFrame,
-    config: Optional[SMACrossoverConfig] = None,
-    position: Optional[SMACrossoverPositionContext] = None,
+    config: SMACrossoverConfig | None = None,
+    position: SMACrossoverPositionContext | None = None,
 ) -> SMACrossoverDecision:
     """Functional wrapper for the latest SMA crossover decision."""
     return SMACrossoverSignalGenerator(config=config).latest_signal(data, position=position)
@@ -308,15 +307,15 @@ get_latest_nifty_sma_crossover_signal = get_latest_sma_crossover_signal
 
 
 __all__ = [
+    "NiftySMACrossoverSignalGenerator",
     "SMACrossoverConfig",
-    "SMACrossoverPositionContext",
     "SMACrossoverDecision",
-    "build_sma_crossover_with_indicators",
+    "SMACrossoverPositionContext",
     "SMACrossoverSignalEngine",
     "SMACrossoverSignalGenerator",
-    "generate_sma_crossover_signals",
-    "get_latest_sma_crossover_signal",
-    "NiftySMACrossoverSignalGenerator",
+    "build_sma_crossover_with_indicators",
     "generate_nifty_sma_crossover_signals",
+    "generate_sma_crossover_signals",
     "get_latest_nifty_sma_crossover_signal",
+    "get_latest_sma_crossover_signal",
 ]

--- a/Signal Generators/Nifty Stochastic Oscillator Signal Generator.py
+++ b/Signal Generators/Nifty Stochastic Oscillator Signal Generator.py
@@ -34,10 +34,9 @@ This module does not resample - feed it already-prepared OHLC candles.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any
 
 import pandas as pd
-
 from misc_strategy_common import finite, normalize_ohlc_frame, require_columns, sma, stochastic
 
 
@@ -94,7 +93,7 @@ class StochasticOscillatorDecision:
 
 def build_stochastic_oscillator_with_indicators(
     ohlc: pd.DataFrame,
-    config: Optional[StochasticOscillatorConfig] = None,
+    config: StochasticOscillatorConfig | None = None,
 ) -> pd.DataFrame:
     """Enrich OHLC candles with %K/%D, trend SMA, crossover flags, and risk levels."""
     config = config or StochasticOscillatorConfig()
@@ -135,7 +134,7 @@ def build_stochastic_oscillator_with_indicators(
 class StochasticOscillatorSignalEngine:
     """Decision engine for stochastic oscillator entries and exits."""
 
-    def __init__(self, config: Optional[StochasticOscillatorConfig] = None) -> None:
+    def __init__(self, config: StochasticOscillatorConfig | None = None) -> None:
         self.config = config or StochasticOscillatorConfig()
 
     def minimum_history_bars(self) -> int:
@@ -153,7 +152,9 @@ class StochasticOscillatorSignalEngine:
     def _direction(direction: str) -> str:
         return str(direction).strip().upper()
 
-    def _evaluate_exit(self, current: pd.Series, position: StochasticOscillatorPositionContext) -> StochasticOscillatorDecision:
+    def _evaluate_exit(
+        self, current: pd.Series, position: StochasticOscillatorPositionContext
+    ) -> StochasticOscillatorDecision:
         direction = self._direction(position.direction)
         high = float(current["high"])
         low = float(current["low"])
@@ -177,7 +178,7 @@ class StochasticOscillatorSignalEngine:
     def evaluate_candle(
         self,
         candles_with_indicators: pd.DataFrame,
-        position: Optional[StochasticOscillatorPositionContext] = None,
+        position: StochasticOscillatorPositionContext | None = None,
     ) -> StochasticOscillatorDecision:
         if candles_with_indicators is None or candles_with_indicators.empty:
             return self._hold("No candles supplied.")
@@ -234,7 +235,7 @@ class StochasticOscillatorSignalEngine:
 class StochasticOscillatorSignalGenerator:
     """Convenience wrapper for full-history and latest-candle stochastic signals."""
 
-    def __init__(self, config: Optional[StochasticOscillatorConfig] = None) -> None:
+    def __init__(self, config: StochasticOscillatorConfig | None = None) -> None:
         self.config = config or StochasticOscillatorConfig()
         self.engine = StochasticOscillatorSignalEngine(self.config)
 
@@ -248,7 +249,7 @@ class StochasticOscillatorSignalGenerator:
         stops: list[float] = []
         targets: list[float] = []
         stream: list[int] = []
-        position: Optional[StochasticOscillatorPositionContext] = None
+        position: StochasticOscillatorPositionContext | None = None
 
         for index in range(len(frame)):
             decision = self.engine.evaluate_candle(frame.iloc[: index + 1], position=position)
@@ -284,7 +285,7 @@ class StochasticOscillatorSignalGenerator:
     def latest_signal(
         self,
         data: pd.DataFrame,
-        position: Optional[StochasticOscillatorPositionContext] = None,
+        position: StochasticOscillatorPositionContext | None = None,
     ) -> StochasticOscillatorDecision:
         frame = build_stochastic_oscillator_with_indicators(data, self.config)
         return self.engine.evaluate_candle(frame, position=position)
@@ -292,15 +293,15 @@ class StochasticOscillatorSignalGenerator:
 
 def generate_stochastic_oscillator_signals(
     data: pd.DataFrame,
-    config: Optional[StochasticOscillatorConfig] = None,
+    config: StochasticOscillatorConfig | None = None,
 ) -> pd.DataFrame:
     return StochasticOscillatorSignalGenerator(config=config).generate(data)
 
 
 def get_latest_stochastic_oscillator_signal(
     data: pd.DataFrame,
-    config: Optional[StochasticOscillatorConfig] = None,
-    position: Optional[StochasticOscillatorPositionContext] = None,
+    config: StochasticOscillatorConfig | None = None,
+    position: StochasticOscillatorPositionContext | None = None,
 ) -> StochasticOscillatorDecision:
     return StochasticOscillatorSignalGenerator(config=config).latest_signal(data, position=position)
 
@@ -311,15 +312,15 @@ get_latest_nifty_stochastic_oscillator_signal = get_latest_stochastic_oscillator
 
 
 __all__ = [
+    "NiftyStochasticOscillatorSignalGenerator",
     "StochasticOscillatorConfig",
-    "StochasticOscillatorPositionContext",
     "StochasticOscillatorDecision",
-    "build_stochastic_oscillator_with_indicators",
+    "StochasticOscillatorPositionContext",
     "StochasticOscillatorSignalEngine",
     "StochasticOscillatorSignalGenerator",
-    "generate_stochastic_oscillator_signals",
-    "get_latest_stochastic_oscillator_signal",
-    "NiftyStochasticOscillatorSignalGenerator",
+    "build_stochastic_oscillator_with_indicators",
     "generate_nifty_stochastic_oscillator_signals",
+    "generate_stochastic_oscillator_signals",
     "get_latest_nifty_stochastic_oscillator_signal",
+    "get_latest_stochastic_oscillator_signal",
 ]

--- a/Signal Generators/Nifty Supertrend Signal Generator.py
+++ b/Signal Generators/Nifty Supertrend Signal Generator.py
@@ -41,10 +41,9 @@ This module does not resample - feed it already-prepared OHLC candles.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any
 
 import pandas as pd
-
 from misc_strategy_common import finite, normalize_ohlc_frame, require_columns, supertrend
 
 
@@ -88,7 +87,7 @@ class SupertrendDecision:
 
 def build_supertrend_with_indicators(
     ohlc: pd.DataFrame,
-    config: Optional[SupertrendConfig] = None,
+    config: SupertrendConfig | None = None,
 ) -> pd.DataFrame:
     """Enrich OHLC candles with the Supertrend line, direction, flip flags, and risk levels."""
     config = config or SupertrendConfig()
@@ -123,7 +122,7 @@ def build_supertrend_with_indicators(
 class SupertrendSignalEngine:
     """Decision engine for Supertrend flip entries and exits."""
 
-    def __init__(self, config: Optional[SupertrendConfig] = None) -> None:
+    def __init__(self, config: SupertrendConfig | None = None) -> None:
         self.config = config or SupertrendConfig()
 
     def minimum_history_bars(self) -> int:
@@ -172,7 +171,7 @@ class SupertrendSignalEngine:
     def evaluate_candle(
         self,
         candles_with_indicators: pd.DataFrame,
-        position: Optional[SupertrendPositionContext] = None,
+        position: SupertrendPositionContext | None = None,
     ) -> SupertrendDecision:
         if candles_with_indicators is None or candles_with_indicators.empty:
             return self._hold("No candles supplied.")
@@ -229,7 +228,7 @@ class SupertrendSignalEngine:
 class SupertrendSignalGenerator:
     """Convenience wrapper for full-history and latest-candle Supertrend signals."""
 
-    def __init__(self, config: Optional[SupertrendConfig] = None) -> None:
+    def __init__(self, config: SupertrendConfig | None = None) -> None:
         self.config = config or SupertrendConfig()
         self.engine = SupertrendSignalEngine(self.config)
 
@@ -243,7 +242,7 @@ class SupertrendSignalGenerator:
         stops: list[float] = []
         targets: list[float] = []
         stream: list[int] = []
-        position: Optional[SupertrendPositionContext] = None
+        position: SupertrendPositionContext | None = None
 
         for index in range(len(frame)):
             decision = self.engine.evaluate_candle(frame.iloc[: index + 1], position=position)
@@ -279,7 +278,7 @@ class SupertrendSignalGenerator:
     def latest_signal(
         self,
         data: pd.DataFrame,
-        position: Optional[SupertrendPositionContext] = None,
+        position: SupertrendPositionContext | None = None,
     ) -> SupertrendDecision:
         frame = build_supertrend_with_indicators(data, self.config)
         return self.engine.evaluate_candle(frame, position=position)
@@ -287,15 +286,15 @@ class SupertrendSignalGenerator:
 
 def generate_supertrend_signals(
     data: pd.DataFrame,
-    config: Optional[SupertrendConfig] = None,
+    config: SupertrendConfig | None = None,
 ) -> pd.DataFrame:
     return SupertrendSignalGenerator(config=config).generate(data)
 
 
 def get_latest_supertrend_signal(
     data: pd.DataFrame,
-    config: Optional[SupertrendConfig] = None,
-    position: Optional[SupertrendPositionContext] = None,
+    config: SupertrendConfig | None = None,
+    position: SupertrendPositionContext | None = None,
 ) -> SupertrendDecision:
     return SupertrendSignalGenerator(config=config).latest_signal(data, position=position)
 
@@ -306,15 +305,15 @@ get_latest_nifty_supertrend_misc_signal = get_latest_supertrend_signal
 
 
 __all__ = [
+    "NiftySupertrendMiscSignalGenerator",
     "SupertrendConfig",
-    "SupertrendPositionContext",
     "SupertrendDecision",
-    "build_supertrend_with_indicators",
+    "SupertrendPositionContext",
     "SupertrendSignalEngine",
     "SupertrendSignalGenerator",
-    "generate_supertrend_signals",
-    "get_latest_supertrend_signal",
-    "NiftySupertrendMiscSignalGenerator",
+    "build_supertrend_with_indicators",
     "generate_nifty_supertrend_misc_signals",
+    "generate_supertrend_signals",
     "get_latest_nifty_supertrend_misc_signal",
+    "get_latest_supertrend_signal",
 ]

--- a/Signal Generators/Nifty Volatility Breakout Signal Generator.py
+++ b/Signal Generators/Nifty Volatility Breakout Signal Generator.py
@@ -34,10 +34,9 @@ This module does not resample - feed it already-prepared OHLC candles.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any
 
 import pandas as pd
-
 from misc_strategy_common import finite, normalize_ohlc_frame, require_columns
 
 
@@ -79,7 +78,7 @@ class VolatilityBreakoutDecision:
 
 def build_volatility_breakout_with_indicators(
     ohlc: pd.DataFrame,
-    config: Optional[VolatilityBreakoutConfig] = None,
+    config: VolatilityBreakoutConfig | None = None,
 ) -> pd.DataFrame:
     """Enrich OHLC candles with breakout trigger levels and cross flags."""
     config = config or VolatilityBreakoutConfig()
@@ -95,8 +94,12 @@ def build_volatility_breakout_with_indicators(
 
     # Breakout = price was on the calm side of the trigger last candle and has
     # punched through it this candle (a fresh cross, not a sustained state).
-    frame["long_setup"] = ((close > frame["upper_trigger"]) & (prev_close <= frame["upper_trigger"].shift(1))).fillna(False)
-    frame["short_setup"] = ((close < frame["lower_trigger"]) & (prev_close >= frame["lower_trigger"].shift(1))).fillna(False)
+    frame["long_setup"] = (
+        (close > frame["upper_trigger"]) & (prev_close <= frame["upper_trigger"].shift(1))
+    ).fillna(False)
+    frame["short_setup"] = (
+        (close < frame["lower_trigger"]) & (prev_close >= frame["lower_trigger"].shift(1))
+    ).fillna(False)
 
     frame["long_entry_price"] = close
     frame["short_entry_price"] = close
@@ -110,7 +113,7 @@ def build_volatility_breakout_with_indicators(
 class VolatilityBreakoutSignalEngine:
     """Decision engine for volatility breakout entries and exits."""
 
-    def __init__(self, config: Optional[VolatilityBreakoutConfig] = None) -> None:
+    def __init__(self, config: VolatilityBreakoutConfig | None = None) -> None:
         self.config = config or VolatilityBreakoutConfig()
 
     def minimum_history_bars(self) -> int:
@@ -128,7 +131,9 @@ class VolatilityBreakoutSignalEngine:
     def _direction(direction: str) -> str:
         return str(direction).strip().upper()
 
-    def _evaluate_exit(self, current: pd.Series, position: VolatilityBreakoutPositionContext) -> VolatilityBreakoutDecision:
+    def _evaluate_exit(
+        self, current: pd.Series, position: VolatilityBreakoutPositionContext
+    ) -> VolatilityBreakoutDecision:
         direction = self._direction(position.direction)
         high = float(current["high"])
         low = float(current["low"])
@@ -152,7 +157,7 @@ class VolatilityBreakoutSignalEngine:
     def evaluate_candle(
         self,
         candles_with_indicators: pd.DataFrame,
-        position: Optional[VolatilityBreakoutPositionContext] = None,
+        position: VolatilityBreakoutPositionContext | None = None,
     ) -> VolatilityBreakoutDecision:
         if candles_with_indicators is None or candles_with_indicators.empty:
             return self._hold("No candles supplied.")
@@ -209,7 +214,7 @@ class VolatilityBreakoutSignalEngine:
 class VolatilityBreakoutSignalGenerator:
     """Convenience wrapper for full-history and latest-candle breakout signals."""
 
-    def __init__(self, config: Optional[VolatilityBreakoutConfig] = None) -> None:
+    def __init__(self, config: VolatilityBreakoutConfig | None = None) -> None:
         self.config = config or VolatilityBreakoutConfig()
         self.engine = VolatilityBreakoutSignalEngine(self.config)
 
@@ -223,7 +228,7 @@ class VolatilityBreakoutSignalGenerator:
         stops: list[float] = []
         targets: list[float] = []
         stream: list[int] = []
-        position: Optional[VolatilityBreakoutPositionContext] = None
+        position: VolatilityBreakoutPositionContext | None = None
 
         for index in range(len(frame)):
             decision = self.engine.evaluate_candle(frame.iloc[: index + 1], position=position)
@@ -259,7 +264,7 @@ class VolatilityBreakoutSignalGenerator:
     def latest_signal(
         self,
         data: pd.DataFrame,
-        position: Optional[VolatilityBreakoutPositionContext] = None,
+        position: VolatilityBreakoutPositionContext | None = None,
     ) -> VolatilityBreakoutDecision:
         frame = build_volatility_breakout_with_indicators(data, self.config)
         return self.engine.evaluate_candle(frame, position=position)
@@ -267,15 +272,15 @@ class VolatilityBreakoutSignalGenerator:
 
 def generate_volatility_breakout_signals(
     data: pd.DataFrame,
-    config: Optional[VolatilityBreakoutConfig] = None,
+    config: VolatilityBreakoutConfig | None = None,
 ) -> pd.DataFrame:
     return VolatilityBreakoutSignalGenerator(config=config).generate(data)
 
 
 def get_latest_volatility_breakout_signal(
     data: pd.DataFrame,
-    config: Optional[VolatilityBreakoutConfig] = None,
-    position: Optional[VolatilityBreakoutPositionContext] = None,
+    config: VolatilityBreakoutConfig | None = None,
+    position: VolatilityBreakoutPositionContext | None = None,
 ) -> VolatilityBreakoutDecision:
     return VolatilityBreakoutSignalGenerator(config=config).latest_signal(data, position=position)
 
@@ -286,15 +291,15 @@ get_latest_nifty_volatility_breakout_signal = get_latest_volatility_breakout_sig
 
 
 __all__ = [
+    "NiftyVolatilityBreakoutSignalGenerator",
     "VolatilityBreakoutConfig",
-    "VolatilityBreakoutPositionContext",
     "VolatilityBreakoutDecision",
-    "build_volatility_breakout_with_indicators",
+    "VolatilityBreakoutPositionContext",
     "VolatilityBreakoutSignalEngine",
     "VolatilityBreakoutSignalGenerator",
-    "generate_volatility_breakout_signals",
-    "get_latest_volatility_breakout_signal",
-    "NiftyVolatilityBreakoutSignalGenerator",
+    "build_volatility_breakout_with_indicators",
     "generate_nifty_volatility_breakout_signals",
+    "generate_volatility_breakout_signals",
     "get_latest_nifty_volatility_breakout_signal",
+    "get_latest_volatility_breakout_signal",
 ]

--- a/Signal Generators/SL Hunting AI Agent/README.md
+++ b/Signal Generators/SL Hunting AI Agent/README.md
@@ -182,6 +182,18 @@ note. Full analysis + provenance in the v3c addendum of `sl_hunting_doc.md`. The
 separately moved the worker's start to 09:15 via `SL_HUNTING_TRADING_START_*` in `.env`
 (config, not code).
 
+## Two-week verbatim sweep (v3c → v3d)
+All 18 in-window Intraday Hunter videos (18 Jun – 2 Jul sessions: 8 live trades, 9 nightly
+plan clips, 1 weekly) were re-extracted from **verbatim transcripts** (15 captured; 2 have no
+transcript; 1 was v3c). The wins AND losses together yielded the v3d layer: **read the gap
+against the prior days** (a big counter-gap is a lure, not a signal; small counter-gaps read
+as flat), the **SL-reachability test** (no hunt when the crowd's stops sit beyond an intact
+level), an **OPENING_DRIVE variant B** (flat-open seller-hunt long after multi-day selling),
+**gap-size asymmetry** across the three indices, the trap-construction leg, direction-first
+hierarchy over divergence setups, and several risk heuristics (two-rejections rule,
+early-adverse = wrong direction on expiry days, loss-streak bias). Per-video provenance and
+the win/loss evidence table live in the v3d addendum of `sl_hunting_doc.md`.
+
 ## Decision log
 The agent decides once per completed bar, but the worker only *logs* the bars where it
 acts — so a HOLD leaves just a `decision cost` line with no record of **what** it decided or

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_agent.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_agent.py
@@ -38,12 +38,11 @@ from typing import Any, Literal
 
 import pandas as pd
 from pydantic import Field, ValidationError, field_validator
-
 from sl_hunting_ai_validation import StrictAIModel
-from sl_hunting_knowledge import FINAL_OUTPUT_INSTRUCTION, build_system_prompt
-from sl_hunting_indicators import SLHuntingIndicatorConfig, prepare_candles
-from sl_hunting_tools import SLHuntingToolContext, build_sl_hunting_mcp_server
 from sl_hunting_executor import TradeExecutor
+from sl_hunting_indicators import SLHuntingIndicatorConfig, prepare_candles
+from sl_hunting_knowledge import FINAL_OUTPUT_INSTRUCTION, build_system_prompt
+from sl_hunting_tools import SLHuntingToolContext, build_sl_hunting_mcp_server
 
 logger = logging.getLogger(__name__)
 
@@ -331,7 +330,8 @@ class SLHuntingAgent:
             if thinking_cfg is not None:
                 options_kwargs["thinking"] = thinking_cfg
             else:
-                logger.warning("SL Hunting fast mode requested but ThinkingConfigDisabled is unavailable; using default thinking.")
+                logger.warning("SL Hunting fast mode requested but ThinkingConfigDisabled "
+                               "is unavailable; using default thinking.")
         options = ClaudeAgentOptions(**options_kwargs)
 
         final_text = ""
@@ -343,7 +343,7 @@ class SLHuntingAgent:
                     result_message = message
                     cost_usd = getattr(message, "total_cost_usd", None)
                     if getattr(message, "result", None):
-                        final_text = message.result
+                        final_text = message.result or ""
                 elif isinstance(message, AssistantMessage):
                     for block in getattr(message, "content", None) or []:
                         block_text = getattr(block, "text", None)
@@ -424,7 +424,10 @@ class SLHuntingAgent:
         """
         prepared = prepare_candles(candles)
         if prepared.empty:
-            return SLHuntingDecision(action="HOLD", confidence=0, setup="no_data", reasoning="No candles available.", model_used=self._model)
+            return SLHuntingDecision(
+                action="HOLD", confidence=0, setup="no_data",
+                reasoning="No candles available.", model_used=self._model,
+            )
 
         tool_context = SLHuntingToolContext.build(
             prepared, executor, cfg=self._cfg, live_active=live_active, broker=broker,

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_ai_validation.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_ai_validation.py
@@ -12,13 +12,10 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
-from typing import TypeVar
 
 from pydantic import BaseModel, ConfigDict
 
 logger = logging.getLogger(__name__)
-
-T = TypeVar("T")
 
 
 class StrictAIModel(BaseModel):
@@ -44,7 +41,7 @@ class AIValidationError(RuntimeError):
         )
 
 
-def parse_with_retry(
+def parse_with_retry[T](
     run_once: Callable[[], str],
     parse_once: Callable[[str], T],
     *,

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_coach.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_coach.py
@@ -30,7 +30,6 @@ from collections.abc import Awaitable
 from typing import Any
 
 from pydantic import ValidationError
-
 from sl_hunting_agent import _disabled_thinking_config
 from sl_hunting_ai_validation import parse_with_retry
 from sl_hunting_lessons import (
@@ -166,14 +165,15 @@ class CoachAgent:
             if thinking_cfg is not None:
                 options_kwargs["thinking"] = thinking_cfg
             else:
-                logger.warning("SL Hunting coach fast mode requested but ThinkingConfigDisabled is unavailable; using default thinking.")
+                logger.warning("SL Hunting coach fast mode requested but ThinkingConfigDisabled "
+                               "is unavailable; using default thinking.")
         options = ClaudeAgentOptions(**options_kwargs)
 
         final_text = ""
         async for message in query(prompt=prompt, options=options):
             if isinstance(message, ResultMessage):
                 if getattr(message, "result", None):
-                    final_text = message.result
+                    final_text = message.result or ""
             elif isinstance(message, AssistantMessage):
                 for block in getattr(message, "content", None) or []:
                     text = getattr(block, "text", None)
@@ -200,7 +200,9 @@ class CoachAgent:
         with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
             return executor.submit(_runner).result()
 
-    def reflect(self, journal_rows: list[dict[str, Any]], *, min_sample: int = 5, max_lessons: int = 6) -> list[ProposedLesson]:
+    def reflect(
+        self, journal_rows: list[dict[str, Any]], *, min_sample: int = 5, max_lessons: int = 6
+    ) -> list[ProposedLesson]:
         """Run one reflection pass and return the proposed lessons (possibly empty)."""
         system_prompt = _coach_system_prompt(min_sample, max_lessons)
         prompt = (
@@ -210,7 +212,9 @@ class CoachAgent:
         runner = self._runner or self._default_run
 
         def _run_once() -> str:
-            return self._run_sync(runner(prompt, system_prompt=system_prompt, model=self._model, max_turns=self.MAX_TURNS))
+            return self._run_sync(
+                runner(prompt, system_prompt=system_prompt, model=self._model, max_turns=self.MAX_TURNS)
+            )
 
         def _parse(text: str) -> CoachOutput:
             payload = _extract_json_object(text)
@@ -293,10 +297,11 @@ def main(argv: list[str] | None = None) -> int:
         for label, path in (("PROPOSED", args.proposed), ("LIVE (approved)", args.live)):
             items = load_lessons(path)
             logger.info("=== %s (%d) ===", label, len(items))
-            for l in consolidate(items, max_lessons=100):
-                ev = l.get("evidence") or {}
-                logger.info("  [%s] %s :: %s (W%s/L%s n%s, conf=%s)", l.get("id"), l.get("scope"),
-                            l.get("lesson"), ev.get("wins"), ev.get("losses"), ev.get("sample_size"), l.get("confidence"))
+            for lesson in consolidate(items, max_lessons=100):
+                ev = lesson.get("evidence") or {}
+                logger.info("  [%s] %s :: %s (W%s/L%s n%s, conf=%s)", lesson.get("id"), lesson.get("scope"),
+                            lesson.get("lesson"), ev.get("wins"), ev.get("losses"), ev.get("sample_size"),
+                            lesson.get("confidence"))
         return 0
 
     # default: reflect

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_coach.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_coach.py
@@ -189,7 +189,12 @@ class CoachAgent:
         loop (ProactorEventLoop on Windows, needed to spawn the Claude CLI subprocess).
         """
         def _runner() -> str:
-            loop = asyncio.ProactorEventLoop() if sys.platform == "win32" else asyncio.new_event_loop()
+            # The statement form (not a ternary) lets mypy narrow sys.platform,
+            # exactly as the trading agent's identical bridge does.
+            if sys.platform == "win32":
+                loop = asyncio.ProactorEventLoop()
+            else:
+                loop = asyncio.new_event_loop()
             try:
                 asyncio.set_event_loop(loop)
                 return loop.run_until_complete(coro)

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -429,3 +429,65 @@ shares those notes, the Friday→Monday concept can be folded into `RETAIL_POSIT
 - `BNF_CROSS_CONFIRMATION`: two cautions (stale early verdicts vs the opening-gap context;
   an opposing verdict is a real vote → HOLD unless textbook).
 - `BNF_SPECIFIC`: expiry-day index = extra fuel for with-gap momentum on a gap morning.
+
+---
+
+## Video addendum — 2-week verbatim sweep (v3d)
+
+> Source: every Intraday Hunter video for the 18 Jun – 2 Jul 2026 sessions, re-extracted from
+> the **verbatim Hindi auto-transcripts** (YouTube transcript panel → page-text capture, the
+> v3c method) — including videos v3a/v3b had only covered via lossy Ask/Gemini summaries.
+> 15 of 18 in-window videos captured; `st8p4CkP8mo` has no transcript, the weekly
+> `s41N7OS17Wk` never loads its panel (v3a's Gemini coverage stands), `WhfVxV0h5bo` was v3c.
+
+Videos (id — session — type — outcome/signal):
+- `G9HR80PLK8E` — 18 Jun — live — WIN: post-flush flat-open long; "flushed buyers don't
+  return"; BNF-moves-first entry; slow-continuous momentum read.
+- `O_PHs9q1QqA` — 19 Jun — live — small LOSS: bought a BIG gap-down against an up-streak
+  ("only the gap itself tells you to sell"); cut when the smaller-gap index (BNF) refused to
+  join the recovery → gap-size asymmetry lesson.
+- `Z2cVRE3sa6s` — for 19 Jun — plan — crowd-QUANTITY read (drip-buyers not huntable).
+- `0Pq2Arc7gRo` — for 22 Jun — plan — gap-size gradation (small counter-gap ≈ flat).
+- `LmO-Y1XzqgY` — 23 Jun — live — LOSS: faded a flat-open recovery after a SIDEWAYS period
+  (positioning unclear = no crowd); held to limit, cut on time + expiry decay.
+- `ZXQZy735-Fo` — for 24 Jun — plan — the conditional plan (gap-up → sell-side; flat/gap-down
+  → buy-side) after a big down day.
+- `J64qDUp2M88` — 24 Jun — live — WIN: executed that plan; flat open + first positive momentum
+  → quick triple-index long; "had it gapped up we'd have SOLD it".
+- `st8p4CkP8mo` — for 25 Jun — plan — no transcript.
+- `1e14YWvOtzs` — 25 Jun — live — WIN: gap-up continuing strength on Sensex expiry → follow;
+  sized up the expiring index; exited when the weakest index stalled.
+- `s41N7OS17Wk` — 28 Jun — weekly — transcript unavailable.
+- `I2BGDZIEc4c` — for 29 Jun — plan — breakout-failure day → trap read; produced the losing
+  29 Jun long (plans can be wrong; direction-first still governs).
+- `gMu0DU4HJ00` — 29 Jun — live — LOSS: trap-CONSTRUCTION leg premise (rally to re-add buyers
+  after a flush); cut when all three rejected together.
+- `FXugPeqs2HQ` — for 30 Jun — plan — KEY CONTRAST: close freshly below the round number →
+  sellers' SLs unreachable → flat/gap-down = go WITH the selling; only a gap-up activates the
+  hunt (→ SL-REACHABILITY TEST).
+- `SKgchmcArt0` — 30 Jun — live — LOSS: textbook cross-index divergence entry failed because
+  the day's DIRECTION was down (→ direction-first hierarchy); open exactly ON the round number
+  = ambiguous; admits loss-streak bias.
+- `yVFhGqGCjMc` — for 1 Jul — plan — mindset-based plan after a choppy day (lower conviction).
+- `Jj9yec-QDvI` — 1 Jul — live — WIN: flat open after 2-3 down days → hunt the comfortable
+  sellers up; gap-down would make old sellers SAFE (fresh herd traps itself); gap-up after a
+  selling streak = "no trust".
+- `kW5phlWuMKM` — for 2 Jul — plan — reads 1 Jul as an over-the-day seller trap; "gap-up →
+  go with, buy-side" = the v3c live trade the agent missed.
+- `2vO3onLbhPc` — for 3 Jul — plan — day-specific (ephemeral), captured for the record.
+
+**Knowledge changes (v3d, all prose):**
+- `PSYCHOLOGY`: trap-CONSTRUCTION leg (post-flush single momentum leg — capture and leave).
+- `RETAIL_POSITIONING`: READ THE GAP AGAINST THE PRIOR DAYS (continuation vs big-counter-gap
+  lure vs small-gap gradation); MULTI-DAY ACCUMULATION (flat-open hunt vs sideways = no crowd;
+  drip-crowds not huntable); SL-REACHABILITY TEST.
+- `OPENING_DRIVE`: Variant B — flat-open seller-hunt long after an extended multi-day down
+  move (same first-candle/no-major-rejection discipline; still no short / no gap-down variant).
+- `BNF_CROSS_CONFIRMATION`: direction-first hierarchy (divergence setups are entry-timing
+  tools; 30 Jun live loss).
+- `BNF_SPECIFIC`: gap-size asymmetry across the three indices + BNF-moves-first entry tell.
+- `RISK`: loss caps in trade units; two-rejections/third-momentum heuristic; early-adverse =
+  wrong direction on one-directional (expiry) days; slow-continuous vs fast momentum quality;
+  loss-streak "recovery trade" bias.
+- `DECISION_RULES`: rule 7 — no-plan zones (abstaining is a valid plan).
+- Test marker: `test_system_prompt_has_v3d_conditional_gap_knowledge`.

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_executor.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_executor.py
@@ -27,6 +27,7 @@ already in a position, and cannot EXIT while flat.
 
 from __future__ import annotations
 
+import contextlib
 import math
 from dataclasses import dataclass
 from datetime import datetime
@@ -145,7 +146,7 @@ class StandaloneExecutor:
     """Paper bookkeeping for the standalone runner.
 
     P&L is a proxy on the underlying: ``(last - entry)`` for LONG and
-    ``(entry - last)`` for SHORT, in NIFTY points × lots × lot_size. This is
+    ``(entry - last)`` for SHORT, in NIFTY points x lots x lot_size. This is
     deliberately simple — it validates the agent's *decisions*, not option pricing.
     The closed-trade log is kept so the runner can print a session summary.
     """
@@ -180,13 +181,17 @@ class StandaloneExecutor:
             reason=str(reason)[:300],
             lots=lots,
         )
-        return {"accepted": True, "action": f"ENTER_{direction}", "entry": self.pos.entry, "stop": self.pos.stop, "target": self.pos.target, "lots": lots, "quantity": lots * self.lot_size}
+        return {
+            "accepted": True, "action": f"ENTER_{direction}",
+            "entry": self.pos.entry, "stop": self.pos.stop, "target": self.pos.target,
+            "lots": lots, "quantity": lots * self.lot_size,
+        }
 
     def exit(self, reason: str, price: float) -> dict[str, Any]:
         """Close the open position at ``price``, append it to the trade log, go flat.
 
         P&L is the simple underlying-points proxy (LONG profits as price rises, SHORT as
-        it falls) × lots × lot_size. Rejects if there is nothing open to close.
+        it falls) x lots x lot_size. Rejects if there is nothing open to close.
         """
         if not self.pos.active:
             return {"accepted": False, "reason": "no open position to exit"}
@@ -229,7 +234,10 @@ class StandaloneExecutor:
             return {"in_position": False}
         pts = (price - self.pos.entry) if self.pos.direction == "LONG" else (self.pos.entry - price)
         lots = self.pos.lots or self.lots
-        return {"in_position": True, "points": round(pts, 2), "lots": lots, "pnl_proxy": round(pts * lots * self.lot_size, 2)}
+        return {
+            "in_position": True, "points": round(pts, 2), "lots": lots,
+            "pnl_proxy": round(pts * lots * self.lot_size, 2),
+        }
 
 
 # ---------------------------------------------------------------------------
@@ -270,8 +278,14 @@ class MasterWorkerExecutor:
             target_underlying=float(target),
         ))
         if not ok:
-            return {"accepted": False, "reason": "worker rejected the entry (e.g. could not resolve option / outside trading window)"}
-        return {"accepted": True, "action": f"ENTER_{direction}", "entry": round(float(price), 2), "stop": round(float(stop), 2), "target": round(float(target), 2)}
+            return {
+                "accepted": False,
+                "reason": "worker rejected the entry (e.g. could not resolve option / outside trading window)",
+            }
+        return {
+            "accepted": True, "action": f"ENTER_{direction}", "entry": round(float(price), 2),
+            "stop": round(float(stop), 2), "target": round(float(target), 2),
+        }
 
     def exit(self, reason: str, price: float) -> dict[str, Any]:
         """Delegate the close to the worker's `exit_position` (which handles P&L/alerts)."""
@@ -300,8 +314,7 @@ class MasterWorkerExecutor:
         }
         getter = getattr(self._w, "_get_open_position_pnl", None)
         if callable(getter):
-            try:
+            # Best-effort enrichment only: any failure just omits the field.
+            with contextlib.suppress(Exception):
                 snap["unrealized_pnl"] = round(float(getter()), 2)
-            except Exception:  # noqa: BLE001 - best-effort enrichment only
-                pass
         return snap

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_indicators.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_indicators.py
@@ -29,7 +29,7 @@ oldest → newest. Helper `prepare_candles` normalises this.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 import pandas as pd
@@ -123,24 +123,24 @@ def _anatomy(row: pd.Series, cfg: SLHuntingIndicatorConfig) -> dict[str, Any]:
 
     Beginner note: a candle has four prices — open/high/low/close (OHLC). We turn
     those into the parts a trader eyeballs:
-    - ``range``  = high − low  (the candle's total height; the denominator for every
+    - ``range``  = high - low  (the candle's total height; the denominator for every
       ratio below, floored at a tiny number so we never divide by zero).
-    - ``body``   = |close − open|  (the thick part).
+    - ``body``   = |close - open|  (the thick part).
     - ``upper_wick`` = the thin line ABOVE the body (high down to the body's top).
     - ``lower_wick`` = the thin line BELOW the body (body's bottom down to the low).
     The boolean flags then label the shape by comparing those parts to the
     fractions in ``cfg`` (e.g. "is this basically all wick and no body?").
     """
-    o, h, l, c = float(row.open), float(row.high), float(row.low), float(row.close)
-    rng = max(h - l, 1e-9)            # total height; 1e-9 floor avoids divide-by-zero
+    o, h, lo, c = float(row.open), float(row.high), float(row.low), float(row.close)
+    rng = max(h - lo, 1e-9)           # total height; 1e-9 floor avoids divide-by-zero
     body = abs(c - o)                 # thick part (direction-agnostic)
     upper = h - max(o, c)            # wick above the body
-    lower = min(o, c) - l            # wick below the body
+    lower = min(o, c) - lo           # wick below the body
     is_bull = c > o                   # green candle (close above open)
     return {
         "open": round(o, 2),
         "high": round(h, 2),
-        "low": round(l, 2),
+        "low": round(lo, 2),
         "close": round(c, 2),
         "range": round(rng, 2),
         "body": round(body, 2),
@@ -239,10 +239,13 @@ def pivot_and_levels(
             "previous_close": _dist(prev_day["close"]) if prev_day else None,
             "previous_high": _dist(prev_day["high"]) if prev_day else None,
             "previous_low": _dist(prev_day["low"]) if prev_day else None,
-            "today_open": _dist(today_levels["open"]),
+            "today_open": _dist(cast(float, today_levels["open"])),
             "nearest_psych": _dist(min(psych, key=lambda p: abs(p - last_price))) if psych else None,
         },
-        "note": "Above pivot = buyers' market; below = sellers'. A WICK at a level = trap/reversal; a clean BREAK = continuation.",
+        "note": (
+            "Above pivot = buyers' market; below = sellers'. A WICK at a level = "
+            "trap/reversal; a clean BREAK = continuation."
+        ),
     }
 
 
@@ -273,9 +276,11 @@ def _swings(df: pd.DataFrame, cfg: SLHuntingIndicatorConfig) -> list[dict[str, A
         is_high = all(hi >= float(window.high.iloc[j]) for j in range(i - left, i + right + 1) if j != i)
         is_low = all(lo <= float(window.low.iloc[j]) for j in range(i - left, i + right + 1) if j != i)
         if is_high:
-            swings.append({"kind": "high", "price": round(hi, 2), "time": str(window.timestamp.iloc[i]), "bars_ago": n - 1 - i})
+            swings.append({"kind": "high", "price": round(hi, 2),
+                           "time": str(window.timestamp.iloc[i]), "bars_ago": n - 1 - i})
         elif is_low:
-            swings.append({"kind": "low", "price": round(lo, 2), "time": str(window.timestamp.iloc[i]), "bars_ago": n - 1 - i})
+            swings.append({"kind": "low", "price": round(lo, 2),
+                           "time": str(window.timestamp.iloc[i]), "bars_ago": n - 1 - i})
     return swings
 
 
@@ -338,8 +343,15 @@ def fibo_levels(
         "last_price": last_price,
         "retracements": retr,
         "extensions": ext,
-        "nearest_retracement": {"level_name": nearest[0], "price": nearest[1], "points_away": round(last_price - nearest[1], 2)},
-        "note": "Only 50/61/78 are valid reversal zones (need pattern + confirmation); 161/261 are targets. 78% is the deepest valid zone.",
+        "nearest_retracement": {
+            "level_name": nearest[0],
+            "price": nearest[1],
+            "points_away": round(last_price - nearest[1], 2),
+        },
+        "note": (
+            "Only 50/61/78 are valid reversal zones (need pattern + confirmation); "
+            "161/261 are targets. 78% is the deepest valid zone."
+        ),
     }
 
 
@@ -362,9 +374,15 @@ def _confirmation(
     for j in range(pattern_idx + 1, n):
         a = _anatomy(df.iloc[j], cfg)
         if direction == "bullish" and a["close"] > pattern_high and a["is_full_body"] and a["is_bull"]:
-            return {"confirmed": True, "bars_after": j - pattern_idx, "close": a["close"], "time": str(df.timestamp.iloc[j])}
+            return {
+                "confirmed": True, "bars_after": j - pattern_idx,
+                "close": a["close"], "time": str(df.timestamp.iloc[j]),
+            }
         if direction == "bearish" and a["close"] < pattern_low and a["is_full_body"] and a["is_bear"]:
-            return {"confirmed": True, "bars_after": j - pattern_idx, "close": a["close"], "time": str(df.timestamp.iloc[j])}
+            return {
+                "confirmed": True, "bars_after": j - pattern_idx,
+                "close": a["close"], "time": str(df.timestamp.iloc[j]),
+            }
     # No confirmation yet — flag a trap if price poked back through after a wick test.
     return {"confirmed": False, "bars_after": None, "close": None, "time": None}
 
@@ -397,7 +415,9 @@ def candle_patterns(
         bars_ago = n - 1 - i
         p_high, p_low = cur["high"], cur["low"]
 
-        def _add(ptype: str, direction: str, hi: float, lo: float) -> None:
+        # Bind the loop variables as defaults so the helper is safe even if a
+        # future refactor stores it past this iteration (ruff B023).
+        def _add(ptype: str, direction: str, hi: float, lo: float, *, i: int = i, bars_ago: int = bars_ago) -> None:
             conf = _confirmation(df, i, direction, hi, lo, cfg)
             found.append({
                 "type": ptype,
@@ -426,8 +446,14 @@ def candle_patterns(
         # covers a prior red body (close ≥ prev open AND open ≤ prev close); bearish is
         # the mirror. Colour matters here (unlike a hammer). Both bodies must be non-zero.
         if cur["body"] > 0 and prev["body"] > 0:
-            bull_engulf = cur["is_bull"] and prev["is_bear"] and cur["close"] >= prev["open"] and cur["open"] <= prev["close"]
-            bear_engulf = cur["is_bear"] and prev["is_bull"] and cur["close"] <= prev["open"] and cur["open"] >= prev["close"]
+            bull_engulf = (
+                cur["is_bull"] and prev["is_bear"]
+                and cur["close"] >= prev["open"] and cur["open"] <= prev["close"]
+            )
+            bear_engulf = (
+                cur["is_bear"] and prev["is_bull"]
+                and cur["close"] <= prev["open"] and cur["open"] >= prev["close"]
+            )
             if bull_engulf:
                 _add("bullish_engulfing", "bullish", max(cur["high"], prev["high"]), min(cur["low"], prev["low"]))
             if bear_engulf:
@@ -448,9 +474,13 @@ def candle_patterns(
         # (bullish); evening star = up→pause→down (bearish).
         small_middle = prev["body"] <= 0.5 * max(prev2["body"], 1e-9)
         if prev2["is_bear"] and small_middle and cur["is_bull"] and cur["close"] > (prev2["open"] + prev2["close"]) / 2:
-            _add("morning_star", "bullish", max(cur["high"], prev["high"], prev2["high"]), min(cur["low"], prev["low"], prev2["low"]))
+            _add("morning_star", "bullish",
+                 max(cur["high"], prev["high"], prev2["high"]),
+                 min(cur["low"], prev["low"], prev2["low"]))
         if prev2["is_bull"] and small_middle and cur["is_bear"] and cur["close"] < (prev2["open"] + prev2["close"]) / 2:
-            _add("evening_star", "bearish", max(cur["high"], prev["high"], prev2["high"]), min(cur["low"], prev["low"], prev2["low"]))
+            _add("evening_star", "bearish",
+                 max(cur["high"], prev["high"], prev2["high"]),
+                 min(cur["low"], prev["low"], prev2["low"]))
 
     confirmed = [p for p in found if p.get("confirmed")]
     return {
@@ -458,7 +488,10 @@ def candle_patterns(
         "latest_candle": _anatomy(df.iloc[-1], cfg),
         "patterns": found[-cfg.pattern_lookback:],
         "confirmed_patterns": confirmed[-5:],
-        "note": "A tradeable setup needs a pattern AT a level AND a confirmation candle that already closed beyond it. No confirmation = no trade.",
+        "note": (
+            "A tradeable setup needs a pattern AT a level AND a confirmation candle "
+            "that already closed beyond it. No confirmation = no trade."
+        ),
     }
 
 
@@ -532,7 +565,10 @@ def market_structure(
         "descending_trendline_points": desc_line,
         "double_top": double_top,
         "double_bottom": double_bottom,
-        "note": "Trade a trendline only on the 3rd touch or a confirmed break (4th+). For W/M, trade the activation after the neckline break, not the breakout itself.",
+        "note": (
+            "Trade a trendline only on the 3rd touch or a confirmed break (4th+). "
+            "For W/M, trade the activation after the neckline break, not the breakout itself."
+        ),
     }
 
 
@@ -615,8 +651,14 @@ def index_position(
         "vs_pivot": vs_pivot,
         "at_support": at_support,
         "at_resistance": at_resistance,
-        "nearest_support": {"name": nearest_support[0], "price": round(nearest_support[1], 2)} if nearest_support else None,
-        "nearest_resistance": {"name": nearest_resistance[0], "price": round(nearest_resistance[1], 2)} if nearest_resistance else None,
+        "nearest_support": (
+            {"name": nearest_support[0], "price": round(nearest_support[1], 2)}
+            if nearest_support else None
+        ),
+        "nearest_resistance": (
+            {"name": nearest_resistance[0], "price": round(nearest_resistance[1], 2)}
+            if nearest_resistance else None
+        ),
         "broke_pivot_down": broke_pivot_down,
         "broke_pivot_up": broke_pivot_up,
     }
@@ -641,7 +683,10 @@ def cross_index_signal(
     n = index_position(nifty_df, cfg)
     b = index_position(bnf_df, cfg) if bnf_df is not None else {"available": False}
     if not (n.get("available") and b.get("available")):
-        return {"available": False, "reason": "BankNIFTY data unavailable; judge on NIFTY alone (be more conservative)."}
+        return {
+            "available": False,
+            "reason": "BankNIFTY data unavailable; judge on NIFTY alone (be more conservative).",
+        }
 
     # Verdict ladder, checked MOST-SPECIFIC first (both-break and both-at-a-level beat
     # the looser "same side of pivot" context). Remember the SL-hunting inversion: both
@@ -663,10 +708,16 @@ def cross_index_signal(
     elif (n["broke_pivot_down"] != b["broke_pivot_down"]) and (n["at_support"] or b["at_support"]):
         holder = "BankNIFTY" if n["broke_pivot_down"] else "NIFTY"
         alignment, bias = "divergence_breakdown", "up"
-        reason = f"One index broke down while {holder} held support -> breakdown likely fails; bias UP toward the holder."
+        reason = (
+            f"One index broke down while {holder} held support -> "
+            "breakdown likely fails; bias UP toward the holder."
+        )
     elif n["vs_pivot"] in ("above", "below") and b["vs_pivot"] in ("above", "below") and n["vs_pivot"] != b["vs_pivot"]:
         alignment, bias = "opposite_sides_of_pivot", "wait"
-        reason = "Indices are on opposite sides of their pivots -> treat pivot as a normal level and WAIT for alignment."
+        reason = (
+            "Indices are on opposite sides of their pivots -> "
+            "treat pivot as a normal level and WAIT for alignment."
+        )
     elif n["vs_pivot"] == b["vs_pivot"] == "above":
         alignment, bias = "both_above_pivot", "up_context"
         reason = "Both above pivot -> buyers' market on both; bullish context."
@@ -681,5 +732,8 @@ def cross_index_signal(
         "reason": reason,
         "nifty": n,
         "bank_nifty": b,
-        "note": "Advisory: weigh with the NIFTY setup. 'wait' = require alignment; if this disagrees with your NIFTY read, prefer HOLD.",
+        "note": (
+            "Advisory: weigh with the NIFTY setup. 'wait' = require alignment; "
+            "if this disagrees with your NIFTY read, prefer HOLD."
+        ),
     }

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_journal.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_journal.py
@@ -21,7 +21,6 @@ from datetime import datetime
 from typing import Any
 
 import pandas as pd
-
 from sl_hunting_indicators import (
     SLHuntingIndicatorConfig,
     candle_patterns,

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
@@ -59,6 +59,10 @@ CORE PSYCHOLOGY (the "why" behind every setup)
 - Fast move one way, then a SLOW move the other way = the operator creating SLs on
   the slow side. The slow-side reversal is the SL-hunt; trade it, do not chase the
   fast trend blindly.
+- After a FLUSH (a rejection already took the nearby crowd's SLs), expect the
+  operator to CONSTRUCT the next trap: a single momentum leg whose job is to re-add
+  traders on one side. That leg is tradeable — but it is ONE leg; capture it and
+  leave, do not read it as a new trend.
 - A long-wicked candle (hammer/doji/pin) marks where money/SLs are parked — the
   longer the wick, the more SLs. These mark targets and reversal zones.
 - Act OPPOSITE to the obvious retail read: after a gap down retail expects more
@@ -84,6 +88,30 @@ retail's stop-losses sit so you can trade where the operator will hunt them.
   shorts). With little trapped on the wrong side there's less to hunt, so a gap-up
   is more likely to FOLLOW its momentum than to reverse — don't reflexively fade it;
   lean with the prevailing direction unless a clear trap/level says otherwise.
+- READ THE GAP AGAINST THE PRIOR DAYS — the same gap means opposite things depending
+  on what preceded it:
+  * Gap CONTINUING prior strength (e.g. gap-up in an established up-move) → the rule
+    above: follow it.
+  * BIG gap AGAINST an extended prior move = a LURE for the starved opposite crowd:
+    a big gap-down after days of up-moves invites the "hungry" sellers who had no
+    trade for days; a gap-up after a multi-day selling streak invites relieved
+    buyers. The herd that takes the bait traps itself, so the recovery back INTO the
+    prior trend is the premise — following such a gap blindly is the retail mistake.
+    (A gap-up after a selling streak is UNTRUSTWORTHY — it tends to fall back; after
+    a big down day the method SELLS a direct gap-up rather than following it.)
+  * Gap SIZE matters: a SMALL counter-gap inside a trend reads like a flat open
+    (keep the with-trend plan); only a gap THROUGH the prior day's extreme flips it.
+- MULTI-DAY ACCUMULATION: after 2-3 one-way days the accumulated crowd sits with SLs
+  just beyond the closing price / round number — a FLAT open then is the prime
+  chance to hunt them (see OPENING DRIVE variant B for the with-gap long after down
+  days). But if the prior days were SIDEWAYS/both-ways, positioning is UNCLEAR —
+  nobody's crowd, low edge: wait for the first momentum tell instead of forcing the
+  flat-open playbook. And a crowd that only TRICKLED in (small-quantity drip-buying
+  of an up-trend) is not huntable — do not target it.
+- SL-REACHABILITY TEST (run alongside the trap-density test): a hunt also needs the
+  crowd's SL zone to be REACHABLE from today's open without crossing an intact major
+  level. If their stops sit beyond an uncrossed round number / closing price, the
+  hunt is off — go WITH the market until a gap or break puts those stops in play.
 - FLAT or GAP-DOWN open → a PRIME TRAP zone, especially after prior panic selling:
   retail is positioned short/wrong-footed, so the operator hunts their stops. Bias to
   trade OPPOSITE the panic (look UP / target the trapped shorts' SLs) on a confirmed
@@ -148,6 +176,15 @@ Conditions (ALL must hold — otherwise this branch simply does not apply):
 - Behavioural confirmation substitutes for the candle rule HERE ONLY: price
   holding above the open / round number without aggressive selling is the
   confirmation. Everywhere else the pattern + confirmation rule is mandatory.
+
+Variant B — FLAT-OPEN seller-hunt long (same discipline, v3d): after an extended
+multi-day DOWN move across all three indices, when the seller crowd's SLs sit within
+reach above (SL-reachability test passed), a FLAT open may also be traded LONG on
+the first positive momentum — at the earliest after the first 1-min candle closes,
+with the same behavioural confirmation and the same no-major-rejection condition.
+Invalidation: price falling back through the open / the closing point. If the prior
+days were SIDEWAYS rather than one-way, this variant does NOT apply. There is still
+NO opening-drive SHORT and NO gap-down variant.
 
 Risk handling for this branch:
 - Stop = below the first-candle low / opening-range low. This stop may be wider
@@ -306,6 +343,17 @@ RISK DISCIPLINE
   level in your favour. Otherwise HOLD and let it run.
 - One position at a time. Never add to or reverse a position in a single decision —
   EXIT first; a fresh entry is a later decision.
+- Loss discipline in TRADE units: never let one trade take 2-3 trades' worth of
+  loss — a capped loss is recoverable by the next normal winner. A reversal premise
+  tolerates roughly TWO rejections; the THIRD momentum must be the recovery — if it
+  is not, exit without waiting for the stop. On days expected to be ONE-directional
+  (especially expiry), meaningful EARLY adverse movement on a directional trade
+  means the DIRECTION itself is wrong — exit early.
+- Momentum quality while holding: SLOW-but-CONTINUOUS with-trend momentum (small
+  candles) is the sustainable kind — let it run; a FAST spike invites a retracement
+  — book into strength or tighten. After consecutive losing days, deliberately
+  reduce risk and prefer clearer setups: the urge for a "recovery trade" is itself
+  a bias the market exploits.
 """
 
 
@@ -344,6 +392,10 @@ Two cautions from live review:
   is stale — weight READING RETAIL POSITIONING first in the opening hour.
 - A verdict that directly OPPOSES your intended direction is a real vote against
   the trade, not a footnote: HOLD unless the setup is genuinely textbook.
+- Level/divergence setups (e.g. one index HOLDS the closing price while the others
+  reclaim it) are ENTRY-TIMING tools SUBORDINATE to the day-direction read: when the
+  direction read is wrong, the textbook divergence fails anyway. Direction first,
+  setup second.
 """
 
 
@@ -378,6 +430,13 @@ you size or place the NIFTY trade. Advisory, not a hard gate.
   (the round "...500" / "...000" levels): they are prime trap / breakout magnets
   where breakout-buyers get trapped — exactly the spots the operator hunts. (For
   NIFTY the equivalent psych levels are tighter — see LEVELS.)
+- GAP-SIZE ASYMMETRY: when the opening gaps differ meaningfully across the three
+  indices, the SMALLER-gap index is the tell — oversized gaps are built to keep
+  participants out. A retracement in the big-gap indices mostly flushes their
+  gap-sellers before the move resumes; if the smaller-gap index (often BankNIFTY)
+  fails to join a recovery, the recovery premise is dead. In the with-trend case,
+  BankNIFTY moving FIRST while the others still dip is an entry tell (the major
+  index drags the rest along).
 """
 
 
@@ -441,6 +500,10 @@ DECISION DISCIPLINE
 6. Do NOT over-focus on being "right" / hit-rate. The edge is the positioning read
    plus discipline — cut losers fast, manage the initial loss, never force a trade.
    A sound process that loses a trade is fine; a forced trade on a weak setup is not.
+7. Not every open type has a plan. When the pre-open situation offers no understood
+   premise (e.g. a gap-down where the sitting crowd's reaction is unreadable), the
+   correct plan is NO trade for that scenario — abstain and reassess once the
+   market shows its hand.
 """
 
 

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_lessons.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_lessons.py
@@ -19,7 +19,6 @@ from datetime import UTC, datetime
 from typing import Any
 
 from pydantic import Field, field_validator
-
 from sl_hunting_ai_validation import StrictAIModel
 
 logger = logging.getLogger(__name__)
@@ -33,7 +32,9 @@ class ProposedLesson(StrictAIModel):
     agent's decision; integer ranges use `@field_validator` so the JSON schema stays
     free of min/max, which Claude rejects)."""
 
-    scope: str = Field(description="Short tag for WHEN this applies (e.g. 'pivot_retest', 'gap_down', 'cross_index_wait').")
+    scope: str = Field(
+        description="Short tag for WHEN this applies (e.g. 'pivot_retest', 'gap_down', 'cross_index_wait')."
+    )
     lesson: str = Field(description="One-line tendency/directive — NOT a hard law.")
     rationale: str = Field(description="Why: the pattern across the trades behind it.")
     wins: int = Field(description="Winning trades supporting it.")
@@ -135,7 +136,7 @@ def consolidate(lessons: list[dict[str, Any]], max_lessons: int = MAX_LIVE_LESSO
             by_id[lid] = lesson
     ranked = sorted(
         by_id.values(),
-        key=lambda l: (_sample(l), str(l.get("updated_at", ""))),
+        key=lambda rec: (_sample(rec), str(rec.get("updated_at", ""))),
         reverse=True,
     )
     return ranked[:max_lessons]
@@ -143,7 +144,7 @@ def consolidate(lessons: list[dict[str, Any]], max_lessons: int = MAX_LIVE_LESSO
 
 def format_lessons(lessons: list[dict[str, Any]]) -> str:
     """Render APPROVED lessons as a `LEARNED LESSONS` prompt block ('' if none)."""
-    approved = [l for l in lessons if l.get("status") == "approved"]
+    approved = [rec for rec in lessons if rec.get("status") == "approved"]
     if not approved:
         return ""
     out = [
@@ -153,10 +154,10 @@ def format_lessons(lessons: list[dict[str, Any]]) -> str:
         "soft priors that refine the method; they never override a clear live read.",
         "",
     ]
-    for l in consolidate(approved):
-        ev = l.get("evidence") or {}
+    for rec in consolidate(approved):
+        ev = rec.get("evidence") or {}
         out.append(
-            f"- [{l.get('scope', '?')}] {str(l.get('lesson', '')).strip()} "
+            f"- [{rec.get('scope', '?')}] {str(rec.get('lesson', '')).strip()} "
             f"(W{ev.get('wins', 0)}/L{ev.get('losses', 0)}, n={ev.get('sample_size', 0)})"
         )
     return "\n".join(out)
@@ -172,7 +173,7 @@ def add_proposed(proposed_path: str, proposed: list[ProposedLesson]) -> list[dic
 
 def promote(proposed_path: str, live_path: str, ids: list[str]) -> list[str]:
     """Move selected PROPOSED lessons into the live (APPROVED) store — the human gate."""
-    proposed = {l.get("id"): l for l in load_lessons(proposed_path)}
+    proposed = {rec.get("id"): rec for rec in load_lessons(proposed_path)}
     live = load_lessons(live_path)
     promoted: list[str] = []
     for lid in ids:

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_runner.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_runner.py
@@ -35,7 +35,6 @@ from __future__ import annotations
 import argparse
 import logging
 import os
-import sys
 
 import numpy as np
 import pandas as pd
@@ -132,9 +131,10 @@ def _synthetic_bnf(nifty_1m: pd.DataFrame, scale: float = 2.2, seed: int = 11) -
     opens = np.concatenate([[closes[0]], closes[:-1]])
     highs = np.maximum(opens, closes) + rng.uniform(0, 15, size=n)
     lows = np.minimum(opens, closes) - rng.uniform(0, 15, size=n)
-    return pd.DataFrame(
-        {"timestamp": nifty_1m["timestamp"].to_numpy(), "open": opens, "high": highs, "low": lows, "close": closes, "volume": 0}
-    )
+    return pd.DataFrame({
+        "timestamp": nifty_1m["timestamp"].to_numpy(),
+        "open": opens, "high": highs, "low": lows, "close": closes, "volume": 0,
+    })
 
 
 def resample_1m_to_n(candles: pd.DataFrame, minutes: int) -> pd.DataFrame:
@@ -210,7 +210,8 @@ def main(argv: list[str] | None = None) -> int:
     src = parser.add_mutually_exclusive_group()
     src.add_argument("--csv", help="Path to a 1-minute NIFTY OHLC CSV (timestamp,open,high,low,close[,volume]).")
     src.add_argument("--synthetic", action="store_true", help="Use a generated random-walk session.")
-    parser.add_argument("--bnf-csv", help="Optional 1-minute BankNIFTY OHLC CSV for cross-confirmation (paired with --csv).")
+    parser.add_argument("--bnf-csv",
+                        help="Optional 1-minute BankNIFTY OHLC CSV for cross-confirmation (paired with --csv).")
     parser.add_argument("--timeframe", type=int, default=int(_env("SL_HUNTING_DERIVED_TIMEFRAME_MINUTES", "1")),
                         help="Decision timeframe in minutes (resampled from 1-min; SL Hunting's default is 1).")
     parser.add_argument("--model", default=_env("SL_HUNTING_MODEL", "claude-opus-4-8"), help="Claude model id.")
@@ -326,7 +327,8 @@ def main(argv: list[str] | None = None) -> int:
     if trades:
         logger.info("Total P&L proxy: %.2f | wins %d/%d (%.0f%%)", total, wins, len(trades), 100.0 * wins / len(trades))
         for t in trades:
-            logger.info("  %s %s->%s (%+.2f pts, %+.2f) [%s]", t["direction"], t["entry"], t["exit"], t["points"], t["pnl_proxy"], t["exit_reason"])
+            logger.info("  %s %s->%s (%+.2f pts, %+.2f) [%s]", t["direction"], t["entry"],
+                        t["exit"], t["points"], t["pnl_proxy"], t["exit_reason"])
     else:
         logger.info("No trades taken (agent held throughout).")
     logger.info("NOTE: P&L proxy is on the NIFTY underlying, not option premium - validates decisions, not pricing.")

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_tools.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_tools.py
@@ -35,7 +35,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 import pandas as pd
-
+from sl_hunting_executor import TradeExecutor, execution_tool_name
 from sl_hunting_indicators import (
     SLHuntingIndicatorConfig,
     candle_patterns,
@@ -45,7 +45,6 @@ from sl_hunting_indicators import (
     pivot_and_levels,
     prepare_candles,
 )
-from sl_hunting_executor import TradeExecutor, execution_tool_name
 
 SERVER_NAME = "slhunting"
 
@@ -90,7 +89,7 @@ class SLHuntingToolContext:
         live_active: bool = False,
         broker: str | None = None,
         bnf_candles: pd.DataFrame | None = None,
-    ) -> "SLHuntingToolContext":
+    ) -> SLHuntingToolContext:
         """Prepare the per-bar context: clean the candles, cache the last price, attach BNF.
 
         Normalises the NIFTY (and optional BankNIFTY) frames once here so each tool call
@@ -177,36 +176,56 @@ def build_sl_hunting_mcp_server(context: SLHuntingToolContext):
     """
     from claude_agent_sdk import create_sdk_mcp_server, tool  # type: ignore[import-not-found, unused-ignore]
 
-    @tool("pivot_and_levels", "Day pivot, previous-day OHLC, today's O/H/L, first-candle hi/lo, psych levels and the previous close, with distances from current price.", {})
+    @tool("pivot_and_levels",
+          "Day pivot, previous-day OHLC, today's O/H/L, first-candle hi/lo, psych levels "
+          "and the previous close, with distances from current price.", {})
     async def _pivot(_args: dict[str, Any]) -> dict[str, Any]:
         return _as_tool_text(context.pivot_and_levels_payload())
 
-    @tool("fibo_levels", "Fibonacci 50/61/78 retracement and 161/261 extension levels of the most recent significant swing, and where price sits relative to them.", {})
+    @tool("fibo_levels",
+          "Fibonacci 50/61/78 retracement and 161/261 extension levels of the most recent "
+          "significant swing, and where price sits relative to them.", {})
     async def _fibo(_args: dict[str, Any]) -> dict[str, Any]:
         return _as_tool_text(context.fibo_levels_payload())
 
-    @tool("candle_patterns", "Reversal candlestick patterns (hammer/doji, engulfing, inside-bar, reversal-bar, star) on recent candles, each tagged with whether a confirmation candle has already printed.", {})
+    @tool("candle_patterns",
+          "Reversal candlestick patterns (hammer/doji, engulfing, inside-bar, reversal-bar, "
+          "star) on recent candles, each tagged with whether a confirmation candle has "
+          "already printed.", {})
     async def _patterns(_args: dict[str, Any]) -> dict[str, Any]:
         return _as_tool_text(context.candle_patterns_payload())
 
-    @tool("market_structure", "Swing points, trend, fast/slow read, trendline points, and W/M / double top-bottom detection.", {})
+    @tool("market_structure",
+          "Swing points, trend, fast/slow read, trendline points, and W/M / double "
+          "top-bottom detection.", {})
     async def _structure(_args: dict[str, Any]) -> dict[str, Any]:
         return _as_tool_text(context.market_structure_payload())
 
-    @tool("position_state", "Your current open position (direction, entry, stop, target, unrealised P&L) or 'flat'.", {})
+    @tool("position_state",
+          "Your current open position (direction, entry, stop, target, unrealised P&L) "
+          "or 'flat'.", {})
     async def _position(_args: dict[str, Any]) -> dict[str, Any]:
         return _as_tool_text(context.position_state_payload())
 
-    @tool("bank_nifty", "BankNIFTY's OWN pivot/levels, market structure and recent candle patterns (for cross-confirmation). Returns available:false when BankNIFTY data is unavailable.", {})
+    @tool("bank_nifty",
+          "BankNIFTY's OWN pivot/levels, market structure and recent candle patterns (for "
+          "cross-confirmation). Returns available:false when BankNIFTY data is unavailable.", {})
     async def _bank_nifty(_args: dict[str, Any]) -> dict[str, Any]:
         return _as_tool_text(context.bank_nifty_payload())
 
-    @tool("cross_index", "NIFTY-vs-BankNIFTY alignment verdict per the NF/BNF rules (both at support -> bias down; both breakdown -> bias up; one fails -> the holder wins; opposite sides of pivot -> wait). Advisory. available:false when BankNIFTY data is unavailable.", {})
+    @tool("cross_index",
+          "NIFTY-vs-BankNIFTY alignment verdict per the NF/BNF rules (both at support -> "
+          "bias down; both breakdown -> bias up; one fails -> the holder wins; opposite "
+          "sides of pivot -> wait). Advisory. available:false when BankNIFTY data is "
+          "unavailable.", {})
     async def _cross_index(_args: dict[str, Any]) -> dict[str, Any]:
         return _as_tool_text(context.cross_index_payload())
 
     order_name = context.action_tool_name()
-    venue = "PAPER" if order_name == "place_paper_order" else ("KOTAK (LIVE)" if order_name == "place_kotak_order" else "SHOONYA (LIVE)")
+    venue = (
+        "PAPER" if order_name == "place_paper_order"
+        else ("KOTAK (LIVE)" if order_name == "place_kotak_order" else "SHOONYA (LIVE)")
+    )
 
     @tool(
         order_name,
@@ -231,5 +250,5 @@ def build_sl_hunting_mcp_server(context: SLHuntingToolContext):
         version="1.0.0",
         tools=[_pivot, _fibo, _patterns, _structure, _position, _bank_nifty, _cross_index, _order],
     )
-    allowed = list(CONTEXT_TOOL_NAMES) + [f"mcp__{SERVER_NAME}__{order_name}"]
+    allowed = [*CONTEXT_TOOL_NAMES, f"mcp__{SERVER_NAME}__{order_name}"]
     return {SERVER_NAME: server}, allowed

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_agent.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_agent.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import json
 
 import pandas as pd
-
 from sl_hunting_agent import AgentRunResult, SLHuntingAgent, SLHuntingDecision
 from sl_hunting_executor import (
     MasterWorkerExecutor,
@@ -169,7 +168,6 @@ class _FakeResult:
 
 def test_raise_for_error_result_classifies_api_status():
     import pytest
-
     from sl_hunting_agent import (
         SLHuntingAgentError,
         SLHuntingAuthError,

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_indicators.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_indicators.py
@@ -3,9 +3,7 @@
 from __future__ import annotations
 
 import pandas as pd
-
 from sl_hunting_indicators import (
-    SLHuntingIndicatorConfig,
     candle_patterns,
     fibo_levels,
     market_structure,

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_journal.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_journal.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 
 import pandas as pd
-
 from sl_hunting_journal import (
     TradeJournal,
     build_entry_context,

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_lessons.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_lessons.py
@@ -5,11 +5,9 @@ from __future__ import annotations
 import json
 
 import pytest
-
 from sl_hunting_agent import SLHuntingAgent
 from sl_hunting_coach import CoachAgent, summarize_journal
 from sl_hunting_lessons import (
-    CoachOutput,
     ProposedLesson,
     add_proposed,
     consolidate,
@@ -18,7 +16,6 @@ from sl_hunting_lessons import (
     promote,
     proposed_to_record,
 )
-
 
 # --------------------------------------------------------------------------
 # Lesson schema
@@ -41,18 +38,27 @@ def test_proposed_lesson_validates_and_omits_min_max():
 # --------------------------------------------------------------------------
 
 def test_consolidate_dedupes_by_id_keeping_bigger_sample_and_caps():
-    base = proposed_to_record(ProposedLesson(scope="s", lesson="L", rationale="r", wins=1, losses=0, sample_size=2, confidence=5))
+    base = proposed_to_record(
+        ProposedLesson(scope="s", lesson="L", rationale="r", wins=1, losses=0, sample_size=2, confidence=5)
+    )
     bigger = dict(base)
     bigger["evidence"] = {"wins": 5, "losses": 1, "sample_size": 6}
     out = consolidate([base, bigger])
     assert len(out) == 1 and out[0]["evidence"]["sample_size"] == 6
     # cap
-    many = [proposed_to_record(ProposedLesson(scope=f"s{i}", lesson=f"L{i}", rationale="r", wins=i, losses=0, sample_size=i, confidence=5)) for i in range(1, 20)]
+    many = [
+        proposed_to_record(
+            ProposedLesson(scope=f"s{i}", lesson=f"L{i}", rationale="r", wins=i, losses=0, sample_size=i, confidence=5)
+        )
+        for i in range(1, 20)
+    ]
     assert len(consolidate(many, max_lessons=5)) == 5
 
 
 def test_format_lessons_only_renders_approved():
-    proposed = proposed_to_record(ProposedLesson(scope="s", lesson="be cautious", rationale="r", wins=1, losses=3, sample_size=4, confidence=4))
+    proposed = proposed_to_record(
+        ProposedLesson(scope="s", lesson="be cautious", rationale="r", wins=1, losses=3, sample_size=4, confidence=4)
+    )
     assert format_lessons([proposed]) == ""  # status=proposed -> nothing
     approved = dict(proposed, status="approved")
     block = format_lessons([approved])
@@ -106,7 +112,8 @@ def test_coach_reflect_empty_on_malformed():
 
 def test_summarize_journal_renders_trades():
     rows = [{"direction": "LONG", "setup": "pivot", "confidence": 7, "followed_method": True,
-             "context": {"cross_index": {"bias": "up"}}, "outcome": {"r_multiple": 2.0, "points": 30, "exit_reason": "target_hit"}}]
+             "context": {"cross_index": {"bias": "up"}},
+             "outcome": {"r_multiple": 2.0, "points": 30, "exit_reason": "target_hit"}}]
     text = summarize_journal(rows)
     assert "1 trades" in text and "pivot" in text and "target_hit" in text
     assert summarize_journal([]).startswith("No trades")

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_runner.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_runner.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import pandas as pd
-
 from sl_hunting_executor import StandaloneExecutor
 from sl_hunting_runner import _manage_open_position, resample_1m_to_n
 
@@ -30,7 +29,7 @@ def test_resample_1m_to_5m_aggregates_ohlc():
     assert len(out) == 4
     # First 5-min bar's high should be the max of its constituent 1-min highs.
     assert out.iloc[0]["high"] == df.iloc[:5]["high"].max()
-    assert set(["timestamp", "open", "high", "low", "close"]).issubset(out.columns)
+    assert {"timestamp", "open", "high", "low", "close"}.issubset(out.columns)
 
 
 def test_resample_drops_incomplete_tail_bucket():

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
@@ -99,3 +99,15 @@ def test_system_prompt_has_v3a_bnf_knowledge():
     # and must NOT weaken the mandatory candle+confirmation rule.
     assert prompt.index("BANK NIFTY — SPECIFIC BEHAVIOUR") > prompt.index("CROSS-INDEX CONFIRMATION")
     assert "execute NIFTY ATM options ONLY" in prompt
+
+
+def test_system_prompt_has_v3d_conditional_gap_knowledge():
+    """v3d: prior-days conditional gap read, reachability, and gap-size asymmetry are present."""
+    prompt = build_system_prompt()
+    assert "READ THE GAP AGAINST THE PRIOR DAYS" in prompt
+    assert "SL-REACHABILITY TEST" in prompt
+    assert "GAP-SIZE ASYMMETRY" in prompt
+    # The flat-open seller-hunt long lives inside the OPENING DRIVE section as variant B.
+    assert "Variant B" in prompt
+    # v3c's opening-drive exception must still be present and scoped.
+    assert "OPENING DRIVE" in prompt

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import pytest
-
 from sl_hunting_agent import SLHuntingDecision
 from sl_hunting_knowledge import FINAL_OUTPUT_INSTRUCTION, build_system_prompt
 

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_v2.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_v2.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 
 import pandas as pd
-
 from sl_hunting_agent import AgentRunResult, SLHuntingAgent
 from sl_hunting_executor import StandaloneExecutor, risk_based_lots, stop_or_target_hit
 from sl_hunting_indicators import cross_index_signal

--- a/Signal Generators/Subhamoy Strategies/Nifty Goldmine Signal Generator.py
+++ b/Signal Generators/Subhamoy Strategies/Nifty Goldmine Signal Generator.py
@@ -7,10 +7,7 @@ actual strategy math lives in `goldmine_strategy_logic.py`.
 
 from __future__ import annotations
 
-from typing import Optional
-
 import pandas as pd
-
 from goldmine_strategy_logic import (
     GoldmineDecision,
     GoldminePositionContext,
@@ -27,7 +24,7 @@ class NiftyGoldmineSignalGenerator(GoldmineSignalGenerator):
 
 def generate_nifty_goldmine_signals(
     data: pd.DataFrame,
-    config: Optional[GoldmineStrategyConfig] = None,
+    config: GoldmineStrategyConfig | None = None,
 ) -> pd.DataFrame:
     """Return full-history NIFTY Goldmine signals."""
     return generate_goldmine_signals(data, config=config)
@@ -35,8 +32,8 @@ def generate_nifty_goldmine_signals(
 
 def get_latest_nifty_goldmine_signal(
     data: pd.DataFrame,
-    config: Optional[GoldmineStrategyConfig] = None,
-    position: Optional[GoldminePositionContext] = None,
+    config: GoldmineStrategyConfig | None = None,
+    position: GoldminePositionContext | None = None,
 ) -> GoldmineDecision:
     """Return only the newest NIFTY Goldmine decision."""
     return get_latest_goldmine_signal(data, config=config, position=position)

--- a/Signal Generators/Subhamoy Strategies/Nifty Money Machine Signal Generator.py
+++ b/Signal Generators/Subhamoy Strategies/Nifty Money Machine Signal Generator.py
@@ -7,10 +7,7 @@ actual strategy math lives in `money_machine_strategy_logic.py`.
 
 from __future__ import annotations
 
-from typing import Optional
-
 import pandas as pd
-
 from money_machine_strategy_logic import (
     MoneyMachineDecision,
     MoneyMachinePositionContext,
@@ -27,7 +24,7 @@ class NiftyMoneyMachineSignalGenerator(MoneyMachineSignalGenerator):
 
 def generate_nifty_money_machine_signals(
     data: pd.DataFrame,
-    config: Optional[MoneyMachineStrategyConfig] = None,
+    config: MoneyMachineStrategyConfig | None = None,
 ) -> pd.DataFrame:
     """Return full-history NIFTY Money Machine signals."""
     return generate_money_machine_signals(data, config=config)
@@ -35,8 +32,8 @@ def generate_nifty_money_machine_signals(
 
 def get_latest_nifty_money_machine_signal(
     data: pd.DataFrame,
-    config: Optional[MoneyMachineStrategyConfig] = None,
-    position: Optional[MoneyMachinePositionContext] = None,
+    config: MoneyMachineStrategyConfig | None = None,
+    position: MoneyMachinePositionContext | None = None,
 ) -> MoneyMachineDecision:
     """Return only the newest NIFTY Money Machine decision."""
     return get_latest_money_machine_signal(data, config=config, position=position)

--- a/Signal Generators/Subhamoy Strategies/goldmine_strategy_logic.py
+++ b/Signal Generators/Subhamoy Strategies/goldmine_strategy_logic.py
@@ -16,11 +16,10 @@ Important:
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any
 
 import numpy as np
 import pandas as pd
-
 from subhamoy_strategy_common import (
     add_candle_anatomy,
     atr,
@@ -186,7 +185,7 @@ def _price_near_sma20(frame: pd.DataFrame, config: GoldmineStrategyConfig) -> pd
 
 def build_goldmine_with_indicators(
     ohlc: pd.DataFrame,
-    config: Optional[GoldmineStrategyConfig] = None,
+    config: GoldmineStrategyConfig | None = None,
 ) -> pd.DataFrame:
     """
     Return OHLC candles enriched with Goldmine indicators and setup columns.
@@ -274,7 +273,7 @@ def build_goldmine_with_indicators(
 class GoldmineSignalEngine:
     """Decision engine for Goldmine entries and exits."""
 
-    def __init__(self, config: Optional[GoldmineStrategyConfig] = None) -> None:
+    def __init__(self, config: GoldmineStrategyConfig | None = None) -> None:
         """
         Store one config object for all later evaluations.
 
@@ -343,7 +342,7 @@ class GoldmineSignalEngine:
     def evaluate_candle(
         self,
         candles_with_indicators: pd.DataFrame,
-        position: Optional[GoldminePositionContext] = None,
+        position: GoldminePositionContext | None = None,
     ) -> GoldmineDecision:
         """Evaluate the newest candle and return HOLD, ENTER_LONG, ENTER_SHORT, or EXIT."""
         if candles_with_indicators is None or candles_with_indicators.empty:
@@ -427,7 +426,7 @@ class GoldmineSignalEngine:
 class GoldmineSignalGenerator:
     """Convenience wrapper for full-history and latest-candle Goldmine signals."""
 
-    def __init__(self, config: Optional[GoldmineStrategyConfig] = None) -> None:
+    def __init__(self, config: GoldmineStrategyConfig | None = None) -> None:
         """
         Create one reusable signal engine for this generator instance.
 
@@ -448,7 +447,7 @@ class GoldmineSignalGenerator:
         stops: list[float] = []
         targets: list[float] = []
         stream: list[int] = []
-        position: Optional[GoldminePositionContext] = None
+        position: GoldminePositionContext | None = None
 
         for index in range(len(frame)):
             # The generator simulates a very simple single-position stream:
@@ -495,7 +494,7 @@ class GoldmineSignalGenerator:
     def latest_signal(
         self,
         data: pd.DataFrame,
-        position: Optional[GoldminePositionContext] = None,
+        position: GoldminePositionContext | None = None,
     ) -> GoldmineDecision:
         """Return only the newest Goldmine decision."""
         frame = build_goldmine_with_indicators(data, self.config)
@@ -504,7 +503,7 @@ class GoldmineSignalGenerator:
 
 def generate_goldmine_signals(
     data: pd.DataFrame,
-    config: Optional[GoldmineStrategyConfig] = None,
+    config: GoldmineStrategyConfig | None = None,
 ) -> pd.DataFrame:
     """Functional wrapper for full-history Goldmine signals."""
     return GoldmineSignalGenerator(config=config).generate(data)
@@ -512,20 +511,20 @@ def generate_goldmine_signals(
 
 def get_latest_goldmine_signal(
     data: pd.DataFrame,
-    config: Optional[GoldmineStrategyConfig] = None,
-    position: Optional[GoldminePositionContext] = None,
+    config: GoldmineStrategyConfig | None = None,
+    position: GoldminePositionContext | None = None,
 ) -> GoldmineDecision:
     """Functional wrapper for the latest Goldmine decision."""
     return GoldmineSignalGenerator(config=config).latest_signal(data, position=position)
 
 
 __all__ = [
-    "GoldmineStrategyConfig",
-    "GoldminePositionContext",
     "GoldmineDecision",
-    "build_goldmine_with_indicators",
+    "GoldminePositionContext",
     "GoldmineSignalEngine",
     "GoldmineSignalGenerator",
+    "GoldmineStrategyConfig",
+    "build_goldmine_with_indicators",
     "generate_goldmine_signals",
     "get_latest_goldmine_signal",
 ]

--- a/Signal Generators/Subhamoy Strategies/money_machine_strategy_logic.py
+++ b/Signal Generators/Subhamoy Strategies/money_machine_strategy_logic.py
@@ -11,11 +11,10 @@ trigger is different:
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any
 
 import numpy as np
 import pandas as pd
-
 from subhamoy_strategy_common import (
     add_candle_anatomy,
     atr,
@@ -158,7 +157,7 @@ def _build_hulk_masks(frame: pd.DataFrame, config: MoneyMachineStrategyConfig) -
 
 def build_money_machine_with_indicators(
     ohlc: pd.DataFrame,
-    config: Optional[MoneyMachineStrategyConfig] = None,
+    config: MoneyMachineStrategyConfig | None = None,
 ) -> pd.DataFrame:
     """
     Return OHLC candles enriched with Money Machine indicators and setup columns.
@@ -262,7 +261,7 @@ def build_money_machine_with_indicators(
 class MoneyMachineSignalEngine:
     """Decision engine for Money Machine entries and exits."""
 
-    def __init__(self, config: Optional[MoneyMachineStrategyConfig] = None) -> None:
+    def __init__(self, config: MoneyMachineStrategyConfig | None = None) -> None:
         """
         Store one config object for all later evaluations.
 
@@ -323,7 +322,7 @@ class MoneyMachineSignalEngine:
     def evaluate_candle(
         self,
         candles_with_indicators: pd.DataFrame,
-        position: Optional[MoneyMachinePositionContext] = None,
+        position: MoneyMachinePositionContext | None = None,
     ) -> MoneyMachineDecision:
         """Evaluate the newest candle and return HOLD, ENTER_LONG, ENTER_SHORT, or EXIT."""
         if candles_with_indicators is None or candles_with_indicators.empty:
@@ -406,7 +405,7 @@ class MoneyMachineSignalEngine:
 class MoneyMachineSignalGenerator:
     """Convenience wrapper for full-history and latest-candle Money Machine signals."""
 
-    def __init__(self, config: Optional[MoneyMachineStrategyConfig] = None) -> None:
+    def __init__(self, config: MoneyMachineStrategyConfig | None = None) -> None:
         """
         Create one reusable engine for this generator instance.
 
@@ -427,7 +426,7 @@ class MoneyMachineSignalGenerator:
         stops: list[float] = []
         targets: list[float] = []
         stream: list[int] = []
-        position: Optional[MoneyMachinePositionContext] = None
+        position: MoneyMachinePositionContext | None = None
 
         for index in range(len(frame)):
             # Full-history generation keeps one simple simulated position so
@@ -471,7 +470,7 @@ class MoneyMachineSignalGenerator:
     def latest_signal(
         self,
         data: pd.DataFrame,
-        position: Optional[MoneyMachinePositionContext] = None,
+        position: MoneyMachinePositionContext | None = None,
     ) -> MoneyMachineDecision:
         """Return only the newest Money Machine decision."""
         frame = build_money_machine_with_indicators(data, self.config)
@@ -480,7 +479,7 @@ class MoneyMachineSignalGenerator:
 
 def generate_money_machine_signals(
     data: pd.DataFrame,
-    config: Optional[MoneyMachineStrategyConfig] = None,
+    config: MoneyMachineStrategyConfig | None = None,
 ) -> pd.DataFrame:
     """Functional wrapper for full-history Money Machine signals."""
     return MoneyMachineSignalGenerator(config=config).generate(data)
@@ -488,20 +487,20 @@ def generate_money_machine_signals(
 
 def get_latest_money_machine_signal(
     data: pd.DataFrame,
-    config: Optional[MoneyMachineStrategyConfig] = None,
-    position: Optional[MoneyMachinePositionContext] = None,
+    config: MoneyMachineStrategyConfig | None = None,
+    position: MoneyMachinePositionContext | None = None,
 ) -> MoneyMachineDecision:
     """Functional wrapper for the latest Money Machine decision."""
     return MoneyMachineSignalGenerator(config=config).latest_signal(data, position=position)
 
 
 __all__ = [
-    "MoneyMachineStrategyConfig",
-    "MoneyMachinePositionContext",
     "MoneyMachineDecision",
-    "build_money_machine_with_indicators",
+    "MoneyMachinePositionContext",
     "MoneyMachineSignalEngine",
     "MoneyMachineSignalGenerator",
+    "MoneyMachineStrategyConfig",
+    "build_money_machine_with_indicators",
     "generate_money_machine_signals",
     "get_latest_money_machine_signal",
 ]

--- a/Signal Generators/Subhamoy Strategies/profit_shooter_strategy_logic.py
+++ b/Signal Generators/Subhamoy Strategies/profit_shooter_strategy_logic.py
@@ -33,7 +33,6 @@ Indicator note:
 """
 
 from dataclasses import dataclass
-from typing import Optional
 
 import numpy as np
 import pandas as pd
@@ -45,8 +44,9 @@ try:
     import talib
 except ImportError:  # pragma: no cover - fallback only used when TA-Lib is unavailable
     # We intentionally keep a fallback path so the strategy does not become
-    # unusable in environments where TA-Lib is not installed yet.
-    talib = None
+    # unusable in environments where TA-Lib is not installed yet. (The ignore
+    # carries both codes because the error only exists where stubs are present.)
+    talib = None  # type: ignore[assignment, unused-ignore]
 
 
 @dataclass(frozen=True)
@@ -353,7 +353,7 @@ def _build_short_setup(frame: pd.DataFrame, config: ProfitShooterConfig) -> pd.S
 
 def build_profit_shooter_with_indicators(
     ohlc: pd.DataFrame,
-    config: Optional[ProfitShooterConfig] = None,
+    config: ProfitShooterConfig | None = None,
 ) -> pd.DataFrame:
     """
     Enrich OHLC candles with the indicators and derived columns used by the strategy.
@@ -532,7 +532,7 @@ class ProfitShooterSignalEngine:
     `build_profit_shooter_with_indicators()` and returns one clean decision.
     """
 
-    def __init__(self, config: Optional[ProfitShooterConfig] = None):
+    def __init__(self, config: ProfitShooterConfig | None = None):
         # Store config on the engine so every caller shares the same rule set.
         self.config = config or ProfitShooterConfig()
 
@@ -740,7 +740,7 @@ class ProfitShooterSignalEngine:
     def evaluate_candle(
         self,
         candles_with_indicators: pd.DataFrame,
-        position: Optional[ProfitShooterPositionContext] = None,
+        position: ProfitShooterPositionContext | None = None,
     ) -> ProfitShooterDecision:
         """
         Evaluate the latest completed candle and return one strategy decision.

--- a/Signal Generators/Subhamoy Strategies/subhamoy_strategy_common.py
+++ b/Signal Generators/Subhamoy Strategies/subhamoy_strategy_common.py
@@ -15,7 +15,7 @@ Beginner mental model:
 
 from __future__ import annotations
 
-from typing import Iterable, Optional
+from collections.abc import Iterable
 
 import numpy as np
 import pandas as pd
@@ -23,15 +23,17 @@ import pandas as pd
 try:
     # TA-Lib is the preferred indicator backend in this repo because it matches
     # the user's request for standard library indicator implementations.
-    import talib  # type: ignore
+    import talib
 except ImportError:  # pragma: no cover - used only when TA-Lib is absent
-    talib = None  # type: ignore
+    # The assignment error only exists where TA-Lib (with stubs) is installed;
+    # on stub-less machines the ignore is unused, hence the dual code.
+    talib = None  # type: ignore[assignment, unused-ignore]
 
 
 OHLC_COLUMNS = ["open", "high", "low", "close"]
 
 
-def find_first_col(frame: pd.DataFrame, names: Iterable[str]) -> Optional[str]:
+def find_first_col(frame: pd.DataFrame, names: Iterable[str]) -> str | None:
     """Find the first matching column name using case-insensitive comparison."""
     lookup = {str(column).strip().lower(): column for column in frame.columns}
     for name in names:
@@ -132,7 +134,7 @@ def sma(values: pd.Series, period: int) -> pd.Series:
     """Calculate simple moving average with TA-Lib first, then pandas."""
     if talib is not None:
         return pd.Series(
-            talib.SMA(values.to_numpy(dtype="float64"), timeperiod=int(period)),  # type: ignore[union-attr]
+            talib.SMA(values.to_numpy(dtype="float64"), timeperiod=int(period)),
             index=values.index,
         )
     return values.rolling(window=int(period), min_periods=int(period)).mean()
@@ -145,7 +147,7 @@ def atr(frame: pd.DataFrame, period: int) -> pd.Series:
     close = frame["close"].astype(float)
     if talib is not None:
         return pd.Series(
-            talib.ATR(  # type: ignore[union-attr]
+            talib.ATR(
                 high.to_numpy(dtype="float64"),
                 low.to_numpy(dtype="float64"),
                 close.to_numpy(dtype="float64"),
@@ -189,6 +191,6 @@ def falling_over_lookback(values: pd.Series, lookback: int) -> pd.Series:
 def finite(value: object) -> bool:
     """Return True only for real finite numbers."""
     try:
-        return bool(np.isfinite(float(value)))
+        return bool(np.isfinite(float(value)))  # type: ignore[arg-type]
     except (TypeError, ValueError):
         return False

--- a/Signal Generators/Subhamoy Strategies/test_subhamoy_strategy_signal_generators.py
+++ b/Signal Generators/Subhamoy Strategies/test_subhamoy_strategy_signal_generators.py
@@ -6,7 +6,6 @@ from pathlib import Path
 
 import pandas as pd
 
-
 STRATEGY_DIR = Path(__file__).resolve().parent
 REPO_ROOT = STRATEGY_DIR.parents[1]
 BACKTEST_DIR = REPO_ROOT / "My Backtest Files (For Reference)" / "Subhamoy Strategies"

--- a/Signal Generators/Supertrend Signal Generator Bullish.py
+++ b/Signal Generators/Supertrend Signal Generator Bullish.py
@@ -56,19 +56,23 @@ ATR if TA-Lib is not installed on the machine.
 
 from __future__ import annotations
 
+import contextlib
+from collections.abc import Iterable
+
 # --- Standard library imports ------------------------------------------------
 # `dataclass` lets us define small "struct-like" classes for settings and
 # decisions without writing `__init__` boilerplate.
 from dataclasses import dataclass
+
 # `IntEnum` is a tidy way to attach human-readable names (LONG, SHORT, ...)
 # to small integer flags. The underlying values are still plain integers, so
 # they can be compared against numpy arrays cheaply.
 from enum import IntEnum
-from typing import Iterable, Optional
 
 # --- Third-party imports -----------------------------------------------------
 # numpy is used for fast array math (no Python for-loops over raw numbers).
 import numpy as np
+
 # pandas is the tabular-data library we accept as input and return as output.
 import pandas as pd
 
@@ -162,7 +166,7 @@ class SupertrendDecision:
 # =============================================================================
 # INPUT PREPARATION HELPERS
 # =============================================================================
-def _find_first_col(frame: pd.DataFrame, names: Iterable[str]) -> Optional[str]:
+def _find_first_col(frame: pd.DataFrame, names: Iterable[str]) -> str | None:
     """
     Return the first column in `frame` whose (case-insensitive, trimmed)
     name is in `names`, or None if nothing matches.
@@ -228,12 +232,10 @@ def _prepare_ohlc_frame(data: pd.DataFrame) -> pd.DataFrame:
         # as-is.
         #
         # We used to pass `errors="ignore"` here, but pandas deprecated that
-        # option (FutureWarning on every call). The try/except below gives
+        # option (FutureWarning on every call). The suppress below gives
         # the same behaviour without the warning.
-        try:
+        with contextlib.suppress(ValueError, TypeError):
             out["timestamp"] = pd.to_datetime(out["timestamp"])
-        except (ValueError, TypeError):
-            pass
     # Reset to a clean integer index so `.iloc[-1]`, `.iloc[-2]` etc. behave
     # predictably regardless of the original index.
     return out.reset_index(drop=True)
@@ -525,7 +527,7 @@ class SupertrendSignalGenerator:
     is equivalent to expressing a long / bullish view on the underlying.
     """
 
-    def __init__(self, settings: Optional[SupertrendSettings] = None) -> None:
+    def __init__(self, settings: SupertrendSettings | None = None) -> None:
         # If the caller does not pass settings, use the class's default
         # configuration (ATR 14, Factor 3) from `SupertrendSettings`.
         self.settings = settings or SupertrendSettings()
@@ -682,7 +684,7 @@ class SupertrendSignalGenerator:
 # unless the caller overrides them.
 def generate_supertrend_signals(
     data: pd.DataFrame,
-    settings: Optional[SupertrendSettings] = None,
+    settings: SupertrendSettings | None = None,
 ) -> pd.DataFrame:
     """Functional alias for `SupertrendSignalGenerator(...).generate(data)`."""
     generator = SupertrendSignalGenerator(settings=settings)
@@ -691,7 +693,7 @@ def generate_supertrend_signals(
 
 def get_latest_supertrend_signal(
     data: pd.DataFrame,
-    settings: Optional[SupertrendSettings] = None,
+    settings: SupertrendSettings | None = None,
 ) -> SupertrendDecision:
     """Functional alias for `SupertrendSignalGenerator(...).latest_signal(data)`."""
     generator = SupertrendSignalGenerator(settings=settings)
@@ -702,8 +704,8 @@ def get_latest_supertrend_signal(
 # names here also serves as a quick table-of-contents for readers.
 __all__ = [
     "Direction",
-    "SupertrendSettings",
     "SupertrendDecision",
+    "SupertrendSettings",
     "SupertrendSignalGenerator",
     "generate_supertrend_signals",
     "get_latest_supertrend_signal",

--- a/Signal Generators/ema_trend_strategy_logic.py
+++ b/Signal Generators/ema_trend_strategy_logic.py
@@ -35,7 +35,6 @@ Beginner mental model:
 """
 
 from dataclasses import dataclass
-from typing import Optional
 
 import numpy as np
 import pandas as pd
@@ -46,8 +45,9 @@ try:
     import talib
 except ImportError:  # pragma: no cover - fallback only used when TA-Lib is unavailable
     # The strategy can still run without TA-Lib because beginner users may not
-    # always have the package installed on the first attempt.
-    talib = None
+    # always have the package installed on the first attempt. (The ignore
+    # carries both codes because the error only exists where stubs are present.)
+    talib = None  # type: ignore[assignment, unused-ignore]
 
 
 @dataclass(frozen=True)
@@ -261,7 +261,7 @@ def _build_short_setup(frame: pd.DataFrame, config: EMATrendConfig) -> pd.Series
 
 def build_ema_trend_with_indicators(
     ohlc: pd.DataFrame,
-    config: Optional[EMATrendConfig] = None,
+    config: EMATrendConfig | None = None,
 ) -> pd.DataFrame:
     """
     Enrich OHLC candles with the indicators and derived signals used by the strategy.
@@ -391,7 +391,7 @@ class EMATrendSignalEngine:
     DataFrame built by `build_ema_trend_with_indicators()`.
     """
 
-    def __init__(self, config: Optional[EMATrendConfig] = None):
+    def __init__(self, config: EMATrendConfig | None = None):
         # Keeping config on the engine means backtests, front-tests, and any
         # future live-trading script can all share the exact same rules.
         self.config = config or EMATrendConfig()
@@ -454,7 +454,7 @@ class EMATrendSignalEngine:
     def evaluate_candle(
         self,
         candles_with_indicators: pd.DataFrame,
-        position: Optional[EMATrendPositionContext] = None,
+        position: EMATrendPositionContext | None = None,
     ) -> EMATrendDecision:
         """
         Evaluate the latest candle and return one decision.

--- a/Signal Generators/heikin_ashi_strategy_logic.py
+++ b/Signal Generators/heikin_ashi_strategy_logic.py
@@ -13,10 +13,8 @@ Quick-start:
 """
 
 from dataclasses import dataclass
-from typing import Optional
 
 import pandas as pd
-
 
 DEFAULT_BOLL_PERIOD = 20
 DEFAULT_BOLL_STD = 2.0
@@ -162,7 +160,7 @@ class HeikinAshiSignalEngine:
     def evaluate_candle(
         self,
         candles_with_indicators: pd.DataFrame,
-        position: Optional[HeikinAshiPositionContext] = None,
+        position: HeikinAshiPositionContext | None = None,
     ) -> HeikinAshiDecision:
         """
         Evaluate the latest candle and return one decision.

--- a/Signal Generators/misc_strategy_common.py
+++ b/Signal Generators/misc_strategy_common.py
@@ -34,7 +34,7 @@ Beginner orientation
 
 from __future__ import annotations
 
-from typing import Iterable, Optional
+from collections.abc import Iterable
 
 import numpy as np
 import pandas as pd
@@ -42,9 +42,11 @@ import pandas as pd
 try:
     # TA-Lib is the preferred indicator backend in this repo because it matches
     # the standard library indicator implementations used by the other folders.
-    import talib  # type: ignore
+    import talib
 except ImportError:  # pragma: no cover - used only when TA-Lib is absent
-    talib = None  # type: ignore
+    # The assignment error only exists where TA-Lib (with stubs) is installed;
+    # on stub-less machines the ignore is unused, hence the dual code.
+    talib = None  # type: ignore[assignment, unused-ignore]
 
 
 OHLC_COLUMNS = ["open", "high", "low", "close"]
@@ -53,7 +55,7 @@ OHLC_COLUMNS = ["open", "high", "low", "close"]
 # ---------------------------------------------------------------------------
 # Column / frame helpers (shared with the Subhamoy convention)
 # ---------------------------------------------------------------------------
-def find_first_col(frame: pd.DataFrame, names: Iterable[str]) -> Optional[str]:
+def find_first_col(frame: pd.DataFrame, names: Iterable[str]) -> str | None:
     """Find the first matching column name using case-insensitive comparison."""
     lookup = {str(column).strip().lower(): column for column in frame.columns}
     for name in names:
@@ -150,7 +152,7 @@ def falling_over_lookback(values: pd.Series, lookback: int) -> pd.Series:
 def finite(value: object) -> bool:
     """Return True only for real finite numbers."""
     try:
-        return bool(np.isfinite(float(value)))
+        return bool(np.isfinite(float(value)))  # type: ignore[arg-type]
     except (TypeError, ValueError):
         return False
 
@@ -337,9 +339,9 @@ def stochastic(
             _as_float_array(close),
             fastk_period=k_period,
             slowk_period=smooth_k,
-            slowk_matype=0,
+            slowk_matype=0,  # type: ignore[arg-type, unused-ignore]
             slowd_period=d_period,
-            slowd_matype=0,
+            slowd_matype=0,  # type: ignore[arg-type, unused-ignore]
         )
         return pd.Series(slowk, index=frame.index), pd.Series(slowd, index=frame.index)
     lowest_low = low.rolling(window=k_period, min_periods=k_period).min()
@@ -409,7 +411,7 @@ def bollinger_bands(
             timeperiod=period,
             nbdevup=num_std,
             nbdevdn=num_std,
-            matype=0,
+            matype=0,  # type: ignore[arg-type, unused-ignore]
         )
         return (
             pd.Series(upper, index=values.index),
@@ -672,26 +674,26 @@ def find_swing_highs(values: pd.Series, window: int) -> list[int]:
 
 __all__ = [
     "OHLC_COLUMNS",
-    "find_first_col",
-    "require_columns",
-    "normalize_ohlc_frame",
     "add_candle_anatomy",
-    "rising_over_lookback",
-    "falling_over_lookback",
-    "finite",
-    "sma",
-    "ema",
-    "atr",
-    "true_range",
-    "rsi",
-    "macd",
-    "stochastic",
     "adx",
+    "atr",
     "bollinger_bands",
-    "keltner_channels",
-    "rolling_zscore",
-    "parabolic_sar",
-    "supertrend",
-    "find_swing_lows",
+    "ema",
+    "falling_over_lookback",
+    "find_first_col",
     "find_swing_highs",
+    "find_swing_lows",
+    "finite",
+    "keltner_channels",
+    "macd",
+    "normalize_ohlc_frame",
+    "parabolic_sar",
+    "require_columns",
+    "rising_over_lookback",
+    "rolling_zscore",
+    "rsi",
+    "sma",
+    "stochastic",
+    "supertrend",
+    "true_range",
 ]

--- a/Signal Generators/renko_strategy_logic.py
+++ b/Signal Generators/renko_strategy_logic.py
@@ -20,7 +20,7 @@ What this file contains:
 """
 
 from dataclasses import dataclass
-from typing import Optional
+
 import pandas as pd
 
 
@@ -175,14 +175,12 @@ def build_renko_with_indicators(ohlc: pd.DataFrame) -> pd.DataFrame:
     Convert OHLC candles into Renko candles plus EMA indicators.
 
     Steps:
-    1. Compute ATR(14).
-    2. Use latest ATR value as dynamic Renko box size.
-    3. Build Renko bricks from close prices.
-    4. Add EMA(5), EMA(21), EMA(44) on Renko close.
+    1. Use the FIXED 12.5-point Renko box size (the ATR(14)-dynamic sizing this
+       function originally used is deliberately disabled — see git history to
+       restore ``float(atr(ohlc, 14).iloc[-1])``).
+    2. Build Renko bricks from close prices.
+    3. Add EMA(5), EMA(21), EMA(44) on Renko close.
     """
-    # ATR is used for dynamic Renko box size.
-    atr_series = atr(ohlc, 14)
-    # box_size = float(atr_series.iloc[-1])
     box_size = 12.5
     if pd.isna(box_size) or box_size <= 0:
         # ATR may be NaN in early warm-up or in malformed data.
@@ -327,7 +325,7 @@ class RenkoSignalEngine:
     def evaluate_candle(
         self,
         renko: pd.DataFrame,
-        position: Optional[RenkoPositionContext] = None,
+        position: RenkoPositionContext | None = None,
     ) -> RenkoDecision:
         """
         Evaluate the latest Renko candle and return one strategy decision.

--- a/Signal Generators/renko_strategy_logic_9_21.py
+++ b/Signal Generators/renko_strategy_logic_9_21.py
@@ -33,7 +33,6 @@ What this file contains:
 """
 
 from dataclasses import dataclass
-from typing import Optional
 
 import pandas as pd
 
@@ -218,10 +217,9 @@ def build_renko_with_indicators(ohlc: pd.DataFrame) -> pd.DataFrame:
     - ema21
     - box_size
     """
-    # ATR(21) is the defining difference in this variant.
-    # We use the most recent ATR value as today's Renko box size.
-    atr_series = atr(ohlc, 21)
-    # box_size = float(atr_series.iloc[-1])
+    # Box size is FIXED at 12.5 points. The ATR(21)-dynamic sizing that defined
+    # this variant is deliberately disabled — see git history to restore
+    # ``float(atr(ohlc, 21).iloc[-1])``.
     box_size = 12.5
     if pd.isna(box_size) or box_size <= 0:
         # ATR can be invalid during warm-up or when incoming data is malformed.
@@ -388,7 +386,7 @@ class RenkoSignalEngine:
     def evaluate_candle(
         self,
         renko: pd.DataFrame,
-        position: Optional[RenkoPositionContext] = None,
+        position: RenkoPositionContext | None = None,
     ) -> RenkoDecision:
         """
         Evaluate the latest Renko candle and return one strategy decision.

--- a/algo.py
+++ b/algo.py
@@ -61,7 +61,7 @@ script's own exit code is returned, so this CLI is transparent to automation.
 """
 
 import argparse
-import subprocess
+import subprocess  # nosec B404 - this CLI exists to launch the repo's own scripts
 import sys
 from pathlib import Path
 
@@ -122,7 +122,8 @@ def _run(relative_path: str, forwarded_args: list) -> int:
     command = [sys.executable, str(script), *forwarded_args]
     # Echo what we're about to do so it's obvious which script is running.
     print(f"[algo] running: {script.name} {' '.join(forwarded_args)}".rstrip())
-    return subprocess.run(command, cwd=str(REPO_ROOT)).returncode
+    # nosec B603 - argv is [sys.executable, <repo-root script>, *user args]; no shell.
+    return subprocess.run(command, cwd=str(REPO_ROOT)).returncode  # nosec B603
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,129 @@
+# Quality-tooling configuration only. This repo is not a packaged distribution
+# (the runner and most strategy files have SPACES in their names and are loaded
+# via importlib -- see load_module() in the master file), so there is no
+# [project] section: this file centralizes ruff + mypy configuration, mirroring
+# the Streamlit Scanner App's setup (the house pattern for CI quality gates).
+
+[tool.ruff]
+# Measured against this codebase: at 100 columns there are ~455 long lines, at
+# 120 there are ~57 (mostly deliberate log/docstring lines). The code was
+# written to a ~100-120 column style, so 120 keeps the lint signal about real
+# problems instead of wrapping churn.
+line-length = 120
+# Local runtime is Python 3.13; CI also runs 3.12, so target the older of the
+# two to avoid suggesting syntax 3.12 cannot parse.
+target-version = "py312"
+extend-exclude = [
+    # Vendored third-party Shoonya SDK -- never linted, never rewritten locally.
+    "Dependencies/Shoonya API/NorenApi.py",
+    # Generated outputs and reference-only backtests are not part of the
+    # runtime quality gate (the backtests are kept as historical reference).
+    "Backtest Outputs",
+]
+
+[tool.ruff.lint]
+# E/W   pycodestyle errors and warnings
+# F     pyflakes (undefined names, unused imports/variables)
+# I     import sorting
+# B     flake8-bugbear (likely bugs: mutable defaults, loop-var closures, ...)
+# UP    pyupgrade (modern 3.12+ syntax)
+# C4    comprehension correctness/efficiency
+# SIM   simplifiable code
+# RUF   Ruff-native checks (mutable class defaults, unused noqa, ...)
+select = ["E", "W", "F", "I", "B", "UP", "C4", "SIM", "RUF"]
+# `# noqa: BLE001` comments document intentional broad-except blocks for a
+# stricter future rule set. BLE is not enabled yet, so tell Ruff the code is
+# external-tool noqa rather than letting RUF100 delete the documentation.
+external = ["BLE"]
+
+[tool.ruff.lint.per-file-ignores]
+# B017: tests intentionally assert on bare Exception for defensive paths.
+# RUF012: test fakes use mutable class attributes as fixtures.
+"**/test_*.py" = ["B017", "RUF012"]
+"test_nifty_multi_strategy_master.py" = ["B017", "RUF012"]
+# Reference-only backtests keep the deliberate sys.path-before-import pattern.
+"My Backtest Files (For Reference)/**" = ["E402"]
+
+[tool.mypy]
+# CI runs 3.12 and 3.13; pin the older so local runs stay honest about what CI
+# will accept.
+python_version = "3.12"
+# First-adoption scope: every module whose FILENAME is a valid Python
+# identifier. The master runner ("Nifty Multi Strategy Front Test - Master
+# File.py") and the per-strategy files with spaces in their names CANNOT be
+# mypy modules (invalid module name); they are covered by `compileall` plus
+# the 133-test master unittest suite instead.
+files = [
+    "algo.py",
+    "Data Extractors/index_1m_5y_data_fetch_dhan_common.py",
+    "Dependencies/dhan_token_setup.py",
+    "Dependencies/Kotak API/kotak_execution.py",
+    "Dependencies/Kotak API/diagnose_kotak_symbol.py",
+    "Dependencies/Shoonya API/shoonya_execution.py",
+    "Dependencies/Shoonya API/diagnose_shoonya_symbol.py",
+    "Dependencies/Flattrade API/flattrade_execution.py",
+    "Dependencies/Flattrade API/diagnose_flattrade_symbol.py",
+    "Signal Generators/ema_trend_strategy_logic.py",
+    "Signal Generators/heikin_ashi_strategy_logic.py",
+    "Signal Generators/renko_strategy_logic.py",
+    "Signal Generators/renko_strategy_logic_9_21.py",
+    "Signal Generators/misc_strategy_common.py",
+    "Signal Generators/CPR Strategy/cpr_strategy_logic.py",
+    "Signal Generators/Subhamoy Strategies/goldmine_strategy_logic.py",
+    "Signal Generators/Subhamoy Strategies/money_machine_strategy_logic.py",
+    "Signal Generators/Subhamoy Strategies/profit_shooter_strategy_logic.py",
+    "Signal Generators/Subhamoy Strategies/subhamoy_strategy_common.py",
+    "Signal Generators/SL Hunting AI Agent/sl_hunting_agent.py",
+    "Signal Generators/SL Hunting AI Agent/sl_hunting_ai_validation.py",
+    "Signal Generators/SL Hunting AI Agent/sl_hunting_coach.py",
+    "Signal Generators/SL Hunting AI Agent/sl_hunting_executor.py",
+    "Signal Generators/SL Hunting AI Agent/sl_hunting_indicators.py",
+    "Signal Generators/SL Hunting AI Agent/sl_hunting_journal.py",
+    "Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py",
+    "Signal Generators/SL Hunting AI Agent/sl_hunting_lessons.py",
+    "Signal Generators/SL Hunting AI Agent/sl_hunting_runner.py",
+    "Signal Generators/SL Hunting AI Agent/sl_hunting_tools.py",
+]
+# Sibling imports (sl_hunting_agent -> sl_hunting_knowledge, shoonya_execution
+# -> NorenApi, logic modules -> *_strategy_common) resolve through these roots.
+mypy_path = [
+    "Signal Generators",
+    "Signal Generators/CPR Strategy",
+    "Signal Generators/Subhamoy Strategies",
+    "Signal Generators/SL Hunting AI Agent",
+    "Dependencies/Shoonya API",
+]
+# First-adoption strictness (Scanner App parity): check function bodies
+# everywhere without yet requiring annotations on every def. Stricter flags
+# (disallow_untyped_defs) and tests/ coverage are deliberate follow-ups.
+check_untyped_defs = true
+no_implicit_optional = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+
+[[tool.mypy.overrides]]
+# Third-party packages that ship no type stubs, optional broker/ML SDKs that
+# are absent on CI, and the vendored NorenApi client. pandas is deliberately
+# untyped here: pandas-stubs would surface a wall of new errors in this
+# pandas-heavy codebase and is its own future migration.
+module = [
+    "dhanhq.*",
+    "pandas.*",
+    "gspread.*",
+    "dotenv.*",
+    "pytz.*",
+    "backtesting.*",
+    "claude_agent_sdk.*",
+    "neo_api_client.*",
+    "pyotp.*",
+    "websocket.*",
+    "sklearn.*",
+    "talib.*",
+    "NorenApi",
+]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+# The vendored Shoonya SDK is third-party code; type-check our wrappers, not it.
+module = ["NorenApi"]
+ignore_errors = true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,13 @@
+# Development / CI quality-gate tools (runtime deps live in requirements.txt).
+# Versions mirror the Streamlit Scanner App's verified set where shared.
+pytest==9.0.3
+ruff==0.15.1
+mypy==1.19.1
+bandit==1.9.4
+pre-commit==4.6.0
+# Type stubs for typed third-party usage in the mypy scope.
+types-requests==2.33.0.20260518
+# Optional runtime deps installed in CI so the SL Hunting suite runs fully
+# instead of skipping (they stay optional for live operation).
+pydantic
+claude-agent-sdk

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,9 @@ bandit==1.9.4
 pre-commit==4.6.0
 # Type stubs for typed third-party usage in the mypy scope.
 types-requests==2.33.0.20260518
-# Optional runtime deps installed in CI so the SL Hunting suite runs fully
-# instead of skipping (they stay optional for live operation).
+# Optional runtime deps installed in CI so the SL Hunting and Shoonya suites
+# run fully instead of skipping (they stay optional for live operation).
 pydantic
 claude-agent-sdk
+pyotp
+websocket-client

--- a/test_nifty_multi_strategy_master.py
+++ b/test_nifty_multi_strategy_master.py
@@ -1854,6 +1854,13 @@ class TestShoonyaFillConfirmation(unittest.TestCase):
     real fill via single_order_history before reporting success.
     """
 
+    def setUp(self):
+        # Same guard as TestShoonyaOrderAck: without the optional Shoonya deps
+        # the master binds shoonya_execution_client to None, and type(None)()
+        # below would blow up instead of skipping.
+        if master_file.shoonya_execution_client is None:
+            self.skipTest("Shoonya execution layer not importable in this environment.")
+
     def _client(self, history):
         c = type(master_file.shoonya_execution_client)()  # fresh instance, not the singleton
         c.client = _StubNoren(history)

--- a/test_nifty_multi_strategy_master.py
+++ b/test_nifty_multi_strategy_master.py
@@ -1,22 +1,23 @@
-import unittest
 import importlib.util
 import hashlib
 import json
-import tempfile
-import threading
-from pathlib import Path
-from datetime import datetime, date, timedelta
-import pandas as pd
-from unittest.mock import MagicMock, patch
 import os
 import sys
+import tempfile
+import threading
+import unittest
+from datetime import date, datetime, timedelta
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 from urllib.parse import parse_qs
+
+import pandas as pd
 
 # =============================================================================
 # DYNAMIC MODULE IMPORT
 # =============================================================================
 # Python usually expects file names without spaces (e.g. "my_script.py").
-# Since the original strategy file has spaces in its name, we must use 
+# Since the original strategy file has spaces in its name, we must use
 # 'importlib' to manually load the file as a module so we can test its contents.
 file_path = Path(__file__).parent / "Nifty Multi Strategy Front Test - Master File.py"
 spec = importlib.util.spec_from_file_location("master_file", file_path)
@@ -26,16 +27,19 @@ sys.modules["master_file"] = master_file
 # =============================================================================
 # MOCKING (FAKE DATA) FOR SAFE TESTING
 # =============================================================================
-# We do not want our tests to accidentally place real trades or connect to 
+# We do not want our tests to accidentally place real trades or connect to
 # the DhanHQ API. So we "mock" (fake) the API connections.
-with patch.dict(os.environ, {"DHAN_CLIENT_CODE": "test", "DHAN_TOKEN_ID": "test"}):
-    # This completely disables the 'dhanhq' module while the script loads
-    with patch("dhanhq.dhanhq"):
-        try:
-            # We execute the file so that all classes and functions become available
-            spec.loader.exec_module(master_file)
-        except Exception as e:
-            print(f"Failed to load master_file for testing: {e}")
+# The patch of 'dhanhq.dhanhq' completely disables the real SDK while the
+# script loads.
+with (
+    patch.dict(os.environ, {"DHAN_CLIENT_CODE": "test", "DHAN_TOKEN_ID": "test"}),
+    patch("dhanhq.dhanhq"),
+):
+    try:
+        # We execute the file so that all classes and functions become available
+        spec.loader.exec_module(master_file)
+    except Exception as e:
+        print(f"Failed to load master_file for testing: {e}")
 
 
 # The Flattrade helper is loaded separately so its low-level REST behaviour can
@@ -105,10 +109,10 @@ class TestMasterFileUtilities(unittest.TestCase):
             "open": [100.0], "high": [105.0], "low": [95.0], "close": [102.0]
         })
         sig = master_file.build_last_row_signature(df)
-        self.assertIsNotNone(sig) 
-        self.assertEqual(sig[0], 1) 
-        self.assertEqual(sig[2], 100.0) 
-        self.assertEqual(sig[5], 102.0) 
+        self.assertIsNotNone(sig)
+        self.assertEqual(sig[0], 1)
+        self.assertEqual(sig[2], 100.0)
+        self.assertEqual(sig[5], 102.0)
 
         self.assertIsNone(master_file.build_last_row_signature(None))
         self.assertIsNone(master_file.build_last_row_signature(pd.DataFrame()))
@@ -135,20 +139,20 @@ class TestSharedMarketDataStore(unittest.TestCase):
         })
         snapshot = self.store.update("1", df)
         self.assertEqual(snapshot.timeframe, "1")
-        
+
         fetched = self.store.get("1")
         self.assertIsNotNone(fetched)
         self.assertEqual(fetched.timeframe, "1")
         self.assertEqual(fetched.frame.iloc[-1]["close"], 102.0)
-        
+
     def test_ltp_cache(self):
         """Verify that the Last Traded Price (LTP) cache stores prices properly and ignores glitches."""
         self.store.update_ltp_map({("NSE_FNO", 1234): 150.5, ("IDX_I", 13): 20000.0})
-        
+
         self.assertEqual(self.store.get_ltp_by_secid("NSE_FNO", 1234), 150.5)
         self.assertEqual(self.store.get_ltp_by_secid("IDX_I", 13), 20000.0)
         self.assertEqual(self.store.get_ltp_by_secid("NSE_FNO", 9999, fallback=10.0), 10.0)
-        
+
         self.store.update_ltp_map({("NSE_FNO", 1234): -50.0})
         self.assertEqual(self.store.get_ltp_by_secid("NSE_FNO", 1234), 150.5)
 
@@ -159,11 +163,11 @@ class TestSharedMarketDataStore(unittest.TestCase):
             right="CE", strike=20000.0, expiry=date(2023, 1, 26)
         )
         self.store.register_option_subscription(sub)
-        
+
         subs = self.store.snapshot_option_subscriptions()
         self.assertEqual(len(subs), 1)
         self.assertEqual(subs[0].security_id, 123)
-        
+
         self.store.unregister_option_subscription("NSE_FNO", 123)
         self.assertEqual(len(self.store.snapshot_option_subscriptions()), 0)
 
@@ -173,7 +177,7 @@ class TestSharedMarketDataStore(unittest.TestCase):
 # =============================================================================
 class TestDataclasses(unittest.TestCase):
     """
-    Dataclasses are like blueprints for storing structured information. 
+    Dataclasses are like blueprints for storing structured information.
     Here we test if the blueprints assemble the objects correctly.
     """
 
@@ -589,6 +593,7 @@ class TestOptionsContractResolver(unittest.TestCase):
             for row, ltp in zip(
                 [r for _, r in puts.iterrows()],
                 [10.0, 50.0, 160.0, 350.0],
+                strict=False,
             )
         }
         pick = resolver.pick_put_by_target_premium(
@@ -607,6 +612,7 @@ class TestOptionsContractResolver(unittest.TestCase):
             for row, ltp in zip(
                 [r for _, r in calls.iterrows()],
                 [350.0, 160.0, 50.0, 10.0],
+                strict=False,
             )
         }
         # First pick - landed at the 160-Rs strike.
@@ -1861,7 +1867,7 @@ class TestShoonyaFillConfirmation(unittest.TestCase):
 
     def test_order_status_parses_latest_row(self):
         c = self._client(self._hist("COMPLETE", fld=50, qty=75))
-        state, filled, qty, reason = c._order_status("ORD1")
+        state, filled, qty, _reason = c._order_status("ORD1")
         self.assertEqual((state, filled, qty), ("complete", 50, 75))
 
     def test_confirm_fill_returns_on_complete(self):
@@ -1878,9 +1884,8 @@ class TestShoonyaFillConfirmation(unittest.TestCase):
         mod = type(c).__module__
         smod = sys.modules[mod]
         with patch.object(smod, "_FILL_TIMEOUT_SECONDS", 0.05), \
-             patch.object(smod, "_FILL_POLL_INTERVAL", 0.01):
-            with self.assertRaises(Exception):
-                c._confirm_fill("ORD1", 75)
+             patch.object(smod, "_FILL_POLL_INTERVAL", 0.01), self.assertRaises(Exception):
+            c._confirm_fill("ORD1", 75)
 
 
 class TestShoonyaSymbolResolution(unittest.TestCase):

--- a/test_nifty_multi_strategy_master.py
+++ b/test_nifty_multi_strategy_master.py
@@ -1,5 +1,5 @@
-import importlib.util
 import hashlib
+import importlib.util
 import json
 import os
 import sys


### PR DESCRIPTION
## Summary

Four commits: the v3d knowledge sweep (committed after PR #33 merged, so it rides here), the
whole-codebase review with executed fixes, the ported quality CI, and a reconciliation with
PR #34's Flattrade live-broker merge.

### 1. SL Hunting v3d — 2-week verbatim video sweep (knowledge-only)

All 18 in-window Intraday Hunter videos (18 Jun – 2 Jul sessions: 8 live trades = 4 wins /
4 losses, 9 nightly plan clips, 1 weekly) re-extracted from **verbatim Hindi transcripts**
(the v3c method — supersedes the lossy Gemini summaries v3a/v3b used). Net-new knowledge:

- **READ THE GAP AGAINST THE PRIOR DAYS** — a big counter-gap is a lure for the starved crowd,
  not a signal (gap-down after an up-streak → buy the recovery; gap-up after a selling streak →
  "no trust"); small counter-gaps read as flat; only a gap through the prior extreme flips the read.
- **SL-REACHABILITY TEST** — no hunt when the crowd's stops sit beyond an intact round number /
  closing price (pairs with v3c's trap-density test).
- **`OPENING_DRIVE` variant B** — flat-open seller-hunt LONG after an extended multi-day down
  move (same first-candle-close + no-major-rejection discipline; still no short, no gap-down variant).
- **Gap-size asymmetry** across BNF/NIFTY/Sensex (smaller-gap index is the tell); trap-construction
  leg; direction-first hierarchy over divergence setups; two-rejections/third-momentum rule;
  early-adverse-on-expiry = wrong direction; loss-streak "recovery trade" bias; no-plan zones.
- Per-video provenance table (id — session — type — outcome) in the v3d addendum of
  `sl_hunting_doc.md`; new marker test (56 SL Hunting tests green).

### 2. Whole-codebase review with fixes (aggressive scope, operator-approved)

~500 findings triaged via the new toolchain + manual money-path reading. Highlights:

- **SECURITY: a real DhanHQ client id + access-token JWT was committed as defaults** in the
  Data Extractors shared engine. Removed (env/CLI resolution unchanged). The token is expired
  per its `exp` claim but remains in old git history — **treat it as burned**.
- Renko logic (both variants): dead ATR computation removed; docstrings no longer claim the
  disabled ATR-dynamic box sizing (box stays fixed at 12.5 — zero behavior change).
- `kotak_execution`: duplicated `__init__` attribute definitions removed; None-guards added.
- SL Hunting pattern detector: loop variables bound (ruff B023) against future late-binding bugs.
- ~419 mechanical autofixes (`Optional[X]` → `X | None`, import order) + ~100 hand fixes
  (long-line wraps, `contextlib.suppress`, ambiguous-name renames, explicit `zip(strict=)`,
  None-guards in diagnose scripts). Behavior-adjacent master hunks verified semantically identical.

### 3. Quality CI (Scanner App parity minus Docker/pip-audit)

`pyproject.toml` (ruff line-length 120 measured, E/W/F/I/B/UP/C4/SIM/RUF; mypy first-adoption
strictness over the 29 identifier-named modules — the spaced-name master is covered by
compileall + its unittest suite), `requirements-dev.txt` (pinned tools + types-requests;
pydantic/claude-agent-sdk so CI exercises the SL Hunting suite), `.pre-commit-config.yaml`
(check-only hooks), `.github/workflows/quality-and-security.yml` (matrix 3.12/3.13, read-only
token: pre-commit validate → master unittest → pytest → compileall → ruff → mypy → bandit).

### 4. Reconciliation with PR #34 (Flattrade live broker)

PR #34 landed mid-flight and wired Flattrade into `LIVE_BROKER`. This branch reviews that drop
and reconciles: **11 new offline unit tests** for the broker helpers (rate limiter, scrip-master
normalization, contract selection, order-status parsing), mypy None-guards in the client,
`AGENTS.md` factual fixes (it claimed the SL Hunting agent was a "Codex agent via
Codex-agent-sdk" — it is a Claude agent via `claude-agent-sdk`), deduplicated `flattrade` key in
`algo.py`'s BROKER_DIAGNOSTICS (git merge artifact), dropped the duplicate env block, and
updated CLAUDE.md/AGENTS.md for the three-broker reality.

**Operator caution:** Flattrade's urlencoded `jData` wire format differs from the vendored
NorenApi's raw-string form and is unverified against the live API — run
`python algo.py diagnose --broker flattrade CE <strike>` once with real credentials before
enabling `LIVE_BROKER=FLATTRADE`.

## Deliberately NOT changed

- Naive `datetime.now()` (IST-only system; tz-aware conversion is churn with real breakage risk).
- Broker wrappers' broad `except Exception` poll-loop fallbacks (tightening risks missing
  broker-SDK exception classes mid-fill).

## Verification (all on the rebased tree)

- `python -m unittest test_nifty_multi_strategy_master` → exit 0 (incl. PR #34's Flattrade tests)
- `python -m pytest "Signal Generators" "Dependencies" -q` → **92 passed**
- `ruff check .` / `mypy` / `bandit` / `compileall` / pre-commit validate → all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
