### PR TITLE
SL Hunting: Intraday-Hunter-style BankNIFTY mirror basket (equal-lot ATM leg)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,9 @@ One process, cooperating threads:
   `claude-agent-sdk`) — off by default (`SL_HUNTING_ENABLED`), it decides once per completed 1-min bar
   (with BankNIFTY cross-confirmation, fetched per bar like CPR Algo 3, and dynamic ~₹2500 risk-based
   sizing) and acts through the same ATM `enter_position`/`exit_position`; its deps are lazily imported
-  so a missing dep just disables it. It stops opening NEW positions after noon
+  so a missing dep just disables it. Every NIFTY entry is mechanically MIRRORED with an equal-lot
+  BankNIFTY ATM leg (`SL_HUNTING_BNF_MIRROR`, default true) entered/exited as one basket — the agent
+  still decides only on NIFTY. It stops opening NEW positions after noon
   (`SL_HUNTING_NO_NEW_ENTRY_HOUR`, default 12:00) — not a square-off (exits + the 15:15 square-off
   still run; when flat past the cutoff it skips the LLM call entirely). It can also **learn from its own trades** (v3): a per-trade journal
   feeds an off-loop reflection coach (`sl_hunting_coach.py`) that proposes lessons; the operator promotes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,9 @@ One process, cooperating threads:
   `claude-agent-sdk`) — off by default (`SL_HUNTING_ENABLED`), it decides once per completed 1-min bar
   (with BankNIFTY cross-confirmation, fetched per bar like CPR Algo 3, and dynamic ~₹2500 risk-based
   sizing) and acts through the same ATM `enter_position`/`exit_position`; its deps are lazily imported
-  so a missing dep just disables it. It stops opening NEW positions after noon
+  so a missing dep just disables it. Every NIFTY entry is mechanically MIRRORED with an equal-lot
+  BankNIFTY ATM leg (`SL_HUNTING_BNF_MIRROR`, default true) entered/exited as one basket — the agent
+  still decides only on NIFTY. It stops opening NEW positions after noon
   (`SL_HUNTING_NO_NEW_ENTRY_HOUR`, default 12:00) — not a square-off (exits + the 15:15 square-off
   still run; when flat past the cutoff it skips the LLM call entirely). It can also **learn from its own trades** (v3): a per-trade journal
   feeds an off-loop reflection coach (`sl_hunting_coach.py`) that proposes lessons; the operator promotes

--- a/Dependencies/Flattrade API/flattrade_execution.py
+++ b/Dependencies/Flattrade API/flattrade_execution.py
@@ -336,8 +336,26 @@ class FlattradeExecutionClient:
             return False
 
         if not isinstance(payload, dict) or str(payload.get("status", "")).lower() != "ok":
-            message = payload.get("emsg", "unknown error") if isinstance(payload, dict) else "malformed response"
-            log.error("Flattrade token exchange rejected: %s", message)
+            # Flattrade's apitoken endpoint often rejects with an EMPTY emsg, so
+            # log every non-secret clue we have. Note this endpoint (uniquely)
+            # uses "status", not the Noren-wide "stat". A silent rejection with
+            # a valid request_code usually means the caller's public IP does not
+            # match the STATIC IP registered with this API key (documented
+            # requirement), or the API secret does not belong to this key.
+            if isinstance(payload, dict):
+                log.error(
+                    "Flattrade token exchange rejected: emsg=%r status=%r "
+                    "(token_present=%s, client=%r). If emsg is empty with a fresh "
+                    "request_code, check that your CURRENT public IP matches the "
+                    "static IP registered for this API key, and that "
+                    "FLATTRADE_API_SECRET belongs to FLATTRADE_API_KEY.",
+                    payload.get("emsg", ""),
+                    payload.get("status", "<missing>"),
+                    bool(str(payload.get("token") or "").strip()),
+                    payload.get("client", ""),
+                )
+            else:
+                log.error("Flattrade token exchange rejected: malformed response %r", type(payload).__name__)
             return False
         token = str(payload.get("token") or "").strip()
         returned_client = str(payload.get("client") or "").strip()

--- a/Dependencies/env.example
+++ b/Dependencies/env.example
@@ -1088,6 +1088,13 @@ SL_HUNTING_LOTS=1
 # from the agent's underlying stop distance (same convention/default as Profit
 # Shooter). The agent does NOT choose lots; this budget does.
 SL_HUNTING_RISK_BUDGET=2500
+# BankNIFTY mirror (Intraday Hunter style): every NIFTY entry also buys the SAME
+# lot count on the BankNIFTY ATM option (BankNIFTY's own target expiry -- BNF has
+# no weekly series, so that is its nearest listed expiry), entered/exited as ONE
+# basket with the NIFTY leg and following the same paper/live gates. NOTE: this
+# roughly DOUBLES the basket's rupee risk beyond SL_HUNTING_RISK_BUDGET (the
+# daily max-loss kill-switch still applies). Set false to trade NIFTY-only.
+SL_HUNTING_BNF_MIRROR=true
 # Daily kill-switch -- SEPARATE from the per-trade RISK_BUDGET above. The strategy
 # halts for the rest of the day once its cumulative P&L (realized + open) hits
 # -(STARTING_CAPITAL * DAILY_MAX_LOSS_PCT). 600000 * 0.0125 = Rs.7,500/day, i.e.

--- a/Nifty Multi Strategy Front Test - Master File.py
+++ b/Nifty Multi Strategy Front Test - Master File.py
@@ -2961,8 +2961,10 @@ class BasePaperStrategyWorker(threading.Thread):
             )
             return False
         # Resolve the broker's order symbol for this contract before ordering.
+        # A leg may name its own underlying (the SL Hunting BankNIFTY mirror);
+        # everything else defaults to the NIFTY constant as before.
         broker_symbol = execution_client.resolve_option_symbol(
-            underlying=UNDERLYING,
+            underlying=leg.get("underlying", UNDERLYING),
             expiry=leg.get("expiry"),
             option_type=leg.get("option_type", ""),
             strike=leg.get("strike", 0.0),
@@ -8805,6 +8807,14 @@ if SL_HUNTING_AVAILABLE:
     # convention/default as Profit Shooter). The agent does NOT choose lots; this is
     # computed from the agent's underlying stop distance.
     SL_HUNTING_RISK_BUDGET = _env_float("SL_HUNTING_RISK_BUDGET", 2500.0)
+    # BankNIFTY mirror (Intraday Hunter style): every NIFTY entry is mirrored
+    # with the SAME lot count on the BankNIFTY ATM option of BankNIFTY's own
+    # target expiry, entered and exited together as ONE basket. The mirror is
+    # mechanical -- the agent does not choose it -- and NOTE: it roughly doubles
+    # the basket's rupee risk beyond SL_HUNTING_RISK_BUDGET (operator-accepted;
+    # the daily max-loss kill-switch still caps the day). Fail-soft: any mirror
+    # problem only skips the mirror, never the NIFTY leg.
+    SL_HUNTING_BNF_MIRROR = _env_bool("SL_HUNTING_BNF_MIRROR", True)
     # Trade journal (v3): record each trade's entry context + exit outcome to a
     # gitignored JSONL the reflection coach reads. Best-effort; never blocks trading.
     SL_HUNTING_JOURNAL_ENABLED = _env_bool("SL_HUNTING_JOURNAL_ENABLED", True)
@@ -8889,6 +8899,25 @@ if SL_HUNTING_AVAILABLE:
             self._decisions_path = (
                 SL_HUNTING_DECISIONS_PATH if SL_HUNTING_DECISIONS_ENABLED else None
             )
+            # BankNIFTY mirror leg (Intraday Hunter style). A second resolver
+            # against the SAME instrument master, pointed at BANKNIFTY; the
+            # mirror position uses the same PaperPosition bookkeeping as the
+            # main leg but is owned entirely by this worker (the base class
+            # never sees it).
+            self._mirror_enabled = SL_HUNTING_BNF_MIRROR
+            self._bnf_resolver = (
+                OptionsContractResolver(
+                    underlying="BANKNIFTY",
+                    instrument_master_glob=INSTRUMENT_MASTER_GLOB,
+                    log=self.log,
+                )
+                if self._mirror_enabled else None
+            )
+            self._mirror_pos = PaperPosition()
+            # Latest BankNIFTY close seen this session (refreshed each decision
+            # bar from the same fetch that feeds cross-confirmation); used to
+            # pick the mirror's ATM strike.
+            self._last_bnf_close = 0.0
 
         def _journal_open_row(self, decision, nifty_df, bnf_df) -> None:
             """Open a journal row for a trade the agent just entered (best-effort)."""
@@ -8909,10 +8938,159 @@ if SL_HUNTING_AVAILABLE:
             except Exception as exc:  # noqa: BLE001 - journaling must never disturb trading
                 self.log.warning("SL Hunting journal open failed: %s", exc)
 
+        # --------------------------------------------------------------
+        # BankNIFTY mirror leg (Intraday Hunter style)
+        # --------------------------------------------------------------
+        def enter_position(self, direction, entry_underlying, stop_underlying=0.0,
+                           target_underlying=0.0, trailing_active=False,
+                           pending_trailing_exit=False) -> bool:
+            """Open the NIFTY leg as usual, then mechanically mirror it on
+            BankNIFTY with the SAME lot count (one basket). The mirror is
+            best-effort: any failure logs and skips it, never the NIFTY leg."""
+            ok = super().enter_position(
+                direction, entry_underlying, stop_underlying, target_underlying,
+                trailing_active, pending_trailing_exit,
+            )
+            if ok and self._mirror_enabled:
+                try:
+                    self._open_bnf_mirror(direction)
+                except Exception as exc:  # noqa: BLE001 - mirror must never disturb the main leg
+                    self.log.warning("BNF mirror entry failed (NIFTY leg unaffected): %s", exc)
+            return ok
+
+        def _open_bnf_mirror(self, direction: str) -> None:
+            """Buy the BankNIFTY ATM CE/PE (BankNIFTY's own target expiry) at the
+            same lot COUNT as the just-opened NIFTY leg."""
+            if self._mirror_pos.active or self._bnf_resolver is None:
+                return
+            nifty_lot_size = max(int(self.pos.option_lot_size), 1)
+            lots = max(int(self.pos.quantity) // nifty_lot_size, 1)
+
+            bnf_spot = float(self._last_bnf_close)
+            if bnf_spot <= 0:
+                self.log.warning("BNF mirror skipped: no BankNIFTY close seen yet this session.")
+                return
+            contract = self._bnf_resolver.get_atm_option(bnf_spot, direction)
+            sec_id = int(contract["security_id"])
+            segment = str(contract["exchange_segment"])
+            symbol = str(contract["trading_symbol"])
+            lot_size = _to_int_safe(contract["lot_size"], 0)
+            if not symbol or sec_id <= 0 or lot_size <= 0:
+                self.log.warning("BNF mirror skipped: unusable contract %r.", symbol)
+                return
+            option_ltp = self._get_option_ltp(segment, sec_id, fallback=0.0)
+            if option_ltp <= 0:
+                self.log.warning("BNF mirror skipped: no LTP for %s (security_id=%s).", symbol, sec_id)
+                return
+
+            quantity = lot_size * lots
+            order_id = self._next_paper_order_id("BUY")
+            real_ok = self._place_real_leg("BUY", {
+                "option_type": contract["option_type"], "strike": contract["strike"],
+                "expiry": contract["expiry_date"], "quantity": quantity,
+                "dhan_symbol": symbol, "underlying": "BANKNIFTY",
+            })
+            self.store.register_option_subscription(OptionSubscription(
+                security_id=sec_id, exchange_segment=segment, trading_symbol=symbol,
+                right=str(contract["option_type"]), strike=float(contract["strike"]),
+                expiry=contract["expiry_date"],
+            ))
+            self._mirror_pos = PaperPosition(
+                active=True, direction=direction, symbol=symbol, quantity=quantity,
+                entry_order_id=str(order_id), entry_underlying=bnf_spot,
+                entry_trade_price=float(option_ltp), option_security_id=sec_id,
+                option_exchange_segment=segment, option_right=str(contract["option_type"]),
+                option_strike=float(contract["strike"]), option_expiry=contract["expiry_date"],
+                option_lot_size=lot_size,
+            )
+            self.log.info(
+                "MIRROR ENTRY %s | OptionSymbol=%s | Strike=%.2f | Qty=%s (lots=%s x %s) | "
+                "BNFSpot=%.2f | EntryOptPx=%.2f | PaperRef=%s",
+                direction, symbol, float(contract["strike"]), quantity, lots, lot_size,
+                bnf_spot, option_ltp, order_id,
+            )
+            self.publish_trade_event({
+                "action": "ENTRY", "mode": self._exec_mode_tag(real_ok),
+                "direction": direction, "lots": lots, "lot_size": lot_size,
+                "quantity": quantity, "spot": bnf_spot,
+                "expiry": contract["expiry_date"].isoformat() if contract["expiry_date"] else "NA",
+                "legs": [{
+                    "symbol": symbol, "side": "BUY", "right": str(contract["option_type"]),
+                    "strike": float(contract["strike"]), "entry_price": option_ltp,
+                }],
+            })
+
+        def _close_bnf_mirror(self, reason: str) -> None:
+            """Sell the mirror leg and fold its P&L into this worker's books.
+
+            Called from `after_exit`, so EVERY main-leg exit path (AI exit,
+            stop/target, max-loss, square-off) also closes the basket. If a LIVE
+            sell fails we still close the books and alert loudly (same policy as
+            the hedged workers' unwind path) rather than leaving a phantom open
+            record that nothing would ever retry."""
+            if not self._mirror_pos.active:
+                return
+            mirror = self._mirror_pos
+            exit_ltp = self._get_option_ltp(
+                mirror.option_exchange_segment, mirror.option_security_id,
+                fallback=mirror.entry_trade_price,
+            )
+            real_ok = self._place_real_leg("SELL", {
+                "option_type": mirror.option_right, "strike": mirror.option_strike,
+                "expiry": mirror.option_expiry, "quantity": mirror.quantity,
+                "dhan_symbol": mirror.symbol, "underlying": "BANKNIFTY",
+            })
+            if self.live_trading and not real_ok:
+                self.log.error(
+                    "MANUAL ACTION NEEDED | BNF mirror SELL not confirmed | %s qty=%s -> a LIVE "
+                    "BankNIFTY long may be OPEN at the broker. Square it off manually.",
+                    mirror.symbol, mirror.quantity,
+                )
+            pnl = (exit_ltp - mirror.entry_trade_price) * mirror.quantity
+            self.realized_pnl += pnl
+            self.store.unregister_option_subscription(
+                mirror.option_exchange_segment, mirror.option_security_id,
+            )
+            self.log.info(
+                "MIRROR EXIT %s | OptionSymbol=%s | Qty=%s | Reason=%s | EntryOptPx=%.2f | "
+                "ExitOptPx=%.2f | P&L=%.2f | CumPnL=%.2f",
+                mirror.direction, mirror.symbol, mirror.quantity, reason,
+                mirror.entry_trade_price, exit_ltp, pnl, self.realized_pnl,
+            )
+            self.publish_trade_event({
+                "action": "EXIT", "mode": self._exec_mode_tag(real_ok),
+                "direction": mirror.direction, "reason": reason, "pnl": pnl,
+                "quantity": mirror.quantity,
+                "legs": [{
+                    "symbol": mirror.symbol, "side": "SELL", "right": mirror.option_right,
+                    "strike": mirror.option_strike, "exit_price": exit_ltp,
+                }],
+            })
+            self._mirror_pos = PaperPosition()
+
+        def _get_open_position_pnl(self) -> float:
+            """Basket MTM: the NIFTY leg plus the BankNIFTY mirror, so the daily
+            max-loss kill-switch and the agent's position_state tool both see the
+            whole basket."""
+            pnl = super()._get_open_position_pnl()
+            if self._mirror_pos.active:
+                live = self._get_option_ltp(
+                    self._mirror_pos.option_exchange_segment,
+                    self._mirror_pos.option_security_id,
+                    fallback=self._mirror_pos.entry_trade_price,
+                )
+                pnl += (live - self._mirror_pos.entry_trade_price) * self._mirror_pos.quantity
+            return pnl
+
         def after_exit(self, closed_position, reason: str) -> None:
             """Universal post-close hook (fires for AI exit, stop/target, max-loss,
-            square-off). Close the open journal row with the underlying outcome."""
+            square-off). Close the BankNIFTY mirror FIRST (so the journal row's
+            option_pnl below reflects the whole basket), then the journal row."""
             super().after_exit(closed_position, reason)
+            try:
+                self._close_bnf_mirror(reason)
+            except Exception as exc:  # noqa: BLE001 - mirror close must never block the journal
+                self.log.warning("BNF mirror close failed: %s", exc)
             if self._journal is None or self._open_trade_id is None:
                 return
             try:
@@ -9002,6 +9180,10 @@ if SL_HUNTING_AVAILABLE:
                         BANKNIFTY_INDEX_INSTRUMENT_TYPE,
                     )
                     bnf_candles = resample_ohlc_from_1m(bnf_1m, self.derived_timeframe_minutes)
+                    if bnf_candles is not None and not bnf_candles.empty:
+                        # Remember BankNIFTY's latest close for the mirror leg's
+                        # ATM pick (no extra API call at entry time).
+                        self._last_bnf_close = float(bnf_candles["close"].iloc[-1])
                 except Exception as exc:
                     self.log.warning(
                         "BankNIFTY fetch failed (%s); SL Hunting goes NIFTY-only this bar.", exc

--- a/Signal Generators/SL Hunting AI Agent/README.md
+++ b/Signal Generators/SL Hunting AI Agent/README.md
@@ -194,6 +194,17 @@ hierarchy over divergence setups, and several risk heuristics (two-rejections ru
 early-adverse = wrong direction on expiry days, loss-streak bias). Per-video provenance and
 the win/loss evidence table live in the v3d addendum of `sl_hunting_doc.md`.
 
+## Live-day match + weekly sweep (v3e)
+First session with v3c+v3d live (3 Jul): the agent and IH independently refused the opening
+drive on a first-candle rejection, and the agent's winning double-top short shared IH's exact
+premise — strong convergence (agent +31.7 pts across 5 trades). v3e adds what IH had that the
+agent didn't: **both-sides participation** (exact-touch bounces that attract only one side are
+fades), the **huge-gap mindset trap** (no nearby SLs exist — fade the first post-gap push),
+**third-index lag** (two indices breaking a level doesn't commit the third), **setup staleness**
+(late breaks reverse on their followers → normal target only), and loss-recovery discipline
+from the revenge-trading lecture. Provenance and the per-trade match table live in the v3e
+addendum of `sl_hunting_doc.md`.
+
 ## Decision log
 The agent decides once per completed bar, but the worker only *logs* the bars where it
 acts — so a HOLD leaves just a `decision cost` line with no record of **what** it decided or

--- a/Signal Generators/SL Hunting AI Agent/README.md
+++ b/Signal Generators/SL Hunting AI Agent/README.md
@@ -205,6 +205,18 @@ fades), the **huge-gap mindset trap** (no nearby SLs exist — fade the first po
 from the revenge-trading lecture. Provenance and the per-trade match table live in the v3e
 addendum of `sl_hunting_doc.md`.
 
+## BankNIFTY mirror basket (v4)
+Intraday Hunter trades a multi-index basket; the worker now mirrors him: every NIFTY entry
+also BUYS the **same lot count** on the **BankNIFTY ATM** option (BankNIFTY's own target
+expiry — BNF has no weekly series), and the mirror **exits the moment the NIFTY leg exits**
+(AI exit, stop/target, max-loss, 15:15 square-off — one basket). The mirror is mechanical:
+the agent still decides ONLY on NIFTY; its prompt just tells it the P&L it sees is basket
+P&L. Same paper/live gates as the NIFTY leg; fail-soft (a mirror problem only skips the
+mirror); **basket risk ≈ 2× the ~Rs.2500 budget** (operator-accepted — the daily max-loss
+kill-switch still caps the day). Toggle: `SL_HUNTING_BNF_MIRROR` (default true). Journal
+rows' `option_pnl` includes both legs; MIRROR ENTRY/EXIT lines appear in the log and
+Telegram.
+
 ## Decision log
 The agent decides once per completed bar, but the worker only *logs* the bars where it
 acts — so a HOLD leaves just a `decision cost` line with no record of **what** it decided or

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -491,3 +491,45 @@ Videos (id — session — type — outcome/signal):
   loss-streak "recovery trade" bias.
 - `DECISION_RULES`: rule 7 — no-plan zones (abstaining is a valid plan).
 - Test marker: `test_system_prompt_has_v3d_conditional_gap_knowledge`.
+
+---
+
+## Video addendum — 3 Jul live match + weekly/lecture sweep (v3e)
+
+> Sources: the 3 Jul live session `BvkCsOgkigI` (**verbatim transcript**, 11:25) matched against
+> the agent's same-day journal; the "Weekly Recap Step 2 Step" `yRITNBXsAXY` (3 May session,
+> 16:13) and the "STOP Revenge Trading" lecture `wBHAjFxfXJE` (14 Jun, 15:39) via YouTube's
+> Ask/Gemini panel (secondary AI summary — the transcript panel never populates on >12-minute
+> videos in our environment, re-verified, and the timedtext endpoint stays gated). The 28 Jun
+> weekly `s41N7OS17Wk` remains covered by v3a's Gemini pass; the other three long lectures
+> (`YRTuOxYDKhw`, `dVGgbkCtCGM`, `QXMuGzdu0CE`) are deferred to a future Ask-panel pass.
+
+**3 Jul: IH vs the agent (the first session with v3c+v3d + the 09:15 start live):**
+- IH: HUGE gap-up (Sensex/NIFTY large, BNF small). Waited out the first momentum; went SHORT on
+  two stacked reads: after a huge gap NO SLs exist nearby — the premise is the MINDSET trap on
+  fresh buyers who add into the first post-gap push; and BNF's bounce off an EXACT closing-price
+  touch would attract only buyers ("the market only works where BOTH sides want to engage") →
+  unsustainable → fade. Booked a NORMAL target after the market held too long ("holding candles
+  INVITE sellers; a late breakdown attracts followers and reverses").
+- Agent (5 trades, +31.7 pts, +Rs.1,053): declined the opening drive on the first-candle
+  full-body rejection (v3c behaving exactly as designed — IH waited too); LONG the flush-to-24300
+  reclaim +27.05; theta stall-exit +1.65; SHORT the rebuilt double-top +19 (the SAME premise as
+  IH's short); double-bottom long -7.7 (stall exit); re-fade of a buyers'-market dip -8.3
+  (stopped — v3d's don't-re-fade counsel plus the new staleness/participation reads all argue
+  that skip).
+- Verdict: strong convergence; the deltas feeding v3e are the participation principle, the
+  huge-gap mindset-trap, and setup staleness.
+
+**Knowledge changes (v3e, all prose):**
+- `PSYCHOLOGY`: BOTH-SIDES PARTICIPATION (+ exact-touch support fragility vs small-rejection
+  go-with tell).
+- `RETAIL_POSITIONING`: HUGE-gap nuance appended to the conditional-gap block (no nearby SLs
+  exist; fade the first post-gap push as a mindset trap, strict loss limit).
+- `BNF_SPECIFIC`: THIRD-INDEX LAG (two indices breaking a shared level does not commit the
+  third; its refusal is a divergence signal) — from the weekly recap (09:48-10:40).
+- `RISK`: SETUP STALENESS (late breaks attract followers then reverse → normal target only) +
+  loss-recovery discipline (no immediate re-entry after a loss; recover big losses across
+  multiple trades; the "one last trade" trap).
+- NOT encoded: the lecture's "observe-only first 1-1.5 hours" rule — it is beginner-discipline
+  framing that contradicts the operator's opening-drive edge (IH himself trades the open).
+- Test marker: `test_system_prompt_has_v3e_participation_knowledge`.

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
@@ -335,6 +335,11 @@ RISK DISCIPLINE
 - Position size is computed AUTOMATICALLY to risk ~Rs.2500 per trade from your stop
   distance — you do NOT choose lots. A tighter stop just means more lots for the
   same rupee risk, so set an honest, tight stop; never widen it to "get size".
+- BASKET NOTE: the system may mechanically MIRROR every NIFTY position with an
+  equal-lot BankNIFTY ATM leg (Intraday Hunter style), entered and exited together
+  with your NIFTY position. You do not control the mirror and still decide ONLY on
+  NIFTY — but the position P&L you see includes BOTH legs, so judge it as basket
+  P&L, not as the NIFTY option alone.
 - Require a worthwhile target: at least ~1:2 reward:risk to the next clear level
   (swing / pivot / fibo / psych). Aim for the LIQUIDITY ZONE where the hunted SLs
   sit (the long-wicked candle / opposite side of the first candle / the trapped

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
@@ -63,6 +63,11 @@ CORE PSYCHOLOGY (the "why" behind every setup)
   operator to CONSTRUCT the next trap: a single momentum leg whose job is to re-add
   traders on one side. That leg is tradeable — but it is ONE leg; capture it and
   leave, do not read it as a new trend.
+- BOTH-SIDES PARTICIPATION: the market only sustains a move through zones where
+  BOTH sides are willing to engage. A bounce that would attract ONLY buyers (e.g.
+  off an EXACT closing-price touch right after a huge gap-up) is unsustainable —
+  fade it. Corollary: an EXACT touch-and-bounce at a level is fragile; small,
+  partial rejections at the level are the go-with tell instead.
 - A long-wicked candle (hammer/doji/pin) marks where money/SLs are parked — the
   longer the wick, the more SLs. These mark targets and reversal zones.
 - Act OPPOSITE to the obvious retail read: after a gap down retail expects more
@@ -101,6 +106,12 @@ retail's stop-losses sit so you can trade where the operator will hunt them.
     a big down day the method SELLS a direct gap-up rather than following it.)
   * Gap SIZE matters: a SMALL counter-gap inside a trend reads like a flat open
     (keep the with-trend plan); only a gap THROUGH the prior day's extreme flips it.
+  * HUGE gap (even WITH the trend): nearby SLs simply do not EXIST on either side —
+    nobody is positioned there. The tradeable premise becomes the MINDSET trap:
+    fresh buyers who add on the first post-gap push are the target, so expect a
+    retracement of that push rather than clean continuation (fade it only with a
+    strict loss limit — a days-long trend can simply keep running). A modest
+    with-trend gap still follows the continuation rule above.
 - MULTI-DAY ACCUMULATION: after 2-3 one-way days the accumulated crowd sits with SLs
   just beyond the closing price / round number — a FLAT open then is the prime
   chance to hunt them (see OPENING DRIVE variant B for the with-gap long after down
@@ -354,6 +365,14 @@ RISK DISCIPLINE
   — book into strength or tighten. After consecutive losing days, deliberately
   reduce risk and prefer clearer setups: the urge for a "recovery trade" is itself
   a bias the market exploits.
+- SETUP STALENESS: a pending break must fire FAST — candles holding at the level
+  INVITE the crowd, and a break that comes only after a long hold attracts
+  followers and then reverses on them. If the level held a long time before
+  breaking, take the NORMAL target on the break and leave; never stretch it.
+- Loss recovery discipline: after a losing trade, do NOT take the next trade
+  immediately (that reflex is where revenge trading starts); recover a BIG loss
+  across MULTIPLE ordinary trades, never in one; and beware the "one last trade"
+  of the day — it is the classic start of over-trading.
 """
 
 
@@ -437,6 +456,10 @@ you size or place the NIFTY trade. Advisory, not a hard gate.
   fails to join a recovery, the recovery premise is dead. In the with-trend case,
   BankNIFTY moving FIRST while the others still dip is an entry tell (the major
   index drags the rest along).
+- THIRD-INDEX LAG: when TWO indices have broken a shared round number / closing
+  price, the THIRD frequently does NOT follow — it lags or reacts in the opposite
+  direction. Do not assume a two-index break commits the third; its refusal is
+  itself a divergence signal (see the divergence-fails rule above).
 """
 
 

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
@@ -110,3 +110,12 @@ def test_system_prompt_has_v3d_conditional_gap_knowledge():
     assert "Variant B" in prompt
     # v3c's opening-drive exception must still be present and scoped.
     assert "OPENING DRIVE" in prompt
+
+
+def test_system_prompt_has_v3e_participation_knowledge():
+    """v3e: both-sides participation, huge-gap nuance, third-index lag, setup staleness."""
+    prompt = build_system_prompt()
+    assert "BOTH-SIDES PARTICIPATION" in prompt
+    assert "HUGE gap" in prompt
+    assert "THIRD-INDEX LAG" in prompt
+    assert "SETUP STALENESS" in prompt

--- a/test_nifty_multi_strategy_master.py
+++ b/test_nifty_multi_strategy_master.py
@@ -1634,6 +1634,126 @@ class TestLongStrangleWorker(unittest.TestCase):
         self.assertEqual(worker.ce_reentry_count, 0)
 
 
+@unittest.skipIf(
+    getattr(master_file, "SLHuntingAIWorker", None) is None,
+    "SL Hunting worker unavailable (claude-agent-sdk / pydantic absent)",
+)
+class TestSLHuntingBnfMirror(unittest.TestCase):
+    """
+    The Intraday-Hunter-style BankNIFTY mirror: every NIFTY entry opens an
+    equal-LOT-count BankNIFTY ATM leg, and every NIFTY exit closes it (one
+    basket). The mirror is fail-soft and must never disturb the NIFTY leg.
+    """
+
+    NIFTY_CONTRACT = {
+        "security_id": 1001, "exchange_segment": None,  # segment filled in setUp
+        "trading_symbol": "NIFTY-24300-CE", "custom_symbol": "NIFTY CE",
+        "strike": 24300.0, "option_type": "CE", "expiry_date": None,
+        "days_to_expiry": 2, "lot_size": 75, "spot_reference": 24300.0,
+        "atm_strike_rounded": 24300.0,
+    }
+    BNF_CONTRACT = {
+        "security_id": 3003, "exchange_segment": None,
+        "trading_symbol": "BANKNIFTY-57900-CE", "custom_symbol": "BANKNIFTY CE",
+        "strike": 57900.0, "option_type": "CE", "expiry_date": None,
+        "days_to_expiry": 20, "lot_size": 35, "spot_reference": 57900.0,
+        "atm_strike_rounded": 57900.0,
+    }
+
+    def _make_worker(self):
+        store = master_file.SharedMarketDataStore()
+        broker = MagicMock()
+        broker.fetch_ltp_map.return_value = {}
+        worker = master_file.SLHuntingAIWorker(
+            store=store, stop_event=threading.Event(), broker=broker
+        )
+        worker._mirror_enabled = True
+        nifty_c = dict(self.NIFTY_CONTRACT,
+                       exchange_segment=master_file.OPTION_EXCHANGE_SEGMENT,
+                       expiry_date=date.today())
+        bnf_c = dict(self.BNF_CONTRACT,
+                     exchange_segment=master_file.OPTION_EXCHANGE_SEGMENT,
+                     expiry_date=date.today() + timedelta(days=20))
+        worker.contract_resolver = MagicMock()
+        worker.contract_resolver.get_atm_option.return_value = nifty_c
+        worker._bnf_resolver = MagicMock()
+        worker._bnf_resolver.get_atm_option.return_value = bnf_c
+        worker._last_bnf_close = 57910.0
+        store.update_ltp_map({
+            (master_file.NIFTY_INDEX_EXCHANGE_SEGMENT, master_file.NIFTY_INDEX_SECURITY_ID): 24300.0,
+            (master_file.OPTION_EXCHANGE_SEGMENT, 1001): 100.0,
+            (master_file.OPTION_EXCHANGE_SEGMENT, 3003): 500.0,
+        })
+        return worker, store
+
+    def test_mirror_opens_with_same_lot_count(self):
+        worker, _ = self._make_worker()
+        # 10-pt stop -> risk_based_lots => ceil(2500 / (10*75)) = 4 NIFTY lots.
+        self.assertTrue(worker.enter_position("LONG", 24300.0, 24290.0, 24400.0))
+        nifty_lots = worker.pos.quantity // 75
+        self.assertTrue(worker._mirror_pos.active)
+        self.assertEqual(worker._mirror_pos.quantity, nifty_lots * 35)
+        self.assertEqual(worker._mirror_pos.option_right, "CE")
+        # The mirror asked BankNIFTY's resolver with the BNF spot + direction.
+        worker._bnf_resolver.get_atm_option.assert_called_once_with(57910.0, "LONG")
+
+    def test_basket_exits_together_and_pnl_includes_both_legs(self):
+        worker, store = self._make_worker()
+        worker.enter_position("LONG", 24300.0, 24290.0, 24400.0)
+        nifty_qty = worker.pos.quantity
+        bnf_qty = worker._mirror_pos.quantity
+        # NIFTY option +10, BNF option +20.
+        store.update_ltp_map({
+            (master_file.OPTION_EXCHANGE_SEGMENT, 1001): 110.0,
+            (master_file.OPTION_EXCHANGE_SEGMENT, 3003): 520.0,
+        })
+        expected = 10.0 * nifty_qty + 20.0 * bnf_qty
+        self.assertAlmostEqual(worker._get_open_position_pnl(), expected)
+        worker.exit_position("AI_TARGET")
+        self.assertFalse(worker.pos.active)
+        self.assertFalse(worker._mirror_pos.active)
+        self.assertAlmostEqual(worker.realized_pnl, expected)
+
+    def test_mirror_failure_never_blocks_the_nifty_leg(self):
+        worker, _ = self._make_worker()
+        worker._bnf_resolver.get_atm_option.side_effect = ValueError("no BNF chain")
+        self.assertTrue(worker.enter_position("LONG", 24300.0, 24290.0, 24400.0))
+        self.assertTrue(worker.pos.active)
+        self.assertFalse(worker._mirror_pos.active)
+
+    def test_mirror_skipped_without_bnf_spot(self):
+        worker, _ = self._make_worker()
+        worker._last_bnf_close = 0.0
+        self.assertTrue(worker.enter_position("LONG", 24300.0, 24290.0, 24400.0))
+        self.assertFalse(worker._mirror_pos.active)
+
+    def test_mirror_disabled_flag_trades_nifty_only(self):
+        worker, _ = self._make_worker()
+        worker._mirror_enabled = False
+        self.assertTrue(worker.enter_position("SHORT", 24300.0, 24310.0, 24200.0))
+        self.assertTrue(worker.pos.active)
+        self.assertFalse(worker._mirror_pos.active)
+        worker._bnf_resolver.get_atm_option.assert_not_called()
+
+    def test_real_leg_uses_banknifty_underlying_for_mirror(self):
+        """_place_real_leg must resolve the mirror's broker symbol as BANKNIFTY."""
+        worker, _ = self._make_worker()
+        captured = []
+
+        def fake_real_leg(side, leg):
+            captured.append((side, dict(leg)))
+            return True
+
+        worker._place_real_leg = fake_real_leg
+        worker.enter_position("LONG", 24300.0, 24290.0, 24400.0)
+        worker.exit_position("AI_TARGET")
+        mirror_legs = [(s, leg) for s, leg in captured if leg.get("underlying") == "BANKNIFTY"]
+        self.assertEqual([s for s, _ in mirror_legs], ["BUY", "SELL"])
+        # The NIFTY legs carry no underlying override (default applies).
+        nifty_legs = [(s, leg) for s, leg in captured if "underlying" not in leg]
+        self.assertEqual([s for s, _ in nifty_legs], ["BUY", "SELL"])
+
+
 class TestLiveOrderRouting(unittest.TestCase):
     """
     Drives the single-leg take-trade methods with `live_trading=True` and a fake


### PR DESCRIPTION
## Summary

The SL Hunting agent now trades **Intraday Hunter's basket style**: when it opens **x lots of
NIFTY ATM**, the worker mechanically buys **x lots of BankNIFTY ATM** too (BankNIFTY's own
target expiry — BNF has no weekly series), and the mirror **exits the moment the NIFTY leg
exits** — AI exit, stop/target, max-loss, or the 15:15 square-off. One basket.

Built to the four operator-confirmed choices:
1. **NIFTY leg unchanged** (nearest-expiry behavior as before).
2. **Basket exit** — the mirror lives and dies with the NIFTY leg (wired through `after_exit`,
   which every exit path already fires).
3. **Same lot count, 2× risk accepted** — the ~₹2500 budget effectively becomes per-leg; the
   daily max-loss kill-switch still applies and now sees **basket MTM** (the open-P&L getter
   includes the mirror, so the agent's `position_state` tool shows basket P&L too).
4. **Same paper/live gates** as the NIFTY leg from day one.

## Implementation notes

- `_place_real_leg` gains an optional per-leg `"underlying"` (defaults to NIFTY — fully
  backward compatible) so live mirror orders resolve **BANKNIFTY** broker symbols on
  Kotak/Shoonya/Flattrade.
- A second `OptionsContractResolver(underlying="BANKNIFTY")` on the same instrument master;
  the mirror's ATM pick uses the BankNIFTY close the worker already fetches each bar for
  cross-confirmation (no extra API call).
- **Fail-soft everywhere**: no BNF close yet / resolution failure / missing LTP → the mirror is
  skipped with a log line and the NIFTY leg proceeds untouched. An unconfirmed LIVE mirror
  exit closes the books and raises a **MANUAL ACTION** alert (the hedged-workers' unwind
  policy) instead of leaving a phantom open record nothing would retry.
- The agent still decides **only on NIFTY**; its RISK knowledge gains a BASKET NOTE so it
  interprets the P&L it sees as basket P&L. Journal `option_pnl` includes both legs.
- Kill-switch: `SL_HUNTING_BNF_MIRROR=false` reverts to NIFTY-only.

## Tests & gates

New `TestSLHuntingBnfMirror` (6 cases): same-lot sizing (4×75 NIFTY → 4×35 BNF), basket exit
with combined P&L, resolver-failure / no-spot / disabled fail-softs, and BANKNIFTY underlying
routing through `_place_real_leg`. Master unittest suite OK, 93 pytest green, ruff / mypy /
bandit / compileall clean.

**Note:** this branch is based on `quality/codebase-review-and-ci` and includes PR #36's two
commits — merging #36 first makes this diff read as the mirror feature alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
