### PR TITLE
OPS-001: startup IST check, Google Sheet retry, mirror-risk docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,9 @@ One process, cooperating threads:
   (with BankNIFTY cross-confirmation, fetched per bar like CPR Algo 3, and dynamic ~₹2500 risk-based
   sizing) and acts through the same ATM `enter_position`/`exit_position`; its deps are lazily imported
   so a missing dep just disables it. Every NIFTY entry is mechanically MIRRORED with an equal-lot
-  BankNIFTY ATM leg (`SL_HUNTING_BNF_MIRROR`, default true): the legs are TIED for hard risk
+  BankNIFTY ATM leg (`SL_HUNTING_BNF_MIRROR`, default true) — NOTE: the mirror roughly DOUBLES the
+  basket's rupee risk beyond `SL_HUNTING_RISK_BUDGET` (operator-accepted; the daily max-loss
+  kill-switch still caps the day): the legs are TIED for hard risk
   (stop/target, max-loss, 15:15 square-off close both) but the agent evaluates each leg's
   premise INDEPENDENTLY and can cut one alone via the EXIT `exit_leg` selector (NIFTY|BNF|BOTH).
   Entry stays NIFTY-only (the mirror copies it). It stops opening NEW positions after noon

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,9 @@ One process, cooperating threads:
   (with BankNIFTY cross-confirmation, fetched per bar like CPR Algo 3, and dynamic ~₹2500 risk-based
   sizing) and acts through the same ATM `enter_position`/`exit_position`; its deps are lazily imported
   so a missing dep just disables it. Every NIFTY entry is mechanically MIRRORED with an equal-lot
-  BankNIFTY ATM leg (`SL_HUNTING_BNF_MIRROR`, default true): the legs are TIED for hard risk
+  BankNIFTY ATM leg (`SL_HUNTING_BNF_MIRROR`, default true) — NOTE: the mirror roughly DOUBLES the
+  basket's rupee risk beyond `SL_HUNTING_RISK_BUDGET` (operator-accepted; the daily max-loss
+  kill-switch still caps the day): the legs are TIED for hard risk
   (stop/target, max-loss, 15:15 square-off close both) but the agent evaluates each leg's
   premise INDEPENDENTLY and can cut one alone via the EXIT `exit_leg` selector (NIFTY|BNF|BOTH).
   Entry stays NIFTY-only (the mirror copies it). It stops opening NEW positions after noon

--- a/Nifty Multi Strategy Front Test - Master File.py
+++ b/Nifty Multi Strategy Front Test - Master File.py
@@ -202,6 +202,7 @@ import queue
 import re
 import sys
 import threading
+import time
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta
 from datetime import time as dt_time
@@ -2708,6 +2709,33 @@ class OptionsContractResolver:
 # =============================================================================
 # TIME HELPERS
 # =============================================================================
+# Every trading-time gate below compares against the machine's LOCAL wall
+# clock and assumes the box runs in IST. main() checks this at startup.
+IST_UTC_OFFSET = timedelta(hours=5, minutes=30)
+
+
+def _timezone_assumption_warning(offset: timedelta | None = None) -> str | None:
+    """Return a loud warning when the system clock's UTC offset is not IST.
+
+    OPS-001. `is_before_time`/`is_after_time` (market open, entry cutoffs, the
+    15:15 square-off) all use naive `datetime.now()` -- the code assumes an IST
+    machine. On a mis-configured box (a UTC VPS, a travelling laptop) every
+    gate silently shifts by hours, so main() logs this check at startup rather
+    than trading at the wrong times. Returns None when the offset is IST.
+    The offset parameter exists for tests; the default reads the system clock.
+    """
+    if offset is None:
+        offset = datetime.now().astimezone().utcoffset()
+    if offset == IST_UTC_OFFSET:
+        return None
+    return (
+        f"System clock UTC offset is {offset}, but every trading-time gate in this "
+        "runner assumes IST (+5:30). Market-open, entry-cutoff and square-off gates "
+        "will fire at the WRONG local times -- fix the machine's timezone before "
+        "trading."
+    )
+
+
 def is_before_time(hour: int, minute: int) -> bool:
     """Return True when local wall-clock time is before HH:MM."""
     now = datetime.now()
@@ -9918,7 +9946,7 @@ def _update_pnl_google_sheet() -> None:
         )
         return
 
-    try:
+    def _attempt() -> None:
         # Step 4: authenticate with the cached OAuth user token. The very first
         # run opens a browser for consent and writes the token file; later runs
         # reuse (and silently refresh) it.
@@ -9972,15 +10000,34 @@ def _update_pnl_google_sheet() -> None:
         logger.info(
             "Google Sheet P&L updated: %d cell(s) written (today=%s).", len(cells), today_str
         )
-    except Exception as exc:
-        # gspread turns some API failures (e.g. a 403 when the Google Sheets API
-        # is disabled for the project, or the account can't access the sheet)
-        # into a *bare* exception whose str() is empty -- which would log a
-        # blank reason. Use %r + exc_info so the type and the full chained
-        # traceback (which carries Google's own message and fix URL) are shown.
-        logger.warning(
-            "Google Sheet P&L update failed (non-fatal): %r", exc, exc_info=True
-        )
+
+    # OPS-001: one transient Google/network hiccup used to skip the day's write
+    # entirely. Take a few slow attempts (this runs AFTER the session, so a
+    # short sleep costs nothing) before the existing non-fatal give-up. The
+    # skip paths inside _attempt (missing tab, nothing to write) return
+    # normally and are never retried.
+    attempts = 3
+    retry_delay_seconds = 5.0
+    for attempt in range(1, attempts + 1):
+        try:
+            _attempt()
+            return
+        except Exception as exc:
+            if attempt < attempts:
+                logger.warning(
+                    "Google Sheet P&L update attempt %d/%d failed (%r); retrying in %.0fs.",
+                    attempt, attempts, exc, retry_delay_seconds,
+                )
+                time.sleep(retry_delay_seconds)
+                continue
+            # gspread turns some API failures (e.g. a 403 when the Google Sheets API
+            # is disabled for the project, or the account can't access the sheet)
+            # into a *bare* exception whose str() is empty -- which would log a
+            # blank reason. Use %r + exc_info so the type and the full chained
+            # traceback (which carries Google's own message and fix URL) are shown.
+            logger.warning(
+                "Google Sheet P&L update failed (non-fatal): %r", exc, exc_info=True
+            )
 
 
 def _strategy_virtual_trading_enabled(strategy_name: str) -> bool:
@@ -10023,6 +10070,13 @@ def main() -> None:
     The MAIN thread does NOT trade. It is purely a supervisor.
     """
     setup_logging()
+    # OPS-001: all trading-time gates assume an IST wall clock -- say so loudly
+    # at startup when the box disagrees, before any worker takes a decision.
+    tz_warning = _timezone_assumption_warning()
+    if tz_warning:
+        logger.warning("%s", tz_warning)
+    else:
+        logger.info("Timezone check: system offset is IST (+5:30), as the trading windows assume.")
     os.chdir(ROOT_DIR)
 
     # Credentials must come from `.env` (or the shell env). We never carry

--- a/test_nifty_multi_strategy_master.py
+++ b/test_nifty_multi_strategy_master.py
@@ -1301,6 +1301,98 @@ class TestEnvBool(unittest.TestCase):
         self.assertFalse(master_file._env_bool("X_FLAG", False))
 
 
+class TestTimezoneAssumption(unittest.TestCase):
+    """OPS-001: every trading-window gate compares against the LOCAL wall clock
+    (naive datetime.now()), assuming the box runs in IST. A wrong system
+    timezone silently shifts market-open, entry cutoffs and the 15:15
+    square-off, so startup must call it out loudly."""
+
+    def test_ist_offset_produces_no_warning(self):
+        offset = timedelta(hours=5, minutes=30)
+        self.assertIsNone(master_file._timezone_assumption_warning(offset))
+
+    def test_non_ist_offset_produces_actionable_warning(self):
+        for offset in (timedelta(0), timedelta(hours=-5), timedelta(hours=5, minutes=45)):
+            warning = master_file._timezone_assumption_warning(offset)
+            self.assertIsNotNone(warning, offset)
+            self.assertIn("IST", warning)
+            self.assertIn("timezone", warning.lower())
+
+    def test_default_uses_system_offset(self):
+        # Whatever this machine's offset is, the helper must not crash and must
+        # answer consistently with an explicit call using the same offset.
+        system_offset = datetime.now().astimezone().utcoffset()
+        self.assertEqual(
+            master_file._timezone_assumption_warning(),
+            master_file._timezone_assumption_warning(system_offset),
+        )
+
+
+class TestGoogleSheetRetry(unittest.TestCase):
+    """OPS-001: one transient gspread/network hiccup used to skip the day's P&L
+    write entirely. The writer now takes a few slow retries before giving up
+    (still strictly non-fatal)."""
+
+    def _fake_gspread(self, fail_times: int):
+        import types as _types
+
+        calls = {"oauth": 0, "updates": []}
+
+        class _WorksheetNotFound(Exception):
+            pass
+
+        class _FakeWorksheet:
+            def get_all_values(self):
+                return [["Strategy", "2026-07-07"], ["Renko", ""]]
+
+            def update_cells(self, cells, value_input_option=""):
+                calls["updates"].append(list(cells))
+
+        class _FakeSpreadsheet:
+            def worksheet(self, name):
+                return _FakeWorksheet()
+
+        class _FakeClient:
+            def open_by_key(self, key):
+                return _FakeSpreadsheet()
+
+        def _oauth(**kwargs):
+            calls["oauth"] += 1
+            if calls["oauth"] <= fail_times:
+                raise ConnectionError("simulated transient Google outage")
+            return _FakeClient()
+
+        module = _types.ModuleType("gspread")
+        module.oauth = _oauth
+        module.WorksheetNotFound = _WorksheetNotFound
+        module.Cell = lambda row, col, value: (row, col, value)
+        return module, calls
+
+    def _run_writer(self, fake_module):
+        with (
+            patch.dict(sys.modules, {"gspread": fake_module}),
+            patch.dict(os.environ, {"GSHEET_ID": "sheet-id"}),
+            patch.object(master_file, "_parse_eod_pnl_by_day",
+                         return_value={"2026-07-07": {"Renko": 123.0}}),
+            patch.object(master_file, "_compute_pnl_sheet_updates",
+                         return_value=([(1, 1, 123.0)], [])),
+            patch.object(master_file.time, "sleep"),   # retries must not slow tests
+        ):
+            master_file._update_pnl_google_sheet()
+
+    def test_transient_failure_is_retried_then_writes(self):
+        fake, calls = self._fake_gspread(fail_times=1)
+        self._run_writer(fake)
+        self.assertEqual(calls["oauth"], 2)            # failed once, then succeeded
+        self.assertEqual(len(calls["updates"]), 1)     # the day's P&L was written
+
+    def test_persistent_failure_stays_bounded_and_nonfatal(self):
+        fake, calls = self._fake_gspread(fail_times=99)
+        self._run_writer(fake)                          # must not raise
+        self.assertEqual(calls["oauth"], 3)             # bounded attempts
+        self.assertEqual(calls["updates"], [])
+
+
 class TestStrategyEnvPrefixMap(unittest.TestCase):
     """Every worker's `strategy_name` must map to an env prefix, or it can never
     be switched live (it would silently stay paper)."""


### PR DESCRIPTION
Three hygiene riders from the July 2026 review: (1) main() now logs a loud startup warning when the system clock's UTC offset is not IST (+5:30) - every trading-time gate uses naive local time; (2) the EOD Google Sheet P&L writer retries transient failures (3 attempts, 5s apart, still non-fatal; deliberate skips never retried); (3) AGENTS.md + CLAUDE.md now document that the BNF mirror ~doubles basket risk beyond SL_HUNTING_RISK_BUDGET (operator-accepted). TDD: 5 new tests watched failing first. Gates: unittest 183 OK, pytest 84 passed, ruff/mypy/compileall clean. Independent of #40-#44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)