### PR TITLE
HEDGE-001: auto-recover a hedge leg orphaned by a live double failure

### DIFF
--- a/Nifty Multi Strategy Front Test - Master File.py
+++ b/Nifty Multi Strategy Front Test - Master File.py
@@ -202,6 +202,7 @@ import queue
 import re
 import sys
 import threading
+import time
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta
 from datetime import time as dt_time
@@ -2873,6 +2874,10 @@ class BasePaperStrategyWorker(threading.Thread):
     trading_start_minute = 15
     square_off_hour = 15
     square_off_minute = 15
+    # HEDGE-001: how often to retry selling-to-close a live leg orphaned by a
+    # hedged-entry double failure. Slow on purpose -- the broker just rejected
+    # the same order, so hammering it seconds later only burns rate limit.
+    ORPHAN_UNWIND_RETRY_SECONDS = 60.0
 
     def __init__(
         self,
@@ -2925,6 +2930,15 @@ class BasePaperStrategyWorker(threading.Thread):
         # real orders on the active broker (see `_place_real_leg`) in addition to
         # the usual paper bookkeeping.
         self.live_trading = False
+
+        # HEDGE-001: live legs orphaned by a hedged-entry DOUBLE failure (the
+        # protective hedge BUY filled, then the main SELL and the unwind SELL
+        # both failed). Each entry is the original leg dict. The worker keeps
+        # retrying to sell these to close (`_sweep_orphan_live_legs`, driven
+        # from wait_for_next_poll + a final forced attempt at shutdown) so
+        # recovery does not depend on a human spotting the Telegram alert.
+        self._orphan_live_legs: list[dict] = []
+        self._next_orphan_retry_ts = 0.0
 
     def _place_real_leg(self, side: str, leg: dict) -> bool:
         """
@@ -3043,9 +3057,11 @@ class BasePaperStrategyWorker(threading.Thread):
                 self.log.error(
                     "MANUAL ACTION NEEDED | %s hedged entry: hedge filled but main "
                     "AND unwind failed -> a LIVE BUY %s strike=%s qty=%s is OPEN and "
-                    "untracked. Square it off manually.",
+                    "untracked. The worker will keep retrying the unwind (every ~%.0fs "
+                    "and at shutdown); square it off manually if it persists.",
                     self.strategy_name, hedge_leg.get("option_type"),
                     hedge_leg.get("strike"), hedge_leg.get("quantity"),
+                    self.ORPHAN_UNWIND_RETRY_SECONDS,
                 )
                 self.publish_trade_event({
                     "action": "UNHEDGED_LEG_OPEN",
@@ -3055,6 +3071,13 @@ class BasePaperStrategyWorker(threading.Thread):
                     "strike": hedge_leg.get("strike"),
                     "quantity": hedge_leg.get("quantity"),
                 })
+                # HEDGE-001: remember the orphan so the worker ITSELF keeps
+                # retrying the unwind (poll cadence + a final forced attempt at
+                # shutdown) instead of relying on the alert being seen. First
+                # retry waits one full cadence -- the broker rejected this very
+                # order milliseconds ago, so an instant retry would just fail.
+                self._orphan_live_legs.append(dict(hedge_leg))
+                self._next_orphan_retry_ts = time.monotonic() + self.ORPHAN_UNWIND_RETRY_SECONDS
             return False
         return True
 
@@ -3072,6 +3095,51 @@ class BasePaperStrategyWorker(threading.Thread):
         main_ok = self._place_real_leg("BUY", main_leg)
         hedge_ok = self._place_real_leg("SELL", hedge_leg)
         return main_ok and hedge_ok
+
+    def _sweep_orphan_live_legs(self, *, force: bool = False) -> None:
+        """Retry selling-to-close any live leg orphaned by a hedged double failure.
+
+        HEDGE-001. Rate-limited to one attempt per ORPHAN_UNWIND_RETRY_SECONDS
+        (a rejected order rarely succeeds seconds later, and retries must never
+        spam the broker); `force=True` -- used by the shutdown handlers -- takes
+        an immediate final attempt regardless of the cadence. Best-effort and
+        exception-proof: a failing sweep only logs and keeps the leg tracked
+        for the next pass. No-op in paper mode and when nothing is orphaned,
+        which is every poll in a normal session.
+        """
+        if not self._orphan_live_legs or not self.live_trading:
+            return
+        now = time.monotonic()
+        if not force and now < self._next_orphan_retry_ts:
+            return
+        self._next_orphan_retry_ts = now + self.ORPHAN_UNWIND_RETRY_SECONDS
+        still_open: list[dict] = []
+        for leg in self._orphan_live_legs:
+            try:
+                closed = self._place_real_leg("SELL", leg)
+            except Exception:  # noqa: BLE001 - the sweep must never kill the worker loop
+                closed = False
+            if closed:
+                self.log.warning(
+                    "Orphaned live leg RECOVERED (sold to close) | %s strike=%s qty=%s",
+                    leg.get("option_type"), leg.get("strike"), leg.get("quantity"),
+                )
+                self.publish_trade_event({
+                    "action": "UNHEDGED_LEG_CLOSED",
+                    "mode": "LIVE",
+                    "leg": "hedge",
+                    "option_type": leg.get("option_type"),
+                    "strike": leg.get("strike"),
+                    "quantity": leg.get("quantity"),
+                })
+            else:
+                still_open.append(leg)
+                self.log.error(
+                    "Orphaned live leg STILL OPEN (unwind retry failed) | %s strike=%s "
+                    "qty=%s | will keep retrying; square it off manually if this persists.",
+                    leg.get("option_type"), leg.get("strike"), leg.get("quantity"),
+                )
+        self._orphan_live_legs = still_open
 
     def publish_trade_event(self, event: dict) -> None:
         """
@@ -3232,6 +3300,11 @@ class BasePaperStrategyWorker(threading.Thread):
         means the worker wakes up immediately when the supervisor sets the
         stop event during Ctrl+C, keeping `join` timeouts meaningful.
         """
+        # HEDGE-001: every worker loop (base and the overriding workers alike)
+        # passes through here each poll, so this is the one shared spot to keep
+        # retrying an orphaned live leg. Rate-limited inside the sweep; a no-op
+        # on the overwhelming majority of polls.
+        self._sweep_orphan_live_legs()
         self.stop_event.wait(self.poll_seconds)
 
     def handle_max_loss_and_stop(self, total_pnl: float, open_pnl: float) -> None:
@@ -3251,6 +3324,9 @@ class BasePaperStrategyWorker(threading.Thread):
                 self.exit_position("MAX_LOSS_BREACH")
         except Exception as exc:
             self.log.exception("Error while exiting active position on max-loss breach: %s", exc)
+        # HEDGE-001: last forced attempt to close any orphaned live leg before
+        # this worker stops for the day (no more poll sweeps after this).
+        self._sweep_orphan_live_legs(force=True)
         self.log.info("Paper summary | %s", self.summary_text())
         self.log.info("Strategy stopped for the day due to max-loss shutdown.")
 
@@ -3269,6 +3345,9 @@ class BasePaperStrategyWorker(threading.Thread):
                 self.exit_position("TIME_CUTOFF")
         except Exception as exc:
             self.log.exception("Error while exiting active position at cutoff: %s", exc)
+        # HEDGE-001: last forced attempt to close any orphaned live leg before
+        # this worker stops for the day (no more poll sweeps after this).
+        self._sweep_orphan_live_legs(force=True)
         self.log.info("Paper summary | %s", self.summary_text())
         self.log.info("Strategy stopped for the day.")
 
@@ -6853,6 +6932,8 @@ class Delta20HedgedSpreadWorker(BasePaperStrategyWorker):
         except Exception as exc:
             self.log.exception("Error while exiting on max-loss breach: %s", exc)
         self._unsubscribe_unentered_legs()
+        # HEDGE-001: last forced attempt to close any orphaned live leg.
+        self._sweep_orphan_live_legs(force=True)
         self.log.info("Paper summary | %s", self.summary_text())
         self.log.info("Strategy stopped for the day due to max-loss shutdown.")
 
@@ -6871,6 +6952,8 @@ class Delta20HedgedSpreadWorker(BasePaperStrategyWorker):
         except Exception as exc:
             self.log.exception("Error while exiting at cutoff: %s", exc)
         self._unsubscribe_unentered_legs()
+        # HEDGE-001: last forced attempt to close any orphaned live leg.
+        self._sweep_orphan_live_legs(force=True)
         self.log.info("Paper summary | %s", self.summary_text())
         self.log.info("Strategy stopped for the day.")
 

--- a/Nifty Multi Strategy Front Test - Master File.py
+++ b/Nifty Multi Strategy Front Test - Master File.py
@@ -1547,6 +1547,14 @@ class HedgedPaperPosition:
     hedge_entry_price: float = 0.0
     hedge_entry_order_id: str = ""
 
+    # True only when BOTH real legs were actually opened at the broker (a live
+    # entry that fully confirmed). A live entry that fell back to paper -- a
+    # rejected/partial fill, or the double-failure orphan path -- leaves this
+    # False, so the later exit must NOT send real closing orders (that would BUY
+    # a never-opened main leg and re-SELL an already-closed hedge, opening
+    # phantom exposure). Paper-mode workers never place live orders regardless.
+    live_legs_open: bool = False
+
 
 @dataclass
 class LTPSnapshot:
@@ -3081,7 +3089,7 @@ class BasePaperStrategyWorker(threading.Thread):
             return False
         return True
 
-    def _place_real_hedged_exit(self, main_leg: dict, hedge_leg: dict) -> bool:
+    def _place_real_hedged_exit(self, main_leg: dict, hedge_leg: dict, *, live_legs_open: bool) -> bool:
         """
         Close a real two-leg hedged position: BUY back the main leg we sold, and
         SELL the hedge leg we bought ("BUY-to-close" / "SELL-to-close").
@@ -3089,8 +3097,14 @@ class BasePaperStrategyWorker(threading.Thread):
         We try BOTH legs no matter what, to close as much as possible. The caller
         always flattens its own paper books afterward either way. Returns True
         only if both legs closed cleanly. No-op returning True in paper mode.
+
+        `live_legs_open` is the closing position's flag: when False the entry
+        never opened real legs (paper mode, or a live entry that fell back to
+        paper / orphaned), so there is nothing to close at the broker and we must
+        NOT send orders -- doing so would open phantom exposure. Returning True
+        here lets the caller flatten its paper books normally.
         """
-        if not self.live_trading:
+        if not self.live_trading or not live_legs_open:
             return True
         main_ok = self._place_real_leg("BUY", main_leg)
         hedge_ok = self._place_real_leg("SELL", hedge_leg)
@@ -5769,6 +5783,7 @@ class SupertrendBullishWorker(BasePaperStrategyWorker):
         self.pos = HedgedPaperPosition(
             active=True,
             direction="LONG",
+            live_legs_open=(self.live_trading and real_ok),
             entry_underlying=float(entry_underlying),
             entry_timestamp=datetime.now(),
             main_symbol=str(main["trading_symbol"]),
@@ -5902,6 +5917,7 @@ class SupertrendBullishWorker(BasePaperStrategyWorker):
             hedge_leg={"option_type": closed.hedge_right, "strike": closed.hedge_strike,
                        "expiry": closed.hedge_expiry, "quantity": closed.hedge_quantity,
                        "dhan_symbol": closed.hedge_symbol},
+            live_legs_open=closed.live_legs_open,
         )
         exec_mode = self._exec_mode_tag(real_ok)
 
@@ -6313,6 +6329,7 @@ class DonchianBearishWorker(BasePaperStrategyWorker):
         self.pos = HedgedPaperPosition(
             active=True,
             direction="SHORT",
+            live_legs_open=(self.live_trading and real_ok),
             entry_underlying=float(spot),
             entry_timestamp=datetime.now(),
             main_symbol=str(main["trading_symbol"]),
@@ -6565,6 +6582,7 @@ class DonchianBearishWorker(BasePaperStrategyWorker):
             hedge_leg={"option_type": closed.hedge_right, "strike": closed.hedge_strike,
                        "expiry": closed.hedge_expiry, "quantity": closed.hedge_quantity,
                        "dhan_symbol": closed.hedge_symbol},
+            live_legs_open=closed.live_legs_open,
         )
         exec_mode = self._exec_mode_tag(real_ok)
 
@@ -7597,6 +7615,7 @@ class Delta20HedgedSpreadWorker(BasePaperStrategyWorker):
         new_pos = HedgedPaperPosition(
             active=True,
             direction=side,  # "CE" or "PE" (used purely for log labelling)
+            live_legs_open=(self.live_trading and real_ok),
             entry_underlying=float(spot),
             entry_timestamp=datetime.now(),
             main_symbol=str(monitor_meta["trading_symbol"]),
@@ -7740,6 +7759,7 @@ class Delta20HedgedSpreadWorker(BasePaperStrategyWorker):
             hedge_leg={"option_type": closed.hedge_right, "strike": closed.hedge_strike,
                        "expiry": closed.hedge_expiry, "quantity": closed.hedge_quantity,
                        "dhan_symbol": closed.hedge_symbol},
+            live_legs_open=closed.live_legs_open,
         )
         exec_mode = self._exec_mode_tag(real_ok)
 

--- a/test_nifty_multi_strategy_master.py
+++ b/test_nifty_multi_strategy_master.py
@@ -2065,15 +2065,28 @@ class TestLiveOrderRouting(unittest.TestCase):
         self.assertEqual(self._sides(fake), [("BUY", 25), ("SELL", 50), ("SELL", 25)])
 
     def test_hedged_exit_buys_main_sells_hedge(self):
-        """Hedged exit: BUY-to-close main, SELL-to-close hedge."""
+        """Hedged exit: BUY-to-close main, SELL-to-close hedge (real legs open)."""
         fake = _FakeShoonya()
         self.worker.live_trading = True
         main_leg = self._leg("PE", 22000.0, 50, "MAIN")
         hedge_leg = self._leg("PE", 21000.0, 25, "HEDGE")
         with patch.object(master_file, "execution_client", fake):
-            ok = self.worker._place_real_hedged_exit(main_leg, hedge_leg)
+            ok = self.worker._place_real_hedged_exit(main_leg, hedge_leg, live_legs_open=True)
         self.assertTrue(ok)
         self.assertEqual(self._sides(fake), [("BUY", 50), ("SELL", 25)])
+
+    def test_hedged_exit_sends_no_orders_for_paper_fallback_position(self):
+        """A live worker whose entry fell back to paper (live_legs_open False) must
+        NOT send closing orders -- there are no real legs, and a BUY main / SELL
+        hedge here would open phantom exposure (P1, Codex on PR #42)."""
+        fake = _FakeShoonya()
+        self.worker.live_trading = True
+        main_leg = self._leg("PE", 22000.0, 50, "MAIN")
+        hedge_leg = self._leg("PE", 21000.0, 25, "HEDGE")
+        with patch.object(master_file, "execution_client", fake):
+            ok = self.worker._place_real_hedged_exit(main_leg, hedge_leg, live_legs_open=False)
+        self.assertTrue(ok)             # caller flattens its paper books normally
+        self.assertEqual(fake.calls, [])  # but nothing was sent to the broker
 
 
 class TestOrphanHedgeLegRecovery(unittest.TestCase):
@@ -2163,6 +2176,51 @@ class TestOrphanHedgeLegRecovery(unittest.TestCase):
         with patch.object(master_file, "execution_client", ok_fake):
             self.worker.handle_square_off_and_stop()
         self.assertEqual(self.worker._orphan_live_legs, [])
+
+
+class TestHedgedPaperFallbackExit(unittest.TestCase):
+    """P1 (Codex on PR #42): a live hedged worker whose entry fell back to paper
+    (live_legs_open False -- rejected/partial fill, or the double-failure orphan
+    path) must NOT send real closing orders at exit. A BUY for the never-opened
+    main leg plus a SELL for the already-closed hedge would open phantom live
+    exposure. The exit still flattens the paper books."""
+
+    def _make_bullish_worker(self, *, live_legs_open: bool):
+        store = master_file.SharedMarketDataStore()
+        worker = master_file.SupertrendBullishWorker(
+            store=store, stop_event=threading.Event(), broker=MagicMock()
+        )
+        worker.live_trading = True
+        seg = master_file.OPTION_EXCHANGE_SEGMENT
+        worker.pos = master_file.HedgedPaperPosition(
+            active=True, direction="LONG", live_legs_open=live_legs_open,
+            entry_underlying=22500.0,
+            main_symbol="NIFTY-22000-PE", main_side="SELL", main_security_id=5001,
+            main_exchange_segment=seg, main_right="PE", main_strike=22000.0,
+            main_quantity=50, main_entry_price=160.0,
+            hedge_symbol="NIFTY-21000-PE", hedge_side="BUY", hedge_security_id=5002,
+            hedge_exchange_segment=seg, hedge_right="PE", hedge_strike=21000.0,
+            hedge_quantity=50, hedge_entry_price=10.0,
+        )
+        store.update_ltp_map({(seg, 5001): 120.0, (seg, 5002): 8.0})
+        return worker
+
+    def test_paper_fallback_exit_sends_no_real_orders_but_flattens(self):
+        worker = self._make_bullish_worker(live_legs_open=False)
+        fake = _FakeShoonya()
+        with patch.object(master_file, "execution_client", fake):
+            worker.exit_position("TIME_CUTOFF")
+        self.assertEqual(fake.calls, [])            # no phantom broker orders
+        self.assertFalse(worker.pos.active)         # paper books flattened
+
+    def test_confirmed_live_exit_still_sends_both_closing_orders(self):
+        worker = self._make_bullish_worker(live_legs_open=True)
+        fake = _FakeShoonya()
+        with patch.object(master_file, "execution_client", fake):
+            worker.exit_position("TIME_CUTOFF")
+        sides = [(side, qty) for (_sym, side, qty) in fake.calls]
+        self.assertEqual(sides, [("BUY", 50), ("SELL", 50)])  # BUY main, SELL hedge
+        self.assertFalse(worker.pos.active)
 
 
 class TestShoonyaOrderAck(unittest.TestCase):

--- a/test_nifty_multi_strategy_master.py
+++ b/test_nifty_multi_strategy_master.py
@@ -2076,6 +2076,95 @@ class TestLiveOrderRouting(unittest.TestCase):
         self.assertEqual(self._sides(fake), [("BUY", 50), ("SELL", 25)])
 
 
+class TestOrphanHedgeLegRecovery(unittest.TestCase):
+    """
+    HEDGE-001: when a hedged entry DOUBLE-fails live (the hedge BUY filled, then
+    the main SELL and the unwind SELL both failed), a real bought option is open
+    with no paper record. Recovery used to be a log line + Telegram alert only.
+    The worker must REMEMBER the orphan and keep trying to close it itself -- on
+    a slow poll cadence, and one final forced attempt at the daily shutdown --
+    so an unnoticed alert cannot leave real money bleeding all afternoon.
+    """
+
+    def setUp(self):
+        self.store = master_file.SharedMarketDataStore()
+        self.worker = master_file.AtmSingleLegStrategyWorker(
+            store=self.store, stop_event=threading.Event(), broker=MagicMock()
+        )
+        self.worker.live_trading = True
+        self.main_leg = {"option_type": "PE", "strike": 22000.0,
+                         "expiry": date.today() + timedelta(days=2), "quantity": 50,
+                         "dhan_symbol": "MAIN"}
+        self.hedge_leg = {"option_type": "PE", "strike": 21000.0,
+                          "expiry": date.today() + timedelta(days=2), "quantity": 25,
+                          "dhan_symbol": "HEDGE"}
+
+    @staticmethod
+    def _sides(fake):
+        return [(side, qty) for (_sym, side, qty) in fake.calls]
+
+    def _double_fail_entry(self):
+        """Drive the double failure: hedge BUY fills, every SELL is rejected."""
+        fake = _FakeShoonya(fail_on=lambda symbol, side: side == "SELL")
+        with patch.object(master_file, "execution_client", fake):
+            ok = self.worker._place_real_hedged_entry(self.main_leg, self.hedge_leg)
+        self.assertFalse(ok)
+        return fake
+
+    def test_double_failure_records_the_orphaned_hedge_leg(self):
+        self._double_fail_entry()
+        self.assertEqual(len(self.worker._orphan_live_legs), 1)
+        orphan = self.worker._orphan_live_legs[0]
+        self.assertEqual(orphan["quantity"], 25)       # the bought hedge, not the main
+        self.assertEqual(orphan["strike"], 21000.0)
+
+    def test_single_failure_with_clean_unwind_records_nothing(self):
+        # Only the MAIN SELL fails (strike 22000); the unwind SELL succeeds.
+        fake = _FakeShoonya(fail_on=lambda symbol, side: side == "SELL" and "22000" in symbol)
+        with patch.object(master_file, "execution_client", fake):
+            ok = self.worker._place_real_hedged_entry(self.main_leg, self.hedge_leg)
+        self.assertFalse(ok)
+        self.assertEqual(self.worker._orphan_live_legs, [])
+
+    def test_sweep_retries_and_closes_orphan_when_broker_recovers(self):
+        self._double_fail_entry()
+        events = MagicMock()
+        self.worker.trade_event_queue = events
+        ok_fake = _FakeShoonya()
+        with patch.object(master_file, "execution_client", ok_fake):
+            self.worker._sweep_orphan_live_legs(force=True)
+        self.assertEqual(self.worker._orphan_live_legs, [])
+        self.assertEqual(self._sides(ok_fake), [("SELL", 25)])  # closed the bought leg
+        actions = [c.args[0].get("action") for c in events.put_nowait.call_args_list]
+        self.assertIn("UNHEDGED_LEG_CLOSED", actions)
+
+    def test_sweep_is_rate_limited_between_retries(self):
+        self._double_fail_entry()
+        fail_fake = _FakeShoonya(fail_on=lambda symbol, side: True)
+        with patch.object(master_file, "execution_client", fail_fake):
+            self.worker._sweep_orphan_live_legs(force=True)    # one attempt, fails
+            attempts_after_first = len(fail_fake.calls)
+            self.worker._sweep_orphan_live_legs()              # inside the cadence -> skipped
+        self.assertEqual(len(fail_fake.calls), attempts_after_first)
+        self.assertEqual(len(self.worker._orphan_live_legs), 1)   # still tracked
+
+    def test_wait_for_next_poll_sweeps_orphans_each_cadence(self):
+        self._double_fail_entry()
+        self.worker.poll_seconds = 0
+        self.worker._next_orphan_retry_ts = 0.0                # cadence elapsed
+        ok_fake = _FakeShoonya()
+        with patch.object(master_file, "execution_client", ok_fake):
+            self.worker.wait_for_next_poll()
+        self.assertEqual(self.worker._orphan_live_legs, [])
+
+    def test_square_off_shutdown_takes_a_final_forced_attempt(self):
+        self._double_fail_entry()
+        ok_fake = _FakeShoonya()
+        with patch.object(master_file, "execution_client", ok_fake):
+            self.worker.handle_square_off_and_stop()
+        self.assertEqual(self.worker._orphan_live_legs, [])
+
+
 class TestShoonyaOrderAck(unittest.TestCase):
     """
     NorenApi.place_order returns None on failure and a dict with stat == "Ok" and


### PR DESCRIPTION
## What this fixes

When a live hedged entry **double-fails** — the protective hedge BUY fills, then the main
SELL *and* the unwind SELL both fail (`_place_real_hedged_entry`) — a real bought option
stays open with **no paper record**. Recovery was a `MANUAL ACTION NEEDED` log + Telegram
alert only: no square-off would touch the leg (nothing in the paper books to trigger an
exit) and no max-loss counted it. Exposure is bounded (a small-premium long option), but
silent if the alert goes unseen.

## Changes

- The double-failure branch now **records the orphan** on the worker
  (`_orphan_live_legs`) in addition to alerting.
- New `BasePaperStrategyWorker._sweep_orphan_live_legs()`: retries the sell-to-close on a
  slow cadence (`ORPHAN_UNWIND_RETRY_SECONDS = 60` — a just-rejected order rarely succeeds
  seconds later), exception-proof, publishes `UNHEDGED_LEG_CLOSED` on recovery, and keeps
  the leg tracked with an error log on every failed retry.
- Hooked in **one shared spot** — `wait_for_next_poll()`, which every worker loop (base
  and the overriding Donchian / Delta-0.2 / Strangle / SL-Hunting loops) passes through
  each poll — plus a final **forced** attempt in the shutdown handlers (base
  max-loss/square-off and Delta-0.2's overrides), since poll sweeps end when a worker
  stops for the day.
- The `MANUAL ACTION NEEDED` log now states the auto-retry behaviour.

## Verification (TDD — all 7 new tests watched failing first)

| Gate | Result |
|---|---|
| `python -m unittest test_nifty_multi_strategy_master` | 184 OK (16 skipped; 7 new) |
| `python -m pytest "Signal Generators" -q` | 84 passed |
| `python -m ruff check .` / `python -m mypy` / `compileall` | all clean |

Scenarios locked: double failure records the orphaned hedge (a clean single-failure
unwind records nothing); a recovered broker clears it and publishes the event; the sweep
is rate-limited between retries; the poll path sweeps on cadence; the square-off shutdown
takes the final forced attempt.

Note: independent of #40/#41 (branched from main); no overlapping hunks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
