### PR TITLE
Re-land LongStrangle live-exit guard onto main (#48 missed main)

### DIFF
--- a/Nifty Multi Strategy Front Test - Master File.py
+++ b/Nifty Multi Strategy Front Test - Master File.py
@@ -8727,7 +8727,7 @@ class LongStrangleWorker(BasePaperStrategyWorker):
             })
         else:
             real_ok = True  # no real leg was ever opened -> nothing to close
-        exec_mode = self._exec_mode_tag(real_ok)
+        exec_mode = self._exec_mode_tag(real_ok, live_legs_open=closed.live_legs_open)
 
         # If a LIVE exit did not confirm a fill, keep the leg OPEN for retry /
         # manual square-off rather than flattening the books (same safety rule

--- a/Nifty Multi Strategy Front Test - Master File.py
+++ b/Nifty Multi Strategy Front Test - Master File.py
@@ -8480,6 +8480,10 @@ class LongStrangleWorker(BasePaperStrategyWorker):
         new_pos = PaperPosition(
             active=True,
             direction=side,
+            # True only if a real broker leg actually opened; a live entry that fell
+            # back to paper leaves this False so `_exit_leg` sends no real SELL. This
+            # runs for the initial entry AND momentum re-entries (both share _buy_leg).
+            live_legs_open=(self.live_trading and real_ok),
             symbol=trading_symbol,
             quantity=quantity,
             entry_order_id=str(order_id),
@@ -8708,12 +8712,21 @@ class LongStrangleWorker(BasePaperStrategyWorker):
             fallback=closed.entry_trade_price,
         )
 
-        # Real execution (live mode only; no-op True in paper mode).
-        real_ok = self._place_real_leg("SELL", {
-            "option_type": closed.option_right, "strike": closed.option_strike,
-            "expiry": closed.option_expiry, "quantity": closed.quantity,
-            "dhan_symbol": closed.symbol,
-        })
+        # Real execution -- but ONLY when this leg actually opened a real leg at the
+        # broker. A live entry that fell back to paper (rejected order or symbol-master
+        # miss) recorded no live leg, so a SELL now would be a naked short of an OTM
+        # option we never bought. In that case there is nothing to close at the broker:
+        # skip the order and treat the exit as paper (real_ok stays True so the books
+        # flatten normally, exactly like paper mode). Mirrors the single-leg ATM worker
+        # / HEDGE-001 live_legs_open guard.
+        if closed.live_legs_open:
+            real_ok = self._place_real_leg("SELL", {
+                "option_type": closed.option_right, "strike": closed.option_strike,
+                "expiry": closed.option_expiry, "quantity": closed.quantity,
+                "dhan_symbol": closed.symbol,
+            })
+        else:
+            real_ok = True  # no real leg was ever opened -> nothing to close
         exec_mode = self._exec_mode_tag(real_ok)
 
         # If a LIVE exit did not confirm a fill, keep the leg OPEN for retry /

--- a/test_nifty_multi_strategy_master.py
+++ b/test_nifty_multi_strategy_master.py
@@ -1983,6 +1983,28 @@ class TestLongStrangleWorker(unittest.TestCase):
         self.assertFalse(worker.ce_pos.active)
         self.assertTrue(worker.pe_pos.active)
 
+    def test_paper_fallback_leg_exit_is_tagged_paper_fallback(self):
+        """Codex on PR #47 (propagated to this stacked PR): a paper-fallback
+        LongStrangle leg exit sends no broker order, so its EXIT event must read
+        PAPER_FALLBACK, not LIVE."""
+        worker, store = self._make_worker()
+        worker.live_trading = True
+        events = MagicMock()
+        worker.trade_event_queue = events
+        store.update_ltp_map({
+            (master_file.NIFTY_INDEX_EXCHANGE_SEGMENT, master_file.NIFTY_INDEX_SECURITY_ID): 22510.0,
+            (master_file.OPTION_EXCHANGE_SEGMENT, 1001): 100.0,
+            (master_file.OPTION_EXCHANGE_SEGMENT, 2002): 90.0,
+        })
+        with patch.object(master_file, "execution_client", _FakeShoonya(fail_on=lambda s, side: True)):
+            worker._enter_both_legs()
+        self.assertFalse(worker.ce_pos.live_legs_open)
+        with patch.object(master_file, "execution_client", _FakeShoonya()):
+            worker._exit_leg("CE", "TEST_EXIT")
+        exit_modes = [c.args[0].get("mode") for c in events.put_nowait.call_args_list
+                      if c.args[0].get("action") == "EXIT"]
+        self.assertEqual(exit_modes, ["PAPER_FALLBACK"])
+
 
 @unittest.skipIf(
     getattr(master_file, "SLHuntingAIWorker", None) is None,

--- a/test_nifty_multi_strategy_master.py
+++ b/test_nifty_multi_strategy_master.py
@@ -1925,6 +1925,64 @@ class TestLongStrangleWorker(unittest.TestCase):
         self.assertFalse(worker.ce_pos.active)
         self.assertEqual(worker.ce_reentry_count, 0)
 
+    def test_paper_fallback_leg_then_exit_sends_no_real_order_but_flattens(self):
+        """P1 (LongStrangle sibling of PR #42 / HEDGE-001 and the single-leg guard):
+        a LIVE worker whose leg BUY fell back to paper (rejected order / symbol-master
+        miss) opened no real leg at the broker, so closing that leg must NOT send a
+        real SELL -- that would be a naked short of an OTM option we never bought.
+        The exit still flattens the paper books (nothing real is open to keep for
+        retry). Mirrors TestLiveOrderRouting.<same name for the single-leg worker>."""
+        worker, store = self._make_worker()
+        worker.live_trading = True
+        store.update_ltp_map({
+            (master_file.NIFTY_INDEX_EXCHANGE_SEGMENT, master_file.NIFTY_INDEX_SECURITY_ID): 22510.0,
+            (master_file.OPTION_EXCHANGE_SEGMENT, 1001): 100.0,
+            (master_file.OPTION_EXCHANGE_SEGMENT, 2002): 90.0,
+        })
+        # Every real order is rejected -> both legs are recorded as paper (no live leg).
+        reject_fake = _FakeShoonya(fail_on=lambda symbol, side: True)
+        with patch.object(master_file, "execution_client", reject_fake):
+            worker._enter_both_legs()
+        self.assertTrue(worker.ce_pos.active)               # tracked as paper
+        self.assertTrue(worker.pe_pos.active)
+        self.assertFalse(worker.ce_pos.live_legs_open)      # ...but no real leg opened
+        self.assertFalse(worker.pe_pos.live_legs_open)
+
+        # A fresh client for the exits must receive ZERO orders...
+        exit_fake = _FakeShoonya()
+        with patch.object(master_file, "execution_client", exit_fake):
+            worker._exit_leg("CE", "TEST_EXIT")
+            worker._exit_leg("PE", "TEST_EXIT")
+        self.assertEqual(exit_fake.calls, [])               # no phantom naked short
+        self.assertFalse(worker.ce_pos.active)              # ...yet both legs flattened
+        self.assertFalse(worker.pe_pos.active)
+        self.assertEqual(worker.completed_trades, 2)
+
+    def test_confirmed_live_leg_marks_legs_open_and_exit_sells(self):
+        """The invariant's other side (non-regression): a confirmed live leg BUY marks
+        live_legs_open True, and closing that leg DOES send the real SELL exactly once.
+        Also covers the shared `_buy_leg` path used by momentum re-entries."""
+        worker, store = self._make_worker()
+        worker.live_trading = True
+        store.update_ltp_map({
+            (master_file.NIFTY_INDEX_EXCHANGE_SEGMENT, master_file.NIFTY_INDEX_SECURITY_ID): 22510.0,
+            (master_file.OPTION_EXCHANGE_SEGMENT, 1001): 100.0,
+            (master_file.OPTION_EXCHANGE_SEGMENT, 2002): 90.0,
+        })
+        entry_fake = _FakeShoonya()                          # every order fills
+        with patch.object(master_file, "execution_client", entry_fake):
+            worker._enter_both_legs()
+        self.assertTrue(worker.ce_pos.live_legs_open)        # both legs really open
+        self.assertTrue(worker.pe_pos.live_legs_open)
+
+        # Closing the CE leg sends exactly one real SELL for that leg; PE untouched.
+        exit_fake = _FakeShoonya()
+        with patch.object(master_file, "execution_client", exit_fake):
+            worker._exit_leg("CE", "TEST_EXIT")
+        self.assertEqual([s for (_sym, s, _q) in exit_fake.calls], ["SELL"])
+        self.assertFalse(worker.ce_pos.active)
+        self.assertTrue(worker.pe_pos.active)
+
 
 @unittest.skipIf(
     getattr(master_file, "SLHuntingAIWorker", None) is None,


### PR DESCRIPTION
## Re-land: LongStrangle live-exit guard never reached `main`

PR #48 shows **MERGED**, but its base branch was `fix/live-exit-guard-single-leg-mirror` (the #47 branch), **not `main`**. #47 merged to main at its pre-#48 tip, so #48 was merged into the #47 branch *after that* and its content never propagated to `main`.

Verified against `origin/main`:
- `6f2a2ba` (#48's tip) is **not** an ancestor of `main`.
- The LongStrangle `_exit_leg` `live_legs_open` gate is **absent** — so on `main`, a live LongStrangle leg whose entry fell back to paper still sends an unconditional real SELL on exit: a **naked short of an OTM option never bought** (the P1 this fix prevents).

## What this PR does

Cherry-picks #48's two real commits onto current `main`:
- **Gate live LongStrangle leg exits on real legs being open** — `_exit_leg` only sends the real SELL when `closed.live_legs_open` (mirrors the single-leg/HEDGE-001 guard already in main); a paper-fallback leg flattens its books with no broker order.
- **Label paper-fallback LongStrangle leg exits `PAPER_FALLBACK`** — passes `live_legs_open` to `_exec_mode_tag` so the EXIT event isn't mislabeled `LIVE` (the Codex-on-#47 fix, propagated).

No new logic — identical to what was reviewed on #48, re-based onto `main`.

## Verification

| Gate | Result |
|---|---|
| `python -m unittest test_nifty_multi_strategy_master` | 216 OK (20 skipped) |
| `python -m pytest "Signal Generators" "Dependencies" "Data Extractors" -q` | 154 passed |
| ruff / mypy / compileall / bandit | all clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
