### PR TITLE
BNF-001: fix BankNIFTY mirror contract resolution + monthly-rollover expiry

### DIFF
--- a/Dependencies/env.example
+++ b/Dependencies/env.example
@@ -81,6 +81,10 @@ OPTION_EXCHANGE_SEGMENT=NSE_FNO
 # NIFTY listed strikes step in 50-point increments. The ATM rule rounds the
 # live spot to the nearest multiple of this step.
 ATM_STRIKE_STEP=50.0
+# BankNIFTY monthly strikes step in 100-point increments (per NSE), used only by
+# the SL Hunting BankNIFTY mirror's ATM pick. Keep at 100 unless NSE changes the
+# BankNIFTY strike granularity.
+BANKNIFTY_STRIKE_STEP=100.0
 
 
 # ==============================================================================

--- a/Dependencies/env.example
+++ b/Dependencies/env.example
@@ -1123,12 +1123,17 @@ SL_HUNTING_LOTS=1
 # Shooter). The agent does NOT choose lots; this budget does.
 SL_HUNTING_RISK_BUDGET=2500
 # BankNIFTY mirror (Intraday Hunter style): every NIFTY entry also buys the SAME
-# lot count on the BankNIFTY ATM option (BankNIFTY's own target expiry -- BNF has
-# no weekly series, so that is its nearest listed expiry), entered/exited as ONE
+# lot count on the BankNIFTY ATM option of the CURRENT BankNIFTY monthly expiry
+# (BNF has no weekly series; see the rollover knob below), entered/exited as ONE
 # basket with the NIFTY leg and following the same paper/live gates. NOTE: this
 # roughly DOUBLES the basket's rupee risk beyond SL_HUNTING_RISK_BUDGET (the
 # daily max-loss kill-switch still applies). Set false to trade NIFTY-only.
 SL_HUNTING_BNF_MIRROR=true
+# Mirror expiry rollover (BNF-001): the mirror trades the CURRENT BNF monthly
+# expiry normally, and rolls to the NEXT month once fewer than this many days
+# remain to the current one (avoids holding an about-to-expire contract while
+# never parking an intraday leg in the illiquid second month out).
+SL_HUNTING_BNF_MIRROR_ROLLOVER_DAYS=7
 # Daily kill-switch -- SEPARATE from the per-trade RISK_BUDGET above. The strategy
 # halts for the rest of the day once its cumulative P&L (realized + open) hits
 # -(STARTING_CAPITAL * DAILY_MAX_LOSS_PCT). 600000 * 0.0125 = Rs.7,500/day, i.e.

--- a/Nifty Multi Strategy Front Test - Master File.py
+++ b/Nifty Multi Strategy Front Test - Master File.py
@@ -94,6 +94,13 @@ expiry rule it uses:
 (CPR Algo 3 is "else" -- it TRADES the next-next ATM -- even though its read-only
 observation legs use the current-week expiry.)
 
+One deliberate exception (BNF-001): the SL Hunting BankNIFTY MIRROR leg uses
+OptionsContractResolver.get_monthly_rollover_expiry() -- the CURRENT BankNIFTY
+monthly expiry, rolling to the next month once fewer than
+SL_HUNTING_BNF_MIRROR_ROLLOVER_DAYS days remain. BankNIFTY lists only monthly
+series, so "next-next" would park an intraday mirror in the illiquid second
+month out.
+
 Both methods live on the same resolver so the choice is one line at
 the call site. That keeps the rule visible in the code and easy to
 audit later without chasing a hidden flag.
@@ -2267,10 +2274,16 @@ class OptionsContractResolver:
             & (work["expiry"] >= today)
         )
         opt_mask &= work["trading_symbol"].str.upper().str.startswith(underlying_prefix)
-        opt_mask &= ~work["trading_symbol"].str.upper().str.startswith("BANKNIFTY-")
-        opt_mask &= ~work["trading_symbol"].str.upper().str.startswith("FINNIFTY-")
-        opt_mask &= ~work["trading_symbol"].str.upper().str.startswith("MIDCPNIFTY-")
-        opt_mask &= ~work["trading_symbol"].str.upper().str.startswith("NIFTYNXT50-")
+        # Belt-and-braces: explicitly reject the OTHER index families, but never
+        # the resolver's OWN underlying (BNF-001). The old unconditional list
+        # excluded "BANKNIFTY-" even when self.underlying == "BANKNIFTY", which
+        # made a BankNIFTY resolver's chain provably empty ("No valid BANKNIFTY
+        # option rows found" despite the CSV having them) -- the SL Hunting
+        # mirror could never open. Subtracting our own prefix keeps the guard
+        # for cousins while letting each underlying see its own rows.
+        sibling_prefixes = {"BANKNIFTY-", "FINNIFTY-", "MIDCPNIFTY-", "NIFTYNXT50-"}
+        for sibling_prefix in sorted(sibling_prefixes - {underlying_prefix}):
+            opt_mask &= ~work["trading_symbol"].str.upper().str.startswith(sibling_prefix)
 
         options = work.loc[
             opt_mask,
@@ -2344,13 +2357,40 @@ class OptionsContractResolver:
             raise ValueError(f"No future {self.underlying} expiry found in instrument master.")
         return expiries[0]
 
+    def get_monthly_rollover_expiry(self, min_days_to_expiry: int) -> date:
+        """
+        Return the FIRST expiry on or after today, rolling to the SECOND when
+        fewer than `min_days_to_expiry` days remain to the first.
+
+        Used by the SL Hunting BankNIFTY mirror leg (BNF-001). BankNIFTY lists
+        only MONTHLY series, so the ATM family's "next-next" rule would park an
+        intraday mirror in the SECOND month out -- low gamma, wide spreads. The
+        operator's rule instead: trade the CURRENT monthly normally, and only
+        roll to the next month once the current contract is inside its final
+        week (threshold via SL_HUNTING_BNF_MIRROR_ROLLOVER_DAYS, default 7).
+
+        Boundary semantics: exactly `min_days_to_expiry` days away is NOT
+        "fewer than", so the current expiry is kept. With a single listed
+        expiry there is nothing to roll to, so it is returned even inside the
+        window -- the mirror is fail-soft and trading the only listed contract
+        beats silently skipping the leg.
+        """
+        options = self._load_option_chain()
+        today = datetime.now().date()
+        expiries = sorted({exp for exp in options["expiry"].tolist() if exp is not None and exp >= today})
+        if not expiries:
+            raise ValueError(f"No future {self.underlying} expiry found in instrument master.")
+        if len(expiries) >= 2 and (expiries[0] - today).days < int(min_days_to_expiry):
+            return expiries[1]
+        return expiries[0]
+
     # ------------------------------------------------------------------
     # ATM strike rule (used by the 8 ATM workers)
     # ------------------------------------------------------------------
-    def get_atm_option(self, spot_price: float, direction: str) -> dict:
+    def get_atm_option(self, spot_price: float, direction: str, expiry_date: date | None = None) -> dict:
         """
         Resolve the ATM option row for the given direction and the
-        next-next expiry.
+        next-next expiry (or an explicitly supplied expiry).
 
         Direction mapping:
         - "LONG"  -> CE
@@ -2361,6 +2401,14 @@ class OptionsContractResolver:
         - If that exact strike is not listed, pick the closest available
           strike (smallest absolute difference, with the lower strike
           breaking ties).
+
+        Expiry rule:
+        - Default (expiry_date=None): `get_target_expiry()` -- the ATM
+          family's "next-next" rule, unchanged for every existing caller.
+        - Explicit `expiry_date`: used as-is. The SL Hunting BankNIFTY
+          mirror passes `get_monthly_rollover_expiry(...)` here (BNF-001),
+          keeping the expiry choice visible at the call site like the rest
+          of this file's explicit if-else expiry rules.
         """
         direction_upper = str(direction).strip().upper()
         if direction_upper == "LONG":
@@ -2375,7 +2423,7 @@ class OptionsContractResolver:
             raise ValueError(f"Invalid spot price for ATM resolution: {spot_price!r}")
 
         options = self._load_option_chain()
-        target_expiry = self.get_target_expiry()
+        target_expiry = expiry_date if expiry_date is not None else self.get_target_expiry()
 
         atm_strike = round(spot / ATM_STRIKE_STEP) * ATM_STRIKE_STEP
 
@@ -8808,13 +8856,19 @@ if SL_HUNTING_AVAILABLE:
     # computed from the agent's underlying stop distance.
     SL_HUNTING_RISK_BUDGET = _env_float("SL_HUNTING_RISK_BUDGET", 2500.0)
     # BankNIFTY mirror (Intraday Hunter style): every NIFTY entry is mirrored
-    # with the SAME lot count on the BankNIFTY ATM option of BankNIFTY's own
-    # target expiry, entered and exited together as ONE basket. The mirror is
+    # with the SAME lot count on the BankNIFTY ATM option of the CURRENT
+    # BankNIFTY monthly expiry (rolling forward inside its final week -- see
+    # the knob below), entered and exited together as ONE basket. The mirror is
     # mechanical -- the agent does not choose it -- and NOTE: it roughly doubles
     # the basket's rupee risk beyond SL_HUNTING_RISK_BUDGET (operator-accepted;
     # the daily max-loss kill-switch still caps the day). Fail-soft: any mirror
     # problem only skips the mirror, never the NIFTY leg.
     SL_HUNTING_BNF_MIRROR = _env_bool("SL_HUNTING_BNF_MIRROR", True)
+    # Mirror expiry rule (BNF-001): BankNIFTY lists only MONTHLY series, so the
+    # ATM family's "next-next" rule would put an intraday mirror in the SECOND
+    # month out. Instead the mirror trades the CURRENT monthly expiry, rolling
+    # to the NEXT one once fewer than this many days remain to the current.
+    SL_HUNTING_BNF_MIRROR_ROLLOVER_DAYS = _env_int("SL_HUNTING_BNF_MIRROR_ROLLOVER_DAYS", 7)
     # Trade journal (v3): record each trade's entry context + exit outcome to a
     # gitignored JSONL the reflection coach reads. Best-effort; never blocks trading.
     SL_HUNTING_JOURNAL_ENABLED = _env_bool("SL_HUNTING_JOURNAL_ENABLED", True)
@@ -8970,8 +9024,9 @@ if SL_HUNTING_AVAILABLE:
             return ok
 
         def _open_bnf_mirror(self, direction: str) -> None:
-            """Buy the BankNIFTY ATM CE/PE (BankNIFTY's own target expiry) at the
-            same lot COUNT as the just-opened NIFTY leg."""
+            """Buy the BankNIFTY ATM CE/PE at the same lot COUNT as the
+            just-opened NIFTY leg, on the CURRENT BankNIFTY monthly expiry
+            (rolled to the next month inside its final week -- BNF-001)."""
             if self._mirror_pos.active or self._bnf_resolver is None:
                 return
             nifty_lot_size = max(int(self.pos.option_lot_size), 1)
@@ -8981,7 +9036,12 @@ if SL_HUNTING_AVAILABLE:
             if bnf_spot <= 0:
                 self.log.warning("BNF mirror skipped: no BankNIFTY close seen yet this session.")
                 return
-            contract = self._bnf_resolver.get_atm_option(bnf_spot, direction)
+            # Explicit expiry at the call site, like every other expiry rule in
+            # this file: current monthly, rolling inside the last-week window.
+            mirror_expiry = self._bnf_resolver.get_monthly_rollover_expiry(
+                SL_HUNTING_BNF_MIRROR_ROLLOVER_DAYS
+            )
+            contract = self._bnf_resolver.get_atm_option(bnf_spot, direction, expiry_date=mirror_expiry)
             sec_id = int(contract["security_id"])
             segment = str(contract["exchange_segment"])
             symbol = str(contract["trading_symbol"])

--- a/Nifty Multi Strategy Front Test - Master File.py
+++ b/Nifty Multi Strategy Front Test - Master File.py
@@ -432,6 +432,11 @@ OPTION_INSTRUMENT_TYPE = _env_str("OPTION_INSTRUMENT_TYPE", "OPTIDX")
 # NIFTY listed strikes step in 50-point increments. The ATM rule rounds the
 # live spot to the nearest multiple of this step.
 ATM_STRIKE_STEP = _env_float("ATM_STRIKE_STEP", 50.0)
+# BankNIFTY monthly strikes step in 100-point increments (per NSE), so the ATM
+# seed must use 100 for the BankNIFTY mirror -- rounding a BNF spot on the 50
+# step lands between two listed strikes and the lower-strike tie-break then
+# buys the wrong one. Keyed per underlying in OptionsContractResolver.
+BANKNIFTY_STRIKE_STEP = _env_float("BANKNIFTY_STRIKE_STEP", 100.0)
 
 
 # =============================================================================
@@ -2176,6 +2181,10 @@ class OptionsContractResolver:
         self.underlying = str(underlying).upper().strip()
         self.instrument_master_glob = instrument_master_glob
         self.log = log
+        # ATM-seed step for THIS underlying: BankNIFTY lists 100-point strikes,
+        # NIFTY (and anything else) 50. Using the right step keeps the rounded
+        # seed on a real listed strike so the nearest-strike pick is exact.
+        self.strike_step = BANKNIFTY_STRIKE_STEP if self.underlying == "BANKNIFTY" else ATM_STRIKE_STEP
         self._option_chain_cache: pd.DataFrame | None = None
         self._cache_date: date | None = None
 
@@ -2425,7 +2434,7 @@ class OptionsContractResolver:
         options = self._load_option_chain()
         target_expiry = expiry_date if expiry_date is not None else self.get_target_expiry()
 
-        atm_strike = round(spot / ATM_STRIKE_STEP) * ATM_STRIKE_STEP
+        atm_strike = round(spot / self.strike_step) * self.strike_step
 
         subset = options[(options["expiry"] == target_expiry) & (options["option_type"] == right)].copy()
         if subset.empty:

--- a/Signal Generators/SL Hunting AI Agent/README.md
+++ b/Signal Generators/SL Hunting AI Agent/README.md
@@ -207,8 +207,10 @@ addendum of `sl_hunting_doc.md`.
 
 ## BankNIFTY mirror basket (v4)
 Intraday Hunter trades a multi-index basket; the worker now mirrors him: every NIFTY entry
-also BUYS the **same lot count** on the **BankNIFTY ATM** option (BankNIFTY's own target
-expiry — BNF has no weekly series). Entry stays NIFTY-only (the mirror copies it). The mirror
+also BUYS the **same lot count** on the **BankNIFTY ATM** option of the **current BNF monthly
+expiry** (BNF has no weekly series), rolling to the next month once fewer than
+`SL_HUNTING_BNF_MIRROR_ROLLOVER_DAYS` (default 7) days remain to it — never the illiquid
+second month out. Entry stays NIFTY-only (the mirror copies it). The mirror
 is mechanical; same paper/live gates as the NIFTY leg; fail-soft (a mirror problem only skips
 the mirror); **basket risk ≈ 2× the ~Rs.2500 budget** (operator-accepted — the daily max-loss
 kill-switch still caps the day). Toggle: `SL_HUNTING_BNF_MIRROR` (default true). Journal rows'

--- a/test_nifty_multi_strategy_master.py
+++ b/test_nifty_multi_strategy_master.py
@@ -785,6 +785,29 @@ class TestOptionsContractResolverUnderlyings(unittest.TestCase):
         resolver = self._resolver(tmpdir, "BANKNIFTY")
         self.assertEqual(resolver.get_monthly_rollover_expiry(7), self.exp_only)
 
+    def test_banknifty_atm_uses_100_point_strike_step(self):
+        """BankNIFTY strikes are 100-point. A 57,960 spot must resolve to the
+        nearest listed 58,000 -- the old global 50-point seed rounded to 57,950,
+        which ties 57,900/58,000 and the lower-strike tie-break wrongly bought
+        57,900 (Codex P2 on PR #40)."""
+        tmpdir = self._mixed_master()  # BANKNIFTY strikes 57800/57900/58000
+        resolver = self._resolver(tmpdir, "BANKNIFTY")
+        contract = resolver.get_atm_option(spot_price=57960.0, direction="LONG")
+        self.assertEqual(contract["strike"], 58000.0)
+        self.assertEqual(contract["atm_strike_rounded"], 58000.0)
+
+    def test_nifty_atm_keeps_50_point_strike_step(self):
+        """NIFTY must be untouched: a 50-point step still seeds the ATM strike,
+        so a spot 40 points above a strike rounds up to it."""
+        exp = (date.today() + timedelta(days=10)).isoformat()
+        rows = self._option_rows("NIFTY", (exp,), (24950, 25000, 25050), "75", 20000)
+        tmpdir = self._write_master(rows)
+        resolver = self._resolver(tmpdir, "NIFTY")
+        # 24,990 rounds to 25,000 on a 50-step; a 100-step would wrongly seed 25,000
+        # too here, so use 24,940 -> 50-step seeds 24,950 (its nearest listed strike).
+        contract = resolver.get_atm_option(spot_price=24940.0, direction="LONG", expiry_date=date.fromisoformat(exp))
+        self.assertEqual(contract["strike"], 24950.0)
+
 
 # =============================================================================
 # TEST SUITE: DHAN BROKER CLIENT (mocked dhanhq SDK)

--- a/test_nifty_multi_strategy_master.py
+++ b/test_nifty_multi_strategy_master.py
@@ -645,6 +645,148 @@ class TestOptionsContractResolver(unittest.TestCase):
 
 
 # =============================================================================
+# TEST SUITE: RESOLVER PER-UNDERLYING FILTER + MIRROR EXPIRY RULE (BNF-001)
+# =============================================================================
+class TestOptionsContractResolverUnderlyings(unittest.TestCase):
+    """
+    BNF-001 regression suite. The instrument-master filter used to hardcode
+    `~startswith("BANKNIFTY-")`-style exclusions regardless of the resolver's
+    own underlying, so a BANKNIFTY resolver could never see a single row
+    ("No valid BANKNIFTY option rows found" even though the CSV had them).
+    These tests pin the fixed behaviour: each resolver sees ONLY its own
+    underlying's rows, and the SL Hunting mirror's monthly-rollover expiry
+    picker chooses the current expiry unless it is about to expire.
+    """
+
+    @staticmethod
+    def _option_rows(underlying: str, expiries, strikes, lot_size: str, sec_start: int):
+        """Build DhanHQ-master-schema rows for one underlying (CE+PE per strike)."""
+        rows = []
+        sec = sec_start
+        for exp in expiries:
+            for strike in strikes:
+                for right in ("CE", "PE"):
+                    rows.append({
+                        "EXCH_ID": "NSE",
+                        "SEGMENT": "D",
+                        "INSTRUMENT": "OPTIDX",
+                        "SYMBOL_NAME": f"{underlying}-{exp}-{strike}-{right}",
+                        "DISPLAY_NAME": f"{underlying} {exp} {strike} {right}",
+                        "SM_EXPIRY_DATE": str(exp),
+                        "LOT_SIZE": lot_size,
+                        "SECURITY_ID": str(sec),
+                        "STRIKE_PRICE": str(strike),
+                        "OPTION_TYPE": right,
+                        "UNDERLYING_SYMBOL": underlying,
+                    })
+                    sec += 1
+        return rows
+
+    def _write_master(self, rows) -> tempfile.TemporaryDirectory:
+        """Write one synthetic instrument master; caller owns the tempdir."""
+        tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmpdir.cleanup)
+        pd.DataFrame(rows).to_csv(Path(tmpdir.name) / "all_instrument 1.csv", index=False)
+        return tmpdir
+
+    def _resolver(self, tmpdir, underlying: str):
+        import logging
+        return master_file.OptionsContractResolver(
+            underlying=underlying,
+            instrument_master_glob=str(Path(tmpdir.name) / "all_instrument *.csv"),
+            log=logging.getLogger("test_resolver_underlyings"),
+        )
+
+    def _mixed_master(self):
+        """One CSV holding NIFTY + BANKNIFTY + FINNIFTY rows over two expiries."""
+        self.exp_first = date.today() + timedelta(days=10)
+        self.exp_second = date.today() + timedelta(days=40)
+        expiries = (self.exp_first.isoformat(), self.exp_second.isoformat())
+        rows = (
+            self._option_rows("NIFTY", expiries, (24200, 24300, 24400), "75", 20000)
+            + self._option_rows("BANKNIFTY", expiries, (57800, 57900, 58000), "35", 30000)
+            + self._option_rows("FINNIFTY", expiries, (26300, 26400), "65", 40000)
+        )
+        return self._write_master(rows)
+
+    def test_banknifty_resolver_returns_banknifty_atm_contract(self):
+        """A BANKNIFTY resolver must resolve a BANKNIFTY contract from a mixed master."""
+        tmpdir = self._mixed_master()
+        resolver = self._resolver(tmpdir, "BANKNIFTY")
+        contract = resolver.get_atm_option(spot_price=57910.0, direction="LONG")
+        self.assertTrue(str(contract["trading_symbol"]).startswith("BANKNIFTY-"))
+        self.assertEqual(contract["option_type"], "CE")
+        self.assertEqual(contract["strike"], 57900.0)
+        self.assertEqual(contract["lot_size"], 35)
+
+    def test_banknifty_chain_contains_only_banknifty_rows(self):
+        """The BANKNIFTY chain must include every BNF row and nothing else."""
+        tmpdir = self._mixed_master()
+        resolver = self._resolver(tmpdir, "BANKNIFTY")
+        chain = resolver._load_option_chain()
+        self.assertEqual(len(chain), 12)  # 2 expiries x 3 strikes x CE/PE
+        self.assertTrue(chain["trading_symbol"].str.startswith("BANKNIFTY-").all())
+
+    def test_nifty_resolver_excludes_other_underlyings(self):
+        """The NIFTY chain must still exclude BANKNIFTY/FINNIFTY rows (regression lock)."""
+        tmpdir = self._mixed_master()
+        resolver = self._resolver(tmpdir, "NIFTY")
+        chain = resolver._load_option_chain()
+        self.assertEqual(len(chain), 12)  # 2 expiries x 3 strikes x CE/PE
+        self.assertTrue(chain["trading_symbol"].str.startswith("NIFTY-").all())
+
+    def test_get_atm_option_accepts_explicit_expiry(self):
+        """An explicit expiry overrides the default next-next rule (mirror wiring)."""
+        tmpdir = self._mixed_master()
+        resolver = self._resolver(tmpdir, "NIFTY")
+        contract = resolver.get_atm_option(
+            spot_price=24310.0, direction="LONG", expiry_date=self.exp_first
+        )
+        self.assertEqual(contract["expiry_date"], self.exp_first)
+        # And the default still lands on the next-next expiry.
+        default_contract = resolver.get_atm_option(spot_price=24310.0, direction="LONG")
+        self.assertEqual(default_contract["expiry_date"], self.exp_second)
+
+    def _bnf_two_expiry_master(self, days_to_first: int, days_to_second: int = 40):
+        self.exp_near = date.today() + timedelta(days=days_to_first)
+        self.exp_far = date.today() + timedelta(days=days_to_second)
+        rows = self._option_rows(
+            "BANKNIFTY",
+            (self.exp_near.isoformat(), self.exp_far.isoformat()),
+            (57900,),
+            "35",
+            30000,
+        )
+        return self._write_master(rows)
+
+    def test_rollover_keeps_current_expiry_when_far(self):
+        """>= min_days to the current expiry -> stay on the current expiry."""
+        tmpdir = self._bnf_two_expiry_master(days_to_first=10)
+        resolver = self._resolver(tmpdir, "BANKNIFTY")
+        self.assertEqual(resolver.get_monthly_rollover_expiry(7), self.exp_near)
+
+    def test_rollover_rolls_to_next_expiry_when_near(self):
+        """< min_days to the current expiry -> roll to the next expiry."""
+        tmpdir = self._bnf_two_expiry_master(days_to_first=3)
+        resolver = self._resolver(tmpdir, "BANKNIFTY")
+        self.assertEqual(resolver.get_monthly_rollover_expiry(7), self.exp_far)
+
+    def test_rollover_boundary_day_keeps_current_expiry(self):
+        """Exactly min_days away is NOT 'fewer than' -> keep the current expiry."""
+        tmpdir = self._bnf_two_expiry_master(days_to_first=7)
+        resolver = self._resolver(tmpdir, "BANKNIFTY")
+        self.assertEqual(resolver.get_monthly_rollover_expiry(7), self.exp_near)
+
+    def test_rollover_returns_only_expiry_when_single(self):
+        """With a single listed expiry there is nothing to roll to -> return it."""
+        self.exp_only = date.today() + timedelta(days=3)
+        rows = self._option_rows("BANKNIFTY", (self.exp_only.isoformat(),), (57900,), "35", 30000)
+        tmpdir = self._write_master(rows)
+        resolver = self._resolver(tmpdir, "BANKNIFTY")
+        self.assertEqual(resolver.get_monthly_rollover_expiry(7), self.exp_only)
+
+
+# =============================================================================
 # TEST SUITE: DHAN BROKER CLIENT (mocked dhanhq SDK)
 # =============================================================================
 class TestDhanBrokerClient(unittest.TestCase):
@@ -1729,8 +1871,12 @@ class TestSLHuntingBnfMirror(unittest.TestCase):
         self.assertTrue(worker._mirror_pos.active)
         self.assertEqual(worker._mirror_pos.quantity, nifty_lots * 35)
         self.assertEqual(worker._mirror_pos.option_right, "CE")
-        # The mirror asked BankNIFTY's resolver with the BNF spot + direction.
-        worker._bnf_resolver.get_atm_option.assert_called_once_with(57910.0, "LONG")
+        # The mirror asked BankNIFTY's resolver with the BNF spot + direction,
+        # pinning the expiry to the monthly-rollover rule (BNF-001).
+        worker._bnf_resolver.get_atm_option.assert_called_once_with(
+            57910.0, "LONG",
+            expiry_date=worker._bnf_resolver.get_monthly_rollover_expiry.return_value,
+        )
 
     def test_basket_exits_together_and_pnl_includes_both_legs(self):
         worker, store = self._make_worker()
@@ -1905,6 +2051,56 @@ class TestSLHuntingBnfMirror(unittest.TestCase):
         self.assertGreater(payload["option_pnl"], 0.0)    # mirror P&L is captured
         self.assertIsNone(worker._pending_journal_exit)
         self.assertIsNone(worker._open_trade_id)
+
+    # ----- BNF-001: the REAL resolver must be able to open the mirror -------
+    def test_mirror_opens_with_real_resolver_and_rollover_expiry(self):
+        """Integration lock for BNF-001: with a real OptionsContractResolver over
+        a synthetic instrument master, the mirror must open a BANKNIFTY contract
+        at the current monthly expiry -- rolled to the NEXT month here because
+        the near expiry is inside the SL_HUNTING_BNF_MIRROR_ROLLOVER_DAYS window.
+        (The other mirror tests mock `_bnf_resolver`, which is exactly how the
+        original always-empty-chain bug slipped through.)"""
+        import logging
+
+        worker, store = self._make_worker()
+        tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmpdir.cleanup)
+        near = date.today() + timedelta(days=3)    # < 7 days -> must roll
+        far = date.today() + timedelta(days=40)
+        rows = []
+        sec = 30000
+        for exp in (near.isoformat(), far.isoformat()):
+            for strike in (57800, 57900, 58000):
+                for right in ("CE", "PE"):
+                    rows.append({
+                        "EXCH_ID": "NSE", "SEGMENT": "D", "INSTRUMENT": "OPTIDX",
+                        "SYMBOL_NAME": f"BANKNIFTY-{exp}-{strike}-{right}",
+                        "DISPLAY_NAME": f"BANKNIFTY {exp} {strike} {right}",
+                        "SM_EXPIRY_DATE": exp, "LOT_SIZE": "35",
+                        "SECURITY_ID": str(sec), "STRIKE_PRICE": str(strike),
+                        "OPTION_TYPE": right, "UNDERLYING_SYMBOL": "BANKNIFTY",
+                    })
+                    sec += 1
+        csv_path = Path(tmpdir.name) / "all_instrument 1.csv"
+        pd.DataFrame(rows).to_csv(csv_path, index=False)
+        worker._bnf_resolver = master_file.OptionsContractResolver(
+            underlying="BANKNIFTY",
+            instrument_master_glob=str(Path(tmpdir.name) / "all_instrument *.csv"),
+            log=logging.getLogger("test_bnf_mirror_real_resolver"),
+        )
+        # Give every synthetic BNF option a live LTP so whichever row the
+        # resolver picks has a price in the shared cache.
+        store.update_ltp_map({
+            (master_file.OPTION_EXCHANGE_SEGMENT, int(row["SECURITY_ID"])): 500.0
+            for row in rows
+        })
+
+        self.assertTrue(worker.enter_position("LONG", 24300.0, 24290.0, 24400.0))
+        self.assertTrue(worker._mirror_pos.active)
+        self.assertTrue(worker._mirror_pos.symbol.startswith("BANKNIFTY-"))
+        self.assertEqual(worker._mirror_pos.option_strike, 57900.0)  # ATM for 57910 spot
+        self.assertEqual(worker._mirror_pos.option_right, "CE")
+        self.assertEqual(worker._mirror_pos.option_expiry, far)      # rolled past `near`
 
 
 class TestLiveOrderRouting(unittest.TestCase):


### PR DESCRIPTION
## What this fixes

The BankNifty mirror leg of the SL Hunting worker **never opened**: every entry logged
`No valid BANKNIFTY option rows found in <instrument csv>` even though the CSV contained
BNF contracts (live symptom, 2026-07-06).

**Root cause** — `OptionsContractResolver._load_option_chain` applied hardcoded sibling
exclusions unconditionally:

```python
opt_mask &= work["trading_symbol"].str.upper().str.startswith(underlying_prefix)   # requires BANKNIFTY-*
opt_mask &= ~work["trading_symbol"].str.upper().str.startswith("BANKNIFTY-")      # excludes BANKNIFTY-*
```

For `underlying="BANKNIFTY"` the mask is a logical contradiction → provably empty chain →
the fail-soft wrapper skipped the mirror every time. The suite missed it because
`TestSLHuntingBnfMirror` mocks `_bnf_resolver` entirely.

## Changes

- **Filter fix:** exclusions now subtract the resolver's own underlying
  (`{"BANKNIFTY-","FINNIFTY-","MIDCPNIFTY-","NIFTYNXT50-"} - {underlying_prefix}`), keeping
  the cousin guard for the NIFTY resolver.
- **Mirror expiry rule (operator-decided):** new `get_monthly_rollover_expiry()` — the
  mirror trades the **current BNF monthly** expiry, rolling to the next month when fewer
  than `SL_HUNTING_BNF_MIRROR_ROLLOVER_DAYS` (default 7) days remain. Without this, the
  inherited "next-next" rule would have put the intraday mirror in the illiquid second
  month out (never observed live — the resolver always crashed first).
- **`get_atm_option(..., expiry_date=None)`:** optional explicit expiry so the mirror's
  choice is visible at its call site; all other callers unchanged.
- **Tests (TDD — all watched failing first):** `TestOptionsContractResolverUnderlyings`
  (mixed-underlying master, chain isolation per underlying, rollover far/near/boundary/
  single-expiry) + an integration test driving the **real** resolver through
  `_open_bnf_mirror` over a synthetic CSV.
- **Docs:** env.example, agent README, and the master-file expiry-rules header now state
  the actual mirror expiry rule (env.example previously *claimed* "nearest listed expiry"
  while the code did next-next).

## Verification

| Gate | Result |
|---|---|
| `python -m unittest test_nifty_multi_strategy_master` | 187 tests OK (9 new) |
| `python -m pytest "Signal Generators" -q` | 84 passed |
| `python -m ruff check .` | clean |
| `python -m mypy` | clean (29 files) |
| `python -m compileall -q .` | OK |

RED evidence: pre-fix, the new tests failed exactly as the live bug predicts — resolver
`ValueError`, missing rollover method, and `_mirror_pos.active == False` through the real
resolver path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
