### PR TITLE
Gate live LongStrangle leg exits on real legs being open

### DIFF
--- a/Nifty Multi Strategy Front Test - Master File.py
+++ b/Nifty Multi Strategy Front Test - Master File.py
@@ -8444,6 +8444,10 @@ class LongStrangleWorker(BasePaperStrategyWorker):
         new_pos = PaperPosition(
             active=True,
             direction=side,
+            # True only if a real broker leg actually opened; a live entry that fell
+            # back to paper leaves this False so `_exit_leg` sends no real SELL. This
+            # runs for the initial entry AND momentum re-entries (both share _buy_leg).
+            live_legs_open=(self.live_trading and real_ok),
             symbol=trading_symbol,
             quantity=quantity,
             entry_order_id=str(order_id),
@@ -8672,12 +8676,21 @@ class LongStrangleWorker(BasePaperStrategyWorker):
             fallback=closed.entry_trade_price,
         )
 
-        # Real execution (live mode only; no-op True in paper mode).
-        real_ok = self._place_real_leg("SELL", {
-            "option_type": closed.option_right, "strike": closed.option_strike,
-            "expiry": closed.option_expiry, "quantity": closed.quantity,
-            "dhan_symbol": closed.symbol,
-        })
+        # Real execution -- but ONLY when this leg actually opened a real leg at the
+        # broker. A live entry that fell back to paper (rejected order or symbol-master
+        # miss) recorded no live leg, so a SELL now would be a naked short of an OTM
+        # option we never bought. In that case there is nothing to close at the broker:
+        # skip the order and treat the exit as paper (real_ok stays True so the books
+        # flatten normally, exactly like paper mode). Mirrors the single-leg ATM worker
+        # / HEDGE-001 live_legs_open guard.
+        if closed.live_legs_open:
+            real_ok = self._place_real_leg("SELL", {
+                "option_type": closed.option_right, "strike": closed.option_strike,
+                "expiry": closed.option_expiry, "quantity": closed.quantity,
+                "dhan_symbol": closed.symbol,
+            })
+        else:
+            real_ok = True  # no real leg was ever opened -> nothing to close
         exec_mode = self._exec_mode_tag(real_ok)
 
         # If a LIVE exit did not confirm a fill, keep the leg OPEN for retry /

--- a/Nifty Multi Strategy Front Test - Master File.py
+++ b/Nifty Multi Strategy Front Test - Master File.py
@@ -8700,7 +8700,7 @@ class LongStrangleWorker(BasePaperStrategyWorker):
             })
         else:
             real_ok = True  # no real leg was ever opened -> nothing to close
-        exec_mode = self._exec_mode_tag(real_ok)
+        exec_mode = self._exec_mode_tag(real_ok, live_legs_open=closed.live_legs_open)
 
         # If a LIVE exit did not confirm a fill, keep the leg OPEN for retry /
         # manual square-off rather than flattening the books (same safety rule

--- a/test_nifty_multi_strategy_master.py
+++ b/test_nifty_multi_strategy_master.py
@@ -1891,6 +1891,28 @@ class TestLongStrangleWorker(unittest.TestCase):
         self.assertFalse(worker.ce_pos.active)
         self.assertTrue(worker.pe_pos.active)
 
+    def test_paper_fallback_leg_exit_is_tagged_paper_fallback(self):
+        """Codex on PR #47 (propagated to this stacked PR): a paper-fallback
+        LongStrangle leg exit sends no broker order, so its EXIT event must read
+        PAPER_FALLBACK, not LIVE."""
+        worker, store = self._make_worker()
+        worker.live_trading = True
+        events = MagicMock()
+        worker.trade_event_queue = events
+        store.update_ltp_map({
+            (master_file.NIFTY_INDEX_EXCHANGE_SEGMENT, master_file.NIFTY_INDEX_SECURITY_ID): 22510.0,
+            (master_file.OPTION_EXCHANGE_SEGMENT, 1001): 100.0,
+            (master_file.OPTION_EXCHANGE_SEGMENT, 2002): 90.0,
+        })
+        with patch.object(master_file, "execution_client", _FakeShoonya(fail_on=lambda s, side: True)):
+            worker._enter_both_legs()
+        self.assertFalse(worker.ce_pos.live_legs_open)
+        with patch.object(master_file, "execution_client", _FakeShoonya()):
+            worker._exit_leg("CE", "TEST_EXIT")
+        exit_modes = [c.args[0].get("mode") for c in events.put_nowait.call_args_list
+                      if c.args[0].get("action") == "EXIT"]
+        self.assertEqual(exit_modes, ["PAPER_FALLBACK"])
+
 
 @unittest.skipIf(
     getattr(master_file, "SLHuntingAIWorker", None) is None,

--- a/test_nifty_multi_strategy_master.py
+++ b/test_nifty_multi_strategy_master.py
@@ -1833,6 +1833,64 @@ class TestLongStrangleWorker(unittest.TestCase):
         self.assertFalse(worker.ce_pos.active)
         self.assertEqual(worker.ce_reentry_count, 0)
 
+    def test_paper_fallback_leg_then_exit_sends_no_real_order_but_flattens(self):
+        """P1 (LongStrangle sibling of PR #42 / HEDGE-001 and the single-leg guard):
+        a LIVE worker whose leg BUY fell back to paper (rejected order / symbol-master
+        miss) opened no real leg at the broker, so closing that leg must NOT send a
+        real SELL -- that would be a naked short of an OTM option we never bought.
+        The exit still flattens the paper books (nothing real is open to keep for
+        retry). Mirrors TestLiveOrderRouting.<same name for the single-leg worker>."""
+        worker, store = self._make_worker()
+        worker.live_trading = True
+        store.update_ltp_map({
+            (master_file.NIFTY_INDEX_EXCHANGE_SEGMENT, master_file.NIFTY_INDEX_SECURITY_ID): 22510.0,
+            (master_file.OPTION_EXCHANGE_SEGMENT, 1001): 100.0,
+            (master_file.OPTION_EXCHANGE_SEGMENT, 2002): 90.0,
+        })
+        # Every real order is rejected -> both legs are recorded as paper (no live leg).
+        reject_fake = _FakeShoonya(fail_on=lambda symbol, side: True)
+        with patch.object(master_file, "execution_client", reject_fake):
+            worker._enter_both_legs()
+        self.assertTrue(worker.ce_pos.active)               # tracked as paper
+        self.assertTrue(worker.pe_pos.active)
+        self.assertFalse(worker.ce_pos.live_legs_open)      # ...but no real leg opened
+        self.assertFalse(worker.pe_pos.live_legs_open)
+
+        # A fresh client for the exits must receive ZERO orders...
+        exit_fake = _FakeShoonya()
+        with patch.object(master_file, "execution_client", exit_fake):
+            worker._exit_leg("CE", "TEST_EXIT")
+            worker._exit_leg("PE", "TEST_EXIT")
+        self.assertEqual(exit_fake.calls, [])               # no phantom naked short
+        self.assertFalse(worker.ce_pos.active)              # ...yet both legs flattened
+        self.assertFalse(worker.pe_pos.active)
+        self.assertEqual(worker.completed_trades, 2)
+
+    def test_confirmed_live_leg_marks_legs_open_and_exit_sells(self):
+        """The invariant's other side (non-regression): a confirmed live leg BUY marks
+        live_legs_open True, and closing that leg DOES send the real SELL exactly once.
+        Also covers the shared `_buy_leg` path used by momentum re-entries."""
+        worker, store = self._make_worker()
+        worker.live_trading = True
+        store.update_ltp_map({
+            (master_file.NIFTY_INDEX_EXCHANGE_SEGMENT, master_file.NIFTY_INDEX_SECURITY_ID): 22510.0,
+            (master_file.OPTION_EXCHANGE_SEGMENT, 1001): 100.0,
+            (master_file.OPTION_EXCHANGE_SEGMENT, 2002): 90.0,
+        })
+        entry_fake = _FakeShoonya()                          # every order fills
+        with patch.object(master_file, "execution_client", entry_fake):
+            worker._enter_both_legs()
+        self.assertTrue(worker.ce_pos.live_legs_open)        # both legs really open
+        self.assertTrue(worker.pe_pos.live_legs_open)
+
+        # Closing the CE leg sends exactly one real SELL for that leg; PE untouched.
+        exit_fake = _FakeShoonya()
+        with patch.object(master_file, "execution_client", exit_fake):
+            worker._exit_leg("CE", "TEST_EXIT")
+        self.assertEqual([s for (_sym, s, _q) in exit_fake.calls], ["SELL"])
+        self.assertFalse(worker.ce_pos.active)
+        self.assertTrue(worker.pe_pos.active)
+
 
 @unittest.skipIf(
     getattr(master_file, "SLHuntingAIWorker", None) is None,


### PR DESCRIPTION
## Context

`LongStrangleWorker` carried the same **live-money phantom-short bug** already fixed for the hedged workers (PR #42 / HEDGE-001) and the single-leg ATM workers + BankNIFTY mirror (#47, `fix/live-exit-guard-single-leg-mirror`). This closes the last remaining unguarded worker.

> **Stacked on #47.** Base branch is `fix/live-exit-guard-single-leg-mirror`, which introduces the `AtmSingleLegStrategyWorker.exit_position` reference pattern and the `test_paper_fallback_entry_then_exit_sends_no_real_order_but_flattens` test this PR mirrors. GitHub will retarget this PR to `main` once #47 merges.

## The bug (on the parent branch)

- `_buy_leg` (the shared entry path for the initial `_enter_leg` **and** the momentum re-entry) recorded an active `ce_pos`/`pe_pos` regardless of whether the live BUY actually filled. A live BUY that fell back to paper (rejected order / symbol-master miss) still became an active leg, with `live_legs_open` defaulting `False`.
- `_exit_leg` then called `_place_real_leg("SELL", ...)` **unconditionally** in live mode — sending a real SELL-to-close for an OTM option that was never bought at the broker (a naked short / phantom exposure).

## The fix (established `PaperPosition.live_legs_open` invariant)

1. `_buy_leg` sets `live_legs_open=(self.live_trading and real_ok)` on the recorded position — covers the initial entry **and** re-entries (same helper).
2. `_exit_leg` places the real SELL only when `closed.live_legs_open` is `True`; otherwise `real_ok = True` and no broker order is sent, so the "kept open for retry" branch (`if self.live_trading and not real_ok`) never fires and the leg's paper books flatten normally.

Both changes are a line-for-line mirror of the single-leg `AtmSingleLegStrategyWorker` guard.

## Tests (TDD — added first, red before the fix)

- `test_paper_fallback_leg_then_exit_sends_no_real_order_but_flattens`: a live worker whose leg BUY fell back to paper sends **ZERO** broker orders on `_exit_leg`, yet flattens both legs. _(Before the fix: two phantom SELLs `SHOONYA-NIFTY-22550-CE` / `-22450-PE`.)_
- `test_confirmed_live_leg_marks_legs_open_and_exit_sells`: a confirmed-live leg marks `live_legs_open` `True` and still SELLs exactly once. _(Before the fix: `live_legs_open` never set.)_

## Gates (all green, run from the worktree)

| Gate | Result |
|---|---|
| `python -m unittest test_nifty_multi_strategy_master` | 204 ok (19 skipped) |
| `python -m pytest "Signal Generators" -q` | 84 passed |
| `python -m ruff check .` | passed |
| `python -m mypy` | no issues (29 files) |
| `python -m compileall -q .` | ok |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
