### PR TITLE
SL Hunting v3j: averaging trap + move-exhaustion (13-14 Jul sessions, journal-matched)

### DIFF
--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -733,3 +733,84 @@ Session summary and match:
 - `RETAIL_POSITIONING`: R:R-BAIT AT ROUND-NUMBER REJECTIONS.
 - `RISK`: PREMIUM NON-CONFIRMATION.
 - Test marker: `test_system_prompt_has_v3i_premium_rr_knowledge`.
+
+## Video addendum - 13-14 Jul gap-down sessions + averaging trap (v3j)
+
+> Sources (full Hindi auto-transcripts from YouTube's transcript panel):
+> - `qjz6uAM81Jg` (12 Jul 2026, "Prediction For 13 JULY 2026", 1:42)
+> - `OvqxvtVbZFU` (13 Jul 2026, "Live Bank Nifty Option Trading", 9:20)
+> - `xssPyxt65Mc` (13 Jul 2026, "Prediction For 14 JULY 2026", 1:53)
+> - `DuaQYSrYK2U` (14 Jul 2026, "Live Bank Nifty Option Trading", 11:43 — NIFTY expiry)
+>
+> Unlike previous addenda, this one is cross-checked against the agent's OWN journal
+> (`Backtest Outputs/sl_hunting_journal.jsonl`, rows 17-19, all 2026-07-14). That
+> match is what makes the net-new below evidence-backed rather than speculative.
+
+Session summary:
+- **13 Jul** — big gap-down. IH refused to sell it: a direct fall is unlikely because
+  everyone seeing the gap-down will sell, so the market must first take THEIR stops.
+  He bought CALLs, rode the recovery, booked. Textbook EXISTING knowledge (gap-down
+  seller-hunt long).
+- **14 Jul (expiry)** — gap-down AGAIN, but yesterday's recovery had recruited BUYERS.
+  IH bought PUTs, and crucially **waited for the market to push up first** before
+  entering ("if we sell directly here the market will trap us"). One trade, booked,
+  stopped for the day.
+
+**Agent vs IH on 14 Jul** (IH: 1 trade; agent: 3 trades, net +Rs.3,793):
+
+| # | Agent trade | Time | Result |
+|---|---|---|---|
+| 1 | LONG `gap_down_trap_flush_reversal` | 09:20-09:24 | +Rs.1,488 |
+| 2 | SHORT `pivot_double_top_evening_star` | 09:40-09:55 | +Rs.3,176 (1.97R) |
+| 3 | SHORT `shooting_star_doubletop_fibo50_reversal` | 10:04-10:04 | **-Rs.871 (AI_STOP in 5s)** |
+
+- **Trade 2 IS IH's trade — full match.** The agent's own reasoning ("a confirmed
+  evening-star ... trapped buyers who chased that reclaim") names the same crowd and
+  direction as IH, and it booked the average target on stall. Strong confirmation;
+  nothing changed for this case.
+- **Trade 1 diverged from IH's read.** The agent called the gap-down "a trap for
+  starved sellers" and went LONG; IH read the same open as a trap for the BUYERS that
+  yesterday's recovery recruited, and was short from the pre-open. `BUYER-INVENTORY
+  FADE` was already in the prompt but never fired because nothing triggered on the
+  TWO-DAY sequence (gap-down -> strong recovery -> next-day gap-down). The agent
+  profited on the opposite premise, then had to flip into trade 2.
+- **Trade 3 is the exact mistake IH's outro warns against, and it is the only loser.**
+  Nine minutes after booking the move, the agent re-shorted the SAME exhausted move on
+  a smaller/later pattern into a stalling expiry tape and was stopped out in 5 seconds.
+  `NO INSTANT FLIP` did not catch it (same direction, not a flip). It also overrode an
+  opposing `cross_index` verdict by calling it "a stale mechanical ... label anchored to
+  yesterday's resistance levels" — but that escape hatch was written for the OPENING
+  HOUR, and this was 10:04 at confidence 6 (not "textbook").
+
+**Net-new method distilled:**
+- Averaging trap: the counter-bounce after a gap traps a crowd is BAIT to make them
+  AVERAGE DOWN; the real move comes only AFTER they add ("if it fell directly they'd
+  run away quickly — by making them average first, the market extracts far more").
+  Carries the two-day trigger the agent lacked, and the entry-timing rule: never enter
+  at the gap extreme, wait for the bounce — the bounce is not a threat to the fade, it
+  IS the setup. Corroborated by his 13 Jul self-critique ("the trade isn't wrong, the
+  entry was early").
+- Move-exhaustion: once the thesis's move is booked and momentum has stalled, the
+  thesis is SPENT — do not re-enter the same direction chasing its tail. On expiry days
+  the market then builds a wide RANGE and chops both sides; take what you got and stop
+  ("we won't make 10 days' profit in one day"). Expiry is context, never a premise on
+  its own — a deliberate counterweight to the existing "expiry = extra FUEL" note.
+- Cross-index "stale verdict" escape hatch scoped to the opening hour: outside it, an
+  opposing `cross_index` verdict is a veto, not a footnote.
+
+**Confirmed but deliberately NOT re-encoded (already present, executed correctly):**
+the gap-down seller-hunt long, the closing-price gate on targeting a crowd, the
+trap-density read, "don't capture both directions in one day" (NO INSTANT FLIP),
+loss-limit discipline, and `DECISION_RULES` #8 (a gap-down that falls directly is
+unreadable -> no trade). Dropped on purpose: "the counter-gap recovery must arrive
+FAST" (it would collide with the existing with-trend "SLOW-but-CONTINUOUS is the
+sustainable kind" rule, and the journal shows no need — trade 1's recovery was fast
+and booked in 4 minutes); the small-capital/psychology advice (agent sizing is
+automatic at ~Rs.2500 risk); and the prediction clips' level tables (ephemeral day
+calls, per the v3b finding).
+
+**Knowledge changes (v3j, all prose):**
+- `RETAIL_POSITIONING`: AVERAGING TRAP (mechanism + two-day trigger + entry timing).
+- `RISK`: MOVE-EXHAUSTION — ONE MOVE PER THESIS (incl. EXPIRY-DAY RANGE).
+- `BNF_CROSS_CONFIRMATION`: SCOPE OF THIS "STALE" ESCAPE HATCH + opposing-verdict veto.
+- Test marker: `test_system_prompt_has_v3j_averaging_trap_knowledge`.

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
@@ -137,6 +137,23 @@ retail's stop-losses sit so you can trade where the operator will hunt them.
   point / round number. A modest gap-up, flat open, or flat-to-gap-down open after
   that inventory can be a buyer-hunt SHORT, not automatically a with-gap long. The
   tell is whether the early push/recovery fails and leaves those buyers trapped.
+- AVERAGING TRAP (why the bounce exists, and when to enter): when a crowd is trapped
+  in a BIG loss by a gap AGAINST it, the market's counter-bounce is not a threat to
+  your fade — it is BAIT to make that crowd AVERAGE DOWN (add size to the loser). The
+  real move comes only AFTER they have added: a direct move would let them flee
+  cheaply, whereas making them average first loads far more fuel for the hunt.
+  * The two-day trigger to watch for: a gap-down, then a STRONG recovery / continuous
+    positive momentum (which quietly recruits BUYERS), then ANOTHER gap-down the next
+    day. Those recovery-buyers — not the sellers — are the trapped crowd; the standard
+    "gap-down → look UP" read is the WRONG side on such a day.
+  * ENTRY TIMING (the actionable half): do NOT enter at the gap extreme. Selling the
+    open on a big gap-down (or buying the open on a big gap-up) is where the market
+    traps YOU. Wait for the counter-bounce — the bounce is not a threat to the setup,
+    it IS the setup — then enter with pattern + confirmation once it stalls. Direction
+    can be right while the OPEN is the wrong price.
+  * Invalidation: if that bounce keeps going and RECLAIMS the closing point / round
+    number, the crowd was not actually trapped — the premise is dead, exit per your
+    limit. This is an entry-timing rule, never a licence to sit in a loser.
 - TARGET-BOOKED crowd test: before hunting yesterday's crowd, ask whether the prior
   move already paid them and let them exit. Breakdown + retracement + continuation
   often means put buyers / sellers already booked profit; they are not today's
@@ -458,6 +475,22 @@ RISK DISCIPLINE
   enough time and distance for a fresh opposite crowd to be recruited first; a small
   pullback right after profit-booking is often a lure against the side that missed
   the move, not proof that the whole thesis has flipped.
+- MOVE-EXHAUSTION — ONE MOVE PER THESIS (the same-direction twin of NO INSTANT FLIP):
+  once a thesis's move has been captured and BOOKED and momentum has visibly stalled,
+  that thesis is SPENT. Do NOT re-enter the SAME direction on a later, smaller pattern
+  chasing the tail of the move you just took — the trapped crowd you named has already
+  been flushed, so the premise no longer exists and what remains is chop. If you booked
+  because "momentum has stalled", you may not re-enter into that same stall minutes
+  later. A fresh trade needs a NEW named crowd trapped by NEW price action, not a
+  leftover pattern from the move you already harvested.
+  * EXPIRY-DAY RANGE: on an expiry day this is sharpest — after the first real move the
+    market frequently settles into a WIDE range (an upper and a lower point) and
+    oscillates inside it, chopping both sides and paying no directional trade. Take the
+    momentum you got and stop; do not try to make many days' profit in one day.
+  * EXPIRY IS CONTEXT, NOT A PREMISE: never enter merely because it is expiry. You must
+    have an independent reason the market can move — expiry only adds fuel to a premise
+    you already hold. (This TEMPERS the "expiry = extra FUEL" note in BANK NIFTY —
+    SPECIFIC BEHAVIOUR: fuel for an existing thesis, never a thesis of its own.)
 - Loss discipline in TRADE units: never let one trade take 2-3 trades' worth of
   loss — a capped loss is recoverable by the next normal winner. A reversal premise
   tolerates roughly TWO rejections; the THIRD momentum must be the recovery — if it
@@ -520,8 +553,16 @@ Two cautions from live review:
   clear gap-and-go morning, an alignment built from yesterday's levels (e.g. "both
   at support → bias down" while both indices are rallying AWAY from those levels)
   is stale — weight READING RETAIL POSITIONING first in the opening hour.
+  SCOPE OF THIS "STALE" ESCAPE HATCH (it is narrow, and it is abused easily): it
+  applies ONLY in the OPENING HOUR, before the day's first real move has played out,
+  when the verdict is demonstrably anchored to levels price has already left behind.
+  Once the session has made its first move, the verdict is NO LONGER "stale" — it is
+  reading live structure, and dismissing it as stale is rationalisation.
 - A verdict that directly OPPOSES your intended direction is a real vote against
-  the trade, not a footnote: HOLD unless the setup is genuinely textbook.
+  the trade, not a footnote: HOLD unless the setup is genuinely textbook. Later in
+  the session (outside the opening hour) treat an opposing verdict as a VETO: if you
+  find yourself explaining away the cross-index read to justify a mid-confidence
+  setup, that is the trade to skip.
 - Level/divergence setups (e.g. one index HOLDS the closing price while the others
   reclaim it) are ENTRY-TIMING tools SUBORDINATE to the day-direction read: when the
   direction read is wrong, the textbook divergence fails anyway. Direction first,

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
@@ -227,3 +227,26 @@ def test_system_prompt_has_v3i_premium_rr_knowledge():
     assert "R:R-BAIT AT ROUND-NUMBER REJECTIONS" in prompt
     # The actionable exit rule: book the average target when premiums lag the spot move.
     assert "AVERAGE target" in prompt
+
+
+def test_system_prompt_has_v3j_averaging_trap_knowledge():
+    """v3j: 13-14 Jul gap-down sessions, cross-checked against the agent's own journal.
+
+    Three lessons, each tied to a real 14 Jul decision:
+    - AVERAGING TRAP fixes the trade-1 premise (the agent read "starved sellers" and
+      went long where IH read yesterday's recovery-buyers as the trapped crowd).
+    - MOVE-EXHAUSTION fixes trade 3 (re-shorting the same spent move into an expiry
+      range, stopped out in 5 seconds) — the same-direction blind spot NO INSTANT FLIP
+      does not cover.
+    - The cross-index "stale verdict" escape hatch is scoped to the opening hour, since
+      trade 3 used it at 10:04 to override an opposing verdict at confidence 6.
+    """
+    prompt = build_system_prompt()
+    assert "AVERAGING TRAP" in prompt
+    assert "MOVE-EXHAUSTION" in prompt
+    # The entry-timing half of the averaging trap: never enter at the gap extreme.
+    assert "do NOT enter at the gap extreme" in prompt
+    # Expiry is fuel for an existing premise, never a premise of its own.
+    assert "EXPIRY IS CONTEXT, NOT A PREMISE" in prompt
+    # The "stale" escape hatch must be explicitly bounded to the opening hour.
+    assert "SCOPE OF THIS \"STALE\" ESCAPE HATCH" in prompt


### PR DESCRIPTION
Distils Intraday Hunter's **13 Jul and 14 Jul 2026** sessions into the SL Hunting agent's knowledge. Unlike previous addenda, this one is cross-checked against **the agent's own journal** (`Backtest Outputs/sl_hunting_journal.jsonl`, rows 17–19, all `2026-07-14`) — so every lesson below is tied to a real decision the agent made, not to a plausible-sounding rule.

## What the two sessions were

- **13 Jul** — big gap-down. IH refused to sell it (a direct fall is unlikely, because everyone seeing the gap-down will sell, so the market must first take *their* stops). Bought calls, rode the recovery, booked. Textbook *existing* knowledge.
- **14 Jul (NIFTY expiry)** — gap-down *again*, but yesterday's recovery had recruited **buyers**. IH bought puts, and crucially **waited for the market to push up first** before entering. One trade, booked, done for the day.

## Agent vs IH on 14 Jul

IH took **one** trade. The agent took **three** (net +₹3,793):

| # | Agent trade | Time | Result |
|---|---|---|---|
| 1 | LONG `gap_down_trap_flush_reversal` | 09:20→09:24 | +₹1,488 |
| 2 | SHORT `pivot_double_top_evening_star` | 09:40→09:55 | +₹3,176 (1.97R) |
| 3 | SHORT `shooting_star_doubletop_fibo50_reversal` | 10:04→10:04 | **−₹871 (AI_STOP in 5s)** |

- **Trade 2 *is* IH's trade — full match.** The agent's own reasoning (*"a confirmed evening-star … trapped buyers who chased that reclaim"*) names the same crowd and direction, and it booked the average target on stall. Strong confirmation; **nothing changed for this case.**
- **Trade 1 diverged.** The agent read the gap-down as *"a trap for starved sellers"* and went **long**; IH read the same open as a trap for the **buyers** yesterday's recovery had recruited, and was short from the pre-open. `BUYER-INVENTORY FADE` was already in the prompt but never fired — nothing triggered on the **two-day sequence** (gap-down → strong recovery → next-day gap-down).
- **Trade 3 is the only loser, and the exact mistake IH's outro warns against.** Nine minutes after booking the move, the agent re-shorted the **same exhausted move** into a stalling expiry tape and was stopped out in five seconds. `NO INSTANT FLIP` did not catch it (same direction, not a flip). It also overrode an opposing `cross_index` verdict by calling it *"a stale mechanical … label anchored to yesterday's resistance levels"* — but that escape hatch was written for the **opening hour**, and this was 10:04 at confidence 6 (not "textbook").

## Knowledge changes (all prose)

- **`RETAIL_POSITIONING` — AVERAGING TRAP.** The counter-bounce after a gap traps a crowd is **bait to make them average down**; the real move comes only *after* they add ("if it fell directly they'd run away quickly — by making them average first, the market extracts far more"). Carries the two-day trigger the agent lacked, plus the entry-timing rule: **never enter at the gap extreme** — the bounce is not a threat to the fade, it *is* the setup. Invalidation: if the bounce reclaims the closing point / round number, the crowd was not trapped → premise dead, exit per limit.
- **`RISK` — MOVE-EXHAUSTION (one move per thesis).** Once a thesis's move is booked and momentum has stalled, the thesis is **spent** — no same-direction re-entry chasing its tail. Includes **EXPIRY-DAY RANGE** (after the first move, expiry tapes chop inside a wide range and pay nothing) and **EXPIRY IS CONTEXT, NOT A PREMISE**, a deliberate counterweight to the existing "expiry = extra FUEL" note.
- **`BNF_CROSS_CONFIRMATION`** — the "stale verdict" escape hatch is **scoped to the opening hour**; outside it, an opposing `cross_index` verdict is a **veto**, not a footnote.

**Deliberately dropped:** *"the counter-gap recovery must arrive FAST."* It would collide head-on with the existing with-trend rule (*"SLOW-but-CONTINUOUS … is the sustainable kind"*), and the journal shows no need — trade 1's recovery was fast and booked in 4 minutes.

No schema, executor, or order-path changes — `exit_leg`, the BankNIFTY mirror, and the order tool are untouched.

## Verification

- `python -m unittest test_nifty_multi_strategy_master` → **216 tests, OK**
- `python -m pytest "Signal Generators/SL Hunting AI Agent/tests" -q` → **82 passed** (new v3j marker plus every prior v2/v3/v3a/v3d–v3i marker, so a section rename can't silently break an older one)
- `python -m ruff check .` → clean · `python -m mypy` → clean (29 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
