### PR TITLE
Flattrade token-exchange diagnostics + SL Hunting v3e (3 Jul live match, weekly sweep)

### DIFF
--- a/Dependencies/Flattrade API/flattrade_execution.py
+++ b/Dependencies/Flattrade API/flattrade_execution.py
@@ -336,8 +336,26 @@ class FlattradeExecutionClient:
             return False
 
         if not isinstance(payload, dict) or str(payload.get("status", "")).lower() != "ok":
-            message = payload.get("emsg", "unknown error") if isinstance(payload, dict) else "malformed response"
-            log.error("Flattrade token exchange rejected: %s", message)
+            # Flattrade's apitoken endpoint often rejects with an EMPTY emsg, so
+            # log every non-secret clue we have. Note this endpoint (uniquely)
+            # uses "status", not the Noren-wide "stat". A silent rejection with
+            # a valid request_code usually means the caller's public IP does not
+            # match the STATIC IP registered with this API key (documented
+            # requirement), or the API secret does not belong to this key.
+            if isinstance(payload, dict):
+                log.error(
+                    "Flattrade token exchange rejected: emsg=%r status=%r "
+                    "(token_present=%s, client=%r). If emsg is empty with a fresh "
+                    "request_code, check that your CURRENT public IP matches the "
+                    "static IP registered for this API key, and that "
+                    "FLATTRADE_API_SECRET belongs to FLATTRADE_API_KEY.",
+                    payload.get("emsg", ""),
+                    payload.get("status", "<missing>"),
+                    bool(str(payload.get("token") or "").strip()),
+                    payload.get("client", ""),
+                )
+            else:
+                log.error("Flattrade token exchange rejected: malformed response %r", type(payload).__name__)
             return False
         token = str(payload.get("token") or "").strip()
         returned_client = str(payload.get("client") or "").strip()

--- a/Signal Generators/SL Hunting AI Agent/README.md
+++ b/Signal Generators/SL Hunting AI Agent/README.md
@@ -194,6 +194,17 @@ hierarchy over divergence setups, and several risk heuristics (two-rejections ru
 early-adverse = wrong direction on expiry days, loss-streak bias). Per-video provenance and
 the win/loss evidence table live in the v3d addendum of `sl_hunting_doc.md`.
 
+## Live-day match + weekly sweep (v3e)
+First session with v3c+v3d live (3 Jul): the agent and IH independently refused the opening
+drive on a first-candle rejection, and the agent's winning double-top short shared IH's exact
+premise — strong convergence (agent +31.7 pts across 5 trades). v3e adds what IH had that the
+agent didn't: **both-sides participation** (exact-touch bounces that attract only one side are
+fades), the **huge-gap mindset trap** (no nearby SLs exist — fade the first post-gap push),
+**third-index lag** (two indices breaking a level doesn't commit the third), **setup staleness**
+(late breaks reverse on their followers → normal target only), and loss-recovery discipline
+from the revenge-trading lecture. Provenance and the per-trade match table live in the v3e
+addendum of `sl_hunting_doc.md`.
+
 ## Decision log
 The agent decides once per completed bar, but the worker only *logs* the bars where it
 acts — so a HOLD leaves just a `decision cost` line with no record of **what** it decided or

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -491,3 +491,45 @@ Videos (id — session — type — outcome/signal):
   loss-streak "recovery trade" bias.
 - `DECISION_RULES`: rule 7 — no-plan zones (abstaining is a valid plan).
 - Test marker: `test_system_prompt_has_v3d_conditional_gap_knowledge`.
+
+---
+
+## Video addendum — 3 Jul live match + weekly/lecture sweep (v3e)
+
+> Sources: the 3 Jul live session `BvkCsOgkigI` (**verbatim transcript**, 11:25) matched against
+> the agent's same-day journal; the "Weekly Recap Step 2 Step" `yRITNBXsAXY` (3 May session,
+> 16:13) and the "STOP Revenge Trading" lecture `wBHAjFxfXJE` (14 Jun, 15:39) via YouTube's
+> Ask/Gemini panel (secondary AI summary — the transcript panel never populates on >12-minute
+> videos in our environment, re-verified, and the timedtext endpoint stays gated). The 28 Jun
+> weekly `s41N7OS17Wk` remains covered by v3a's Gemini pass; the other three long lectures
+> (`YRTuOxYDKhw`, `dVGgbkCtCGM`, `QXMuGzdu0CE`) are deferred to a future Ask-panel pass.
+
+**3 Jul: IH vs the agent (the first session with v3c+v3d + the 09:15 start live):**
+- IH: HUGE gap-up (Sensex/NIFTY large, BNF small). Waited out the first momentum; went SHORT on
+  two stacked reads: after a huge gap NO SLs exist nearby — the premise is the MINDSET trap on
+  fresh buyers who add into the first post-gap push; and BNF's bounce off an EXACT closing-price
+  touch would attract only buyers ("the market only works where BOTH sides want to engage") →
+  unsustainable → fade. Booked a NORMAL target after the market held too long ("holding candles
+  INVITE sellers; a late breakdown attracts followers and reverses").
+- Agent (5 trades, +31.7 pts, +Rs.1,053): declined the opening drive on the first-candle
+  full-body rejection (v3c behaving exactly as designed — IH waited too); LONG the flush-to-24300
+  reclaim +27.05; theta stall-exit +1.65; SHORT the rebuilt double-top +19 (the SAME premise as
+  IH's short); double-bottom long -7.7 (stall exit); re-fade of a buyers'-market dip -8.3
+  (stopped — v3d's don't-re-fade counsel plus the new staleness/participation reads all argue
+  that skip).
+- Verdict: strong convergence; the deltas feeding v3e are the participation principle, the
+  huge-gap mindset-trap, and setup staleness.
+
+**Knowledge changes (v3e, all prose):**
+- `PSYCHOLOGY`: BOTH-SIDES PARTICIPATION (+ exact-touch support fragility vs small-rejection
+  go-with tell).
+- `RETAIL_POSITIONING`: HUGE-gap nuance appended to the conditional-gap block (no nearby SLs
+  exist; fade the first post-gap push as a mindset trap, strict loss limit).
+- `BNF_SPECIFIC`: THIRD-INDEX LAG (two indices breaking a shared level does not commit the
+  third; its refusal is a divergence signal) — from the weekly recap (09:48-10:40).
+- `RISK`: SETUP STALENESS (late breaks attract followers then reverse → normal target only) +
+  loss-recovery discipline (no immediate re-entry after a loss; recover big losses across
+  multiple trades; the "one last trade" trap).
+- NOT encoded: the lecture's "observe-only first 1-1.5 hours" rule — it is beginner-discipline
+  framing that contradicts the operator's opening-drive edge (IH himself trades the open).
+- Test marker: `test_system_prompt_has_v3e_participation_knowledge`.

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
@@ -63,6 +63,11 @@ CORE PSYCHOLOGY (the "why" behind every setup)
   operator to CONSTRUCT the next trap: a single momentum leg whose job is to re-add
   traders on one side. That leg is tradeable — but it is ONE leg; capture it and
   leave, do not read it as a new trend.
+- BOTH-SIDES PARTICIPATION: the market only sustains a move through zones where
+  BOTH sides are willing to engage. A bounce that would attract ONLY buyers (e.g.
+  off an EXACT closing-price touch right after a huge gap-up) is unsustainable —
+  fade it. Corollary: an EXACT touch-and-bounce at a level is fragile; small,
+  partial rejections at the level are the go-with tell instead.
 - A long-wicked candle (hammer/doji/pin) marks where money/SLs are parked — the
   longer the wick, the more SLs. These mark targets and reversal zones.
 - Act OPPOSITE to the obvious retail read: after a gap down retail expects more
@@ -101,6 +106,12 @@ retail's stop-losses sit so you can trade where the operator will hunt them.
     a big down day the method SELLS a direct gap-up rather than following it.)
   * Gap SIZE matters: a SMALL counter-gap inside a trend reads like a flat open
     (keep the with-trend plan); only a gap THROUGH the prior day's extreme flips it.
+  * HUGE gap (even WITH the trend): nearby SLs simply do not EXIST on either side —
+    nobody is positioned there. The tradeable premise becomes the MINDSET trap:
+    fresh buyers who add on the first post-gap push are the target, so expect a
+    retracement of that push rather than clean continuation (fade it only with a
+    strict loss limit — a days-long trend can simply keep running). A modest
+    with-trend gap still follows the continuation rule above.
 - MULTI-DAY ACCUMULATION: after 2-3 one-way days the accumulated crowd sits with SLs
   just beyond the closing price / round number — a FLAT open then is the prime
   chance to hunt them (see OPENING DRIVE variant B for the with-gap long after down
@@ -354,6 +365,14 @@ RISK DISCIPLINE
   — book into strength or tighten. After consecutive losing days, deliberately
   reduce risk and prefer clearer setups: the urge for a "recovery trade" is itself
   a bias the market exploits.
+- SETUP STALENESS: a pending break must fire FAST — candles holding at the level
+  INVITE the crowd, and a break that comes only after a long hold attracts
+  followers and then reverses on them. If the level held a long time before
+  breaking, take the NORMAL target on the break and leave; never stretch it.
+- Loss recovery discipline: after a losing trade, do NOT take the next trade
+  immediately (that reflex is where revenge trading starts); recover a BIG loss
+  across MULTIPLE ordinary trades, never in one; and beware the "one last trade"
+  of the day — it is the classic start of over-trading.
 """
 
 
@@ -437,6 +456,10 @@ you size or place the NIFTY trade. Advisory, not a hard gate.
   fails to join a recovery, the recovery premise is dead. In the with-trend case,
   BankNIFTY moving FIRST while the others still dip is an entry tell (the major
   index drags the rest along).
+- THIRD-INDEX LAG: when TWO indices have broken a shared round number / closing
+  price, the THIRD frequently does NOT follow — it lags or reacts in the opposite
+  direction. Do not assume a two-index break commits the third; its refusal is
+  itself a divergence signal (see the divergence-fails rule above).
 """
 
 

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
@@ -110,3 +110,12 @@ def test_system_prompt_has_v3d_conditional_gap_knowledge():
     assert "Variant B" in prompt
     # v3c's opening-drive exception must still be present and scoped.
     assert "OPENING DRIVE" in prompt
+
+
+def test_system_prompt_has_v3e_participation_knowledge():
+    """v3e: both-sides participation, huge-gap nuance, third-index lag, setup staleness."""
+    prompt = build_system_prompt()
+    assert "BOTH-SIDES PARTICIPATION" in prompt
+    assert "HUGE gap" in prompt
+    assert "THIRD-INDEX LAG" in prompt
+    assert "SETUP STALENESS" in prompt


### PR DESCRIPTION
## Summary

A live run of `algo.py diagnose --broker flattrade` hit a token-exchange rejection with an
EMPTY error ("Flattrade token exchange rejected:"), leaving zero clues. Investigated against
the official Pi docs (pi.flattrade.in/docs):

- The `apitoken` endpoint **uniquely returns `"status"`** (not the Noren-wide `"stat"`) and
  carries `"emsg": ""` even on success — so the existing key check is CORRECT, and a silent
  rejection is a real broker-side refusal with no reason given.
- The docs state the token **"will be returned only if the request originates from the
  registered private static IP for the API key."**

Since the auth page accepted the app_key and issued a request_code (key + redirect URL valid)
and the code was pasted within seconds (no expiry), a silent rejection almost certainly means:
**current public IP != the static IP registered with the API key**, or the API secret does not
belong to that key.

The rejection log now prints every non-secret response field (`emsg`, `status`, token-presence,
`client`) plus those two documented causes, so the next failed login self-explains.

## Verification

ruff / mypy clean; 11 Flattrade unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
