### PR TITLE
Add per-strategy virtual (paper) trading toggle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,10 @@ Backtest Outputs/                                  # generated CSVs/logs (gitign
   (`KOTAK` | `SHOONYA` | `FLATTRADE`) selects the broker; an unknown value **fails closed** (live
   disabled, paper only).
   Any order failure falls back to paper for that trade. Every broker HTTP call must have a timeout.
+- **Per-strategy on/off:** each strategy also has a `<PREFIX>_VIRTUAL_TRADING` gate (default true).
+  Set it false to stop that strategy's worker thread from starting at all (neither paper nor live).
+  Unlike live trading there is **no** global master switch — default is everything runs. `main()`
+  filters the `workers` list via `_strategy_virtual_trading_enabled` before starting threads.
 - **Broker layer:** the Kotak and Shoonya clients expose the SAME surface — `ensure_logged_in`,
   `preload_scrip_master`, `resolve_option_symbol`, `place_market_order`, `extract_order_id`, `logout`,
   `is_logged_in` — so the runner only ever touches the generic `execution_client`. The Shoonya `NorenApi`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,10 @@ Backtest Outputs/                                  # generated CSVs/logs (gitign
   (`KOTAK` | `SHOONYA` | `FLATTRADE`) selects the broker; an unknown value **fails closed** (live
   disabled, paper only).
   Any order failure falls back to paper for that trade. Every broker HTTP call must have a timeout.
+- **Per-strategy on/off:** each strategy also has a `<PREFIX>_VIRTUAL_TRADING` gate (default true).
+  Set it false to stop that strategy's worker thread from starting at all (so it does neither paper
+  nor live). Unlike live trading there is **no** global master switch — default is everything runs.
+  `main()` filters the `workers` list via `_strategy_virtual_trading_enabled` before starting threads.
 - **Broker layer:** the Kotak, Shoonya and Flattrade clients expose the SAME surface —
   `ensure_logged_in`, `preload_scrip_master`, `resolve_option_symbol`, `place_market_order`,
   `extract_order_id`, `logout`, `is_logged_in` — so the runner only ever touches the generic

--- a/Dependencies/env.example
+++ b/Dependencies/env.example
@@ -1058,6 +1058,40 @@ STOCHASTIC_LIVE_TRADING=false
 SUPERTREND_PORT_LIVE_TRADING=false
 VOLATILITY_BREAKOUT_LIVE_TRADING=false
 
+# ---- Per-strategy virtual (paper) toggles (all default TRUE; flip individually) ----
+# Turn a strategy OFF entirely: when <PREFIX>_VIRTUAL_TRADING=false its worker
+# thread is NOT started, so it does no paper trading (and, since the thread never
+# runs, no live trading either -- this overrides its *_LIVE_TRADING above). There
+# is deliberately NO master virtual switch: default is that EVERYTHING runs, and
+# you set individual strategies to false to silence them. Prefixes match each
+# strategy's other <PREFIX>_* knobs.
+RENKO_VIRTUAL_TRADING=true
+EMA_VIRTUAL_TRADING=true
+HEIKIN_VIRTUAL_TRADING=true
+PROFIT_SHOOTER_VIRTUAL_TRADING=true
+GOLDMINE_VIRTUAL_TRADING=true
+MONEY_MACHINE_VIRTUAL_TRADING=true
+OPENING_STRIKE_VIRTUAL_TRADING=true
+CPR_VIRTUAL_TRADING=true
+CPR_ALGO3_VIRTUAL_TRADING=true
+BULLISH_VIRTUAL_TRADING=true
+BEARISH_VIRTUAL_TRADING=true
+DELTA20_VIRTUAL_TRADING=true
+STRANGLE_VIRTUAL_TRADING=true
+SMA_CROSSOVER_VIRTUAL_TRADING=true
+BOLLINGER_BANDS_VIRTUAL_TRADING=true
+KELTNER_SQUEEZE_VIRTUAL_TRADING=true
+MEAN_REVERSION_ZSCORE_VIRTUAL_TRADING=true
+ML_ENSEMBLE_VIRTUAL_TRADING=true
+MULTI_TIMEFRAME_VIRTUAL_TRADING=true
+OPENING_RANGE_BREAKOUT_VIRTUAL_TRADING=true
+PARABOLIC_SAR_VIRTUAL_TRADING=true
+RSI_DIVERGENCE_VIRTUAL_TRADING=true
+RSI_REVERSAL_VIRTUAL_TRADING=true
+STOCHASTIC_VIRTUAL_TRADING=true
+SUPERTREND_PORT_VIRTUAL_TRADING=true
+VOLATILITY_BREAKOUT_VIRTUAL_TRADING=true
+
 # =============================================================================
 # SL Hunting AI Agent (OPTIONAL, LLM-driven) — opt-in add-on strategy
 # =============================================================================
@@ -1124,6 +1158,11 @@ BANKNIFTY_INDEX_EXCHANGE_SEGMENT=IDX_I
 BANKNIFTY_INDEX_INSTRUMENT_TYPE=INDEX
 # Real orders ONLY if this AND LIVE_TRADING_ENABLED (above) are both true.
 SL_HUNTING_LIVE_TRADING=false
+# Per-strategy virtual (paper) gate, default true (see the block near the live
+# toggles). false = the SL Hunting worker thread is not started at all -- note this
+# is separate from SL_HUNTING_ENABLED (which decides whether the optional agent
+# module loads); either being off keeps the strategy out of the roster.
+SL_HUNTING_VIRTUAL_TRADING=true
 # --- v3: learn from mistakes (trade journal + human-gated lessons) ---
 # Journal: record every trade's entry context + exit outcome to a gitignored JSONL
 # (the reflection coach reads this). Best-effort; never blocks trading.

--- a/Nifty Multi Strategy Front Test - Master File.py
+++ b/Nifty Multi Strategy Front Test - Master File.py
@@ -9876,6 +9876,25 @@ def _update_pnl_google_sheet() -> None:
         )
 
 
+def _strategy_virtual_trading_enabled(strategy_name: str) -> bool:
+    """Per-strategy virtual (paper) trading gate.
+
+    A strategy's worker thread STARTS unless its `<PREFIX>_VIRTUAL_TRADING` is
+    explicitly false. Default: everything runs. Deliberately has NO global master
+    switch (unlike `LIVE_TRADING_ENABLED`) -- turning virtual trading off is a
+    per-strategy decision only. A strategy with no known env prefix always runs
+    (fail-open, so a mapping gap can never silently disable a strategy).
+
+    Note: because a disabled strategy's thread never starts, this also stops it
+    trading LIVE regardless of its `<PREFIX>_LIVE_TRADING` flag -- a thread that
+    does not run trades nothing.
+    """
+    prefix = STRATEGY_ENV_PREFIX.get(strategy_name)
+    if not prefix:
+        return True
+    return _env_bool(f"{prefix}_VIRTUAL_TRADING", True)
+
+
 # =============================================================================
 # MAIN ENTRY POINT
 # =============================================================================
@@ -9986,6 +10005,26 @@ def main() -> None:
     #       (the live-wiring below applies the same double-gate as every strategy).
     if SLHuntingAIWorker is not None:
         workers.append(SLHuntingAIWorker(store, stop_event, broker))
+
+    # -------------------------------------------------------------------------
+    # Per-strategy virtual (paper) trading gate.
+    # -------------------------------------------------------------------------
+    # Drop any strategy whose <PREFIX>_VIRTUAL_TRADING is false so its thread is
+    # never started (and thus never live-gated, wired to Telegram, joined, or in
+    # the EOD summary -- filtering this one list handles all of that uniformly).
+    # Default is true: everything runs. There is intentionally no master switch.
+    enabled_workers, disabled_workers = [], []
+    for worker in workers:
+        target = enabled_workers if _strategy_virtual_trading_enabled(worker.strategy_name) else disabled_workers
+        target.append(worker)
+    for worker in disabled_workers:
+        logger.warning(
+            "VIRTUAL TRADING DISABLED for %s (%s_VIRTUAL_TRADING=false); thread will NOT start.",
+            worker.strategy_name, STRATEGY_ENV_PREFIX.get(worker.strategy_name, "?"),
+        )
+    workers = enabled_workers
+    if not workers:
+        logger.warning("No strategies enabled for virtual trading; nothing will run this session.")
 
     # -------------------------------------------------------------------------
     # Decide which strategies trade for real vs on paper.

--- a/test_nifty_multi_strategy_master.py
+++ b/test_nifty_multi_strategy_master.py
@@ -1339,6 +1339,41 @@ class TestStrategyEnvPrefixMap(unittest.TestCase):
             self.assertTrue(master and per)
 
 
+class TestVirtualTradingToggle(unittest.TestCase):
+    """The per-strategy virtual (paper) gate: a strategy runs unless its
+    `<PREFIX>_VIRTUAL_TRADING` is explicitly false. Default is everything runs,
+    and there is deliberately NO global master switch."""
+
+    def test_default_is_enabled_when_key_absent(self):
+        os.environ.pop("RENKO_VIRTUAL_TRADING", None)
+        self.assertTrue(master_file._strategy_virtual_trading_enabled("Renko"))
+
+    def test_explicit_false_disables(self):
+        with patch.dict(os.environ, {"RENKO_VIRTUAL_TRADING": "false"}):
+            self.assertFalse(master_file._strategy_virtual_trading_enabled("Renko"))
+
+    def test_explicit_true_enables(self):
+        with patch.dict(os.environ, {"RENKO_VIRTUAL_TRADING": "true"}):
+            self.assertTrue(master_file._strategy_virtual_trading_enabled("Renko"))
+
+    def test_unmapped_strategy_fails_open(self):
+        """A strategy name with no env prefix must never be silently disabled."""
+        self.assertTrue(master_file._strategy_virtual_trading_enabled("NoSuchStrategy"))
+
+    def test_toggle_is_independent_per_strategy(self):
+        """Disabling one strategy does not affect another."""
+        with patch.dict(os.environ, {"RENKO_VIRTUAL_TRADING": "false"}):
+            self.assertFalse(master_file._strategy_virtual_trading_enabled("Renko"))
+            self.assertTrue(master_file._strategy_virtual_trading_enabled("EMA"))
+
+    def test_sl_hunting_prefix_respected(self):
+        """The optional agent maps to SL_HUNTING; its virtual gate must work too."""
+        if "SL Hunting AI" not in master_file.STRATEGY_ENV_PREFIX:
+            self.skipTest("SL Hunting worker not loaded in this environment.")
+        with patch.dict(os.environ, {"SL_HUNTING_VIRTUAL_TRADING": "false"}):
+            self.assertFalse(master_file._strategy_virtual_trading_enabled("SL Hunting AI"))
+
+
 # =============================================================================
 # TEST SUITE: LONG STRANGLE WORKER
 # =============================================================================


### PR DESCRIPTION
## Summary

Adds a per-strategy **`<PREFIX>_VIRTUAL_TRADING`** toggle (default **true**). When set to
`false`, that strategy's worker thread is **never started** — so it does no paper trading, and
since the thread never runs, no live trading either (this overrides its `<PREFIX>_LIVE_TRADING`).
This lets you run only the strategies you want on a given day instead of the full ~26-strategy
roster.

Per the operator's explicit requirements:
- Per-strategy `.env` toggle; false → thread doesn't even start. ✅
- **No global master switch** (deliberately unlike `LIVE_TRADING_ENABLED`). ✅
- **Default = everything runs** (missing/blank key → runs). ✅

## Implementation

Mirrors the existing per-strategy convention with **no new infrastructure**:

- **New pure helper** `_strategy_virtual_trading_enabled(strategy_name)` reuses
  `STRATEGY_ENV_PREFIX` + `_env_bool(..., default=True)`. **Fail-open**: a strategy whose name
  isn't in the prefix map always runs, so a mapping gap can never silently disable a strategy.
- **`main()` filters the `workers` list once** — right after it's built, before the live-trading
  gate — and logs each disabled strategy. Because the entire runner iterates that one list (live
  gating, Telegram wiring, `.start()`, supervisor `.join()`, EOD P&L summary, Google Sheet), a
  filtered-out worker is uniformly absent everywhere with no other edits. Empty-roster case logs
  a clear warning.
- **No worker-class changes** — `BasePaperStrategyWorker.__init__` and every strategy are
  untouched; the gate lives entirely in `main()` + the helper.
- `env.example` gains a `<PREFIX>_VIRTUAL_TRADING=true` block for all 26 strategies +
  `SL_HUNTING_VIRTUAL_TRADING`, mirroring the `*_LIVE_TRADING` block, with a header explaining
  default-true / no-master-switch / also-disables-live semantics.

## Tests & gates

New `TestVirtualTradingToggle` (6 cases): default-on when key absent, explicit false/true,
unmapped-name-fails-open, per-strategy independence, SL Hunting prefix respected. All gates
green: **169** master unittests, **93** pytest, ruff / mypy / compileall / bandit clean.

## Verify manually (no market needed)
Set e.g. `RENKO_VIRTUAL_TRADING=false` in `Dependencies/.env`, run `python algo.py run`, and
confirm the startup log shows `VIRTUAL TRADING DISABLED for Renko ...` and Renko is absent from
the running threads while everything else starts normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
