### PR TITLE
Re-land SLH-002 stop/target sanity guard onto main (#43 missed main)

### DIFF
--- a/Signal Generators/SL Hunting AI Agent/README.md
+++ b/Signal Generators/SL Hunting AI Agent/README.md
@@ -117,6 +117,10 @@ cutoff the agent isn't called at all, so it makes **no LLM calls for the rest of
   and the agent records a fail-soft `HOLD`. If the CLI stays hung, subsequent bars
   are **gated** until the abandoned call finishes — so at most one hung agent
   call/subprocess exists at a time instead of one accumulating per bar.
+- Entry **stop/target are sanity-checked at the order tool** against the live price
+  (correct side; stop within ~3%, target within ~10%) and bounded in the schema —
+  a hallucinated level cannot silently disable the mechanical stop; the rejected
+  order returns to the agent mid-loop so it can correct its levels.
 - Both extra deps are **lazily imported**, so a missing dep just disables this one
   worker — the rest of the master and its test suite are unaffected.
 

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_agent.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_agent.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import math
 import re
 import sys
 import threading
@@ -171,6 +172,27 @@ class SLHuntingDecision(StrictAIModel):
     def _validate_confidence_range(cls, value: int) -> int:
         if not 0 <= value <= 10:
             raise ValueError(f"confidence must be between 0 and 10 inclusive, got {value}")
+        return value
+
+    @field_validator("stop", "target")
+    @classmethod
+    def _validate_level_sanity(cls, value: float) -> float:
+        """Reject hallucinated stop/target garbage (SLH-002).
+
+        These are UNDERLYING price levels the mechanical per-poll exit uses
+        verbatim -- a negative or absurd stop silently disables the stop for
+        the whole trade. 0.0 stays valid as the documented EXIT/HOLD
+        placeholder. Bounds live here (not `Field(ge=/le=)`) for the same
+        reason as `confidence`: Claude rejects `minimum`/`maximum` keys in
+        the JSON schema we describe to it. Price-aware checks (side, distance
+        band) happen in the order tool, which knows the current price.
+        """
+        if not math.isfinite(value):
+            raise ValueError(f"stop/target must be a finite number, got {value!r}")
+        if value < 0:
+            raise ValueError(f"stop/target must be >= 0, got {value}")
+        if value > 10_000_000:
+            raise ValueError(f"stop/target is implausibly large for an index level: {value}")
         return value
 
 

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_agent.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_agent.py
@@ -38,7 +38,7 @@ from dataclasses import dataclass
 from typing import Any, Literal
 
 import pandas as pd
-from pydantic import Field, ValidationError, field_validator
+from pydantic import Field, ValidationError, field_validator, model_validator
 from sl_hunting_ai_validation import StrictAIModel
 from sl_hunting_executor import TradeExecutor
 from sl_hunting_indicators import SLHuntingIndicatorConfig, prepare_candles
@@ -194,6 +194,23 @@ class SLHuntingDecision(StrictAIModel):
         if value > 10_000_000:
             raise ValueError(f"stop/target is implausibly large for an index level: {value}")
         return value
+
+    @model_validator(mode="after")
+    def _require_levels_for_entries(self) -> SLHuntingDecision:
+        """An ENTER decision must carry a positive stop AND target (SLH-002 / Codex).
+
+        The order tool already rejects zero/omitted levels when the agent CALLS
+        it, but the final JSON is a separate self-report: without this, an
+        ENTER_LONG/ENTER_SHORT with the 0.0 defaults would still validate and be
+        recorded as a real entry with no levels, corrupting the decision journal
+        and defeating the tool-side guard. EXIT/HOLD keep their 0.0 placeholders.
+        """
+        if self.action in ("ENTER_LONG", "ENTER_SHORT") and not (self.stop > 0 and self.target > 0):
+            raise ValueError(
+                f"{self.action} requires a positive stop and target, got "
+                f"stop={self.stop}, target={self.target}"
+            )
+        return self
 
 
 def _extract_json_object(text: str) -> dict[str, Any] | None:

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_tools.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_tools.py
@@ -31,6 +31,7 @@ names are namespaced ``mcp__<server>__<tool>``.
 from __future__ import annotations
 
 import json
+import math
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -47,6 +48,38 @@ from sl_hunting_indicators import (
 )
 
 SERVER_NAME = "slhunting"
+
+# SLH-002: sanity bands for the agent's ENTRY stop/target, as fractions of the
+# current underlying price. Generous on purpose -- real SL-Hunting stops are a
+# few dozen points (<<1% of NIFTY), so these only catch hallucinated garbage
+# (wrong-instrument levels, sign flips, absurd numbers), never a real setup.
+MAX_STOP_DISTANCE_FRACTION = 0.03
+MAX_TARGET_DISTANCE_FRACTION = 0.10
+
+
+def _entry_levels_error(direction: str, stop: float, target: float, price: float) -> str | None:
+    """Explain why these entry levels are unusable, or return None when sane.
+
+    The mechanical per-poll exit uses these UNDERLYING levels verbatim: a stop on
+    the wrong side either fires instantly or never fires at all, and a non-finite
+    or far-away level silently disables the stop, leaving only max-loss and the
+    15:15 square-off. Checked at the order tool because only it knows the price.
+    """
+    if price <= 0:
+        return "no current underlying price available to validate the levels"
+    if not (math.isfinite(stop) and math.isfinite(target)):
+        return "stop and target must be finite numbers"
+    if stop <= 0 or target <= 0:
+        return "an entry requires a positive stop AND target on the underlying"
+    if direction == "LONG" and not (stop < price < target):
+        return f"a LONG needs stop below and target above the current price {price:.2f}"
+    if direction == "SHORT" and not (target < price < stop):
+        return f"a SHORT needs stop above and target below the current price {price:.2f}"
+    if abs(stop - price) > MAX_STOP_DISTANCE_FRACTION * price:
+        return f"stop is more than {MAX_STOP_DISTANCE_FRACTION:.0%} away from the current price"
+    if abs(target - price) > MAX_TARGET_DISTANCE_FRACTION * price:
+        return f"target is more than {MAX_TARGET_DISTANCE_FRACTION:.0%} away from the current price"
+    return None
 
 # Read-only context tools are always present; the action tool's name is decided at
 # build time by the environment, so it is appended in `build_sl_hunting_mcp_server`.
@@ -168,6 +201,11 @@ class SLHuntingToolContext:
         `exit_leg` applies only to EXIT: NIFTY / BNF / BOTH (default). It lets the agent
         cut one leg of the BankNIFTY-mirror basket on premise-invalidation while leaving
         the other running; hard risk (stop/target/max-loss/square-off) still ties both.
+
+        SLH-002: entry stop/target are validated against the CURRENT price here --
+        this is the one price-aware choke point for the agent's numbers. A rejected
+        entry goes back to the model mid-loop as `accepted: false` with the reason,
+        so it can correct its levels; the executor is never touched.
         """
         if self.expired_reason:
             return {
@@ -175,10 +213,14 @@ class SLHuntingToolContext:
                 "reason": f"decision window expired ({self.expired_reason}); order refused",
             }
         action = (action or "").strip().upper()
-        if action == "ENTER_LONG":
-            return self.executor.enter("LONG", float(stop or 0.0), float(target or 0.0), reason, self.last_price)
-        if action == "ENTER_SHORT":
-            return self.executor.enter("SHORT", float(stop or 0.0), float(target or 0.0), reason, self.last_price)
+        if action in ("ENTER_LONG", "ENTER_SHORT"):
+            direction = "LONG" if action == "ENTER_LONG" else "SHORT"
+            stop = float(stop or 0.0)
+            target = float(target or 0.0)
+            problem = _entry_levels_error(direction, stop, target, self.last_price)
+            if problem:
+                return {"accepted": False, "reason": f"invalid entry levels: {problem}"}
+            return self.executor.enter(direction, stop, target, reason, self.last_price)
         if action == "EXIT":
             leg = (exit_leg or "BOTH").strip().upper()
             if leg not in ("NIFTY", "BNF", "BOTH"):
@@ -257,7 +299,10 @@ def build_sl_hunting_mcp_server(context: SLHuntingToolContext):
         f"Place an SL-Hunting order on NIFTY ATM options via the {venue} venue (the "
         "configuration chose this venue; you cannot change it). action is ENTER_LONG "
         "(buy CALL), ENTER_SHORT (buy PUT) or EXIT. stop and target are NIFTY "
-        "UNDERLYING price levels (required for entries; ignored for EXIT). reason is "
+        "UNDERLYING price levels (required for entries; ignored for EXIT). They must "
+        "BRACKET the current price on the correct side (LONG: stop below, target "
+        "above; SHORT: reversed), with the stop within ~3% and the target within "
+        "~10% of the current price -- otherwise the order is rejected. reason is "
         "a one-line justification. exit_leg (EXIT only) is NIFTY, BNF or BOTH (default "
         "BOTH): every NIFTY entry is mirrored by an equal-lot BankNIFTY ATM leg, and "
         "you may cut ONE leg on premise-invalidation while the other runs — but hard "

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_agent.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_agent.py
@@ -298,6 +298,75 @@ def test_master_worker_executor_delegates():
 
 
 # --------------------------------------------------------------------------
+# SLH-002: agent-provided ENTRY stop/target must be sane at the order tool.
+# The mechanical per-poll exit uses these UNDERLYING levels verbatim, so a
+# hallucinated stop (wrong side / absurd distance / non-finite) silently
+# disables the stop for that trade -- only max-loss and square-off remain.
+# The order tool is the one price-aware choke point, so it validates there
+# and rejects, which the agent sees mid-loop and can correct.
+# --------------------------------------------------------------------------
+
+def test_do_order_rejects_wrong_side_stop_for_long():
+    ex = StandaloneExecutor()
+    ctx = SLHuntingToolContext.build(_candles(), ex)
+    price = ctx.last_price
+    res = ctx.do_order("ENTER_LONG", stop=price + 50, target=price + 100, reason="stop above price")
+    assert res["accepted"] is False
+    assert ex.snapshot()["in_position"] is False
+
+
+def test_do_order_rejects_wrong_side_target_for_short():
+    ex = StandaloneExecutor()
+    ctx = SLHuntingToolContext.build(_candles(), ex)
+    price = ctx.last_price
+    res = ctx.do_order("ENTER_SHORT", stop=price + 50, target=price + 100, reason="target above price")
+    assert res["accepted"] is False
+    assert ex.snapshot()["in_position"] is False
+
+
+def test_do_order_rejects_nonpositive_and_nonfinite_levels():
+    ex = StandaloneExecutor()
+    ctx = SLHuntingToolContext.build(_candles(), ex)
+    price = ctx.last_price
+    bad_pairs = [
+        (0.0, price + 100),            # missing stop on an entry
+        (-1e9, price + 100),           # hallucinated negative stop
+        (float("nan"), price + 100),   # non-finite stop
+        (price - 50, float("inf")),    # non-finite target
+    ]
+    for stop, target in bad_pairs:
+        res = ctx.do_order("ENTER_LONG", stop=stop, target=target, reason="garbage levels")
+        assert res["accepted"] is False, (stop, target)
+    assert ex.snapshot()["in_position"] is False
+
+
+def test_do_order_rejects_levels_too_far_from_price():
+    ex = StandaloneExecutor()
+    ctx = SLHuntingToolContext.build(_candles(), ex)
+    price = ctx.last_price
+    # A stop 10% away dwarfs any real SL-Hunting stop (>3% band).
+    res = ctx.do_order("ENTER_LONG", stop=price * 0.90, target=price + 100, reason="stop too far")
+    assert res["accepted"] is False
+    # A target 20% away is outside the 10% band.
+    res2 = ctx.do_order("ENTER_LONG", stop=price - 30, target=price * 1.20, reason="target too far")
+    assert res2["accepted"] is False
+    assert ex.snapshot()["in_position"] is False
+
+
+def test_do_order_accepts_sane_entry_and_exit_ignores_levels():
+    ex = StandaloneExecutor()
+    ctx = SLHuntingToolContext.build(_candles(), ex)
+    price = ctx.last_price
+    res = ctx.do_order("ENTER_LONG", stop=price - 30, target=price + 60, reason="pivot bounce")
+    assert res["accepted"] is True
+    assert ex.snapshot()["in_position"] is True
+    # EXIT carries no meaningful levels (schema placeholder 0) -- never blocked by them.
+    out = ctx.do_order("EXIT", stop=0.0, target=0.0, reason="premise done")
+    assert out["accepted"] is True
+    assert ex.snapshot()["in_position"] is False
+
+
+# --------------------------------------------------------------------------
 # SLH-001: the SDK call must be TIME-BOUNDED. decide() runs on the strategy
 # worker's own thread -- while it blocks, the per-poll stop/target check,
 # max-loss and the 15:15 square-off are all frozen, so a hung CLI call would

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
@@ -53,6 +53,30 @@ def test_stop_and_target_bounds_are_enforced():
     assert decision.stop == 0.0 and decision.target == 0.0
 
 
+def test_entry_actions_require_positive_stop_and_target():
+    """SLH-002 / Codex (PR #43): an ENTER decision with a 0 (or omitted) stop or
+    target must fail validation, so a hallucinated entry can't be recorded as a
+    real trade with no levels (which would defeat the order-tool guard and
+    corrupt the decision journal). EXIT/HOLD keep their 0.0 placeholders."""
+    for action in ("ENTER_LONG", "ENTER_SHORT"):
+        with pytest.raises(Exception):
+            SLHuntingDecision.model_validate(_valid_payload(action=action, stop=0.0))
+        with pytest.raises(Exception):
+            SLHuntingDecision.model_validate(_valid_payload(action=action, target=0.0))
+        # Omitted stop/target default to 0.0 -> also rejected for entries.
+        with pytest.raises(Exception):
+            payload = _valid_payload(action=action)
+            payload.pop("stop")
+            payload.pop("target")
+            SLHuntingDecision.model_validate(payload)
+        # Both positive -> valid.
+        ok = SLHuntingDecision.model_validate(_valid_payload(action=action, stop=24950.0, target=25100.0))
+        assert ok.action == action
+    for action in ("EXIT", "HOLD"):
+        ok = SLHuntingDecision.model_validate(_valid_payload(action=action, stop=0.0, target=0.0))
+        assert ok.action == action
+
+
 def test_json_schema_omits_min_max_on_stop_and_target():
     """Same Claude-schema constraint as confidence: bounds live in validators,
     never as minimum/maximum keys in the described JSON schema."""

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
@@ -34,6 +34,34 @@ def test_confidence_out_of_range_is_rejected():
         SLHuntingDecision.model_validate(_valid_payload(confidence=-1))
 
 
+def test_stop_and_target_bounds_are_enforced():
+    """SLH-002: hallucinated stop/target garbage must fail schema validation.
+
+    A negative or absurd stop silently disables the mechanical underlying
+    stop for the trade (only max-loss/square-off remain), so the record of
+    the decision must never carry such values.
+    """
+    for bad in (-1.0, -1e9, float("nan"), float("inf"), 10_000_001.0):
+        with pytest.raises(Exception):
+            SLHuntingDecision.model_validate(_valid_payload(stop=bad))
+        with pytest.raises(Exception):
+            SLHuntingDecision.model_validate(_valid_payload(target=bad))
+    # 0.0 stays valid -- the documented placeholder for EXIT/HOLD decisions.
+    decision = SLHuntingDecision.model_validate(
+        _valid_payload(action="HOLD", stop=0.0, target=0.0)
+    )
+    assert decision.stop == 0.0 and decision.target == 0.0
+
+
+def test_json_schema_omits_min_max_on_stop_and_target():
+    """Same Claude-schema constraint as confidence: bounds live in validators,
+    never as minimum/maximum keys in the described JSON schema."""
+    schema = SLHuntingDecision.model_json_schema()
+    for field_name in ("stop", "target"):
+        props = schema["properties"][field_name]
+        assert "minimum" not in props and "maximum" not in props
+
+
 def test_strict_rejects_unknown_fields_and_coercion():
     # extra field forbidden
     with pytest.raises(Exception):


### PR DESCRIPTION
## Re-land: SLH-002 (stop/target sanity guard) never reached `main`

Like #48, PR #43 shows **MERGED** but its base branch was `feat/slh-001-sdk-call-timeout` (the #41 branch), **not `main`**. #41 merged to main at its pre-#43 tip, so #43 merged into the #41 branch afterwards and its content never propagated to `main`.

Verified against `origin/main` — all three SLH-002 markers are **absent**:
- `_entry_levels_error` (order-tool sanity check on entry stop/target): 0
- `_validate_level_sanity` (schema bounds on stop/target): 0
- `_require_levels_for_entries` (model validator rejecting zero-level entries — Codex #43 fix): 0

So on `main`, the SL Hunting agent's entry stop/target are **not** validated: a hallucinated stop (wrong side, absurd distance, or zero) could silently disable the mechanical per-poll stop, and an `ENTER` with zero/omitted levels would be recorded as a real trade.

## What this PR does

Cherry-picks #43's two real commits onto current `main` (README safety-note conflict resolved to keep both the #41 gating note already in main and the SLH-002 note):
- **Sanity-bound the agent's entry stop/target** — `_entry_levels_error` validates entry levels at the order tool (finite, positive, bracketing price on the correct side, stop ≤ 3% / target ≤ 10% away); schema bounds via `_validate_level_sanity`.
- **Reject entry decisions with zero stop/target** (Codex P2) — a `model_validator` requiring positive stop AND target for `ENTER_LONG`/`ENTER_SHORT`; `EXIT`/`HOLD` keep their 0.0 placeholders.

No new logic — identical to what was reviewed on #43, re-based onto `main`.

## Verification

| Gate | Result |
|---|---|
| `python -m unittest test_nifty_multi_strategy_master` | 213 OK (20 skipped) |
| `python -m pytest "Signal Generators" "Dependencies" "Data Extractors" -q` | 162 passed |
| ruff / mypy / compileall / bandit | all clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
