### PR TITLE
SL Hunting v3k (15 Jul flat-open gate) + Profit Shooter 5-min resample

### DIFF
--- a/Dependencies/env.example
+++ b/Dependencies/env.example
@@ -225,6 +225,9 @@ PROFIT_SHOOTER_LAST_SETUP_MINUTE=14
 # Profit Shooter strategy - signal/indicator tuning
 # ==============================================================================
 # (Master file only) Pin-bar detection and breakout/trail rules.
+# Profit Shooter is a 5-minute method: the shared 1-min OHLC is locally
+# resampled into candles of this size before indicator evaluation.
+PROFIT_SHOOTER_DERIVED_TIMEFRAME_MINUTES=5
 PROFIT_SHOOTER_SMA_FAST_PERIOD=20
 PROFIT_SHOOTER_SMA_SLOW_PERIOD=200
 PROFIT_SHOOTER_ATR_PERIOD=14

--- a/Nifty Multi Strategy Front Test - Master File.py
+++ b/Nifty Multi Strategy Front Test - Master File.py
@@ -15,7 +15,7 @@ the union of two earlier files plus one Greeks-driven addition:
            * Renko          (1-min source)
            * EMA Trend      (1-min source, locally resampled to 5-min)
            * Heikin Ashi    (1-min source)
-           * Profit Shooter (1-min source)
+           * Profit Shooter (1-min source, locally resampled to 5-min)
 
   2. "Nifty Supertrend Front Test - DhanHQ Hedged Puts.py"
        - 2 strategies that trade two-leg HEDGED option spreads of the
@@ -538,6 +538,11 @@ CPR_ALGO3_ITM_OFFSET = _env_float("CPR_ALGO3_ITM_OFFSET", 100.0)
 # Sizing/risk + trading window. Indicator/pin-bar tuning lives further down
 # inside `PROFIT_SHOOTER_STRATEGY_CONFIG` (also env-driven).
 PROFIT_SHOOTER_POLL_SECONDS = _env_int("PROFIT_SHOOTER_POLL_SECONDS", 2)
+
+# Strategy timeframe: Profit Shooter's pin-bar method is designed for 5-minute
+# candles, so the shared 1-minute OHLC is locally resampled into N-minute
+# candles before indicator evaluation (same pattern as EMA / Goldmine).
+PROFIT_SHOOTER_DERIVED_TIMEFRAME_MINUTES = _env_int("PROFIT_SHOOTER_DERIVED_TIMEFRAME_MINUTES", 5)
 
 PROFIT_SHOOTER_TRADING_START_HOUR = _env_int("PROFIT_SHOOTER_TRADING_START_HOUR", 9)
 PROFIT_SHOOTER_TRADING_START_MINUTE = _env_int("PROFIT_SHOOTER_TRADING_START_MINUTE", 25)
@@ -4187,7 +4192,9 @@ class HeikinAshiStrategyWorker(AtmSingleLegStrategyWorker):
 # =============================================================================
 class ProfitShooterStrategyWorker(AtmSingleLegStrategyWorker):
     """
-    Profit Shooter pin-bar strategy.
+    Profit Shooter pin-bar strategy. Reads 1-minute data from the shared
+    store, locally resamples it into complete 5-minute candles (the method's
+    native timeframe), then runs the SMA/ATR/pin-bar pipeline.
 
     What is unusual here:
     - The strategy is multi-stage. Once 1.5R is hit, the trade switches to
@@ -4200,6 +4207,7 @@ class ProfitShooterStrategyWorker(AtmSingleLegStrategyWorker):
     strategy_name = "ProfitShooter"
     timeframe = "1"
     poll_seconds = PROFIT_SHOOTER_POLL_SECONDS
+    derived_timeframe_minutes = PROFIT_SHOOTER_DERIVED_TIMEFRAME_MINUTES
     lots = PROFIT_SHOOTER_LOTS
     max_loss = PROFIT_SHOOTER_MAX_LOSS
     trading_start_hour = PROFIT_SHOOTER_TRADING_START_HOUR
@@ -4274,7 +4282,12 @@ class ProfitShooterStrategyWorker(AtmSingleLegStrategyWorker):
         return int(lots)
 
     def build_strategy_frame(self, ohlc: pd.DataFrame) -> pd.DataFrame:
-        return PROFIT_SHOOTER_LOGIC.build_profit_shooter_with_indicators(ohlc, PROFIT_SHOOTER_STRATEGY_CONFIG)
+        """
+        Resample shared 1-minute OHLC into complete 5-minute candles, then
+        attach the Profit Shooter indicator columns.
+        """
+        ohlc_5m = resample_ohlc_from_1m(ohlc, self.derived_timeframe_minutes)
+        return PROFIT_SHOOTER_LOGIC.build_profit_shooter_with_indicators(ohlc_5m, PROFIT_SHOOTER_STRATEGY_CONFIG)
 
     def process_strategy_frame(self, strategy_frame: pd.DataFrame) -> None:
         latest_candle_time = pd.to_datetime(strategy_frame.iloc[-1]["timestamp"]).time()

--- a/Nifty Multi Strategy Front Test - Master File.py
+++ b/Nifty Multi Strategy Front Test - Master File.py
@@ -9187,10 +9187,17 @@ if SL_HUNTING_AVAILABLE:
             """Open a journal row for a trade the agent just entered (best-effort)."""
             try:
                 lot_size = max(int(getattr(self.pos, "option_lot_size", 0)), 1)
+                # If the SDK call timed out (or its final JSON failed to parse) AFTER the
+                # order tool already fired this ENTER, `decision` is the fail-soft
+                # placeholder ("agent_error"/"Agent call timed out; holding."). Recover the
+                # model's real rationale from the order tool payload the executor captured.
+                order_payload = getattr(self._executor, "last_entry_order", None)
+                setup, confidence, reasoning = SL_HUNTING_JOURNAL_MODULE.resolve_entry_narrative(
+                    decision, order_payload)
                 entry = SL_HUNTING_JOURNAL_MODULE.make_entry_record(
                     direction=getattr(self.pos, "direction", ""),
-                    setup=decision.setup, confidence=decision.confidence,
-                    reasoning=decision.reasoning,
+                    setup=setup, confidence=confidence,
+                    reasoning=reasoning,
                     stop=float(getattr(self.pos, "stop_underlying", 0.0)),
                     target=float(getattr(self.pos, "target_underlying", 0.0)),
                     entry_underlying=float(getattr(self.pos, "entry_underlying", 0.0)),
@@ -9201,6 +9208,11 @@ if SL_HUNTING_AVAILABLE:
                 self._entry_realized_pnl = self.realized_pnl
             except Exception as exc:  # noqa: BLE001 - journaling must never disturb trading
                 self.log.warning("SL Hunting journal open failed: %s", exc)
+            finally:
+                # Consume the captured ENTER payload either way so it can never leak into
+                # a later bar's journal row.
+                if getattr(self, "_executor", None) is not None:
+                    self._executor.last_entry_order = None
 
         # --------------------------------------------------------------
         # BankNIFTY mirror leg (Intraday Hunter style)

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -814,3 +814,63 @@ calls, per the v3b finding).
 - `RISK`: MOVE-EXHAUSTION — ONE MOVE PER THESIS (incl. EXPIRY-DAY RANGE).
 - `BNF_CROSS_CONFIRMATION`: SCOPE OF THIS "STALE" ESCAPE HATCH + opposing-verdict veto.
 - Test marker: `test_system_prompt_has_v3j_averaging_trap_knowledge`.
+
+## Video addendum - 15 Jul gap-up seller-hunt + flat-open participation gate (v3k)
+
+> Sources (full Hindi auto-transcripts from YouTube's transcript panel):
+> - `40j_l5DtwS4` (14 Jul 2026 evening, "Prediction For 15 JULY 2026", 1:48)
+> - `ciQ19XPXoXk` (15 Jul 2026, "Live Bank Nifty Option Trading", 8:35)
+>
+> Cross-checked against the agent's journal (`Backtest Outputs/sl_hunting_journal.jsonl`,
+> row 20, 2026-07-15).
+
+Session summary:
+- Pre-open plan (prediction clip): after 14 Jul's gap-down + persistent selling that
+  closed BankNIFTY below the round number, sellers may be seated — **gap-up OR
+  gap-down -> hunt those sellers (buy-side); FLAT -> "we cannot follow that structure",
+  go WITH the market (sell-side)**, because the fearful sellers may never have really
+  sized in ("the market made no big momentum; if no scared traders are seated, benefit
+  by going with the market") and a flat open parks price on the closing-point support.
+- Live session: mild gap-up + immediate positive momentum -> instant with-gap CALL
+  basket (BankNIFTY 1170 / Sensex 900 / NIFTY 1430 qty), sharp continuation with no
+  retracement, booked ~140 pts at the round-number test ("greed has a limit — we
+  tested the round number directly, cut and go"). Textbook EXISTING knowledge:
+  OPENING DRIVE gap-up branch, prior-day seller inventory, round-number booking, and
+  the momentum-quality read (his "fast momentum invites greedy buyers -> retracement
+  risk; small candles would be safer" is the RISK momentum-quality rule verbatim).
+
+**Agent vs IH on 15 Jul** (IH: 1 trade, ~+140 pts; agent: 1 trade):
+- The agent SHORTED at 09:32 (`shooting_star`/`evening_star`/`inside_bar` at the 24200
+  psych level, entry 24195) on a gap-up-and-go morning with price +123 pts above pivot
+  and `cross_index` reading "up_context" — the exact fade that GAP-UP MORNING /
+  TRAP-DENSITY / R:R-BAIT already prohibit ("a bearish pattern at a psych level is
+  NOT, by itself, a short on a gap-up morning"). IH rode the same morning long.
+- The exit redeemed it: 5 minutes later the agent named "gap-up-and-go continuation
+  confirmed", cut both legs ~10 pts before the stop, and the basket closed POSITIVE
+  (+Rs.832, the BankNIFTY mirror leg outran the NIFTY leg's -7.9 pts).
+- **Journal-fidelity finding (operational, not knowledge):** row 20 carries
+  `setup: "agent_error"`, `confidence: 0`, `reasoning: "Agent call timed out;
+  holding."` for a REAL trade. The LLM call that placed the short TIMED OUT after the
+  order tool had already fired, so the worker's timeout placeholder — not the model's
+  reasoning — became the journal row. The entry cannot be audited, and the reflection
+  coach would learn from placeholder text. Worth a separate fix (journal the order
+  tool's `reason` argument as a fallback); no knowledge change can address it.
+
+**Net-new method distilled:**
+- FLAT-OPEN PARTICIPATION GATE: the flat-open SL-hunt requires the prior crowd to have
+  really participated. After a WEAK-momentum down day (hesitant selling, no big move),
+  a flat open puts nobody in pain and leaves the closing-point support in the way —
+  plan WITH the prior direction there, while a gap in EITHER direction re-arms the
+  hunt (gap-up pressures the sellers; gap-down pays them into complacency and the
+  recovery hunts their stops). Scopes the blanket "FLAT or GAP-DOWN -> look UP" rule
+  and complements MULTI-DAY ACCUMULATION ("a crowd that only TRICKLED in is not
+  huntable").
+
+**Confirmed but deliberately NOT re-encoded (already present):** the with-gap opening
+drive and its behavioural confirmation, prior-day seller-inventory read, round-number
+booking without greed, momentum-quality (fast spike -> retracement risk), and the
+round-number-magnet notes. The live session contained no averaging/psychology segment.
+
+**Knowledge changes (v3k, all prose):**
+- `RETAIL_POSITIONING`: FLAT-OPEN PARTICIPATION GATE.
+- Test marker: `test_system_prompt_has_v3k_flat_open_gate_knowledge`.

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_executor.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_executor.py
@@ -265,6 +265,11 @@ class MasterWorkerExecutor:
 
     def __init__(self, worker: Any) -> None:
         self._w = worker
+        # Payload of the ENTER the order tool fired THIS bar (action/reason/levels).
+        # The worker reads it in _journal_open_row so a real entry whose SDK call then
+        # timed out is journaled from the model's actual reason, not the fail-soft
+        # "Agent call timed out; holding." placeholder. Consumed (cleared) once journaled.
+        self.last_entry_order: dict[str, Any] | None = None
 
     def enter(self, direction: str, stop: float, target: float, reason: str, price: float) -> dict[str, Any]:
         """Delegate the entry to the master worker's safe `enter_position`.
@@ -299,6 +304,14 @@ class MasterWorkerExecutor:
                 "accepted": False,
                 "reason": "worker rejected the entry (e.g. could not resolve option / outside trading window)",
             }
+        # Remember what the tool actually sent so the journal can recover the real
+        # rationale if the SDK call times out (or its final JSON fails to parse) AFTER
+        # this ENTER has already fired. reason is dropped from enter_position (the safe
+        # path takes only levels); this is the one place it survives for journaling.
+        self.last_entry_order = {
+            "action": f"ENTER_{direction}", "reason": str(reason)[:300],
+            "stop": round(float(stop), 2), "target": round(float(target), 2),
+        }
         return {
             "accepted": True, "action": f"ENTER_{direction}", "entry": round(float(price), 2),
             "stop": round(float(stop), 2), "target": round(float(target), 2),

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_journal.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_journal.py
@@ -108,6 +108,33 @@ def make_entry_record(
     }
 
 
+def resolve_entry_narrative(
+    decision: Any, order_payload: dict[str, Any] | None
+) -> tuple[str, int, str]:
+    """Pick the (setup, confidence, reasoning) for an ENTRY journal row.
+
+    Normally these come straight from the agent's returned `decision`. But the order
+    tool has SIDE EFFECTS — the model can ENTER *during* the SDK call, and if that call
+    then times out (or its final JSON fails to parse) the agent returns a fail-soft
+    placeholder (`setup="agent_error"`, `confidence=0`, "Agent call timed out; holding.").
+    Journaling a REAL trade from that placeholder loses the model's actual rationale.
+
+    So when the decision is that placeholder AND an order tool fired an ENTER this bar
+    (its `order_payload` was captured by the executor), prefer the tool's real `reason`.
+    `setup` becomes a distinct sentinel (not `agent_error`, which is reserved for no-op
+    holds) so the reflection coach groups these real trades separately; `confidence`
+    stays 0 because the model never returned it. Levels/direction are unaffected — they
+    come from the executor position and are already correct.
+    """
+    setup = str(getattr(decision, "setup", "") or "")
+    confidence = int(getattr(decision, "confidence", 0) or 0)
+    reasoning = str(getattr(decision, "reasoning", "") or "")
+    if setup == "agent_error" and order_payload:
+        reasoning = str(order_payload.get("reason") or reasoning)
+        setup = "agent_order_no_final_decision"  # order fired; structured decision lost
+    return setup, confidence, reasoning
+
+
 def make_decision_record(
     decision: Any,
     nifty_df: pd.DataFrame,

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
@@ -177,6 +177,18 @@ retail's stop-losses sit so you can trade where the operator will hunt them.
   trade OPPOSITE the panic (look UP / target the trapped shorts' SLs) on a confirmed
   reversal — this is the textbook SL-hunt. But run the TARGET-BOOKED test first:
   if sellers already got paid and exited, there may be no seller crowd left to hunt.
+- FLAT-OPEN PARTICIPATION GATE (scopes the rule above): the flat-open hunt also needs
+  the prior day's crowd to have REALLY participated. When the prior down-day's selling
+  had NO big momentum (a hesitant grind — fearful traders who dreaded a recovery never
+  sized in), a FLAT open puts NOBODY in play: the thin sellers feel no pain at their own
+  entry price, and the closing point sits as support directly in the recovery's path.
+  There the plan flips WITH the prior direction (sell-side setups), not the hunt.
+  A GAP in EITHER direction re-arms the seller-hunt instead: a gap-up pressures the
+  sellers directly, while a gap-down PAYS them into complacency and the recovery back
+  up hunts their stops — so "gap-up or gap-down → hunt the sellers (look UP); flat →
+  go with the selling" is the asymmetry to remember after a weak-momentum down day.
+  (After a genuinely one-way, high-momentum down move, MULTI-DAY ACCUMULATION still
+  applies and the flat open IS the prime hunt.)
 - A FLAT open that then STRUGGLES to push up is itself a tell the OTHER way: had the
   market truly meant to rise it would have gapped up or shown immediate momentum.
   A hesitant flat open that lures buyers to buy "support" expecting a breakout is a

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_journal.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_journal.py
@@ -10,6 +10,7 @@ from sl_hunting_journal import (
     build_entry_context,
     followed_method,
     make_entry_record,
+    resolve_entry_narrative,
 )
 
 
@@ -80,6 +81,70 @@ def test_build_entry_context_and_make_record():
     assert rec["direction"] == "LONG" and rec["lots"] == 2
     assert "context" in rec and "followed_method" in rec
     assert rec["stop"] == 24985.0 and rec["target"] == 25060.0
+
+
+def test_timeout_entry_journals_order_reason_not_placeholder(tmp_path):
+    """A real ENTER whose SDK call then times out AFTER firing must journal the order
+    tool's real reason and levels -- not the fail-soft 'Agent call timed out; holding.'
+    placeholder (2026-07-15 journal-fidelity fix; see journal row 20)."""
+    from types import SimpleNamespace
+
+    # The agent returned the fail-soft placeholder (the call timed out AFTER the order
+    # tool had already placed the SHORT this bar).
+    placeholder = SimpleNamespace(
+        action="HOLD", confidence=0, setup="agent_error",
+        reasoning="Agent call timed out; holding.", model_used="m")
+    # ...but the executor captured what the order tool actually sent this bar.
+    order_payload = {
+        "action": "ENTER_SHORT",
+        "reason": "Gap-up-and-go rejected the psych level; hunting trapped buyers.",
+        "stop": 24230, "target": 24120,
+    }
+    setup, confidence, reasoning = resolve_entry_narrative(placeholder, order_payload)
+    assert reasoning == order_payload["reason"]
+    assert "Agent call timed out" not in reasoning
+    assert setup != "agent_error"          # a distinct sentinel, not the no-op-hold one
+    assert confidence == 0                  # never returned by the model; stays 0
+
+    # End-to-end through the journal (rows persist on close): the finished row carries
+    # the real rationale/levels, exactly as the master worker's _journal_open_row wires
+    # resolve_entry_narrative into make_entry_record.
+    df = _two_day()
+    j = TradeJournal(str(tmp_path / "j.jsonl"))
+    entry = make_entry_record(
+        direction="SHORT", setup=setup, confidence=confidence, reasoning=reasoning,
+        stop=order_payload["stop"], target=order_payload["target"],
+        entry_underlying=24195, lots=2, nifty_df=df, bnf_df=None,
+    )
+    tid = j.open_trade(entry)
+    j.close_trade(tid, {"exit_underlying": 24187, "exit_reason": "AI_EXIT", "points": 8})
+    lines = (tmp_path / "j.jsonl").read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 1
+    parsed = json.loads(lines[0])
+    assert parsed["trade_id"] == tid
+    assert parsed["reasoning"] == order_payload["reason"]
+    assert "Agent call timed out" not in parsed["reasoning"]
+    assert parsed["setup"] != "agent_error"
+    assert parsed["stop"] == 24230.0 and parsed["target"] == 24120.0
+
+
+def test_resolve_entry_narrative_leaves_genuine_decisions_untouched():
+    """The fallback fires ONLY for the placeholder-with-order case: a real parsed
+    decision is returned unchanged even if an order payload is present, and a genuine
+    fail-soft hold (no order this bar) keeps its placeholder text."""
+    from types import SimpleNamespace
+
+    real = SimpleNamespace(setup="pivot_support_hammer", confidence=7,
+                           reasoning="Hammer at pivot support with BNF confirmation.")
+    payload = {"action": "ENTER_LONG", "reason": "different tool reason", "stop": 1, "target": 2}
+    assert resolve_entry_narrative(real, payload) == (
+        "pivot_support_hammer", 7, "Hammer at pivot support with BNF confirmation.")
+
+    # Placeholder but NO order fired this bar (a true hold) -> left exactly as-is.
+    hold = SimpleNamespace(setup="agent_error", confidence=0,
+                           reasoning="Agent call timed out; holding.")
+    assert resolve_entry_narrative(hold, None) == (
+        "agent_error", 0, "Agent call timed out; holding.")
 
 
 def test_decision_log_records_holds_and_actions(tmp_path):

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
@@ -250,3 +250,19 @@ def test_system_prompt_has_v3j_averaging_trap_knowledge():
     assert "EXPIRY IS CONTEXT, NOT A PREMISE" in prompt
     # The "stale" escape hatch must be explicitly bounded to the opening hour.
     assert "SCOPE OF THIS \"STALE\" ESCAPE HATCH" in prompt
+
+
+def test_system_prompt_has_v3k_flat_open_gate_knowledge():
+    """v3k: 15 Jul sessions — the flat-open hunt needs a crowd that really participated.
+
+    After a WEAK-momentum down day, a flat open puts nobody in pain (and leaves the
+    closing-point support in the recovery's path) — the plan flips WITH the prior
+    direction, while a gap in EITHER direction re-arms the seller-hunt. Scopes the
+    blanket "FLAT or GAP-DOWN -> look UP" default.
+    """
+    prompt = build_system_prompt()
+    assert "FLAT-OPEN PARTICIPATION GATE" in prompt
+    # The asymmetry in one line: either-direction gap hunts, flat goes with-trend.
+    assert "flat" in prompt and "go with the selling" in prompt
+    # It must scope, not delete, the textbook flat/gap-down hunt above it.
+    assert "PRIME TRAP zone" in prompt

--- a/test_nifty_multi_strategy_master.py
+++ b/test_nifty_multi_strategy_master.py
@@ -1281,6 +1281,26 @@ class TestProfitShooterStrategyWorker(unittest.TestCase):
         self.assertIsInstance(lots, int)
         self.assertGreaterEqual(lots, 1)
 
+    def test_build_strategy_frame_resamples_to_five_minutes(self):
+        """Profit Shooter is a 5-minute method: the strategy frame must be built
+        from the 1-min source resampled to 5-min candles, not raw 1-min bars."""
+        n = 400
+        ts = pd.date_range("2026-05-15 09:15", periods=n, freq="1min")
+        close = pd.Series([22500.0 + i * 0.5 for i in range(n)])
+        ohlc = pd.DataFrame({
+            "timestamp": ts,
+            "open":  close.shift(1).fillna(22500.0).values,
+            "high":  (close + 1.5).values,
+            "low":   (close - 1.5).values,
+            "close": close.values,
+        })
+        frame = self.worker.build_strategy_frame(ohlc)
+        # 400 complete 1-min bars -> 80 complete 5-min buckets.
+        self.assertEqual(len(frame), n // 5)
+        spacing = pd.to_datetime(frame["timestamp"]).diff().dropna().unique()
+        self.assertEqual(len(spacing), 1)
+        self.assertEqual(pd.Timedelta(spacing[0]), pd.Timedelta(minutes=5))
+
 
 # =============================================================================
 # TEST SUITE: GOLDMINE DYNAMIC LOT SIZING


### PR DESCRIPTION
Two independent changes on one branch.

## 1. SL Hunting knowledge v3k — 15 Jul flat-open participation gate (knowledge-only)

Distils Intraday Hunter's **15 Jul** session (`ciQ19XPXoXk`) and the day's prediction clip (`40j_l5DtwS4`), cross-checked against **the agent's own journal** (`Backtest Outputs/sl_hunting_journal.jsonl`, row 20, `2026-07-15`).

**What IH did.** One trade: a gap-up seller-hunt long, booked ~140 points at the round number. This is textbook *existing* knowledge — the opening-drive gap-up branch, prior-day seller inventory, round-number booking, and the fast-momentum→retracement read (his *"small candles would be safer; fast momentum invites greedy buyers → retracement risk"* is the RISK momentum-quality rule verbatim).

**Agent vs IH.** The agent **shorted** the same gap-up-and-go morning at 09:32 (a shooting-star/evening-star at the 24200 psych level, +123 pts above pivot) — the exact fade that `GAP-UP MORNING` / `TRAP-DENSITY` / `R:R-BAIT` already prohibit. The **exit redeemed it**: five minutes later it named *"gap-up-and-go continuation confirmed"*, cut both legs ~10 pts before the stop, and the basket closed **+₹832** (the BankNIFTY mirror leg outran the NIFTY leg's −7.9 pts).

**Net-new encoded — `FLAT-OPEN PARTICIPATION GATE`** (in `RETAIL_POSITIONING`). The flat-open SL-hunt needs a crowd that actually participated. After a **weak-momentum** down day (hesitant selling, fearful traders who never sized in), a **flat** open puts nobody in pain and leaves the closing-point support directly in the recovery's path — so the plan flips **with** the prior direction (sell-side), while a **gap in either direction re-arms the hunt** (gap-up pressures the sellers; gap-down pays them into complacency and the recovery back up hunts their stops). This scopes the blanket *"FLAT or GAP-DOWN → look UP"* default and complements `MULTI-DAY ACCUMULATION` (*"a crowd that only trickled in is not huntable"*). After a genuinely one-way, high-momentum down move the flat open **is** still the prime hunt.

**Journal-fidelity finding (recorded in the doc, not fixed here).** Row 20 carries `setup: "agent_error"`, `confidence: 0`, `"Agent call timed out; holding."` for a *real* trade — the LLM call timed out *after* the order tool had already fired, so the worker's timeout placeholder became the journal row. The entry can't be audited and the reflection coach would learn from placeholder text. Worth a separate fix (fall back to the order tool's `reason` argument); no knowledge change can address it.

## 2. Profit Shooter: resample to 5-minute (bug fix)

Profit Shooter's pin-bar method is designed for the **5-minute** timeframe, but `ProfitShooterStrategyWorker` was feeding the engine **raw 1-minute** candles. Fix mirrors the existing EMA / Goldmine / Money Machine pattern:

- New `PROFIT_SHOOTER_DERIVED_TIMEFRAME_MINUTES` (default `5`), read via `_env_int`.
- `build_strategy_frame` now calls `resample_ohlc_from_1m(ohlc, 5)` before attaching indicators.
- `minimum_strategy_rows` (`PROFIT_SHOOTER_MIN_BARS`) now correctly counts **5-min** candles for SMA200/ATR warm-up.
- Env knob added to `Dependencies/env.example` (and mirrored into the gitignored local `.env`).

## Verification

- `python -m unittest test_nifty_multi_strategy_master` → **217 tests, OK** (new: `test_build_strategy_frame_resamples_to_five_minutes` asserts 400 1-min bars → 80 complete 5-min buckets at 5-min spacing)
- `python -m pytest "Signal Generators/SL Hunting AI Agent/tests" -q` → **83 passed** (new v3k marker plus every prior v2/v3/v3a/v3d–v3j marker)
- `python -m ruff check .` → clean · `python -m mypy` → clean (29 files) · `compileall` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
