### PR TITLE
Gate live single-leg + BNF-mirror exits on real legs being open

### DIFF
--- a/Nifty Multi Strategy Front Test - Master File.py
+++ b/Nifty Multi Strategy Front Test - Master File.py
@@ -3793,7 +3793,7 @@ class AtmSingleLegStrategyWorker(BasePaperStrategyWorker):
             })
         else:
             real_ok = True  # no real leg was ever opened -> nothing to close
-        exec_mode = self._exec_mode_tag(real_ok)
+        exec_mode = self._exec_mode_tag(real_ok, live_legs_open=closed_position.live_legs_open)
 
         # If a LIVE exit did not confirm a fill, the real broker position is still
         # open. Do NOT flatten the books - keep the position active so the worker
@@ -9281,7 +9281,7 @@ if SL_HUNTING_AVAILABLE:
                 mirror.entry_trade_price, exit_ltp, pnl, self.realized_pnl,
             )
             self.publish_trade_event({
-                "action": "EXIT", "mode": self._exec_mode_tag(real_ok),
+                "action": "EXIT", "mode": self._exec_mode_tag(real_ok, live_legs_open=mirror.live_legs_open),
                 "direction": mirror.direction, "reason": reason, "pnl": pnl,
                 "quantity": mirror.quantity,
                 "legs": [{

--- a/Nifty Multi Strategy Front Test - Master File.py
+++ b/Nifty Multi Strategy Front Test - Master File.py
@@ -3020,17 +3020,26 @@ class BasePaperStrategyWorker(threading.Thread):
             )
             return False
 
-    def _exec_mode_tag(self, real_ok: bool) -> str:
+    def _exec_mode_tag(self, real_ok: bool, *, live_legs_open: bool = True) -> str:
         """
         Return a short label describing how a trade was actually executed, used in
         logs and Telegram messages so you can tell real fills from paper ones:
         - "PAPER"          : strategy is in paper mode.
         - "LIVE"           : live mode and the real order(s) succeeded.
-        - "PAPER_FALLBACK" : live mode but the real order failed, so it was
+        - "PAPER_FALLBACK" : live mode but no real order confirmed, so it was
                              recorded/closed as paper instead.
+
+        `live_legs_open` matters for EXITS: a live worker closing a position whose
+        entry fell back to paper sends NO broker order (there is nothing to close),
+        so `real_ok` is a vacuous True. Passing `live_legs_open=False` labels that
+        as PAPER_FALLBACK instead of LIVE, so an operator is never told a broker
+        leg was closed when it was deliberately skipped. Entry callers keep the
+        default (True) and are unaffected.
         """
         if not self.live_trading:
             return "PAPER"
+        if not live_legs_open:
+            return "PAPER_FALLBACK"
         return "LIVE" if real_ok else "PAPER_FALLBACK"
 
     def _place_real_hedged_entry(self, main_leg: dict, hedge_leg: dict) -> bool:
@@ -5919,7 +5928,7 @@ class SupertrendBullishWorker(BasePaperStrategyWorker):
                        "dhan_symbol": closed.hedge_symbol},
             live_legs_open=closed.live_legs_open,
         )
-        exec_mode = self._exec_mode_tag(real_ok)
+        exec_mode = self._exec_mode_tag(real_ok, live_legs_open=closed.live_legs_open)
 
         # If a LIVE hedged exit did not confirm fills on BOTH legs, real exposure
         # is still open. Do NOT flatten the books - keep the position so the worker
@@ -6584,7 +6593,7 @@ class DonchianBearishWorker(BasePaperStrategyWorker):
                        "dhan_symbol": closed.hedge_symbol},
             live_legs_open=closed.live_legs_open,
         )
-        exec_mode = self._exec_mode_tag(real_ok)
+        exec_mode = self._exec_mode_tag(real_ok, live_legs_open=closed.live_legs_open)
 
         # If a LIVE hedged exit did not confirm fills on BOTH legs, real exposure
         # is still open. Do NOT flatten the books - keep the position so the worker
@@ -7761,7 +7770,7 @@ class Delta20HedgedSpreadWorker(BasePaperStrategyWorker):
                        "dhan_symbol": closed.hedge_symbol},
             live_legs_open=closed.live_legs_open,
         )
-        exec_mode = self._exec_mode_tag(real_ok)
+        exec_mode = self._exec_mode_tag(real_ok, live_legs_open=closed.live_legs_open)
 
         # If a LIVE hedged exit did not confirm fills on BOTH legs, real exposure
         # is still open. Do NOT flatten the books - keep the position so the worker

--- a/Nifty Multi Strategy Front Test - Master File.py
+++ b/Nifty Multi Strategy Front Test - Master File.py
@@ -1494,6 +1494,14 @@ class PaperPosition:
     option_strike: float = 0.0
     option_expiry: date | None = None
     option_lot_size: int = 0
+    # True only when a REAL broker leg was actually opened for this position (a
+    # live entry that confirmed). A live entry that fell back to paper -- a
+    # rejected/partial order or a symbol-master miss -- still records the position
+    # for paper tracking but leaves this False, so the later exit must NOT send a
+    # real closing order: SELLing an option we never bought would be a naked short,
+    # opening phantom live exposure. Paper-mode workers never place live orders
+    # regardless. Mirrors HedgedPaperPosition.live_legs_open (PR #42 / HEDGE-001).
+    live_legs_open: bool = False
 
 
 @dataclass
@@ -3616,6 +3624,9 @@ class AtmSingleLegStrategyWorker(BasePaperStrategyWorker):
         self.pos = PaperPosition(
             active=True,
             direction=direction,
+            # True only if a real broker leg actually opened; a live entry that fell
+            # back to paper leaves this False so the exit sends no real SELL.
+            live_legs_open=(self.live_trading and real_ok),
             symbol=trading_symbol,
             quantity=quantity,
             entry_order_id=str(order_id),
@@ -3701,12 +3712,21 @@ class AtmSingleLegStrategyWorker(BasePaperStrategyWorker):
             fallback=closed_position.entry_trade_price,
         )
 
-        # Real execution (live mode only; no-op True in paper mode).
-        real_ok = self._place_real_leg(exit_side, {
-            "option_type": closed_position.option_right, "strike": closed_position.option_strike,
-            "expiry": closed_position.option_expiry, "quantity": closed_position.quantity,
-            "dhan_symbol": closed_position.symbol,
-        })
+        # Real execution -- but ONLY when this position actually opened a real leg
+        # at the broker. A live entry that fell back to paper (rejected order or a
+        # symbol-master miss) recorded no live leg, so a SELL now would be a naked
+        # short of an option we never bought. In that case there is nothing to close
+        # at the broker: skip the order and treat the exit as paper (real_ok stays
+        # True so we flatten the books normally, exactly like paper mode). Mirrors
+        # the HedgedPaperPosition.live_legs_open guard (PR #42 / HEDGE-001).
+        if closed_position.live_legs_open:
+            real_ok = self._place_real_leg(exit_side, {
+                "option_type": closed_position.option_right, "strike": closed_position.option_strike,
+                "expiry": closed_position.option_expiry, "quantity": closed_position.quantity,
+                "dhan_symbol": closed_position.symbol,
+            })
+        else:
+            real_ok = True  # no real leg was ever opened -> nothing to close
         exec_mode = self._exec_mode_tag(real_ok)
 
         # If a LIVE exit did not confirm a fill, the real broker position is still
@@ -9111,6 +9131,9 @@ if SL_HUNTING_AVAILABLE:
             ))
             self._mirror_pos = PaperPosition(
                 active=True, direction=direction, symbol=symbol, quantity=quantity,
+                # True only if the mirror BUY actually opened live; a paper fallback
+                # leaves it False so _close_bnf_mirror sends no real SELL.
+                live_legs_open=(self.live_trading and real_ok),
                 entry_order_id=str(order_id), entry_underlying=bnf_spot,
                 entry_trade_price=float(option_ltp), option_security_id=sec_id,
                 option_exchange_segment=segment, option_right=str(contract["option_type"]),
@@ -9149,11 +9172,19 @@ if SL_HUNTING_AVAILABLE:
                 mirror.option_exchange_segment, mirror.option_security_id,
                 fallback=mirror.entry_trade_price,
             )
-            real_ok = self._place_real_leg("SELL", {
-                "option_type": mirror.option_right, "strike": mirror.option_strike,
-                "expiry": mirror.option_expiry, "quantity": mirror.quantity,
-                "dhan_symbol": mirror.symbol, "underlying": "BANKNIFTY",
-            })
+            # Only close a REAL mirror leg. A live mirror BUY that fell back to
+            # paper (rejected / symbol-master miss) opened nothing at the broker, so
+            # a SELL now would be a phantom BankNIFTY short. Skip it and treat the
+            # close as paper (real_ok stays True -> no false "manual action" alert;
+            # the books still flatten below). Mirrors PR #42 / HEDGE-001.
+            if mirror.live_legs_open:
+                real_ok = self._place_real_leg("SELL", {
+                    "option_type": mirror.option_right, "strike": mirror.option_strike,
+                    "expiry": mirror.option_expiry, "quantity": mirror.quantity,
+                    "dhan_symbol": mirror.symbol, "underlying": "BANKNIFTY",
+                })
+            else:
+                real_ok = True  # no real mirror leg was opened -> nothing to close
             if self.live_trading and not real_ok:
                 self.log.error(
                     "MANUAL ACTION NEEDED | BNF mirror SELL not confirmed | %s qty=%s -> a LIVE "

--- a/test_nifty_multi_strategy_master.py
+++ b/test_nifty_multi_strategy_master.py
@@ -2121,6 +2121,29 @@ class TestSLHuntingBnfMirror(unittest.TestCase):
         bnf_sells = [c for c in exit_fake.calls if "BANKNIFTY" in c[0] and c[1] == "SELL"]
         self.assertEqual(len(bnf_sells), 1)
 
+    def test_mirror_paper_fallback_close_is_tagged_paper_fallback(self):
+        """Codex on PR #47: a paper-fallback mirror close sends no broker SELL, so
+        its MIRROR EXIT event must read PAPER_FALLBACK, not LIVE."""
+        worker, store = self._make_worker()
+        worker.live_trading = True
+        events = MagicMock()
+        worker.trade_event_queue = events
+        with patch.object(master_file, "execution_client",
+                          _FakeShoonya(fail_on=lambda symbol, side: "BANKNIFTY" in symbol)):
+            worker.enter_position("LONG", 24300.0, 24290.0, 24400.0)
+        self.assertFalse(worker._mirror_pos.live_legs_open)
+        store.update_ltp_map({(master_file.OPTION_EXCHANGE_SEGMENT, 3003): 520.0})
+        with patch.object(master_file, "execution_client", _FakeShoonya()):
+            worker.exit_position("AI_TARGET")
+
+        def _is_mirror_exit(ev):
+            legs = ev.get("legs") or [{}]
+            return ev.get("action") == "EXIT" and "BANKNIFTY" in str(legs[0].get("symbol", ""))
+
+        mirror_exit_modes = [c.args[0].get("mode") for c in events.put_nowait.call_args_list
+                             if _is_mirror_exit(c.args[0])]
+        self.assertEqual(mirror_exit_modes, ["PAPER_FALLBACK"])
+
     # ----- BNF-001: the REAL resolver must be able to open the mirror -------
     def test_mirror_opens_with_real_resolver_and_rollover_expiry(self):
         """Integration lock for BNF-001: with a real OptionsContractResolver over
@@ -2335,6 +2358,21 @@ class TestLiveOrderRouting(unittest.TestCase):
             self.worker.exit_position("TEST_EXIT")
         self.assertIn(("SELL", 50 * self.worker.lots), self._sides(fake))
         self.assertFalse(self.worker.pos.active)
+
+    def test_paper_fallback_single_leg_exit_is_tagged_paper_fallback(self):
+        """Codex on PR #47: a paper-fallback single-leg exit sends no broker order,
+        so its EXIT event must read PAPER_FALLBACK, not LIVE."""
+        self.worker.live_trading = True
+        events = MagicMock()
+        self.worker.trade_event_queue = events
+        with patch.object(master_file, "execution_client", _FakeShoonya(fail_on=lambda s, side: True)):
+            self.worker.enter_position(direction="LONG", entry_underlying=22500.0)
+        self.store.update_ltp_map({(master_file.OPTION_EXCHANGE_SEGMENT, 49081): 130.0})
+        with patch.object(master_file, "execution_client", _FakeShoonya()):
+            self.worker.exit_position("TEST_EXIT")
+        exit_modes = [c.args[0].get("mode") for c in events.put_nowait.call_args_list
+                      if c.args[0].get("action") == "EXIT"]
+        self.assertEqual(exit_modes, ["PAPER_FALLBACK"])
 
     # --- Hedged helpers: leg dicts as built by the call sites. ---
     def _leg(self, option_type, strike, qty, dhan):

--- a/test_nifty_multi_strategy_master.py
+++ b/test_nifty_multi_strategy_master.py
@@ -1780,6 +1780,10 @@ class TestSLHuntingBnfMirror(unittest.TestCase):
             return True
 
         worker._place_real_leg = fake_real_leg
+        # Exit orders are now gated on live_legs_open, which is only set True when the
+        # entry ran live and confirmed. Run this worker live so both legs' exits fire
+        # and we can assert the BANKNIFTY underlying on every real call.
+        worker.live_trading = True
         worker.enter_position("LONG", 24300.0, 24290.0, 24400.0)
         worker.exit_position("AI_TARGET")
         mirror_legs = [(s, leg) for s, leg in captured if leg.get("underlying") == "BANKNIFTY"]
@@ -1905,6 +1909,48 @@ class TestSLHuntingBnfMirror(unittest.TestCase):
         self.assertGreater(payload["option_pnl"], 0.0)    # mirror P&L is captured
         self.assertIsNone(worker._pending_journal_exit)
         self.assertIsNone(worker._open_trade_id)
+
+    # ----- P1: a paper-fallback mirror must not phantom-short (sibling of PR #42) --
+    def test_mirror_paper_fallback_close_sends_no_real_order(self):
+        """If the BankNIFTY mirror BUY fell back to paper (rejected / symbol-master
+        miss) the mirror opened no real leg, so closing it must NOT send a real
+        SELL -- that would be a phantom BankNIFTY short of an option never bought.
+        The NIFTY leg (really open) still sells; the mirror books flatten silently."""
+        worker, store = self._make_worker()
+        worker.live_trading = True
+        # Only the BankNIFTY mirror leg is rejected at the broker; the NIFTY leg fills.
+        entry_fake = _FakeShoonya(fail_on=lambda symbol, side: "BANKNIFTY" in symbol)
+        with patch.object(master_file, "execution_client", entry_fake):
+            worker.enter_position("LONG", 24300.0, 24290.0, 24400.0)
+        self.assertTrue(worker.pos.live_legs_open)           # NIFTY leg really open
+        self.assertTrue(worker._mirror_pos.active)           # mirror tracked (paper)
+        self.assertFalse(worker._mirror_pos.live_legs_open)  # ...but no real BNF leg
+
+        exit_fake = _FakeShoonya()
+        store.update_ltp_map({(master_file.OPTION_EXCHANGE_SEGMENT, 3003): 520.0})
+        with patch.object(master_file, "execution_client", exit_fake):
+            worker.exit_position("AI_TARGET")
+        self.assertFalse(worker._mirror_pos.active)          # mirror books flattened
+        self.assertFalse(worker.pos.active)
+        bnf_orders = [c for c in exit_fake.calls if "BANKNIFTY" in c[0]]
+        self.assertEqual(bnf_orders, [])                     # no phantom BNF short
+        # The real NIFTY leg still sold exactly once.
+        self.assertEqual([s for (_sym, s, _q) in exit_fake.calls], ["SELL"])
+
+    def test_confirmed_live_mirror_close_sends_real_sell(self):
+        """Non-regression: when BOTH legs opened live, closing the basket still
+        SELLs the BankNIFTY mirror leg exactly once."""
+        worker, _ = self._make_worker()
+        worker.live_trading = True
+        ok_fake = _FakeShoonya()
+        with patch.object(master_file, "execution_client", ok_fake):
+            worker.enter_position("LONG", 24300.0, 24290.0, 24400.0)
+        self.assertTrue(worker._mirror_pos.live_legs_open)
+        exit_fake = _FakeShoonya()
+        with patch.object(master_file, "execution_client", exit_fake):
+            worker.exit_position("AI_TARGET")
+        bnf_sells = [c for c in exit_fake.calls if "BANKNIFTY" in c[0] and c[1] == "SELL"]
+        self.assertEqual(len(bnf_sells), 1)
 
 
 class TestLiveOrderRouting(unittest.TestCase):
@@ -2034,6 +2080,42 @@ class TestLiveOrderRouting(unittest.TestCase):
             ok = self.worker.enter_position(direction="LONG", entry_underlying=22500.0)
         self.assertTrue(ok)
         self.assertTrue(self.worker.pos.active)
+
+    def test_paper_fallback_entry_then_exit_sends_no_real_order_but_flattens(self):
+        """P1 (single-leg sibling of PR #42 / HEDGE-001): a LIVE worker whose ENTRY
+        fell back to paper (rejected order / symbol-master miss) opened no real leg,
+        so its exit must NOT send a real SELL -- that would be a naked short of an
+        option we never bought at the broker. The exit still flattens the paper
+        books (the position is not a real one to keep open for retry)."""
+        # Entry rejected at the broker -> position recorded as paper (no live leg).
+        reject_fake = _FakeShoonya(fail_on=lambda symbol, side: True)
+        self.worker.live_trading = True
+        with patch.object(master_file, "execution_client", reject_fake):
+            self.worker.enter_position(direction="LONG", entry_underlying=22500.0)
+        self.assertTrue(self.worker.pos.active)             # tracked as paper
+        self.assertFalse(self.worker.pos.live_legs_open)    # but no real leg opened
+
+        # A fresh client for the exit must receive ZERO orders...
+        exit_fake = _FakeShoonya()
+        self.store.update_ltp_map({(master_file.OPTION_EXCHANGE_SEGMENT, 49081): 130.0})
+        with patch.object(master_file, "execution_client", exit_fake):
+            self.worker.exit_position("TEST_EXIT")
+        self.assertEqual(exit_fake.calls, [])               # no phantom naked short
+        self.assertFalse(self.worker.pos.active)            # ...yet books flattened
+        self.assertEqual(self.worker.completed_trades, 1)
+
+    def test_confirmed_live_entry_marks_legs_open_and_exit_sells(self):
+        """The invariant's other side (non-regression): a confirmed live entry marks
+        live_legs_open True and its exit DOES send the real SELL."""
+        fake = _FakeShoonya()
+        self.worker.live_trading = True
+        with patch.object(master_file, "execution_client", fake):
+            self.worker.enter_position(direction="LONG", entry_underlying=22500.0)
+            self.assertTrue(self.worker.pos.live_legs_open)
+            self.store.update_ltp_map({(master_file.OPTION_EXCHANGE_SEGMENT, 49081): 130.0})
+            self.worker.exit_position("TEST_EXIT")
+        self.assertIn(("SELL", 50 * self.worker.lots), self._sides(fake))
+        self.assertFalse(self.worker.pos.active)
 
     # --- Hedged helpers: leg dicts as built by the call sites. ---
     def _leg(self, option_type, strike, qty, dhan):

--- a/test_nifty_multi_strategy_master.py
+++ b/test_nifty_multi_strategy_master.py
@@ -2222,6 +2222,55 @@ class TestHedgedPaperFallbackExit(unittest.TestCase):
         self.assertEqual(sides, [("BUY", 50), ("SELL", 50)])  # BUY main, SELL hedge
         self.assertFalse(worker.pos.active)
 
+    def test_paper_fallback_exit_is_tagged_paper_fallback_not_live(self):
+        """Codex on PR #47: the EXIT event for a paper-fallback position must NOT
+        claim `LIVE` -- no broker order was sent -- or an operator would think a
+        real leg was closed. It must read PAPER_FALLBACK."""
+        worker = self._make_bullish_worker(live_legs_open=False)
+        events = MagicMock()
+        worker.trade_event_queue = events
+        fake = _FakeShoonya()
+        with patch.object(master_file, "execution_client", fake):
+            worker.exit_position("TIME_CUTOFF")
+        modes = [c.args[0].get("mode") for c in events.put_nowait.call_args_list
+                 if c.args[0].get("action") == "EXIT"]
+        self.assertEqual(modes, ["PAPER_FALLBACK"])
+
+    def test_confirmed_live_exit_is_tagged_live(self):
+        worker = self._make_bullish_worker(live_legs_open=True)
+        events = MagicMock()
+        worker.trade_event_queue = events
+        fake = _FakeShoonya()
+        with patch.object(master_file, "execution_client", fake):
+            worker.exit_position("TIME_CUTOFF")
+        modes = [c.args[0].get("mode") for c in events.put_nowait.call_args_list
+                 if c.args[0].get("action") == "EXIT"]
+        self.assertEqual(modes, ["LIVE"])
+
+
+class TestExecModeTag(unittest.TestCase):
+    """`_exec_mode_tag` labels how a trade actually executed (Codex PR #47)."""
+
+    def _worker(self, *, live: bool):
+        w = master_file.AtmSingleLegStrategyWorker(
+            store=master_file.SharedMarketDataStore(),
+            stop_event=threading.Event(), broker=MagicMock(),
+        )
+        w.live_trading = live
+        return w
+
+    def test_paper_worker_is_always_paper(self):
+        w = self._worker(live=False)
+        self.assertEqual(w._exec_mode_tag(True), "PAPER")
+        self.assertEqual(w._exec_mode_tag(True, live_legs_open=False), "PAPER")
+
+    def test_live_worker_labels(self):
+        w = self._worker(live=True)
+        self.assertEqual(w._exec_mode_tag(True), "LIVE")                       # confirmed real order
+        self.assertEqual(w._exec_mode_tag(False), "PAPER_FALLBACK")            # real order failed
+        # No real legs open -> no broker order sent -> PAPER_FALLBACK even though real_ok is a vacuous True.
+        self.assertEqual(w._exec_mode_tag(True, live_legs_open=False), "PAPER_FALLBACK")
+
 
 class TestShoonyaOrderAck(unittest.TestCase):
     """


### PR DESCRIPTION
## Problem

A live entry that fell back to paper — a rejected/partial broker order, or a
symbol-master resolution miss — still recorded an **active** `PaperPosition`.
The later exit then called `_place_real_leg("SELL", ...)` unconditionally in
live mode, sending a real SELL-to-close for an option **that was never bought
at the broker** — a naked short / phantom live exposure.

This is the same live-money bug fixed for the hedged workers in #42
(HEDGE-001, `5817993`), but in **two exit paths that PR did not touch**:

1. **Single-leg ATM workers** — `AtmSingleLegStrategyWorker.exit_position`.
2. **BankNIFTY SL-Hunting mirror** — `_open_bnf_mirror` / `_close_bnf_mirror`.

## Fix

Applies the same invariant PR #42 introduced with
`HedgedPaperPosition.live_legs_open`:

- `PaperPosition` gains **`live_legs_open`** (default `False`), set at each
  entry site to `(self.live_trading and real_ok)` — `True` only when a real
  broker leg actually confirmed. A paper fallback leaves it `False`.
- The single-leg exit and `_close_bnf_mirror` send the real closing SELL
  **only when the position's `live_legs_open` is `True`**. When `False`,
  there is nothing to close: the order is skipped (`real_ok` stays `True` so
  the paper books flatten normally, and the mirror's "manual action needed"
  alert does not fire).
- Marking at **entry** (not exit) means the exit can never send a live order
  for a position whose legs were never opened live.

Paper-mode behaviour is unchanged (`_place_real_leg` already no-ops in paper),
and a confirmed-live position still sends its real SELL and still keeps the
position open for retry if that live SELL fails.

## Tests (TDD — failing first, mirroring `TestHedgedPaperFallbackExit`)

- **Single-leg:** a live worker whose entry fell back to paper exits with
  **zero broker orders yet flattens**; a confirmed-live entry marks
  `live_legs_open` and still SELLs at exit.
- **BNF mirror:** a mirror BUY that fell back to paper closes with **no real
  BankNIFTY order** while the real NIFTY leg still sells; a confirmed-live
  mirror still SELLs. The existing underlying-routing test now runs live so
  the (now gated) exit legs fire.

## Gates (all green)

| Gate | Result |
|---|---|
| `unittest test_nifty_multi_strategy_master` | 191 OK (0 skipped with `SL_HUNTING_ENABLED`; 18 skipped otherwise) |
| `pytest "Signal Generators" -q` | 84 passed |
| `ruff check .` | clean |
| `mypy` | clean (29 files) |
| `compileall -q .` | clean |

## Scope note

A **third** exit path — `LongStrangleWorker._exit_leg` — has the identical
pattern (records the leg regardless of entry `real_ok`, then SELLs
unconditionally in live mode). It is intentionally **out of scope** here
(one PR per ticket) and flagged for a separate follow-up; this PR adds the
`live_legs_open` field it will reuse.

Branched off `origin/main` (which already includes #42).
