### PR TITLE
SLH-001: time-bound the SL Hunting SDK call and disarm abandoned bars

### DIFF
--- a/Dependencies/env.example
+++ b/Dependencies/env.example
@@ -1110,6 +1110,14 @@ SL_HUNTING_ENABLED=false
 SL_HUNTING_MODEL=claude-opus-4-8
 # true = disable extended thinking (lower latency, lower quality).
 SL_HUNTING_FAST_MODE=false
+# Hard time budget (seconds) for ONE Claude SDK call (SLH-001). The per-bar decision
+# runs on the strategy worker's own thread -- the same thread that enforces the
+# per-poll stop/target check, max-loss and the 15:15 square-off -- so a hung CLI
+# call would otherwise freeze every mechanical protection for the open basket.
+# On timeout the call is abandoned, that bar's order tool is disarmed (no late
+# "zombie" orders) and the agent records a fail-soft HOLD. <=0 disables the bound
+# (not recommended for the live runner).
+SL_HUNTING_SDK_TIMEOUT_SECONDS=90
 # Evaluate once per completed N-minute bar. SL Hunting trades on 1-min by design (the
 # method's "daily trades" are 1-min; 5-min is only the opening-setup nuance). NOTE: the
 # agent makes ONE LLM/subscription call PER bar, so 1-min is ~5x the calls/usage of 5-min

--- a/Nifty Multi Strategy Front Test - Master File.py
+++ b/Nifty Multi Strategy Front Test - Master File.py
@@ -8879,6 +8879,11 @@ if SL_HUNTING_AVAILABLE:
                 fast_mode=_env_bool("SL_HUNTING_FAST_MODE", False),
                 indicator_config=SL_HUNTING_INDICATOR_CONFIG,
                 lessons_block=lessons_block,
+                # SLH-001: bound each SDK call. decide() blocks THIS worker's
+                # thread -- the same thread that enforces the per-poll
+                # stop/target check, max-loss and the 15:15 square-off -- so a
+                # hung CLI call must cost one bar's decision, not the safety net.
+                sdk_timeout_seconds=_env_float("SL_HUNTING_SDK_TIMEOUT_SECONDS", 90.0),
             )
             # The order tool routes through this executor into our own safe methods.
             self._executor = SL_HUNTING_EXECUTOR_MODULE.MasterWorkerExecutor(self)

--- a/Signal Generators/SL Hunting AI Agent/README.md
+++ b/Signal Generators/SL Hunting AI Agent/README.md
@@ -114,7 +114,9 @@ cutoff the agent isn't called at all, so it makes **no LLM calls for the rest of
   The per-bar decision blocks the worker thread that also enforces stop/target,
   max-loss and the 15:15 square-off, so a hung CLI call is abandoned at the budget:
   that bar's order tool is disarmed (a late-waking loop cannot fire a zombie order)
-  and the agent records a fail-soft `HOLD`.
+  and the agent records a fail-soft `HOLD`. If the CLI stays hung, subsequent bars
+  are **gated** until the abandoned call finishes — so at most one hung agent
+  call/subprocess exists at a time instead of one accumulating per bar.
 - Both extra deps are **lazily imported**, so a missing dep just disables this one
   worker — the rest of the master and its test suite are unaffected.
 

--- a/Signal Generators/SL Hunting AI Agent/README.md
+++ b/Signal Generators/SL Hunting AI Agent/README.md
@@ -110,6 +110,11 @@ cutoff the agent isn't called at all, so it makes **no LLM calls for the rest of
   malformed output, **auth 401 / usage-limit 429**, …) returns a safe `HOLD`, and the
   warning log names the cause (e.g. "authentication failed (HTTP 401) — run
   `claude setup-token`") so it's actionable.
+- Each SDK call is **time-bounded** (`SL_HUNTING_SDK_TIMEOUT_SECONDS`, default 90s).
+  The per-bar decision blocks the worker thread that also enforces stop/target,
+  max-loss and the 15:15 square-off, so a hung CLI call is abandoned at the budget:
+  that bar's order tool is disarmed (a late-waking loop cannot fire a zombie order)
+  and the agent records a fail-soft `HOLD`.
 - Both extra deps are **lazily imported**, so a missing dep just disables this one
   worker — the rest of the master and its test suite are unaffected.
 

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_agent.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_agent.py
@@ -77,8 +77,12 @@ class SLHuntingTimeoutError(SLHuntingAgentError):
     (a fail-soft HOLD), not the position's entire mechanical safety net.
     """
 
-    def __init__(self, timeout_seconds: float) -> None:
+    def __init__(self, timeout_seconds: float, thread: threading.Thread | None = None) -> None:
         self.timeout_seconds = float(timeout_seconds)
+        # The still-running worker thread we abandoned. decide() keeps a reference
+        # so it can gate new calls until this one finishes -- otherwise a CLI that
+        # hangs every bar would pile up daemon threads + subprocesses.
+        self.thread = thread
         super().__init__(
             f"Claude Agent SDK call exceeded {self.timeout_seconds:.0f}s and was "
             "abandoned; this bar's order tool has been disarmed."
@@ -263,6 +267,10 @@ class SLHuntingAgent:
         self._sdk_timeout_seconds: float | None = (
             float(sdk_timeout_seconds) if float(sdk_timeout_seconds) > 0 else None
         )
+        # SLH-001 / Codex: a worker thread from a PRIOR timed-out call that is
+        # still alive. While set, decide() gates new calls (no fresh thread or
+        # subprocess) so a persistently hung CLI can accumulate at most one.
+        self._abandoned_call: threading.Thread | None = None
         # Optional v3 LEARNED LESSONS block (loaded + formatted by the caller, gated by
         # SL_HUNTING_LESSONS_ENABLED). Injected ONCE here, before the output contract,
         # so the system prefix stays stable per session and prompt caching is preserved.
@@ -447,7 +455,9 @@ class SLHuntingAgent:
         thread.start()
         thread.join(timeout=timeout_seconds)
         if thread.is_alive():
-            raise SLHuntingTimeoutError(timeout_seconds or 0.0)
+            # Hand the still-running thread back so the caller can gate future
+            # calls on it instead of spawning another abandoned worker each bar.
+            raise SLHuntingTimeoutError(timeout_seconds or 0.0, thread=thread)
         if not outcome:  # pragma: no cover - the runner always records one entry
             raise SLHuntingAgentError("SDK call thread ended without recording a result.")
         kind, value = outcome[0]
@@ -458,6 +468,23 @@ class SLHuntingAgent:
     # ------------------------------------------------------------------
     # Public entry point
     # ------------------------------------------------------------------
+
+    def _previous_call_still_running(self) -> bool:
+        """True while a PRIOR timed-out SDK call's thread is still alive.
+
+        SLH-001 / Codex (PR #41). A hung CLI would otherwise let each bar spawn
+        another abandoned daemon thread + subprocess, piling up resources and
+        stale agent loops. We gate new calls until the previous one finishes, so
+        at most one abandoned call exists at a time. Clears the reference once
+        the thread dies, resuming normal operation on the next bar.
+        """
+        thread = self._abandoned_call
+        if thread is None:
+            return False
+        if thread.is_alive():
+            return True
+        self._abandoned_call = None
+        return False
 
     def decide(
         self,
@@ -520,6 +547,16 @@ class SLHuntingAgent:
                 reasoning=reasoning, model_used=self._model,
             )
 
+        # Codex (PR #41): if a prior call timed out and its worker thread is still
+        # hung, do NOT start another one -- gate to a fail-soft HOLD until it
+        # finishes so we never accumulate abandoned threads/subprocesses.
+        if self._previous_call_still_running():
+            logger.warning(
+                "SL Hunting agent holding — a previous SDK call is still running past its "
+                "timeout; skipping this bar to avoid stacking hung agent loops."
+            )
+            return _hold("Previous agent call still running; holding.")
+
         # IMPORTANT: do NOT retry the agentic loop. Unlike the read-only Scanner
         # agents, our order tool has SIDE EFFECTS — the agent ENTERS/EXITS via the
         # executor DURING the loop. Re-running the loop after a malformed final JSON
@@ -533,6 +570,9 @@ class SLHuntingAgent:
             # still be alive on its daemon thread. Disarm this bar's order tool so
             # a late-waking loop cannot fire a zombie order, then fail-soft HOLD.
             tool_context.expire("sdk_timeout")
+            # Track the still-running thread so the NEXT bar gates on it instead of
+            # spawning another (Codex PR #41). Cleared once it finally finishes.
+            self._abandoned_call = exc.thread
             logger.warning("SL Hunting agent holding — %s", exc)
             return _hold("Agent call timed out; holding.")
         except SLHuntingUsageLimitError as exc:

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_agent.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_agent.py
@@ -27,11 +27,11 @@ safe HOLD decision.
 from __future__ import annotations
 
 import asyncio
-import concurrent.futures
 import json
 import logging
 import re
 import sys
+import threading
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any, Literal
@@ -66,6 +66,23 @@ class SLHuntingAgentError(RuntimeError):
 
 class SLHuntingUsageLimitError(SLHuntingAgentError):
     """The Claude subscription's Agent SDK usage/rate limit was hit (HTTP 429)."""
+
+
+class SLHuntingTimeoutError(SLHuntingAgentError):
+    """The SDK call exceeded its time budget and was abandoned (SLH-001).
+
+    decide() runs on the strategy worker's OWN thread; while it blocks, the
+    worker's per-poll stop/target check, max-loss and 15:15 square-off are all
+    frozen. Bounding the call means a hung Claude CLI costs one bar's decision
+    (a fail-soft HOLD), not the position's entire mechanical safety net.
+    """
+
+    def __init__(self, timeout_seconds: float) -> None:
+        self.timeout_seconds = float(timeout_seconds)
+        super().__init__(
+            f"Claude Agent SDK call exceeded {self.timeout_seconds:.0f}s and was "
+            "abandoned; this bar's order tool has been disarmed."
+        )
 
 
 class SLHuntingAuthError(SLHuntingAgentError):
@@ -231,6 +248,7 @@ class SLHuntingAgent:
         fast_mode: bool = False,
         indicator_config: SLHuntingIndicatorConfig | None = None,
         lessons_block: str = "",
+        sdk_timeout_seconds: float = 90.0,
     ) -> None:
         if not model:
             raise ValueError("SLHuntingAgent: model is required.")
@@ -238,6 +256,13 @@ class SLHuntingAgent:
         self._runner = runner
         self._fast_mode = bool(fast_mode)
         self._cfg = indicator_config or SLHuntingIndicatorConfig()
+        # SLH-001: hard budget for one SDK call. decide() blocks the worker
+        # thread that also enforces stop/target/max-loss/square-off, so a hung
+        # CLI call must cost one bar (fail-soft HOLD), not the safety net.
+        # <= 0 disables the bound (not recommended for the live runner).
+        self._sdk_timeout_seconds: float | None = (
+            float(sdk_timeout_seconds) if float(sdk_timeout_seconds) > 0 else None
+        )
         # Optional v3 LEARNED LESSONS block (loaded + formatted by the caller, gated by
         # SL_HUNTING_LESSONS_ENABLED). Injected ONCE here, before the output contract,
         # so the system prefix stays stable per session and prompt caching is preserved.
@@ -384,29 +409,51 @@ class SLHuntingAgent:
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _run_sync(coro: Awaitable[AgentRunResult]) -> AgentRunResult:
+    def _run_sync(
+        coro: Awaitable[AgentRunResult], *, timeout_seconds: float | None = None
+    ) -> AgentRunResult:
         """Run an async coroutine to completion from sync/threaded code.
 
         Uses a dedicated worker thread with its OWN event loop so we never collide
         with any running loop. On Windows a ProactorEventLoop is required because
         the Agent SDK launches the Claude CLI as a subprocess (identical to the
         Scanner app's bridge).
-        """
 
-        def _runner() -> AgentRunResult:
+        `timeout_seconds` bounds the wait (SLH-001). The worker is a DAEMON
+        thread: when the budget is exceeded we stop waiting and raise
+        `SLHuntingTimeoutError`, abandoning the thread (a daemon can never block
+        process exit, and a hung CLI subprocess dies with the process). The
+        caller must then treat this bar's tool context as expired -- the
+        abandoned loop may wake later and must not be allowed to act.
+        """
+        # ("ok", result) or ("err", exception), appended by the worker thread.
+        outcome: list[tuple[str, Any]] = []
+
+        def _runner() -> None:
             if sys.platform == "win32":
                 loop = asyncio.ProactorEventLoop()
             else:
                 loop = asyncio.new_event_loop()
             try:
                 asyncio.set_event_loop(loop)
-                return loop.run_until_complete(coro)
+                outcome.append(("ok", loop.run_until_complete(coro)))
+            except BaseException as exc:  # noqa: BLE001 - re-raised on the caller thread below
+                outcome.append(("err", exc))
             finally:
                 asyncio.set_event_loop(None)
                 loop.close()
 
-        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-            return executor.submit(_runner).result()
+        thread = threading.Thread(target=_runner, name="sl-hunting-sdk-call", daemon=True)
+        thread.start()
+        thread.join(timeout=timeout_seconds)
+        if thread.is_alive():
+            raise SLHuntingTimeoutError(timeout_seconds or 0.0)
+        if not outcome:  # pragma: no cover - the runner always records one entry
+            raise SLHuntingAgentError("SDK call thread ended without recording a result.")
+        kind, value = outcome[0]
+        if kind == "err":
+            raise value
+        return value
 
     # ------------------------------------------------------------------
     # Public entry point
@@ -453,7 +500,8 @@ class SLHuntingAgent:
                     model=self._model,
                     max_turns=self.MAX_TURNS,
                     tool_context=tool_context,
-                )
+                ),
+                timeout_seconds=self._sdk_timeout_seconds,
             )
             if run_result.cost_usd is not None:
                 logger.info("SLHuntingAgent decision cost ~$%.4f", run_result.cost_usd)
@@ -480,6 +528,13 @@ class SLHuntingAgent:
         # a bad/missing final JSON simply yields a safe HOLD record (no further action).
         try:
             text = _run_once()
+        except SLHuntingTimeoutError as exc:
+            # SLH-001: the call was ABANDONED, not finished -- the agentic loop may
+            # still be alive on its daemon thread. Disarm this bar's order tool so
+            # a late-waking loop cannot fire a zombie order, then fail-soft HOLD.
+            tool_context.expire("sdk_timeout")
+            logger.warning("SL Hunting agent holding — %s", exc)
+            return _hold("Agent call timed out; holding.")
         except SLHuntingUsageLimitError as exc:
             # Actionable, content-free message (e.g. "...usage limit was hit (HTTP 429)").
             logger.warning("SL Hunting agent holding — %s", exc)

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_tools.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_tools.py
@@ -78,6 +78,12 @@ class SLHuntingToolContext:
     broker: str | None = None
     last_price: float = field(default=0.0)
     bnf_candles: pd.DataFrame | None = None
+    # Set via `expire()` when the agent abandons this bar's SDK call (SLH-001,
+    # e.g. a timed-out CLI call). The abandoned agentic loop keeps running on
+    # its daemon thread and could otherwise still call the order tool MINUTES
+    # later, against a market that has moved on; once expired, `do_order`
+    # refuses instead of touching the executor.
+    expired_reason: str | None = field(default=None)
 
     @classmethod
     def build(
@@ -150,6 +156,10 @@ class SLHuntingToolContext:
     def action_tool_name(self) -> str:
         return execution_tool_name(self.live_active, self.broker)
 
+    def expire(self, reason: str) -> None:
+        """Disarm this bar's order tool (the decision window is over -- SLH-001)."""
+        self.expired_reason = str(reason)
+
     def do_order(
         self, action: str, stop: float, target: float, reason: str, exit_leg: str = "BOTH"
     ) -> dict[str, Any]:
@@ -159,6 +169,11 @@ class SLHuntingToolContext:
         cut one leg of the BankNIFTY-mirror basket on premise-invalidation while leaving
         the other running; hard risk (stop/target/max-loss/square-off) still ties both.
         """
+        if self.expired_reason:
+            return {
+                "accepted": False,
+                "reason": f"decision window expired ({self.expired_reason}); order refused",
+            }
         action = (action or "").strip().upper()
         if action == "ENTER_LONG":
             return self.executor.enter("LONG", float(stop or 0.0), float(target or 0.0), reason, self.last_price)

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_agent.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_agent.py
@@ -295,3 +295,82 @@ def test_master_worker_executor_delegates():
     assert ex.enter("SHORT", 1, 2, "y", 25000)["accepted"] is False
     assert ex.exit("done", price=25050)["accepted"] is True
     assert ex.snapshot()["in_position"] is False
+
+
+# --------------------------------------------------------------------------
+# SLH-001: the SDK call must be TIME-BOUNDED. decide() runs on the strategy
+# worker's own thread -- while it blocks, the per-poll stop/target check,
+# max-loss and the 15:15 square-off are all frozen, so a hung CLI call would
+# suspend every mechanical protection for the open basket. And because the
+# order tool has side effects, an ABANDONED call must also be disarmed so a
+# late-waking loop cannot fire a zombie order against a market that moved on.
+# --------------------------------------------------------------------------
+
+def test_run_sync_raises_timeout_when_coroutine_hangs():
+    import asyncio
+    import time
+
+    import pytest
+    from sl_hunting_agent import SLHuntingTimeoutError
+
+    async def _hang():
+        await asyncio.sleep(30)
+        return AgentRunResult(text="never")
+
+    start = time.monotonic()
+    with pytest.raises(SLHuntingTimeoutError):
+        SLHuntingAgent._run_sync(_hang(), timeout_seconds=0.2)
+    assert time.monotonic() - start < 5  # abandoned promptly, not after 30s
+
+
+def test_run_sync_without_timeout_still_returns_result():
+    async def _quick():
+        return AgentRunResult(text="done", cost_usd=None)
+
+    result = SLHuntingAgent._run_sync(_quick())
+    assert result.text == "done"
+
+
+def test_expired_tool_context_rejects_orders():
+    ex = StandaloneExecutor()
+    ctx = SLHuntingToolContext.build(_candles(), ex)
+    ctx.expire("sdk_timeout")
+    res = ctx.do_order("ENTER_LONG", stop=24990, target=25080, reason="late")
+    assert res["accepted"] is False
+    assert "expired" in res["reason"]
+    assert ex.snapshot()["in_position"] is False  # the executor was never touched
+
+
+def test_agent_decide_times_out_holds_and_disarms_order_tool():
+    """A hung SDK call ends as a fail-soft HOLD within the budget, and the
+    abandoned loop's order tool is disarmed (no zombie orders later)."""
+    import asyncio
+    import time
+
+    captured = {}
+
+    class _HangingRunner:
+        async def __call__(self, prompt, *, system_prompt, model, max_turns, tool_context=None):
+            captured["tool_context"] = tool_context
+            await asyncio.sleep(30)
+            return AgentRunResult(text="{}")
+
+    ex = StandaloneExecutor()
+    agent = SLHuntingAgent(model="test-model", runner=_HangingRunner(), sdk_timeout_seconds=0.2)
+    start = time.monotonic()
+    decision = agent.decide(_candles(), ex)
+    assert time.monotonic() - start < 5          # bounded, not 30s
+    assert decision.action == "HOLD"
+    assert decision.setup == "agent_error"       # fail-soft, same family as other infra failures
+    assert "timed out" in decision.reasoning.lower()
+
+    # The runner's coroutine body runs on the abandoned daemon thread; give it a
+    # beat to have captured the context (it starts well before the timeout).
+    for _ in range(100):
+        if "tool_context" in captured:
+            break
+        time.sleep(0.02)
+    ctx = captured["tool_context"]
+    late = ctx.do_order("ENTER_LONG", stop=24990, target=25080, reason="zombie order")
+    assert late["accepted"] is False             # disarmed: refused, executor untouched
+    assert ex.snapshot()["in_position"] is False

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_agent.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_agent.py
@@ -374,3 +374,67 @@ def test_agent_decide_times_out_holds_and_disarms_order_tool():
     late = ctx.do_order("ENTER_LONG", stop=24990, target=25080, reason="zombie order")
     assert late["accepted"] is False             # disarmed: refused, executor untouched
     assert ex.snapshot()["in_position"] is False
+
+
+def test_timeout_error_carries_the_abandoned_thread():
+    import asyncio
+
+    import pytest
+    from sl_hunting_agent import SLHuntingTimeoutError
+
+    async def _hang():
+        await asyncio.sleep(30)
+        return AgentRunResult(text="never")
+
+    with pytest.raises(SLHuntingTimeoutError) as ei:
+        SLHuntingAgent._run_sync(_hang(), timeout_seconds=0.2)
+    assert ei.value.thread is not None
+    assert ei.value.thread.is_alive()  # still running -> the caller must gate on it
+
+
+def test_hung_call_gates_next_bars_then_resumes_when_it_finishes():
+    """Codex (PR #41): if the CLI keeps hanging, decide() must NOT spawn a fresh
+    daemon thread + subprocess every bar. While a prior timed-out call is still
+    alive, new bars are gated (fail-soft HOLD, no new call); once it finishes the
+    agent resumes normally -- so at most ONE abandoned call exists at a time."""
+    import asyncio
+    import threading
+    import time
+
+    release = threading.Event()
+    calls = {"n": 0}
+    hold_json = '{"action": "HOLD", "confidence": 0, "reasoning": "ok", "setup": "none"}'
+
+    async def _runner(prompt, *, system_prompt, model, max_turns, tool_context=None):
+        calls["n"] += 1
+        while not release.is_set():
+            await asyncio.sleep(0.01)
+        return AgentRunResult(text=hold_json)
+
+    ex = StandaloneExecutor()
+    agent = SLHuntingAgent(model="test-model", runner=_runner, sdk_timeout_seconds=0.2)
+
+    # Bar 1: the call hangs -> times out -> HOLD, one abandoned thread tracked.
+    d1 = agent.decide(_candles(), ex)
+    assert d1.action == "HOLD"
+    assert calls["n"] == 1
+    assert agent._abandoned_call is not None and agent._abandoned_call.is_alive()
+
+    # Bar 2: prior call still hung -> gated, runner NOT invoked again.
+    d2 = agent.decide(_candles(), ex)
+    assert d2.action == "HOLD"
+    assert "still" in d2.reasoning.lower()
+    assert calls["n"] == 1
+
+    # Let the abandoned call finish; once its thread dies the gate clears.
+    release.set()
+    for _ in range(200):
+        if agent._abandoned_call is None or not agent._abandoned_call.is_alive():
+            break
+        time.sleep(0.02)
+
+    # Bar 3: resumes normally -- a fresh call runs to completion.
+    d3 = agent.decide(_candles(), ex)
+    assert d3.action == "HOLD"
+    assert calls["n"] == 2
+    assert agent._abandoned_call is None


### PR DESCRIPTION
## What this fixes

`SLHuntingAgent.decide()` runs on the strategy worker's own thread — the same thread
that enforces the **per-poll stop/target check, max-loss and the 15:15 square-off**
(master file, `process_strategy_frame`). The sync bridge waited on the Claude CLI call
with **no time bound**, so a hung SDK/CLI call suspended every mechanical protection for
the open basket (NIFTY leg + BankNIFTY mirror) indefinitely.

## Changes

- **Bounded bridge:** `_run_sync(..., timeout_seconds=...)` runs the SDK call on a
  daemon thread; past the budget it raises `SLHuntingTimeoutError` and abandons the
  thread (daemon ⇒ can never block process exit; a hung CLI subprocess dies with the
  process).
- **Zombie-order disarm:** the order tool has side effects and the abandoned agentic
  loop may wake later. `SLHuntingToolContext.expire()` disarms the bar's order tool;
  `decide()`'s timeout path calls it, so a late-waking loop's `do_order` is refused
  (`"decision window expired (sdk_timeout)"`) instead of firing minutes late.
- **Fail-soft:** the timeout maps to the same HOLD family as auth/usage-limit failures.
- **Knob:** `SL_HUNTING_SDK_TIMEOUT_SECONDS` (default 90s, `<=0` disables) wired in the
  master worker; documented in `env.example` and the agent README's Safety section.

## Verification (TDD — all new tests watched failing first)

| Gate | Result |
|---|---|
| `python -m unittest test_nifty_multi_strategy_master` | 178 OK (16 skipped) |
| `python -m pytest "Signal Generators" -q` | 88 passed (4 new) |
| `python -m ruff check .` / `python -m mypy` / `compileall` | all clean |

New tests: `_run_sync` raises `SLHuntingTimeoutError` promptly on a hanging coroutine
(and still returns results unbounded); an expired tool context refuses orders with the
executor untouched; a hanging fake runner ends as a bounded fail-soft HOLD with the
captured per-bar tool context disarmed.

Note: independent of #40 (branched from main); no file conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
