### PR TITLE
SL Hunting v3l (16 Jul split-gap: closing-point hold test + shared-gap requirement) + ProfitShooter 5m log

### DIFF
--- a/Nifty Multi Strategy Front Test - Master File.py
+++ b/Nifty Multi Strategy Front Test - Master File.py
@@ -10358,7 +10358,7 @@ def main() -> None:
     logger.info(
         "Starting NIFTY Multi Strategy MASTER paper runner (dhanhq) | "
         "ATM single-leg family (22): 9 core - Renko 1m, EMA 5m, HeikinAshi 1m, "
-        "ProfitShooter 1m, Goldmine 5m, MoneyMachine 5m, OpeningStrike 5m "
+        "ProfitShooter 5m, Goldmine 5m, MoneyMachine 5m, OpeningStrike 5m "
         "PCR/VWAP/ATR, CPR 5m, CPR Algo 3 5m (multi-instrument); + 13 TradingBot ports (%dm) - SMA Crossover, "
         "Bollinger Bands, Keltner Squeeze, Mean Reversion Z-Score, ML Ensemble, "
         "Multi-Timeframe, Opening Range Breakout, Parabolic SAR, RSI Divergence, "

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -874,3 +874,93 @@ round-number-magnet notes. The live session contained no averaging/psychology se
 **Knowledge changes (v3k, all prose):**
 - `RETAIL_POSITIONING`: FLAT-OPEN PARTICIPATION GATE.
 - Test marker: `test_system_prompt_has_v3k_flat_open_gate_knowledge`.
+
+## Video addendum - 16 Jul split-gap session + closing-point hold test (v3l)
+
+> Sources (full Hindi auto-transcripts from YouTube's transcript panel):
+> - `1uB29qR9V0A` (15 Jul 2026 evening, "Prediction For 16 JULY 2026", 2:07)
+> - `ojc_NGulszU` (16 Jul 2026, "Live Bank Nifty Option Trading", 9:51)
+>
+> Cross-checked against the agent's journal (`Backtest Outputs/sl_hunting_journal.jsonl`,
+> rows 21-22, 2026-07-16).
+>
+> EXTRACTION NOTE: both 16 Jul watch pages loaded as SKELETON placeholders — zero
+> `ytd-engagement-panel-section-list-renderer` nodes, no "Show transcript" button, no
+> recommendations sidebar — across reloads AND a fresh tab. Fix that worked:
+> `resize_window` (e.g. 1400x900) THEN `location.reload()`; the forced re-layout makes
+> the panels hydrate (9 of them), after which the normal recipe applies. Captions
+> existed the whole time (`hi/asr` in `ytInitialPlayerResponse`), so an absent button
+> is a hydration failure, NOT a missing transcript.
+
+Session summary:
+- Pre-open plan (prediction clip): the prior day rejected but **held above the closing
+  price**, so "not many are sitting short" — plan was flat/gap-down -> sell-side; a
+  direct gap-up -> buy-side (a gap-up would put any seated sellers in trouble).
+- Live open: **a SPLIT gap** — Sensex and NIFTY opened with a mild GAP-UP while
+  **BankNIFTY opened FLAT, right at its own closing price**. IH read the flat major
+  index as the honest tell: if BNF took support there and cleared 58,000, "only buyers
+  would come" and the down-move would be dead; instead he expected the small trap and a
+  fall. He bought PUTs across all three (BNF 57800+57700 PE, Sensex 900 qty — Sensex
+  expiry that day, NIFTY 1365 qty).
+- Core reasoning (the day's whole thesis): the prior rejection **never broke the
+  closing point**, so whoever sold it booked the momentum and left rather than holding
+  overnight -> **no seller inventory** -> there are no seller SLs to hunt upward ->
+  therefore FOLLOW the selling down instead of hunting sellers up. He stated the
+  converse explicitly: had the market broken down and then HELD below, sellers WOULD be
+  seated, and then the market would reject and run them UP.
+- Exit: not a stop or a target. BankNIFTY — the index he expected to LEAD — failed to
+  lead, and all three indices began drifting down together in small steps. He cut,
+  because an evenly shared, visible move "invites sellers", and a freshly recruited
+  seller crowd is exactly what gets hunted next ("then the market can suddenly turn").
+
+**Agent vs IH on 16 Jul** (IH: 1 trade, booked; agent: 2 trades, net -Rs.709):
+
+| # | Agent trade | Time | Result |
+|---|---|---|---|
+| 1 | LONG `opening_drive_gapup_continuation` | 09:17-09:22 | +2.3 pts but **-Rs.1,333** |
+| 2 | SHORT `gap_up_after_selldown_buyer_trap_short` | 09:28-09:42 | +2.45 pts, **+Rs.624** |
+
+- **Trade 1 is the divergence, and it is the loser.** The agent fired the OPENING DRIVE
+  gap-up branch on NIFTY's own mild gap (24142 vs 24073.45 prev close) — "retail is
+  largely un-positioned so there's no SL-hunt available; the with-gap continuation is
+  the trade" — while IH was reading the SAME open as a short because **BankNIFTY had no
+  gap at all**. Nothing in OPENING_DRIVE required the gap to be SHARED, and
+  `cross_index` returned "neutral"/"none", so the split gap never registered. Note the
+  basket cost: +2.3 NIFTY points still lost Rs.1,333 because the BankNIFTY mirror leg —
+  the very index that was flat — went against it.
+- **Trade 2 converged with IH's direction** (short) and made money, though via a
+  different premise (agent: untrustworthy gap-up recruiting fresh buyers; IH: no seller
+  inventory -> follow the selling). The agent then exited on a stall at 09:42 while IH
+  held the same direction longer for a better target.
+- Exit discipline was sound in both rows (row 1 cut in ~5 min on a confirmed rejection,
+  well before the stop) — the loss came from the ENTRY premise, not the management.
+
+**Net-new method distilled:**
+- CLOSING-POINT HOLD TEST: whether an overnight crowd exists at all is answered by one
+  question — did the prior rejection/selling BREAK the closing point and HOLD beyond it?
+  Broke-and-held -> the crowd is seated with live SLs -> huntable (look the other way).
+  Never broke it -> they booked and left -> no inventory -> FOLLOW the prevailing move.
+  Sharper and more mechanical than the existing TARGET-BOOKED test (which keys off
+  breakdown+retracement+continuation); this keys off a single named level.
+- OPENING DRIVE — SHARED-GAP REQUIREMENT: the gap-up branch's premise ("nobody is
+  positioned, so there is no hunt available") is FALSE when the major index (BankNIFTY)
+  opened FLAT at its own closing point while NIFTY gapped. A flat major index beside a
+  gapped NIFTY is a SHORT tell — GAP-SIZE ASYMMETRY ("the smaller-gap index is the
+  tell") at its strongest, a zero-gap index. Directly prevents the agent's -Rs.1,333.
+- Leader-fails-to-lead exit MECHANISM (folded into the existing BNF_SPECIFIC bullet,
+  which already prescribed the exit): an evenly shared, small-step move across all three
+  indices RECRUITS the crowd onto your own side, and a freshly recruited crowd is the
+  next hunt target — once your side IS the crowd, the edge is gone. Scoped explicitly to
+  the leader failing to lead, so it does not collide with the RISK rule that
+  leader-led "SLOW-but-CONTINUOUS" momentum is the sustainable kind.
+
+**Confirmed but deliberately NOT re-encoded (already present):** the one-directional-day
+read ("either profit or loss, the market will pick a side — don't dream it comes back"),
+premise-invalidation exits, average-target booking without greed, expiry-day context, and
+round-number magnets.
+
+**Knowledge changes (v3l, all prose):**
+- `RETAIL_POSITIONING`: CLOSING-POINT HOLD TEST.
+- `OPENING_DRIVE`: SHARED-GAP REQUIREMENT condition.
+- `BNF_SPECIFIC`: the "why" clause on the leader-fails-to-lead exit.
+- Test marker: `test_system_prompt_has_v3l_closing_point_and_shared_gap_knowledge`.

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
@@ -154,6 +154,20 @@ retail's stop-losses sit so you can trade where the operator will hunt them.
   * Invalidation: if that bounce keeps going and RECLAIMS the closing point / round
     number, the crowd was not actually trapped — the premise is dead, exit per your
     limit. This is an entry-timing rule, never a licence to sit in a loser.
+- CLOSING-POINT HOLD TEST (the sharpest read on whether an overnight crowd EXISTS —
+  run it before planning any hunt of yesterday's crowd): ask whether yesterday's
+  rejection/selling actually BROKE the closing point and then HELD beyond it.
+  * BROKE it and held beyond → that crowd is SEATED overnight with live SLs. They are
+    huntable: expect a rejection and a move back THROUGH their stops (the textbook
+    hunt — after a down-break that held, look UP).
+  * Did NOT break it (price rejected but stalled at/above the closing point, often
+    hovering there a long time) → whoever traded that move BOOKED the momentum and
+    LEFT; they did not carry the position overnight. There is NO inventory to hunt,
+    so do not plan a hunt against them — FOLLOW the prevailing move instead (after a
+    rejection that failed to break the closing point, the continuation DOWN is the
+    trade, not the hunt up).
+  The level does the work here: an unbroken closing point means the crowd never got
+  the confirmation it needed to hold, so its SLs never came into being.
 - TARGET-BOOKED crowd test: before hunting yesterday's crowd, ask whether the prior
   move already paid them and let them exit. Breakdown + retracement + continuation
   often means put buyers / sellers already booked profit; they are not today's
@@ -263,6 +277,16 @@ Conditions (ALL must hold — otherwise this branch simply does not apply):
 - First ~15 minutes of the session only.
 - Gap-up branch: ONLY as ENTER_LONG on a clear GAP-UP (open above the previous
   close AND holding above/at a round number).
+- SHARED-GAP REQUIREMENT (check this BEFORE the branch fires): the gap must be broadly
+  shared across the indices. If the MAJOR index (BankNIFTY — check `bank_nifty` /
+  `cross_index`) opened FLAT at/near its OWN closing point while NIFTY gapped, there is
+  NO shared gap: BankNIFTY's crowd is untouched, its closing point sits right there as
+  support, and the "nobody is positioned → no hunt available" premise that justifies
+  this whole branch is FALSE. A flat major index beside a gapped NIFTY is a SHORT tell,
+  not a long one — the flat index is the honest read (see GAP-SIZE ASYMMETRY: the
+  smaller-gap index is the tell, and a ZERO-gap major index is that rule at its
+  strongest). HOLD, or trade the flat index's read instead; do NOT fire this branch on
+  NIFTY's gap alone.
 - GAP-DOWN CONTINUATION SHORT branch: ONLY as ENTER_SHORT on a narrow/moderate
   gap-down after prior breakdown + retracement + continuation likely let sellers
   book. The open/early recovery must fail below the closing point / round number
@@ -604,7 +628,16 @@ you size or place the NIFTY trade. Advisory, not a hard gate.
 - BankNIFTY is treated as the MAJOR index that sets the base bias; NIFTY/Sensex
   confirm. When the leading index (BankNIFTY) WEAKENS or fails to sustain
   momentum versus the others — especially if the weakest one starts to reverse —
-  treat that as an exit / avoid signal for the shared direction.
+  treat that as an exit / avoid signal for the shared direction. WHY it is an exit
+  and not merely a delay: when the expected leader does NOT lead and instead all
+  three indices drift the same way together in small steps, that visible, evenly
+  shared move RECRUITS the crowd onto YOUR OWN side — and a freshly recruited crowd
+  is precisely what the operator hunts next. Your edge is being with the operator
+  against the crowd; once your side IS the crowd, the edge is gone and a sudden
+  reversal is the risk. Book what the move has given and leave. (Scope: this is
+  about the LEADER failing to lead, not about momentum speed in general — a genuine
+  leader-led move that grinds on in small candles is still the sustainable kind
+  described in RISK.)
 - MASKED BNF LAG: temporary BankNIFTY weakness can also be a mask that keeps
   NIFTY/Sensex breakout buyers away while the operator continues the original
   thesis. Treat BNF lag as invalidation only when it actually breaks the premise

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
@@ -266,3 +266,25 @@ def test_system_prompt_has_v3k_flat_open_gate_knowledge():
     assert "flat" in prompt and "go with the selling" in prompt
     # It must scope, not delete, the textbook flat/gap-down hunt above it.
     assert "PRIME TRAP zone" in prompt
+
+
+def test_system_prompt_has_v3l_closing_point_and_shared_gap_knowledge():
+    """v3l: 16 Jul split-gap session, cross-checked against journal rows 21-22.
+
+    - CLOSING-POINT HOLD TEST answers whether an overnight crowd exists at all: a prior
+      rejection that never BROKE the closing point means that crowd booked and left, so
+      there is no inventory to hunt -> follow the move instead.
+    - The OPENING DRIVE gap-up branch now requires the gap to be SHARED: the agent fired
+      it on NIFTY's gap while BankNIFTY opened flat at its own closing point (IH read the
+      same open as a short) and the basket lost Rs.1,333.
+    """
+    prompt = build_system_prompt()
+    assert "CLOSING-POINT HOLD TEST" in prompt
+    assert "SHARED-GAP REQUIREMENT" in prompt
+    # The decisive tell: a flat major index beside a gapped NIFTY kills the long branch.
+    assert "flat major index" in prompt.lower()
+    # The hold test must state both arms (seated-and-huntable vs booked-and-gone).
+    assert "BROKE it and held beyond" in prompt
+    # The leader-fails-to-lead exit keeps its scope so it can't collide with RISK's
+    # "SLOW-but-CONTINUOUS is the sustainable kind" rule.
+    assert "SLOW-but-CONTINUOUS" in prompt


### PR DESCRIPTION
Two changes: the 16 Jul knowledge distillation, and the follow-on ProfitShooter log fix.

## 1. SL Hunting knowledge v3l — 16 Jul split-gap session (knowledge-only)

Distils Intraday Hunter's **16 Jul** session (`ojc_NGulszU`) and prediction clip (`1uB29qR9V0A`), cross-checked against **the agent's own journal** (rows 21–22, `2026-07-16`).

### The day: a split gap

Sensex and NIFTY opened with a **mild gap-up**; **BankNIFTY opened FLAT, right at its own closing price**. IH read the flat major index as the honest tell and bought PUTs across all three. The agent fired its **OPENING DRIVE gap-up LONG** on NIFTY's gap alone.

### Agent vs IH — IH: 1 trade, booked. Agent: 2 trades, **net −₹709**

| # | Agent trade | Time | Result |
|---|---|---|---|
| 1 | LONG `opening_drive_gapup_continuation` | 09:17→09:22 | +2.3 pts but **−₹1,333** |
| 2 | SHORT `gap_up_after_selldown_buyer_trap_short` | 09:28→09:42 | +2.45 pts, **+₹624** |

- **Trade 1 is the divergence and the loser.** The agent's reasoning — *"retail is largely un-positioned so there's no SL-hunt available; the with-gap continuation is the trade"* — was reading NIFTY's gap in isolation. Nothing in `OPENING_DRIVE` required the gap to be **shared**, and `cross_index` returned `neutral`/`none`, so the split gap never registered. Note the basket cost: **+2.3 NIFTY points still lost ₹1,333**, because the BankNIFTY mirror leg — the very index that was flat — went against it.
- **Trade 2 converged** with IH's direction (short) and made money, though on a different premise (agent: untrustworthy gap-up recruiting buyers; IH: no seller inventory → follow the selling). The agent exited on a stall at 09:42 while IH held longer for a better target.
- **Exit discipline was sound in both rows** (row 1 cut in ~5 min on a confirmed rejection, well before the stop). The loss came from the **entry premise**, not the management.

### Net-new encoded

1. **`CLOSING-POINT HOLD TEST`** (`RETAIL_POSITIONING`) — this was IH's entire thesis for the day. Whether an overnight crowd exists at all reduces to one question: *did the prior rejection **break** the closing point and **hold** beyond it?*
   - Broke and held → that crowd is **seated** with live SLs → huntable (look the other way).
   - Never broke it → they **booked the momentum and left**; they never carried it overnight → **no inventory to hunt** → *follow* the prevailing move instead.

   Sharper and more mechanical than the existing `TARGET-BOOKED` test (which keys off breakdown+retracement+continuation); this keys off a single named level. IH stated the converse explicitly too: had the market broken down and *held* below, sellers would be seated and the market would reject and run them up.

2. **`SHARED-GAP REQUIREMENT`** (`OPENING_DRIVE`) — the gap-up branch's whole premise (*"nobody is positioned, so there is no hunt available"*) is **false** when the major index opened flat at its own closing point while NIFTY gapped: BankNIFTY's crowd is untouched and its closing point sits right there as support. A flat major index beside a gapped NIFTY is a **short** tell — `GAP-SIZE ASYMMETRY` ("the smaller-gap index is the tell") at its strongest, a zero-gap index. **Directly prevents the −₹1,333 entry.**

3. **`BNF_SPECIFIC`** — added the *why* to the existing leader-fails-to-lead exit (which already prescribed the action). IH's actual exit driver: BankNIFTY failed to lead and all three indices drifted down together in small steps, which **recruits the crowd onto your own side** — and a freshly recruited crowd is the next hunt target. Once your side *is* the crowd, the edge is gone. Scoped explicitly to the leader failing to lead, so it can't collide with RISK's *"SLOW-but-CONTINUOUS is the sustainable kind"*.

**Confirmed but not re-encoded:** the one-directional-day read, premise-invalidation exits, average-target booking without greed, expiry context, round-number magnets.

**Extraction note (recorded in the doc).** Both 16 Jul watch pages loaded as **skeleton placeholders** — zero engagement panels, no transcript button, no sidebar — across reloads *and* a fresh tab, while captions existed the whole time (`hi/asr`). Fix that worked: `resize_window` **then** `location.reload()`; the forced re-layout hydrates the panels. An absent button is a hydration failure, not a missing transcript.

## 2. ProfitShooter startup log: `1m` → `5m`

Follow-on from the resample fix in #57. The runner's startup banner still advertised `ProfitShooter 1m`. Profit Shooter is a 5-minute method and now resamples accordingly, so the banner was actively misleading about what's running.

## Verification

- `python -m unittest test_nifty_multi_strategy_master` → **217 tests, OK**
- `python -m pytest "Signal Generators/SL Hunting AI Agent/tests" -q` → **86 passed** (new v3l marker plus every prior v2/v3/v3a/v3d–v3k marker)
- `python -m ruff check .` → clean · `python -m mypy` → clean (29 files) · `compileall` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
