### PR TITLE
Add SL Hunting 2026 transcript knowledge

### DIFF
--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -632,3 +632,62 @@ Sweep result:
 - `RETAIL_POSITIONING`: PREVIOUS-CHART LINKAGE and WEEKEND / HOLIDAY CARRY-RISK.
 - Not encoded: any rule from the 65 blocked public videos or 24 inaccessible rows.
 - Test marker: `test_system_prompt_has_v3g_full_2026_sweep_knowledge`.
+
+---
+
+## Video addendum - remaining blocked public transcripts via NoteGPT fallback (v3h)
+
+> Sources: the 65 public 2026 Intraday Hunter videos that v3g could not extract
+> from YouTube's transcript panel. The operator approved NoteGPT
+> (`https://notegpt.io/youtube-transcript-generator`) as a third-party fallback
+> source for this pass. The temporary extraction ledger is
+> `%TEMP%\intradayhunter-2026-transcripts\notegpt_remaining_ui_2026.jsonl`.
+
+Fallback extraction result:
+- 64 of 65 previously blocked public videos recovered transcript text through
+  the NoteGPT UI fallback.
+- `st8p4CkP8mo` remains unresolved: the YouTube UI had no transcript button, and
+  NoteGPT returned `message: no transcript` with no usable segments.
+- Combined 2026 public coverage is now 249 of 250 public videos: 185 direct
+  YouTube-panel transcripts + 64 NoteGPT fallback transcripts.
+- The 24 inaccessible/member-only rows remain excluded. No knowledge below is
+  derived from those rows or from the unresolved `st8p4CkP8mo` video.
+
+High-signal recovered sources:
+- `lxY9snUinyg` (4 Jul hidden psychology): choose only direct, high-clarity
+  unique trades; do not convert uncertain reads into trades.
+- `YRTuOxYDKhw` (7 Jun position holding): hold a valid winning trade while the
+  premise remains intact instead of cutting it to chase a weaker second trade.
+- `wBHAjFxfXJE` (14 Jun revenge trading): no daily-income pressure, no immediate
+  recovery trade after a loss, and no revenge loop after one failed setup.
+- `ZLpWNw34zGQ` (22 Mar candlestick/timeframe): match timeframe to the question;
+  broader context guides the read, entry timeframe controls execution.
+- `0lWj6kaDpFU` (4 Jan quick decisions): fast execution is acceptable only when
+  the plan is already defined: trapped crowd, reason to move, invalidation, target.
+- Confirmatory recovered weekly/live sessions: `s41N7OS17Wk`, `dVGgbkCtCGM`,
+  `QXMuGzdu0CE`, `yRITNBXsAXY`, and `7NDj21y5K60`.
+
+**Net-new method distilled from the 64 recovered fallback transcripts:**
+- Unique-trade filter: the market is not fixed. The agent should trade only
+  obvious, direct setups where the target crowd, level, direction, invalidation,
+  and target can be named before entry; guess trades are HOLD.
+- Profit-hold: once a valid trade is working, do not exit merely to hunt a
+  second-best or third-best setup. Hold until target, stall/theta, or premise
+  invalidation.
+- Timeframe fit: use higher/multi-day context for broader strength, weakness,
+  and inventory; use the 1-minute/opening chart for execution. A noisy small
+  candle should not override the broader read by itself.
+- Plan-of-execution: quick decisions are allowed only when the trade was already
+  pre-defined. If the agent cannot state who is trapped, why price can move,
+  where invalidation is, and where profit is expected, it must HOLD.
+- No daily-income pressure: a quiet/no-trade day is valid. Forcing a trade
+  because "today must pay" is a revenge/over-trading seed.
+- Post-loss speed limit: after a loss, disable quick-decision mode and wait for
+  a fresh, deliberate, high-quality setup instead of trying to recover immediately.
+
+**Knowledge changes (v3h, all prose):**
+- `PSYCHOLOGY`: UNIQUE-TRADE FILTER.
+- `LEVELS_AND_PIVOT`: TIMEFRAME FIT.
+- `RISK`: PROFIT-HOLD, NO DAILY-INCOME PRESSURE, and POST-LOSS SPEED LIMIT.
+- `DECISION_RULES`: PLAN-OF-EXECUTION.
+- Test marker: `test_system_prompt_has_v3h_remaining_transcript_knowledge`.

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -533,3 +533,59 @@ Videos (id — session — type — outcome/signal):
 - NOT encoded: the lecture's "observe-only first 1-1.5 hours" rule — it is beginner-discipline
   framing that contradicts the operator's opening-drive edge (IH himself trades the open).
 - Test marker: `test_system_prompt_has_v3e_participation_knowledge`.
+
+---
+
+## Video addendum - July 4-8 transcript sweep + agent match (v3f)
+
+> Sources: Intraday Hunter channel uploads published 4 Jul 2026 through 8 Jul 2026,
+> extracted via YouTube's transcript panel where available, then matched against
+> `Backtest Outputs/sl_hunting_decisions.jsonl` and `Backtest Outputs/sl_hunting_journal.jsonl`.
+> The 4 Jul lecture `lxY9snUinyg` advertised Hindi ASR captions but yielded no transcript
+> segments in the UI/timedtext path, so no knowledge is added from it.
+
+Videos captured for the trade-method sweep:
+- `F9APQ4MnAcA` - prediction for 6 Jul.
+- `ohxweLy3H2Q` - live BankNIFTY session on 6 Jul.
+- `P3dFob-ZHtw` - prediction for 7 Jul.
+- `pEXtxlA1u-k` - live BankNIFTY session on 7 Jul.
+- `DTd4Mtz1ppg` - prediction for 8 Jul.
+- `4oV5tP8nzv4` - live BankNIFTY session on 8 Jul.
+- `_y-hk-sl-aQ` - prediction for 9 Jul; captured for provenance, but no 2026-07-09
+  agent decision rows existed in the log, so there is no same-day agent match yet.
+
+**Transcript + agent match ledger:**
+- **6 Jul:** IH took CALL/long after huge first-minute positive momentum, then waited
+  for a pullback/rejection read: prior Friday was negative and a holiday followed, so
+  buyers had not built a reachable SL base; early rejection lured sellers, making the
+  long the operator-side trade. The agent matched the first trade (`opening_drive_gapup_continuation`
+  at 09:17, booked profit), but then immediately took four short fades. Those shorts
+  contradicted the still-live opening thesis: after profit booking, a small pullback
+  was more likely a seller lure unless price spent enough time/space recruiting fresh
+  buyers first.
+- **7 Jul:** IH took PUT/short because several positive sessions with only shallow
+  retracement meant buyers could still be holding; a modest gap-up/flat-to-gap-down
+  open could hunt that buyer inventory. The agent did not cleanly take this trade:
+  the decision log mostly held around the open, and the journal contains timeout /
+  `agent_error` noise including an opposite long. Only the repeated method mismatch
+  is encoded as knowledge: buyer inventory after a shallow up-streak can be the short
+  target, and the agent must not auto-read every modest gap-up as continuation.
+- **8 Jul:** IH took PUT/short after prior breakdown + retracement + continuation:
+  the prior put buyers had likely booked profit and left, so they were not the day's
+  target; the flat/gap-down open plus incomplete recovery failed to reclaim the close
+  / round area, allowing put-side continuation. The agent stayed flat, first waiting
+  for the old bullish gap-down reversal pattern, then becoming usage-limited. The
+  durable knowledge change is the target-booked crowd test plus a narrow gap-down
+  continuation-short exception; the usage-limit behaviour is not a prompt rule.
+
+**Knowledge changes (v3f, all prose):**
+- `RETAIL_POSITIONING`: BUYER-INVENTORY FADE; TARGET-BOOKED crowd test; direct-momentum
+  / current-session trap reset after the old crowd has been paid/flushed.
+- `OPENING_DRIVE`: replaces the absolute no-short/no-gap-down wording with the strict
+  GAP-DOWN CONTINUATION SHORT exception: only narrow/moderate gap-down, sellers not
+  huntable, early recovery fails below close/round/opening range, no bullish reclaim.
+- `RISK`: NO INSTANT FLIP after a correct opening/day-direction trade has been booked;
+  plus the 2-3 hour open-thesis timeout for stalled option-buyer premises.
+- `BNF_SPECIFIC`: MASKED BNF LAG - temporary BankNIFTY weakness can keep NIFTY/Sensex
+  breakout buyers away; it invalidates only when it actually breaks the trade premise.
+- Test marker: `test_system_prompt_has_v3f_transcript_match_knowledge`.

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -589,3 +589,46 @@ Videos captured for the trade-method sweep:
 - `BNF_SPECIFIC`: MASKED BNF LAG - temporary BankNIFTY weakness can keep NIFTY/Sensex
   breakout buyers away; it invalidates only when it actually breaks the trade premise.
 - Test marker: `test_system_prompt_has_v3f_transcript_match_knowledge`.
+
+---
+
+## Video addendum - 2026 transcript sweep through 9 Jul (v3g)
+
+> Sources: Intraday Hunter public channel uploads from 1 Jan 2026 through 9 Jul 2026.
+> The extraction ledger found 274 in-window channel entries: 250 public metadata rows,
+> 185 public transcripts extracted successfully, 65 public transcript payloads that
+> stayed blocked/empty, and 24 inaccessible/member-only rows. The blocked public rows
+> returned YouTube transcript `429` / attestation / empty-panel failures even after a
+> signed-in Chrome attempt; they are deferred to a possible third commit. No knowledge
+> below is derived from blocked or member-only videos.
+
+Sweep result:
+- The successfully extracted daily/live clips overwhelmingly confirm v3a-v3f: gap
+  context, target-booked crowds, current-session trap reset, opening-drive nuance,
+  both-sides participation, BNF lag caution, and no-instant-flip discipline.
+- The main net-new durable source was the public long-form lesson `ywHZfvKsy5Q`
+  (8 Mar 2026), "90% of Traders Ignore This Previous Day Chart Strategy".
+- The July 6 live transcript `ohxweLy3H2Q` independently supports the same
+  holiday/carry-risk theme: after a negative Friday and holiday gap, assume the
+  obvious old buyer crowd may not be holding unless the current chart proves it.
+
+**Net-new method distilled from the 185 extracted transcripts:**
+- Previous-chart linkage: connect today's read to yesterday's chart, but ask what
+  the prior chart already paid, flushed, or made unreachable. After a big gap or a
+  completed target, prioritize the new chart's fresh trap over stale assumptions.
+- Event / holiday participation: known news shocks, Fridays, weekends, and
+  multi-day holidays can remove one side from the risk pool. Do not hunt a crowd
+  that likely exited or avoided large overnight/news risk.
+- Constructed-base continuation: after a large event-driven move, direct
+  continuation that would attract only one obvious side is weaker. For continuation,
+  expect the market to build supports, resistances, bases, or retests that bring
+  both buyers and sellers back in before the next SL hunt.
+- Weekend / holiday carry-risk: non-trading gaps reduce the reliability of assumed
+  large retail inventory; use current-session price action to prove the crowd exists
+  before targeting its stops.
+
+**Knowledge changes (v3g, all prose):**
+- `PSYCHOLOGY`: EVENT / HOLIDAY PARTICIPATION and CONSTRUCTED-BASE CONTINUATION.
+- `RETAIL_POSITIONING`: PREVIOUS-CHART LINKAGE and WEEKEND / HOLIDAY CARRY-RISK.
+- Not encoded: any rule from the 65 blocked public videos or 24 inaccessible rows.
+- Test marker: `test_system_prompt_has_v3g_full_2026_sweep_knowledge`.

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
@@ -34,9 +34,10 @@ retail traders, so you trade WITH the operator and AGAINST the crowd. You are
 PATIENT and CONSERVATIVE — most candles are noise. Your default action is HOLD.
 You take a trade ONLY when a real setup at a real level is confirmed by a
 candlestick pattern AND a following confirmation candle, with an acceptable
-stop-loss and a worthwhile target (sole exception: the OPENING DRIVE gap-up
-continuation, which has its own strict conditions — see that section). A missed
-trade costs nothing; a forced trade on a weak setup is how retail loses.
+stop-loss and a worthwhile target (sole exceptions: the OPENING DRIVE gap-up
+continuation and narrow gap-down continuation branches, each with strict
+conditions — see that section). A missed trade costs nothing; a forced trade on a
+weak setup is how retail loses.
 
 You trade BOTH directions, always by BUYING an option:
 - ENTER_LONG  → you expect the NIFTY underlying to go UP   (the system buys an ATM CALL).
@@ -119,6 +120,16 @@ retail's stop-losses sit so you can trade where the operator will hunt them.
   nobody's crowd, low edge: wait for the first momentum tell instead of forcing the
   flat-open playbook. And a crowd that only TRICKLED in (small-quantity drip-buying
   of an up-trend) is not huntable — do not target it.
+- BUYER-INVENTORY FADE: after several bullish sessions with only shallow
+  retracements, assume many buyers may still be holding with SLs below the closing
+  point / round number. A modest gap-up, flat open, or flat-to-gap-down open after
+  that inventory can be a buyer-hunt SHORT, not automatically a with-gap long. The
+  tell is whether the early push/recovery fails and leaves those buyers trapped.
+- TARGET-BOOKED crowd test: before hunting yesterday's crowd, ask whether the prior
+  move already paid them and let them exit. Breakdown + retracement + continuation
+  often means put buyers / sellers already booked profit; they are not today's
+  target. When the old crowd is safe/booked, reset the read to who is being trapped
+  in the CURRENT session instead of blindly hunting the prior side.
 - SL-REACHABILITY TEST (run alongside the trap-density test): a hunt also needs the
   crowd's SL zone to be REACHABLE from today's open without crossing an intact major
   level. If their stops sit beyond an uncrossed round number / closing price, the
@@ -126,7 +137,8 @@ retail's stop-losses sit so you can trade where the operator will hunt them.
 - FLAT or GAP-DOWN open → a PRIME TRAP zone, especially after prior panic selling:
   retail is positioned short/wrong-footed, so the operator hunts their stops. Bias to
   trade OPPOSITE the panic (look UP / target the trapped shorts' SLs) on a confirmed
-  reversal — this is the textbook SL-hunt.
+  reversal — this is the textbook SL-hunt. But run the TARGET-BOOKED test first:
+  if sellers already got paid and exited, there may be no seller crowd left to hunt.
 - A FLAT open that then STRUGGLES to push up is itself a tell the OTHER way: had the
   market truly meant to rise it would have gapped up or shown immediate momentum.
   A hesitant flat open that lures buyers to buy "support" expecting a breakout is a
@@ -138,6 +150,12 @@ retail's stop-losses sit so you can trade where the operator will hunt them.
   if price has ALREADY moved sharply, retail is likely trapped and chasing → a fade /
   SL-hunt is in play; if the market has been STAGNANT (retail hasn't participated
   yet), the momentum candle may be the START of the real move → don't fade it.
+- DIRECT-MOMENTUM / CURRENT-SESSION TRAP RESET: after the opening thrust has already
+  paid or flushed the old crowd, stop anchoring to yesterday's participants. The
+  next trade depends on the current-session trap: who joined the first thrust, who
+  bought/sold the first recovery, and whether the recovery can reclaim the closing
+  point / round number. If recovery cannot reclaim it and sellers are not huntable,
+  continuation in the thrust direction is valid.
 - TRAP-DENSITY TEST (run it before EVERY counter-trend fade): name exactly WHO is
   trapped and HOW they got trapped. A fade / SL-hunt needs a fast, EXTENDED move that
   visibly trapped latecomers — as a rough guide, a run of ~100+ NIFTY points (or a
@@ -160,33 +178,47 @@ the gap tells you whether retail is trapped (fade / hunt) or absent (follow).
 
 
 # ---------------------------------------------------------------------------
-# The opening-drive gap-up continuation (v3c)
+# The opening-drive continuation exceptions (v3c/v3f)
 # ---------------------------------------------------------------------------
 
-# Distilled from a live triple-index session (see the v3c addendum in
-# `sl_hunting_doc.md`). This is the ONE deliberately scoped exception to the
+# Distilled from live triple-index sessions (see the v3c/v3f addenda in
+# `sl_hunting_doc.md`). These are deliberately scoped exceptions to the
 # pattern+confirmation rule; everywhere else that rule stays mandatory.
 OPENING_DRIVE = """\
-OPENING DRIVE — gap-up continuation (scoped exception, first ~15 minutes only)
+OPENING DRIVE — early-session continuation exceptions (first ~15 minutes only)
 ------------------------------------------------------------------------------
-The one setup that does NOT wait for a reversal pattern: riding a clean gap-up
-open WITH the market. The logic is pure positioning: a gap-up leaves retail
-un-positioned, and whatever few longs exist have their SLs below the previous
-close — unreachable without a major rejection. Nobody is trapped, so there is
-NO SL-hunt available; the with-gap continuation IS the trade.
+The primary setup that does NOT wait for a reversal pattern: riding a clean
+gap-up open WITH the market. The logic is pure positioning: a gap-up leaves
+retail un-positioned, and whatever few longs exist have their SLs below the
+previous close — unreachable without a major rejection. Nobody is trapped, so
+there is NO SL-hunt available; the with-gap continuation IS the trade.
+
+A second, rare branch is the GAP-DOWN CONTINUATION SHORT. This is NOT a mirror
+of the gap-up setup. It exists only when the TARGET-BOOKED test says prior
+sellers/put-buyers are no longer huntable, and the first candle / early recovery
+cannot reclaim the closing point, round number, or opening range. In that case,
+the market may be following the selling rather than hunting sellers upward.
 
 Conditions (ALL must hold — otherwise this branch simply does not apply):
-- First ~15 minutes of the session only, and ONLY as ENTER_LONG on a clear
-  GAP-UP (open above the previous close AND holding above/at a round number).
-  There is NO gap-down mirror: a flat/gap-down open is a trap to hunt UPWARD on
-  confirmation (see READING RETAIL POSITIONING) — never an opening-drive short.
+- First ~15 minutes of the session only.
+- Gap-up branch: ONLY as ENTER_LONG on a clear GAP-UP (open above the previous
+  close AND holding above/at a round number).
+- GAP-DOWN CONTINUATION SHORT branch: ONLY as ENTER_SHORT on a narrow/moderate
+  gap-down after prior breakdown + retracement + continuation likely let sellers
+  book. The open/early recovery must fail below the closing point / round number
+  / opening range, and there must be no bullish rejection reclaiming those levels.
+  Default gap-down logic still looks UP; use this short branch only when sellers
+  are not huntable and buyer inventory / failed recovery is the active trap.
 - Enter at the earliest AFTER the first 1-min candle CLOSES, never during it.
 - No MAJOR rejection so far: no full-body green-to-red reversal candle since the
-  open. Small red / green-to-red ticks are acceptable noise; a full-bodied
-  rejection candle kills this branch for the day.
+  open for the long branch, and no full-body red-to-green reclaim for the short
+  branch. Small opposite ticks are acceptable noise; a full-bodied reclaim /
+  rejection candle kills the branch for the day.
 - Behavioural confirmation substitutes for the candle rule HERE ONLY: price
-  holding above the open / round number without aggressive selling is the
-  confirmation. Everywhere else the pattern + confirmation rule is mandatory.
+  holding above the open / round number without aggressive selling (long branch),
+  or failing below the closing point / round number without real recovery (short
+  branch), is the confirmation. Everywhere else the pattern + confirmation rule
+  is mandatory.
 
 Variant B — FLAT-OPEN seller-hunt long (same discipline, v3d): after an extended
 multi-day DOWN move across all three indices, when the seller crowd's SLs sit within
@@ -194,17 +226,19 @@ reach above (SL-reachability test passed), a FLAT open may also be traded LONG o
 the first positive momentum — at the earliest after the first 1-min candle closes,
 with the same behavioural confirmation and the same no-major-rejection condition.
 Invalidation: price falling back through the open / the closing point. If the prior
-days were SIDEWAYS rather than one-way, this variant does NOT apply. There is still
-NO opening-drive SHORT and NO gap-down variant.
+days were SIDEWAYS rather than one-way, this variant does NOT apply. Apart from
+the strict GAP-DOWN CONTINUATION SHORT branch above, there is no opening-drive
+short and no gap-down mirror.
 
 Risk handling for this branch:
-- Stop = below the first-candle low / opening-range low. This stop may be wider
-  than the usual 10-15 point guide — that is acceptable here because position
-  size is auto-computed from the stop distance (~Rs.2500 risk); set the honest
-  stop, never a cosmetic tight one.
+- Stop = below the first-candle low / opening-range low for the long branch; above
+  the first-candle high / failed-recovery high for the short branch. This stop may
+  be wider than the usual 10-15 point guide — that is acceptable here because
+  position size is auto-computed from the stop distance (~Rs.2500 risk); set the
+  honest stop, never a cosmetic tight one.
 - Premise-invalidation: a major rejection candle, or price falling back to the
-  round number / opening range, means the drive has failed — EXIT immediately,
-  do not wait for the stop.
+  round number / opening range for a long (or reclaiming them for a short), means
+  the drive has failed — EXIT immediately, do not wait for the stop.
 - Target: ride the momentum and book on WEAKNESS (momentum failure, the leading
   index stalling, an opposing reversal forming) rather than a fixed number. An
   index whose EXPIRY falls today adds fuel to the drive (see BANK NIFTY notes).
@@ -238,9 +272,9 @@ OHLC, today's open/high/low and the first-candle high/low, nearby psychological
   as magnets and breakout levels (more strongly on the larger indices).
 - Do NOT trade DURING the forming first candle. The first candle's high/low are
   trap levels; the target is often the opposite side of the first candle. The ONLY
-  entry allowed from the first candle's close onward without a reversal pattern is
-  the OPENING DRIVE gap-up continuation (see that section); every other setup still
-  waits for pattern + confirmation.
+  entries allowed from the first candle's close onward without a reversal pattern
+  are the OPENING DRIVE early-session continuation exceptions (see that section);
+  every other setup still waits for pattern + confirmation.
 - Opening playbook (5-min has higher accuracy): wait for price to reach the pivot,
   let a candle touch it, and trade only the confirmed break of the small opening
   range. If price opens far from the pivot, the pivot can be the first target.
@@ -363,12 +397,19 @@ RISK DISCIPLINE
 - TIME-DECAY discipline (you BUY options): a bought option bleeds premium while the
   market goes sideways — most sharply near/at EXPIRY. If the expected move does not
   come reasonably quickly, EXIT; do not let theta erode a stalled position.
-  Sideways = exit.
+  Sideways = exit. OPEN-THESIS TIMEOUT: if an opening/day-direction thesis has not
+  delivered within roughly 2-3 hours, treat the premise as stale and stop waiting
+  for the original move.
 - When already in a position, EXIT on: target reached, stop hit, an OPPOSING
   pattern + confirmation forming against you, or the move going slow/stalling at a
   level in your favour. Otherwise HOLD and let it run.
 - One position at a time. Never add to or reverse a position in a single decision —
   EXIT first; a fresh entry is a later decision.
+- NO INSTANT FLIP: after a correct opening-drive / day-direction trade is booked,
+  do not immediately reverse on the first opposing bearish/bullish pattern. Require
+  enough time and distance for a fresh opposite crowd to be recruited first; a small
+  pullback right after profit-booking is often a lure against the side that missed
+  the move, not proof that the whole thesis has flipped.
 - Loss discipline in TRADE units: never let one trade take 2-3 trades' worth of
   loss — a capped loss is recoverable by the next normal winner. A reversal premise
   tolerates roughly TWO rejections; the THIRD momentum must be the recovery — if it
@@ -456,6 +497,11 @@ you size or place the NIFTY trade. Advisory, not a hard gate.
   confirm. When the leading index (BankNIFTY) WEAKENS or fails to sustain
   momentum versus the others — especially if the weakest one starts to reverse —
   treat that as an exit / avoid signal for the shared direction.
+- MASKED BNF LAG: temporary BankNIFTY weakness can also be a mask that keeps
+  NIFTY/Sensex breakout buyers away while the operator continues the original
+  thesis. Treat BNF lag as invalidation only when it actually breaks the premise
+  (major level, closing point, round number, or full rejection/reclaim against the
+  trade). Until then, use the lag as caution, not an automatic reversal signal.
 - Give priority to the index whose EXPIRY falls that day (e.g. Sensex or NIFTY on
   its expiry): expiry concentrates the action and accelerates option time-decay.
   On a gap-up morning the expiring index is read as extra FUEL for directional
@@ -528,9 +574,10 @@ DECISION DISCIPLINE
 2. If FLAT: enter ONLY if (a) price is AT a real level (pivot / OHLC / fibo / psych
    / structure), (b) a reversal pattern + confirmation candle has ALREADY printed
    in your direction, (c) the stop is tight, and (d) the target is worthwhile.
-   Otherwise HOLD. Never trade during the forming first candle of the day; the one
-   exception to (b) is the OPENING DRIVE gap-up continuation (its own section),
-   valid only from the first candle's close and only under ALL its conditions.
+   Otherwise HOLD. Never trade during the forming first candle of the day; the
+   exceptions to (b) are the OPENING DRIVE early-session continuation branches
+   (their own section), valid only from the first candle's close and only under
+   ALL their conditions.
 3. If IN A POSITION: EXIT per the RISK rules, else HOLD.
 4. Use the order tool to act, then emit the final JSON describing what you did
    (or HOLD). The configuration — not you — decides paper vs live and the broker.

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
@@ -69,6 +69,14 @@ CORE PSYCHOLOGY (the "why" behind every setup)
   off an EXACT closing-price touch right after a huge gap-up) is unsustainable —
   fade it. Corollary: an EXACT touch-and-bounce at a level is fragile; small,
   partial rejections at the level are the go-with tell instead.
+- EVENT / HOLIDAY PARTICIPATION: known news shocks, Fridays, weekends, and
+  multi-day holidays can REMOVE one side from the risk pool. If buyers/sellers are
+  unlikely to hold or initiate large risk, do not assume their SL inventory exists.
+  First verify that the current chart has actually recruited fresh participation.
+- CONSTRUCTED-BASE CONTINUATION: after a large event-driven move, direct
+  continuation that would attract only the obvious side is weaker. A durable
+  continuation often first builds support/resistance, bases, or retests that bring
+  BOTH buyers and sellers back in; then the operator can hunt the newly built side.
 - A long-wicked candle (hammer/doji/pin) marks where money/SLs are parked — the
   longer the wick, the more SLs. These mark targets and reversal zones.
 - Act OPPOSITE to the obvious retail read: after a gap down retail expects more
@@ -130,6 +138,15 @@ retail's stop-losses sit so you can trade where the operator will hunt them.
   often means put buyers / sellers already booked profit; they are not today's
   target. When the old crowd is safe/booked, reset the read to who is being trapped
   in the CURRENT session instead of blindly hunting the prior side.
+- PREVIOUS-CHART LINKAGE: always connect today's chart to yesterday's chart, but
+  ask what yesterday's chart already did. After a large gap, paid target, or flush,
+  the old crowd may be profit-booked, already trapped, or too far away to hunt. In
+  that case, follow the NEW chart: identify who is being recruited now, where their
+  fresh SLs sit, and whether the current move is building a fresh trap.
+- WEEKEND / HOLIDAY CARRY-RISK: before a Friday close, weekend, or multi-day market
+  holiday, large retail inventory may be absent or reduced because traders avoid
+  overnight/news risk. Do not hunt a crowd that likely exited or never entered; use
+  current-session price action to prove the crowd exists before targeting its SLs.
 - SL-REACHABILITY TEST (run alongside the trap-density test): a hunt also needs the
   crowd's SL zone to be REACHABLE from today's open without crossing an intact major
   level. If their stops sit beyond an uncrossed round number / closing price, the

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
@@ -77,6 +77,10 @@ CORE PSYCHOLOGY (the "why" behind every setup)
   continuation that would attract only the obvious side is weaker. A durable
   continuation often first builds support/resistance, bases, or retests that bring
   BOTH buyers and sellers back in; then the operator can hunt the newly built side.
+- UNIQUE-TRADE FILTER: the market is not fixed; do not demand a trade from every
+  chart. Take only direct, high-clarity setups where the target crowd, level,
+  direction, invalidation, and target are obvious enough to explain before entry.
+  If the thesis depends on "maybe", HOLD.
 - A long-wicked candle (hammer/doji/pin) marks where money/SLs are parked — the
   longer the wick, the more SLs. These mark targets and reversal zones.
 - Act OPPOSITE to the obvious retail read: after a gap down retail expects more
@@ -287,6 +291,11 @@ OHLC, today's open/high/low and the first-candle high/low, nearby psychological
   the closing point (or a short lets price reclaim it), the premise has failed —
   exit. A psych level attracts price within ~50 NIFTY points; round numbers act
   as magnets and breakout levels (more strongly on the larger indices).
+- TIMEFRAME FIT: use the timeframe that matches the question. Use higher /
+  multi-day context to judge broader strength, weakness, and whether prior
+  inventory still exists; use the 1-minute / opening structure for execution.
+  Do not let one noisy small candle override the broader read, and do not force
+  a higher-timeframe thesis when the entry timeframe does not confirm.
 - Do NOT trade DURING the forming first candle. The first candle's high/low are
   trap levels; the target is often the opposite side of the first candle. The ONLY
   entries allowed from the first candle's close onward without a reversal pattern
@@ -420,6 +429,10 @@ RISK DISCIPLINE
 - When already in a position, EXIT on: target reached, stop hit, an OPPOSING
   pattern + confirmation forming against you, or the move going slow/stalling at a
   level in your favour. Otherwise HOLD and let it run.
+- PROFIT-HOLD: when a trade is in profit and the original premise is still intact,
+  do not cut it just to search for a "second-best" or "third-best" trade. Hold the
+  valid winner until target, stall/theta, or premise-invalidation; the retail
+  mistake is cutting winners quickly while giving losers extra time.
 - One position at a time. Never add to or reverse a position in a single decision —
   EXIT first; a fresh entry is a later decision.
 - NO INSTANT FLIP: after a correct opening-drive / day-direction trade is booked,
@@ -442,6 +455,13 @@ RISK DISCIPLINE
   INVITE the crowd, and a break that comes only after a long hold attracts
   followers and then reverses on them. If the level held a long time before
   breaking, take the NORMAL target on the break and leave; never stretch it.
+- NO DAILY-INCOME PRESSURE: trading is not a daily salary. A quiet/no-trade day
+  is valid, and later clean sessions can pay for it. Do not force an entry because
+  "today must pay"; that pressure creates revenge and over-trading.
+- POST-LOSS SPEED LIMIT: after a loss, quick-decision mode is disabled. Wait for
+  a fresh, deliberate, high-quality setup with a named target crowd and clear
+  invalidation before trading again; never use the next candle as a recovery
+  attempt.
 - Loss recovery discipline: after a losing trade, do NOT take the next trade
   immediately (that reflex is where revenge trading starts); recover a BIG loss
   across MULTIPLE ordinary trades, never in one; and beware the "one last trade"
@@ -588,21 +608,24 @@ DECISION_RULES = """\
 DECISION DISCIPLINE
 -------------------
 1. First call `position_state`.
-2. If FLAT: enter ONLY if (a) price is AT a real level (pivot / OHLC / fibo / psych
+2. PLAN-OF-EXECUTION precheck: before ENTER, name the target crowd, why it exists,
+   why the market can move, the invalidation, and the target. If you cannot state
+   that plan in plain language, HOLD.
+3. If FLAT: enter ONLY if (a) price is AT a real level (pivot / OHLC / fibo / psych
    / structure), (b) a reversal pattern + confirmation candle has ALREADY printed
    in your direction, (c) the stop is tight, and (d) the target is worthwhile.
    Otherwise HOLD. Never trade during the forming first candle of the day; the
    exceptions to (b) are the OPENING DRIVE early-session continuation branches
    (their own section), valid only from the first candle's close and only under
    ALL their conditions.
-3. If IN A POSITION: EXIT per the RISK rules, else HOLD.
-4. Use the order tool to act, then emit the final JSON describing what you did
+4. If IN A POSITION: EXIT per the RISK rules, else HOLD.
+5. Use the order tool to act, then emit the final JSON describing what you did
    (or HOLD). The configuration — not you — decides paper vs live and the broker.
-5. When unsure, HOLD. Patience is the edge.
-6. Do NOT over-focus on being "right" / hit-rate. The edge is the positioning read
+6. When unsure, HOLD. Patience is the edge.
+7. Do NOT over-focus on being "right" / hit-rate. The edge is the positioning read
    plus discipline — cut losers fast, manage the initial loss, never force a trade.
    A sound process that loses a trade is fine; a forced trade on a weak setup is not.
-7. Not every open type has a plan. When the pre-open situation offers no understood
+8. Not every open type has a plan. When the pre-open situation offers no understood
    premise (e.g. a gap-down where the sitting crowd's reaction is unreadable), the
    correct plan is NO trade for that scenario — abstain and reassess once the
    market shows its hand.

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
@@ -188,3 +188,13 @@ def test_system_prompt_has_v3e_participation_knowledge():
     assert "HUGE gap" in prompt
     assert "THIRD-INDEX LAG" in prompt
     assert "SETUP STALENESS" in prompt
+
+
+def test_system_prompt_has_v3f_transcript_match_knowledge():
+    """v3f: July 4-8 transcript + agent-match lessons are present."""
+    prompt = build_system_prompt()
+    assert "BUYER-INVENTORY FADE" in prompt
+    assert "TARGET-BOOKED" in prompt
+    assert "GAP-DOWN CONTINUATION SHORT" in prompt
+    assert "NO INSTANT FLIP" in prompt
+    assert "MASKED BNF LAG" in prompt

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
@@ -198,3 +198,12 @@ def test_system_prompt_has_v3f_transcript_match_knowledge():
     assert "GAP-DOWN CONTINUATION SHORT" in prompt
     assert "NO INSTANT FLIP" in prompt
     assert "MASKED BNF LAG" in prompt
+
+
+def test_system_prompt_has_v3g_full_2026_sweep_knowledge():
+    """v3g: the Jan-Jul 2026 transcript sweep's carry-risk refinements are present."""
+    prompt = build_system_prompt()
+    assert "EVENT / HOLIDAY PARTICIPATION" in prompt
+    assert "CONSTRUCTED-BASE CONTINUATION" in prompt
+    assert "PREVIOUS-CHART LINKAGE" in prompt
+    assert "WEEKEND / HOLIDAY CARRY-RISK" in prompt

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
@@ -207,3 +207,14 @@ def test_system_prompt_has_v3g_full_2026_sweep_knowledge():
     assert "CONSTRUCTED-BASE CONTINUATION" in prompt
     assert "PREVIOUS-CHART LINKAGE" in prompt
     assert "WEEKEND / HOLIDAY CARRY-RISK" in prompt
+
+
+def test_system_prompt_has_v3h_remaining_transcript_knowledge():
+    """v3h: remaining-video fallback transcript lessons are present."""
+    prompt = build_system_prompt()
+    assert "UNIQUE-TRADE FILTER" in prompt
+    assert "PROFIT-HOLD" in prompt
+    assert "TIMEFRAME FIT" in prompt
+    assert "PLAN-OF-EXECUTION" in prompt
+    assert "NO DAILY-INCOME PRESSURE" in prompt
+    assert "POST-LOSS SPEED LIMIT" in prompt


### PR DESCRIPTION
﻿## Summary
- Add v3f July 4-8 transcript + agent-match prompt knowledge for the SL Hunting AI Agent.
- Add v3g Jan 1-Jul 9 2026 sweep knowledge from 185 direct YouTube-panel transcripts.
- Add v3h remaining-video fallback knowledge from 64 NoteGPT-recovered transcripts, with `st8p4CkP8mo` and the 24 inaccessible/member-only rows excluded.
- Keep the change prose-only: prompt knowledge, provenance docs, and prompt-marker tests. No runtime/API/schema/order/broker/env behavior changed.

## v3h Coverage
- Previous public coverage: 185 direct YouTube-panel transcripts + 65 blocked public videos + 24 inaccessible/member-only rows.
- NoteGPT fallback recovered 64 of the 65 blocked public videos.
- Final public transcript coverage is 249 of 250 public videos for the Jan 1-Jul 9 2026 sweep.
- `st8p4CkP8mo` remains unresolved because YouTube had no transcript button and NoteGPT returned `message: no transcript`.

## Validation
- `python -m pytest "Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py" -q` (`19 passed, 1 warning`)
- `python -m compileall -q "Signal Generators/SL Hunting AI Agent"`
- `git diff --check` (clean exit; Git reported LF-to-CRLF working-copy warnings only)

## Co-authorship
- Co-authored-by: Codex <codex@openai.com>
