### PR TITLE
Review fixes for MAT-101/103/108 + docs pass

### DIFF
--- a/Data Extractors/Readme.md
+++ b/Data Extractors/Readme.md
@@ -15,10 +15,10 @@ Each wrapper has the index-specific defaults baked in, so this is enough:
 ```
 python "Data Extractors/Nifty 1m 5Y Data Fetch Dhan.py"
 ```
-Override anything via CLI — `--from-date`, `--to-date`, `--output`, `--client-id`, `--access-token`, `--chunk-days`. Run with `--help` for the full list.
+Override anything via CLI — `--from-date`, `--to-date`, `--output`, `--client-id`, `--chunk-days`. Run with `--help` for the full list. (The access token has no CLI flag on purpose — see Credentials.)
 
 # Where the CSV lands
 By default, in `<repo_root>/Backtest Outputs/<index>_renko_futures_5y_1min_data.csv`. The folder is auto-created. Override with `--output`.
 
 # Credentials
-Either set `DHAN_CLIENT_CODE` and `DHAN_TOKEN_ID` as environment variables, or pass them via `--client-id` and `--access-token`.
+Set `DHAN_CLIENT_CODE` and `DHAN_TOKEN_ID` as environment variables (e.g. in `Dependencies/.env`). The client id may also be passed via `--client-id`; the access token is deliberately environment-only — a token typed on the command line would land in shell history and process listings.

--- a/Data Extractors/index_1m_5y_data_fetch_dhan_common.py
+++ b/Data Extractors/index_1m_5y_data_fetch_dhan_common.py
@@ -62,9 +62,12 @@ class IndexFetchDefaults:
     instrument_type: str = "INDEX"
     interval: int = 1
     lookback: str = "5y"
-    # SECURITY: never hardcode credentials here. Resolution order is CLI flag ->
-    # environment variable (DHAN_CLIENT_CODE / DHAN_TOKEN_ID, e.g. from
-    # Dependencies/.env) -> these blanks. A real client id + access token used
+    # SECURITY: never hardcode credentials here. The client id resolves CLI
+    # flag -> environment variable (DHAN_CLIENT_CODE) -> this blank. The access
+    # token is a SECRET and resolves environment variable (DHAN_TOKEN_ID, e.g.
+    # from Dependencies/.env) -> this blank ONLY -- there is deliberately no
+    # CLI flag for it (MAT-108): a token typed on the command line lands in
+    # shell history and process listings. A real client id + access token used
     # to live in these defaults; they were removed (and remain in old git
     # history, so treat that token as burned).
     default_client_id: str = ""
@@ -88,17 +91,15 @@ def parse_args(defaults: IndexFetchDefaults):
     )
 
     # Credentials:
-    # - first preference: explicit CLI values
-    # - second preference: environment variables
-    # - last fallback: wrapper-provided defaults (blank unless you choose
-    #   to hardcode them in the wrapper)
+    # - the CLIENT ID is an account identifier (not a secret), so it may come
+    #   from the CLI flag, then the environment, then the wrapper default.
+    # - the ACCESS TOKEN is a secret and is read from the environment ONLY
+    #   (DHAN_TOKEN_ID, e.g. loaded from Dependencies/.env). There is
+    #   deliberately no --access-token flag: a token typed on the command
+    #   line would land in shell history and process listings.
     parser.add_argument(
         "--client-id",
         default=os.getenv("DHAN_CLIENT_CODE", defaults.default_client_id),
-    )
-    parser.add_argument(
-        "--access-token",
-        default=os.getenv("DHAN_TOKEN_ID", defaults.default_access_token),
     )
 
     parser.add_argument(
@@ -139,7 +140,11 @@ def parse_args(defaults: IndexFetchDefaults):
     )
     parser.add_argument("--start-date", default="")
     parser.add_argument("--end-date", default="")
-    return parser.parse_args()
+    args = parser.parse_args()
+    # Attach the token AFTER parsing so it can never be supplied (or leaked)
+    # through the command line; downstream code keeps reading args.access_token.
+    args.access_token = os.getenv("DHAN_TOKEN_ID", defaults.default_access_token)
+    return args
 
 
 def resolve_date_range(args):
@@ -478,8 +483,9 @@ def run_index_fetcher(defaults: IndexFetchDefaults) -> None:
 
     if not args.client_id or not args.access_token:
         raise ValueError(
-            "Missing credentials. Set DHAN_CLIENT_CODE and DHAN_TOKEN_ID, "
-            "or pass --client-id and --access-token."
+            "Missing credentials. Set DHAN_CLIENT_CODE and DHAN_TOKEN_ID in the "
+            "environment (e.g. Dependencies/.env). Only --client-id may be "
+            "overridden on the command line; the token is environment-only."
         )
 
     if args.chunk_days <= 0 or args.chunk_days > 90:

--- a/Data Extractors/test_index_fetch_construction.py
+++ b/Data Extractors/test_index_fetch_construction.py
@@ -56,6 +56,26 @@ def test_fetch_builds_dhan_context_not_two_positional_args():
     assert list(result.columns) == ["timestamp", "open", "high", "low", "close", "volume"]
 
 
+def test_access_token_is_environment_only_never_a_cli_flag(monkeypatch):
+    """MAT-108: a secret typed on the command line lands in shell history."""
+
+    defaults = fetcher.IndexFetchDefaults(
+        display_name="NIFTY",
+        security_id="13",
+        default_output="out.csv",
+    )
+    monkeypatch.setenv("DHAN_TOKEN_ID", "env-only-token")
+    monkeypatch.setattr(sys, "argv", ["fetcher"])
+
+    args = fetcher.parse_args(defaults)
+    assert args.access_token == "env-only-token"
+
+    # The old --access-token flag must be gone: argparse rejects it (exit 2).
+    monkeypatch.setattr(sys, "argv", ["fetcher", "--access-token", "cli-token"])
+    with pytest.raises(SystemExit):
+        fetcher.parse_args(defaults)
+
+
 def _payload(timestamps, *, close=None):
     count = len(timestamps)
     return {

--- a/Dependencies/Flattrade API/flattrade_execution.py
+++ b/Dependencies/Flattrade API/flattrade_execution.py
@@ -367,7 +367,15 @@ class FlattradeExecutionClient:
             ) from exc
 
     def recover_after_reconciliation(self) -> bool:
-        """Explicitly clear deadline poison after the abandoned call has ended."""
+        """Explicitly clear deadline poison after the abandoned call has ended.
+
+        "Poisoned" means an earlier HTTP call outlived its 10-second budget and
+        was abandoned -- but Python cannot kill a running thread, so that call
+        may STILL be dribbling a response (or completing an order) inside
+        ``requests``.  Only after (a) reconciliation has proven the account
+        state and (b) the abandoned call has actually finished is it safe to
+        accept new orders; this method refuses (returns False) until both hold.
+        """
 
         with self._lock:
             if self._timed_out_future is not None and not self._timed_out_future.done():

--- a/Dependencies/Flattrade API/flattrade_execution.py
+++ b/Dependencies/Flattrade API/flattrade_execution.py
@@ -74,6 +74,7 @@ if str(_DEPENDENCIES_DIR) not in sys.path:
     sys.path.insert(0, str(_DEPENDENCIES_DIR))
 
 from broker_contract import (  # noqa: E402
+    TERMINAL_BROKER_STATES,
     BrokerQueryResult,
     OpenOrder,
     OpenPosition,
@@ -1027,7 +1028,17 @@ class FlattradeExecutionClient:
         )
 
     def _confirm_fill(self, order_id: str, want_qty: int) -> OrderResult:
-        """Poll briefly for a terminal result without hiding ambiguity."""
+        """Poll until the order reaches a truly terminal state, or time out.
+
+        Why the loop keeps polling on PARTIAL/UNKNOWN snapshots: a market order
+        is often observed mid-fill (Noren state "open" with some quantity
+        already traded on `fillshares`).  That is TRANSIENT -- the next 0.5s
+        poll usually shows COMPLETE -- so returning it as the final outcome
+        would freeze every live strategy over a perfectly healthy order.  A
+        partial/unknown snapshot becomes the real outcome only when the broker
+        label is terminal (the order can never fill further, e.g. a partial
+        fill followed by a cancel) or the timeout below expires.
+        """
         deadline = time.monotonic() + _FILL_TIMEOUT_SECONDS
         last_result = normalize_order_result(
             order_id=order_id,
@@ -1038,14 +1049,16 @@ class FlattradeExecutionClient:
         )
         while time.monotonic() < deadline:
             last_result = self.get_order_status(order_id, requested_quantity=want_qty)
-            if last_result.status is not OrderStatus.UNKNOWN:
+            if last_result.status in {OrderStatus.FILLED, OrderStatus.REJECTED}:
+                return last_result
+            if last_result.broker_state in TERMINAL_BROKER_STATES:
+                # Terminal label with a partial/contradictory quantity snapshot:
+                # no further fills are possible, so this IS the final outcome.
                 return last_result
             # A failed/malformed status call is already indeterminate. Repeating
             # it inside the same order interaction risks exceeding the deadline
             # without adding evidence, so return immediately with the known id.
             if "query failed" in last_result.reason.lower():
-                return last_result
-            if last_result.broker_state not in {"", "OPEN", "PENDING", "TRIGGER_PENDING"}:
                 return last_result
             time.sleep(_FILL_POLL_INTERVAL)
         return normalize_order_result(

--- a/Dependencies/Kotak API/kotak_execution.py
+++ b/Dependencies/Kotak API/kotak_execution.py
@@ -308,9 +308,12 @@ class KotakExecutionClient:
     def recover_after_reconciliation(self) -> bool:
         """Clear timeout poison only after the abandoned SDK call has returned.
 
-        MAT-102 can call this hook after it reconciles orders and positions. The
-        method refuses early recovery while the timed-out operation is still
-        running, preserving the no-overlap guarantee.
+        "Poisoned" means an earlier SDK call outlived its 10-second budget and
+        was abandoned -- but Python cannot kill a running thread, so that call
+        may STILL be executing inside the SDK and may still place/affect an
+        order.  MAT-102 can call this hook after it reconciles orders and
+        positions.  The method refuses early recovery while any timed-out
+        operation is still running, preserving the no-overlap guarantee.
         """
 
         with self._lock:

--- a/Dependencies/Kotak API/kotak_execution.py
+++ b/Dependencies/Kotak API/kotak_execution.py
@@ -82,6 +82,7 @@ if str(_DEPENDENCIES_DIR) not in sys.path:
     sys.path.insert(0, str(_DEPENDENCIES_DIR))
 
 from broker_contract import (  # noqa: E402
+    TERMINAL_BROKER_STATES,
     BrokerQueryResult,
     OpenOrder,
     OpenPosition,
@@ -908,10 +909,20 @@ class KotakExecutionClient:
         )
 
     def _confirm_fill(self, order_id: str, want_qty: int) -> OrderResult:
-        """Poll briefly for a terminal result without hiding ambiguity.
+        """Poll until the order reaches a truly terminal state, or time out.
 
         Every status read still flows through the same single-worker executor, so
         it cannot overlap the placement call that preceded it.
+
+        Why the loop keeps polling on PARTIAL/UNKNOWN snapshots: a market order
+        is often observed mid-fill (state "open" with some quantity already
+        traded) or in one of Kotak's routine hand-off states ("validation
+        pending", "put order req received").  Those are TRANSIENT -- the next
+        0.5s poll usually shows COMPLETE -- so returning them as the final
+        outcome would freeze every live strategy over a perfectly healthy
+        order.  A partial/unknown snapshot becomes the real outcome only when
+        the broker label is terminal (the order can never fill further, e.g. a
+        partial fill followed by a cancel) or the timeout below expires.
         """
         deadline = time.monotonic() + _FILL_TIMEOUT_SECONDS
         last_result = normalize_order_result(
@@ -923,11 +934,15 @@ class KotakExecutionClient:
         )
         while time.monotonic() < deadline:
             last_result = self.get_order_status(order_id, requested_quantity=want_qty)
-            if last_result.status is not OrderStatus.UNKNOWN:
+            if last_result.status in {OrderStatus.FILLED, OrderStatus.REJECTED}:
+                return last_result
+            if last_result.broker_state in TERMINAL_BROKER_STATES:
+                # Terminal label with a partial/contradictory quantity snapshot:
+                # no further fills are possible, so this IS the final outcome.
                 return last_result
             if "error:" in last_result.reason.lower() or self.session_poisoned:
-                return last_result
-            if last_result.broker_state not in {"", "OPEN", "PENDING", "TRIGGER_PENDING"}:
+                # A failed status read is already indeterminate; repeating it
+                # inside the same order interaction adds no evidence.
                 return last_result
             time.sleep(_FILL_POLL_INTERVAL)
         return normalize_order_result(

--- a/Dependencies/Shoonya API/shoonya_execution.py
+++ b/Dependencies/Shoonya API/shoonya_execution.py
@@ -80,6 +80,7 @@ if str(_DEPENDENCIES_DIR) not in sys.path:
     sys.path.insert(0, str(_DEPENDENCIES_DIR))
 
 from broker_contract import (  # noqa: E402
+    TERMINAL_BROKER_STATES,
     BrokerQueryResult,
     OpenOrder,
     OpenPosition,
@@ -794,10 +795,19 @@ class ShoonyaExecutionClient:
         )
 
     def _confirm_fill(self, order_id: str, want_qty: int) -> OrderResult:
-        """Poll briefly for a terminal result without hiding ambiguity.
+        """Poll until the order reaches a truly terminal state, or time out.
 
         Polling happens outside the lock; each history request re-takes it only
         for the native, deadline-bound Noren call.
+
+        Why the loop keeps polling on PARTIAL/UNKNOWN snapshots: a market order
+        is often observed mid-fill (Noren state "open" with some quantity
+        already traded on `fillshares`).  That is TRANSIENT -- the next 0.5s
+        poll usually shows COMPLETE -- so returning it as the final outcome
+        would freeze every live strategy over a perfectly healthy order.  A
+        partial/unknown snapshot becomes the real outcome only when the broker
+        label is terminal (the order can never fill further, e.g. a partial
+        fill followed by a cancel) or the timeout below expires.
         """
         deadline = time.monotonic() + _FILL_TIMEOUT_SECONDS
         last_result = normalize_order_result(
@@ -809,11 +819,15 @@ class ShoonyaExecutionClient:
         )
         while time.monotonic() < deadline:
             last_result = self.get_order_status(order_id, requested_quantity=want_qty)
-            if last_result.status is not OrderStatus.UNKNOWN:
+            if last_result.status in {OrderStatus.FILLED, OrderStatus.REJECTED}:
+                return last_result
+            if last_result.broker_state in TERMINAL_BROKER_STATES:
+                # Terminal label with a partial/contradictory quantity snapshot:
+                # no further fills are possible, so this IS the final outcome.
                 return last_result
             if "error:" in last_result.reason.lower():
-                return last_result
-            if last_result.broker_state not in {"", "OPEN", "PENDING", "TRIGGER_PENDING"}:
+                # A failed status read is already indeterminate; repeating it
+                # inside the same order interaction adds no evidence.
                 return last_result
             time.sleep(_FILL_POLL_INTERVAL)
         return normalize_order_result(

--- a/Dependencies/Shoonya API/shoonya_execution.py
+++ b/Dependencies/Shoonya API/shoonya_execution.py
@@ -274,7 +274,15 @@ class ShoonyaExecutionClient:
             self._lock.release()
 
     def recover_after_reconciliation(self) -> bool:
-        """Explicitly clear deadline poison after the abandoned call has ended."""
+        """Explicitly clear deadline poison after the abandoned call has ended.
+
+        "Poisoned" means an earlier call outlived its 10-second budget and was
+        abandoned -- but Python cannot kill a running thread, so that call may
+        STILL be executing inside the SDK and may still place/affect an order.
+        Only after (a) reconciliation has proven the account state and (b) the
+        abandoned call has actually finished is it safe to accept new orders;
+        this method refuses (returns False) until both hold.
+        """
 
         with self._lock:
             if self._timed_out_future is not None and not self._timed_out_future.done():

--- a/Dependencies/broker_contract.py
+++ b/Dependencies/broker_contract.py
@@ -89,6 +89,16 @@ _PARTIAL_STATES = frozenset(
     {"PARTIAL", "PARTIALLY FILLED", "PARTIALLY_FILLED", "PARTIALLY-FILLED"}
 )
 
+# Every broker label that means "this order can never fill any further".  The
+# adapters' fill-confirmation loops poll until they see one of these (or their
+# timeout expires): anything else -- "OPEN", "PENDING", Kotak's "VALIDATION
+# PENDING" / "PUT ORDER REQ RECEIVED", or an unrecognized label -- is a
+# TRANSIENT state that a healthy order passes through on its way to COMPLETE,
+# so returning early on it would report a half-finished snapshot as the final
+# outcome.  This is deliberately the same terminality rule the execution
+# ledger applies when it decides whether a PARTIAL fill is final.
+TERMINAL_BROKER_STATES = _FILLED_STATES | _REJECTED_STATES
+
 
 def _non_negative_int(value: Any) -> int | None:
     """Return an exact non-negative integer, never a rounded quantity."""

--- a/Dependencies/broker_contract.py
+++ b/Dependencies/broker_contract.py
@@ -127,6 +127,29 @@ def normalize_order_result(
     A positive filled quantity always wins over a broker's rejection label because
     it proves exposure exists.  Conversely, a full requested quantity is called
     ``FILLED`` only when the broker also reports a recognized terminal fill state.
+
+    Decision table (checked top to bottom; first match wins):
+
+    ======================================  =========  ==========================
+    evidence                                status     why
+    ======================================  =========  ==========================
+    malformed/negative/fractional counts    UNKNOWN    numbers cannot be trusted,
+                                                       so neither can "zero fill"
+    0 < filled < requested                  PARTIAL    real exposure exists, and
+                                                       the count proves how much
+    partial label, no usable fill count     UNKNOWN    "partial" admits exposure
+                                                       but not its size
+    filled == requested AND terminal fill   FILLED     count and label agree the
+    label (COMPLETE/TRADED/...)                        whole order traded
+    filled == 0 AND terminal reject label   REJECTED   the only combination that
+    (REJECTED/CANCELLED/...)                           PROVES nothing traded
+    anything else                           UNKNOWN    e.g. full count while the
+                                                       order still shows OPEN
+    ======================================  =========  ==========================
+
+    The asymmetry is deliberate: a fill count beats a rejection label (a
+    cancelled order can still have partially filled first), but a fill count
+    alone never earns ``FILLED`` without a terminal label to confirm it.
     """
 
     requested = _non_negative_int(requested_quantity)

--- a/Dependencies/execution_ledger.py
+++ b/Dependencies/execution_ledger.py
@@ -142,7 +142,28 @@ class OrderAttemptHandle:
 
 @dataclass(frozen=True, slots=True)
 class LiveLegState:
-    """Coherent immutable snapshot of one live strategy leg."""
+    """Coherent immutable snapshot of one live strategy leg.
+
+    Beginner's map of the quantity fields (all in units, not lots):
+
+    - ``spec.target_quantity``      : what the strategy WANTS open in total.
+    - ``requested_quantity``        : entry quantity submitted so far.
+    - ``filled_quantity``           : entry quantity the broker confirmed
+                                      filled so far (cumulative).
+    - ``remaining_quantity``        : entry quantity still to be filled
+                                      (= target - filled).
+    - ``confirmed_live_quantity``   : what is open at the broker RIGHT NOW --
+                                      entry fills minus confirmed close fills.
+    - ``exposure_indeterminate``    : True while the newest order attempt has
+                                      not reached a terminal broker state, so
+                                      MORE quantity than confirmed may exist.
+
+    Brokers report fills CUMULATIVELY per order ("35 of 75 filled", later
+    "75 of 75"), so the ledger applies each report as a DELTA against the
+    previous snapshot of the same attempt.  Applying deltas -- instead of
+    overwriting totals -- is what makes it impossible for a repeated or
+    re-ordered status report to double-count a fill or silently erase one.
+    """
 
     exposure_id: str
     spec: LegSpec
@@ -198,7 +219,13 @@ class LiveLegState:
 
     @property
     def safe_open_retry_quantity(self) -> int:
-        """Known unfinished entry quantity, or zero while the last order may fill."""
+        """Known unfinished entry quantity, or zero while the last order may fill.
+
+        Zero means "do not submit anything yet": either the previous order is
+        still non-terminal (it may fill more on its own -- adding quantity now
+        could overshoot the target) or closing has already started.  A positive
+        number is the exact remainder a retry may safely request.
+        """
 
         if self.closing_started:
             return 0
@@ -210,7 +237,12 @@ class LiveLegState:
 
     @property
     def safe_close_retry_quantity(self) -> int:
-        """Known remaining exposure safe to submit as a reducing order."""
+        """Known remaining exposure safe to submit as a reducing order.
+
+        Only broker-CONFIRMED open quantity may be closed; while the state is
+        indeterminate this is zero, because selling units that may never have
+        been bought would open a naked short instead of reducing risk.
+        """
 
         if self.exposure_indeterminate:
             return 0
@@ -218,7 +250,14 @@ class LiveLegState:
 
     @property
     def risk_quantity(self) -> int:
-        """Conservative quantity to use for risk and shutdown decisions."""
+        """Conservative quantity to use for risk and shutdown decisions.
+
+        The mirror-image of the two "safe retry" properties: where those round
+        AMBIGUITY DOWN (never submit quantity that might not be needed), risk
+        maths must round ambiguity UP -- an indeterminate open attempt is
+        counted as if its whole remainder filled, so mark-to-market and
+        max-loss checks can never treat possible exposure as flat.
+        """
 
         attempt = self.latest_attempt
         if self.exposure_indeterminate and attempt is not None and attempt.intent is OrderIntent.OPEN:

--- a/Dependencies/next_open_entry.py
+++ b/Dependencies/next_open_entry.py
@@ -1,4 +1,25 @@
-"""One-bar lifetime and price rebasing for ``NEXT_OPEN`` strategy signals."""
+"""One-bar lifetime and price rebasing for ``NEXT_OPEN`` strategy signals.
+
+Some strategies (Goldmine, Money Machine) generate a setup on a COMPLETED
+candle but are only allowed to enter at the OPEN of the candle that follows.
+This module holds the two rules that make that safe:
+
+1.  **Exactly one bar of life.**  Candles in this repo are labelled by their
+    START time: a 5-minute candle stamped 09:20 covers 09:20-09:24 and is
+    complete at 09:25.  So a signal read from the 09:20 candle may execute
+    only at the bar labelled 09:25 (``signal_at + timeframe``) and expires the
+    moment data for 09:30 or later exists.  A gap in the feed can therefore
+    never revive a stale setup minutes later at prices the setup never
+    contemplated.
+
+2.  **Rebasing keeps DISTANCES, not levels.**  The setup's stop and target are
+    meaningful relative to its intended entry price.  If the next bar opens
+    with a gap, re-using the original absolute levels could put the target
+    behind the new entry (an instant "win") or the stop absurdly far away.
+    Rebasing shifts stop and target onto the ACTUAL observed open while
+    preserving the original stop/target distances, then re-checks that the
+    geometry still makes sense.
+"""
 
 from __future__ import annotations
 
@@ -24,7 +45,11 @@ def _finite_price(value: Any) -> float | None:
 
 @dataclass(frozen=True, slots=True)
 class RebasedNextOpenEntry:
-    """Observed entry plus stop/target shifted by the setup distances."""
+    """Observed entry plus stop/target shifted by the setup distances.
+
+    ``entry`` is the real next-bar open the market printed; ``stop`` and
+    ``target`` sit at the setup's original distances from that entry.
+    """
 
     direction: str
     observed_at: datetime
@@ -111,7 +136,14 @@ class PendingNextOpenEntry:
         observed_at: datetime,
         observed_entry: float,
     ) -> RebasedNextOpenEntry | None:
-        """Shift stop/target distances onto the exact observed next-bar open."""
+        """Shift stop/target distances onto the exact observed next-bar open.
+
+        Returns ``None`` (no trade) unless the observed row is EXACTLY the
+        expected next bar, its open is a usable price, and the rebased levels
+        still form valid geometry (stop below a LONG entry, target above it,
+        and mirrored for SHORT).  A gap large enough to break that geometry
+        rejects the entry rather than trading a setup that no longer exists.
+        """
 
         if not isinstance(observed_at, datetime):
             return None

--- a/Dependencies/secret_redaction.py
+++ b/Dependencies/secret_redaction.py
@@ -1,4 +1,26 @@
-"""Shared fail-safe redaction for broker, OAuth, and notifier diagnostics."""
+"""Shared fail-safe redaction for broker, OAuth, and notifier diagnostics.
+
+Broker replies, login errors, and Telegram failures are exactly the payloads
+an operator most wants to see in a log -- and exactly the payloads most likely
+to carry a session token, password, TOTP, or personal identifier.  This module
+gives every diagnostic call site one shared way to strip those values before
+they can reach a log file or an alert.
+
+Which helper to use when
+------------------------
+- ``redact_text``    : you have ONE string (an exception message, a response
+  body, a URL) and want a safe copy of it.
+- ``redact_payload`` : you have a STRUCTURE (the dict/list a broker returned)
+  and want a safe deep copy -- sensitive KEYS are blanked wholesale, and every
+  string VALUE inside is additionally run through ``redact_text``.
+- ``RedactingFilter`` / ``install_redaction_filter`` : a last-line guard you
+  can attach to a logger so even records someone forgets to redact are
+  scrubbed on their way out (DEBUG lines and exception tracebacks included).
+
+Redaction here deliberately prefers false positives (blanking something
+harmless) over false negatives (leaking a credential): a blanked field costs a
+little debugging convenience, a leaked token is a live-money security problem.
+"""
 
 from __future__ import annotations
 
@@ -8,25 +30,51 @@ from collections.abc import Iterable, Mapping
 from typing import Any
 
 REDACTED = "<redacted>"
+
+# Substrings that mark a dict KEY as sensitive.  Matching is by substring on a
+# normalized (lowercased, punctuation-stripped) key, so "jKey", "JKey" and
+# "j-key" all hit "jkey", and "accessToken"/"access_token" both hit "token".
+# The cost of that looseness is occasional over-redaction (e.g. a key named
+# "companyName" contains "pan") -- accepted on purpose, see the module note.
 _SENSITIVE_PARTS = (
     "token", "jkey", "password", "passwd", "mpin", "totp", "secret",
     "appkey", "app_key", "api_key", "apikey", "authorization", "cookie",
     "session", "pan", "dob", "birth", "client_id", "clientid",
 )
+
+# Credential ASSIGNMENTS embedded in free text.  Matches shapes such as
+#   token=abc123        password: "hunter2"      jKey='SESSIONKEY'
+# i.e. a known credential word, then ':' or '=' (optionally quoted), then the
+# value itself.  Group 1 keeps the name, group 2 keeps the separator, and the
+# value (group 3) is replaced -- so the log still shows WHICH field was
+# present, just never what it contained.
 _ASSIGNMENT_RE = re.compile(
     r"(?i)(token|jkey|password|passwd|mpin|totp|secret|app[_-]?key|api[_-]?key|"
     r"authorization|session|pan|dob)(\s*[\"']?\s*[:=]\s*[\"']?)([^\s,;&}\"']+)"
 )
+
+# Telegram bakes the bot token INTO the request URL
+# (https://api.telegram.org/bot<token>/sendMessage), so an HTTP exception's
+# text leaks it verbatim.  Replace everything between "/bot" and the next "/".
 _TELEGRAM_URL_RE = re.compile(r"(?i)(api\.telegram\.org/bot)[^/\s]+")
 
 
 def _sensitive_key(key: object) -> bool:
+    """Return whether a mapping key names credential/identity material."""
     normalized = re.sub(r"[^a-z0-9_]", "", str(key).lower())
     return any(part in normalized for part in _SENSITIVE_PARTS)
 
 
 def redact_text(value: object, secrets: Iterable[str] = ()) -> str:
-    """Redact credential assignments, Telegram URL tokens, and known secrets."""
+    """Return a log-safe string: known secrets, URL tokens, and assignments gone.
+
+    ``secrets`` are the exact values THIS call site already holds (the
+    password it sent, the token it used).  They are replaced first, longest
+    value first, so a secret that happens to contain a shorter secret cannot
+    leave a recognizable fragment behind.  The Telegram-URL and
+    assignment-pattern passes then catch credentials the caller did not know
+    were embedded in the text.
+    """
     text = str(value)
     for secret in sorted({str(item) for item in secrets if str(item)}, key=len, reverse=True):
         text = text.replace(secret, REDACTED)
@@ -35,7 +83,14 @@ def redact_text(value: object, secrets: Iterable[str] = ()) -> str:
 
 
 def redact_payload(value: Any, secrets: Iterable[str] = ()) -> Any:
-    """Recursively return a log-safe copy without mutating the broker response."""
+    """Recursively return a log-safe copy without mutating the broker response.
+
+    Dictionaries get key-based blanking (a key like ``jKey`` loses its whole
+    value regardless of what that value looks like); every nested string also
+    goes through :func:`redact_text`.  Non-container, non-string leaves
+    (numbers, booleans, ``None``) pass through untouched.  The original object
+    is never modified -- the caller may still need the real values to trade.
+    """
     if isinstance(value, Mapping):
         return {
             key: REDACTED if _sensitive_key(key) else redact_payload(item, secrets)
@@ -53,7 +108,12 @@ def redact_payload(value: Any, secrets: Iterable[str] = ()) -> Any:
 
 
 class RedactingFilter(logging.Filter):
-    """Last-line log guard, including DEBUG records and exception strings."""
+    """Last-line log guard, including DEBUG records and exception strings.
+
+    Attached to a logger (or handler), this rewrites each record in place
+    BEFORE it is formatted: the message text, the lazy ``%s`` arguments, and
+    -- most importantly -- any attached exception.
+    """
 
     def __init__(self, secrets: Iterable[str] = ()) -> None:
         super().__init__()
@@ -64,8 +124,12 @@ class RedactingFilter(logging.Filter):
         if record.args:
             record.args = redact_payload(record.args, self._secrets)
         if record.exc_info:
-            # Format now, redact, and clear exc_info so logging cannot append the
-            # original secret-bearing exception again after this filter returns.
+            # A raw exception object can carry the offending request/response
+            # in its args, and logging would normally format that traceback
+            # AFTER all filters have run -- bypassing this guard entirely.
+            # Format the traceback NOW, redact the resulting text, fold it
+            # into the message, and clear exc_info/exc_text so the logging
+            # machinery has nothing secret-bearing left to append.
             formatter = logging.Formatter()
             record.msg = f"{record.msg}\n{redact_text(formatter.formatException(record.exc_info), self._secrets)}"
             record.exc_info = None
@@ -74,7 +138,13 @@ class RedactingFilter(logging.Filter):
 
 
 def install_redaction_filter(logger: logging.Logger, secrets: Iterable[str] = ()) -> None:
-    """Install one filter on a logger and all of its current handlers."""
+    """Install one filter on a logger and all of its current handlers.
+
+    The filter goes on the handlers as well because logger-level filters only
+    see records CREATED through that logger -- records propagated up from
+    child loggers reach the handlers directly.  Handlers added after this call
+    are not covered; install the filter after logging setup is complete.
+    """
     guard = RedactingFilter(secrets)
     logger.addFilter(guard)
     for handler in logger.handlers:

--- a/Dependencies/test_broker_contract.py
+++ b/Dependencies/test_broker_contract.py
@@ -306,6 +306,62 @@ def test_flattrade_place_order_normalizes_terminal_outcomes(
     assert result.remaining_quantity == remaining
 
 
+def test_flattrade_mid_fill_open_snapshot_polls_to_completion(
+    flattrade_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """A market order caught mid-fill (state OPEN) is transient, not terminal.
+
+    Returning that first snapshot as PARTIAL would freeze every live entry
+    over a healthy order; the loop must poll again and report the full fill.
+    """
+
+    client = _ready_flattrade_client(flattrade_module, monkeypatch)
+    monkeypatch.setattr(flattrade_module, "_FILL_POLL_INTERVAL", 0.001)
+    replies = iter(
+        [
+            {"stat": "Ok", "norenordno": "FT-MIDFILL"},
+            [{"stat": "Ok", "status": "OPEN", "fillshares": "25", "qty": "75"}],
+            [{"stat": "Ok", "status": "COMPLETE", "fillshares": "75", "qty": "75"}],
+        ]
+    )
+    monkeypatch.setattr(client, "_post_api", lambda *args, **kwargs: next(replies))
+
+    result = client.place_market_order("NIFTY", "BUY", 75)
+
+    assert result.status.name == "FILLED"
+    assert result.order_id == "FT-MIDFILL"
+    assert result.filled_quantity == 75
+    assert result.remaining_quantity == 0
+
+
+def test_flattrade_partial_then_cancelled_is_terminal_partial(
+    flattrade_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """A partial fill followed by a cancel can never fill further.
+
+    The terminal broker label makes the very first snapshot the final
+    outcome; no further polling is needed (or possible -- the reply iterator
+    holds exactly one status response).
+    """
+
+    client = _ready_flattrade_client(flattrade_module, monkeypatch)
+    replies = iter(
+        [
+            {"stat": "Ok", "norenordno": "FT-PARTCXL"},
+            [{"stat": "Ok", "status": "CANCELED", "fillshares": "25", "qty": "75"}],
+        ]
+    )
+    monkeypatch.setattr(client, "_post_api", lambda *args, **kwargs: next(replies))
+
+    result = client.place_market_order("NIFTY", "BUY", 75)
+
+    assert result.status.name == "PARTIAL"
+    assert result.filled_quantity == 25
+    assert result.remaining_quantity == 50
+
+
 def test_flattrade_transmits_execution_ledger_tag(
     flattrade_module: ModuleType,
     monkeypatch,
@@ -863,6 +919,40 @@ def test_shoonya_place_order_normalizes_terminal_outcomes(
     assert result.remaining_quantity == remaining
 
 
+def test_shoonya_mid_fill_open_snapshot_polls_to_completion(
+    shoonya_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """A mid-fill OPEN snapshot keeps polling until the fill completes."""
+
+    class _SequencedNoren(_FakeNorenClient):
+        """History fake that replays a sequence, then repeats the last reply."""
+
+        def __init__(self, sequence) -> None:
+            super().__init__()
+            self._sequence = list(sequence)
+
+        def single_order_history(self, order_id):
+            if len(self._sequence) > 1:
+                return self._sequence.pop(0)
+            return self._sequence[0]
+
+    fake = _SequencedNoren(
+        [
+            [{"stat": "Ok", "status": "OPEN", "fillshares": "25", "qty": "75"}],
+            [{"stat": "Ok", "status": "COMPLETE", "fillshares": "75", "qty": "75"}],
+        ]
+    )
+    client = _ready_shoonya_client(shoonya_module, monkeypatch, fake)
+    monkeypatch.setattr(shoonya_module, "_FILL_POLL_INTERVAL", 0.001)
+
+    result = client.place_market_order("NIFTY", "BUY", 75)
+
+    assert result.status.name == "FILLED"
+    assert result.filled_quantity == 75
+    assert result.remaining_quantity == 0
+
+
 def test_shoonya_transmits_execution_ledger_tag(
     shoonya_module: ModuleType,
     monkeypatch,
@@ -1403,6 +1493,45 @@ def test_kotak_place_order_normalizes_terminal_outcomes(
     assert result.order_id == "KT-1"
     assert result.filled_quantity == filled
     assert result.remaining_quantity == remaining
+
+
+def test_kotak_transient_hand_off_states_poll_to_completion(
+    kotak_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """Kotak's routine hand-off states must not end fill confirmation early.
+
+    "put order req received" and "validation pending" are states every healthy
+    Kotak order passes through.  Treating them as terminal would report a
+    perfectly normal order as UNKNOWN and freeze all live entries.
+    """
+
+    class _SequencedKotakSdk(_FakeKotakSdk):
+        """History fake that replays a sequence, then repeats the last row."""
+
+        def __init__(self, rows) -> None:
+            super().__init__()
+            self._rows = list(rows)
+
+        def order_history(self, order_id):
+            row = self._rows.pop(0) if len(self._rows) > 1 else self._rows[0]
+            return {"data": {"stat": "Ok", "data": [row]}}
+
+    fake = _SequencedKotakSdk(
+        [
+            {"ordSt": "put order req received", "fldQty": "0", "qty": "75"},
+            {"ordSt": "validation pending", "fldQty": "0", "qty": "75"},
+            {"ordSt": "complete", "fldQty": "75", "qty": "75"},
+        ]
+    )
+    client = _ready_kotak_client(kotak_module, monkeypatch, fake)
+    monkeypatch.setattr(kotak_module, "_FILL_POLL_INTERVAL", 0.001)
+
+    result = client.place_market_order("NIFTY", "BUY", 75)
+
+    assert result.status.name == "FILLED"
+    assert result.filled_quantity == 75
+    assert client.session_poisoned is False
 
 
 def test_kotak_zero_broker_quantity_cannot_confirm_a_fill(

--- a/Nifty Multi Strategy Front Test - Master File.py
+++ b/Nifty Multi Strategy Front Test - Master File.py
@@ -12967,11 +12967,17 @@ def _start_and_supervise_runtime_threads(
     return False
 
 
-def _shutdown_account_audit(
-    store: SharedMarketDataStore,
-    client: ExecutionClient | None,
-) -> StartupExposureAudit:
-    """Return fixed-vocabulary evidence that process-wide exposure is flat."""
+def _runner_exposure_audit(store: SharedMarketDataStore) -> StartupExposureAudit:
+    """Hard finalization gate: is the RUNNER's own tracked exposure flat?
+
+    The execution ledger registers every live order attempt BEFORE it is
+    submitted and keeps the leg active while any quantity is confirmed open or
+    still indeterminate, so an empty ledger means every order this process
+    placed is broker-confirmed flat.  Exposure the runner did not create --
+    the operator's own manual trades in the same account -- is deliberately
+    NOT part of this gate: it is reported loudly by the advisory account
+    audit below instead of blocking results/logout forever.
+    """
 
     active_states = store.execution_ledger.active_states()
     if active_states:
@@ -12983,23 +12989,44 @@ def _shutdown_account_audit(
                 f"risk_quantity={sum(state.risk_quantity for state in active_states)}",
             ),
         )
+    return StartupExposureAudit(
+        safe_to_enable_live=True,
+        reasons=(),
+        evidence=("tracked_legs=0",),
+    )
+
+
+def _advisory_account_audit(
+    store: SharedMarketDataStore,
+    client: ExecutionClient | None,
+) -> StartupExposureAudit:
+    """Best-effort ACCOUNT-level book check, reported but never blocking.
+
+    The operator may hold manual positions or working orders in the same
+    account, so a non-flat account combined with a flat runner ledger is a
+    WARNING (log + Telegram alert), not a reason to withhold the day's
+    results or the logout forever.  Fixed vocabulary only: raw broker
+    payloads, symbols and order ids never reach the alert text.
+    """
 
     if client is None:
         if store.live_session_started:
             return StartupExposureAudit(
                 safe_to_enable_live=False,
                 reasons=("The live broker client was unavailable at shutdown.",),
-                evidence=("execution_client=unavailable", "tracked_legs=0"),
+                evidence=("execution_client=unavailable",),
             )
         return StartupExposureAudit(
             safe_to_enable_live=True,
             reasons=(),
-            evidence=("execution_client=unavailable", "tracked_legs=0"),
+            evidence=("execution_client=unavailable",),
         )
 
     login_state = getattr(client, "is_logged_in", None)
     if login_state is False:
         if store.live_session_started:
+            # One best-effort re-login so the books can actually be read for
+            # the warning; a failure downgrades to "session unavailable".
             try:
                 recovered = client.ensure_logged_in()
             except Exception:  # noqa: BLE001 - never log broker auth payloads
@@ -13008,23 +13035,20 @@ def _shutdown_account_audit(
                 return StartupExposureAudit(
                     safe_to_enable_live=False,
                     reasons=("The live broker session was unavailable at shutdown.",),
-                    evidence=(
-                        "broker_session=recovery_failed",
-                        "tracked_legs=0",
-                    ),
+                    evidence=("broker_session=recovery_failed",),
                 )
             login_state = True
         else:
             return StartupExposureAudit(
                 safe_to_enable_live=True,
                 reasons=(),
-                evidence=("broker_session=not_logged_in", "tracked_legs=0"),
+                evidence=("broker_session=not_logged_in",),
             )
     if login_state is not True:
         return StartupExposureAudit(
             safe_to_enable_live=False,
             reasons=("Broker session state was indeterminate at shutdown.",),
-            evidence=("broker_session=indeterminate", "tracked_legs=0"),
+            evidence=("broker_session=indeterminate",),
         )
 
     try:
@@ -13037,6 +13061,48 @@ def _shutdown_account_audit(
         )
 
 
+def _warn_if_account_not_flat(
+    store: SharedMarketDataStore,
+    client: ExecutionClient | None,
+    event_queue: queue.Queue | None,
+) -> bool:
+    """Alert (never block) when the ACCOUNT shows exposure after the runner is flat.
+
+    Returns True when a warning was raised, so tests can assert the alert path.
+    """
+
+    try:
+        advisory = _advisory_account_audit(store, client)
+    except KeyboardInterrupt:
+        logger.error(
+            "Advisory account check interrupted; finalizing on the flat runner ledger."
+        )
+        return False
+    if advisory.safe_to_enable_live:
+        return False
+    safe_detail = " ".join((*advisory.reasons, *advisory.evidence))
+    logger.error(
+        "SHUTDOWN ACCOUNT WARNING | the runner's own exposure is flat, but the "
+        "account books are not proven flat (manual positions/orders, or an "
+        "unreadable book) | %s",
+        safe_detail,
+    )
+    if event_queue is not None:
+        with contextlib.suppress(Exception):
+            event_queue.put_nowait(
+                {
+                    "action": "SHUTDOWN_ACCOUNT_WARNING",
+                    "strategy": "Process Supervisor",
+                    # The generic Telegram format renders `direction` as the
+                    # detail line, exactly like the startup-exposure alert.
+                    "direction": safe_detail,
+                    "reason": safe_detail,
+                    "mode": "LIVE" if store.live_session_started else "PAPER",
+                }
+            )
+    return True
+
+
 def _wait_for_shutdown_account_flat(
     store: SharedMarketDataStore,
     client: ExecutionClient | None,
@@ -13045,11 +13111,14 @@ def _wait_for_shutdown_account_flat(
     sleep=time.sleep,
     max_attempts: int | None = None,
 ) -> bool:
-    """Retry the final account audit forever in production until it is flat.
+    """Retry until the RUNNER's tracked exposure is broker-confirmed flat.
 
     ``max_attempts`` exists only for deterministic tests and diagnostics.  The
-    production caller leaves it as ``None`` so a permanent broker failure keeps
+    production caller leaves it as ``None`` so unresolved runner exposure keeps
     the process alive and alerting instead of allowing logout or clean results.
+    Account-level books are deliberately not part of this gate: the operator
+    may hold manual positions in the same account, and those are reported as
+    a warning by `_finalize_flat_session` rather than blocking here forever.
     """
 
     if max_attempts is not None and max_attempts <= 0:
@@ -13058,24 +13127,25 @@ def _wait_for_shutdown_account_flat(
     while True:
         attempt += 1
         try:
-            audit = _shutdown_account_audit(store, client)
+            audit = _runner_exposure_audit(store)
         except KeyboardInterrupt:
             logger.error(
-                "Shutdown reconciliation is still proving broker exposure flat; "
+                "Shutdown reconciliation is still proving runner exposure flat; "
                 "interrupt ignored."
             )
             continue
         if audit.safe_to_enable_live:
             logger.info(
-                "SHUTDOWN ACCOUNT FLAT | final broker audit passed after %d attempt(s).",
+                "SHUTDOWN RUNNER FLAT | the execution ledger confirmed flat "
+                "after %d attempt(s).",
                 attempt,
             )
             return True
 
         safe_detail = " ".join((*audit.reasons, *audit.evidence))
         logger.error(
-            "DEGRADED PROCESS SHUTDOWN | account is not broker-confirmed flat | "
-            "attempt=%d | %s",
+            "DEGRADED PROCESS SHUTDOWN | runner exposure is not broker-confirmed "
+            "flat | attempt=%d | %s",
             attempt,
             safe_detail,
         )
@@ -13100,7 +13170,7 @@ def _wait_for_shutdown_account_flat(
             sleep(delay)
         except KeyboardInterrupt:
             logger.error(
-                "Shutdown reconciliation is still proving broker exposure flat; "
+                "Shutdown reconciliation is still proving runner exposure flat; "
                 "interrupt ignored."
             )
 
@@ -13113,22 +13183,31 @@ def _finalize_flat_session(
     trade_event_queue: queue.Queue | None,
     natural_eod: bool,
 ) -> bool:
-    """Write results, logout, and refresh only after a fresh flat audit."""
+    """Write results, logout, and refresh once the RUNNER's exposure is flat.
+
+    The hard gate is the execution ledger (this process's own tracked
+    exposure).  The account-level books are then checked once, as an advisory
+    warning: the operator's manual positions must not strand the day's
+    results, the logout, or the next-day instrument refresh forever.
+    """
 
     try:
-        audit = _shutdown_account_audit(store, client)
+        audit = _runner_exposure_audit(store)
     except KeyboardInterrupt:
         logger.error(
-            "Final broker-flat proof is still in progress; interrupt ignored and "
+            "Final runner-flat proof is still in progress; interrupt ignored and "
             "session finalization remains blocked."
         )
         return False
     if not audit.safe_to_enable_live:
         logger.error(
-            "SESSION FINALIZATION BLOCKED | broker exposure is not confirmed flat | %s",
+            "SESSION FINALIZATION BLOCKED | the runner's tracked exposure is not "
+            "confirmed flat | %s",
             " ".join((*audit.reasons, *audit.evidence)),
         )
         return False
+
+    _warn_if_account_not_flat(store, client, trade_event_queue)
 
     if natural_eod:
         _publish_eod_summary(workers, trade_event_queue)
@@ -13345,9 +13424,11 @@ def main() -> None:
         workers,
     )
 
-    # Even after every local owner reaches STOPPED, the broker books get one
-    # process-wide proof. An indeterminate/open book keeps this process alive
-    # on 1/2/5-second capped retries; no logout, result write, or refresh occurs.
+    # Even after every local owner reaches STOPPED, the execution ledger gets
+    # one process-wide proof. Unresolved RUNNER exposure keeps this process
+    # alive on 1/2/5-second capped retries; no logout, result write, or refresh
+    # occurs. Account-level books (which may hold the operator's own manual
+    # positions) are then checked once and reported as a warning, not a block.
     _wait_for_shutdown_account_flat(
         store,
         execution_client,

--- a/Nifty Multi Strategy Front Test - Master File.py
+++ b/Nifty Multi Strategy Front Test - Master File.py
@@ -3408,6 +3408,16 @@ class BasePaperStrategyWorker(threading.Thread):
         opening_side = str(opening_side).upper().strip()
         if not re.fullmatch(r"[A-Z0-9]{8}", correlation_id):
             return False
+        # Each tuple is (completed anchor's role, companion's role, anchor's
+        # opening side, companion's opening side) -- the ONLY basket shapes
+        # this runner ever builds:
+        #   H -> M : protective hedge BUY confirmed, now the main short SELL
+        #            (the hedged-puts / Delta-0.2 spread order of operations);
+        #   N -> B : NIFTY leg BUY confirmed, now the equal-lot BankNIFTY
+        #            mirror BUY (SL Hunting basket);
+        #   C -> P : strangle CE BUY confirmed, now its PE BUY twin.
+        # Anything not in this table is a brand-new exposure, which a frozen
+        # account must never accept.
         allowed_transitions = {
             ("H", "M", "BUY", "SELL"),
             ("N", "B", "BUY", "BUY"),
@@ -4949,7 +4959,15 @@ class BasePaperStrategyWorker(threading.Thread):
         )
 
     def _wait_for_shutdown_retry(self) -> None:
-        """Wait without spinning even when the legacy stop event is already set."""
+        """Wait without spinning even when the legacy stop event is already set.
+
+        The run loop cannot use ``stop_event.wait`` here: during shutdown the
+        event is typically already set, so waiting on it would return
+        immediately and turn the flatten/reconcile loop into a busy spin.  A
+        plain sleep, capped at the poll cadence and floored at 50ms, keeps the
+        worker responsive to its 1/2/5-second retry schedule without burning a
+        CPU core while it waits to become broker-confirmed flat.
+        """
 
         snapshot = self.lifecycle.snapshot()
         if snapshot.state in {LifecycleState.FLAT, LifecycleState.STOPPED}:
@@ -11660,7 +11678,17 @@ if SL_HUNTING_AVAILABLE:
             self.log.debug("SL Hunting inference invalidated: %s", reason)
 
         def _consume_agent_decision(self) -> None:
-            """Collect a completed background pass without ever waiting for it."""
+            """Collect a completed background pass without ever waiting for it.
+
+            The harvest half of the inference cycle: `_start_agent_inference`
+            launches a daemon thread and returns immediately; every later poll
+            calls this first to pick up the finished decision (log + journal
+            it) -- never `join()`ing, so a hung SDK call can never delay the
+            stop/target, max-loss, or 15:15 square-off checks that run right
+            after.  Any real order the agent placed already happened DURING
+            the pass via the locked tool context; a stale generation here only
+            skips the bookkeeping, never an order.
+            """
             payload = None
             with self._agent_inference_lock:
                 thread = self._agent_inference_thread
@@ -11702,7 +11730,14 @@ if SL_HUNTING_AVAILABLE:
         def _start_agent_inference(
             self, strategy_frame: pd.DataFrame, bnf_candles: pd.DataFrame | None
         ) -> bool:
-            """Start one daemon inference pass; return immediately to the risk loop."""
+            """Start one daemon inference pass; return immediately to the risk loop.
+
+            At most one pass exists at a time (returns False while one is
+            running).  Bumping the generation counter first makes every
+            previously issued tool capability stale, and deep-copying both
+            frames gives the pass an immutable market snapshot the fetcher
+            thread cannot mutate mid-inference.
+            """
             with self._agent_inference_lock:
                 if self._agent_inference_thread is not None:
                     return False

--- a/Nifty Multi Strategy Front Test - Master File.py
+++ b/Nifty Multi Strategy Front Test - Master File.py
@@ -4834,20 +4834,23 @@ class BasePaperStrategyWorker(threading.Thread):
         )
 
     def request_worker_shutdown(self, reason: str) -> None:
-        """Block entries immediately and start this worker's safe shutdown."""
+        """Block THIS worker's entries immediately and start its safe shutdown.
+
+        The block is deliberately scoped to this one worker: its own lifecycle
+        gate refuses new opening orders both at the top of `_place_real_leg`
+        and again at the final broker-submission boundary, so a max-loss stop
+        or an early square-off here never freezes the shared account-wide
+        entry gate that the OTHER strategies are still trading through.  The
+        shared gate stays reserved for conditions that genuinely make the
+        whole account unsafe: indeterminate broker exposure, a failed startup
+        audit, and the stale-market-data guard.
+        """
 
         before = self.lifecycle.snapshot()
         snapshot = self.lifecycle.request_shutdown(reason)
         if before.state is LifecycleState.RUNNING:
-            # An unattributed freeze is intentional: shutdown forbids even a
-            # planned basket companion from increasing account exposure.
-            self.store.execution_safety.freeze_entries(
-                f"{self.strategy_name} shutdown requested: {snapshot.shutdown_reason}"
-            )
-            self._live_execution_frozen = True
-            self._live_execution_freeze_reason = snapshot.shutdown_reason
             self.log.warning(
-                "LIFECYCLE %s -> %s | reason=%s | new entries blocked.",
+                "LIFECYCLE %s -> %s | reason=%s | new entries blocked for this worker.",
                 before.state.value,
                 snapshot.state.value,
                 snapshot.shutdown_reason,

--- a/test_nifty_multi_strategy_master.py
+++ b/test_nifty_multi_strategy_master.py
@@ -6465,6 +6465,49 @@ class TestCoordinatedShutdownSupervisor(unittest.TestCase):
             BrokerQueryResult.success(()),
         )
 
+    @staticmethod
+    def _store_with_tracked_leg():
+        """Build a store whose execution ledger tracks one unresolved live leg."""
+        from Dependencies.execution_ledger import LegSpec
+
+        store = master_file.SharedMarketDataStore()
+        spec = LegSpec(
+            strategy="Renko",
+            correlation_id="ABCD1234",
+            role="N",
+            underlying="NIFTY",
+            symbol="NIFTY16JUL2622500CE",
+            option_type="CE",
+            strike=22500.0,
+            expiry=None,
+            opening_side="BUY",
+            target_quantity=75,
+        )
+        state = store.execution_ledger.register(spec)
+        return store, state
+
+    @staticmethod
+    def _flatten_tracked_leg(store, state):
+        """Resolve the tracked leg with a terminal zero-fill rejection (flat)."""
+        from Dependencies.broker_contract import OrderResult, OrderStatus
+        from Dependencies.execution_ledger import OrderIntent
+
+        handle = store.execution_ledger.start_attempt(
+            state.exposure_id, OrderIntent.OPEN, 75
+        )
+        store.execution_ledger.apply_result(
+            handle,
+            OrderResult(
+                order_id="TEST-FLAT-1",
+                requested_quantity=75,
+                filled_quantity=0,
+                remaining_quantity=75,
+                status=OrderStatus.REJECTED,
+                broker_state="REJECTED",
+                reason="test rejection",
+            ),
+        )
+
     def test_ctrl_c_requests_worker_shutdown_without_setting_terminal_event(self):
         workers = [MagicMock(), MagicMock()]
         terminal_event = threading.Event()
@@ -6513,28 +6556,34 @@ class TestCoordinatedShutdownSupervisor(unittest.TestCase):
         self.assertFalse(worker.alive)
         self.assertEqual(worker.shutdown_requests, ["KEYBOARD_INTERRUPT"])
 
-    def test_transient_account_audit_retries_then_proves_flat(self):
-        client = self._ShutdownClient(
-            [self._indeterminate_books(), self._flat_books()]
-        )
+    def test_wait_retries_until_runner_ledger_confirms_flat(self):
+        """Unresolved RUNNER exposure blocks; account books never block here."""
+
+        client = self._ShutdownClient([self._indeterminate_books()])
+        store, state = self._store_with_tracked_leg()
         sleeps = []
 
+        def flattening_sleep(delay):
+            sleeps.append(delay)
+            self._flatten_tracked_leg(store, state)
+
         flat = master_file._wait_for_shutdown_account_flat(
-            master_file.SharedMarketDataStore(),
+            store,
             client,
-            sleep=sleeps.append,
+            sleep=flattening_sleep,
             max_attempts=3,
         )
 
         self.assertTrue(flat)
         self.assertEqual(sleeps, [1.0])
 
-    def test_permanent_account_failure_never_allows_clean_finalization(self):
-        client = self._ShutdownClient([self._indeterminate_books()])
+    def test_permanent_runner_exposure_never_allows_clean_finalization(self):
+        client = self._ShutdownClient([self._flat_books()])
+        store, _state = self._store_with_tracked_leg()
         sleeps = []
 
         flat = master_file._wait_for_shutdown_account_flat(
-            master_file.SharedMarketDataStore(),
+            store,
             client,
             sleep=sleeps.append,
             max_attempts=4,
@@ -6547,7 +6596,7 @@ class TestCoordinatedShutdownSupervisor(unittest.TestCase):
         store = master_file.SharedMarketDataStore()
         store.live_session_started = True
 
-        audit = master_file._shutdown_account_audit(store, None)
+        audit = master_file._advisory_account_audit(store, None)
 
         self.assertFalse(audit.safe_to_enable_live)
         self.assertIn("unavailable", " ".join(audit.reasons).lower())
@@ -6568,7 +6617,7 @@ class TestCoordinatedShutdownSupervisor(unittest.TestCase):
         store.live_session_started = True
         client = RecoveringClient()
 
-        audit = master_file._shutdown_account_audit(store, client)
+        audit = master_file._advisory_account_audit(store, client)
 
         self.assertTrue(audit.safe_to_enable_live)
         self.assertEqual(client.ensure_calls, 1)
@@ -6580,33 +6629,34 @@ class TestCoordinatedShutdownSupervisor(unittest.TestCase):
         store = master_file.SharedMarketDataStore()
         store.live_session_started = True
 
-        audit = master_file._shutdown_account_audit(store, client)
+        audit = master_file._advisory_account_audit(store, client)
 
         self.assertFalse(audit.safe_to_enable_live)
         client.ensure_logged_in.assert_called_once_with()
 
-    def test_additional_interrupt_cannot_bypass_final_account_reconciliation(self):
-        client = self._ShutdownClient(
-            [self._indeterminate_books(), self._flat_books()]
-        )
+    def test_additional_interrupt_cannot_bypass_final_runner_reconciliation(self):
+        client = self._ShutdownClient([self._flat_books()])
+        store, state = self._store_with_tracked_leg()
         sleeps = []
 
-        def interrupted_sleep(delay):
+        def interrupted_flattening_sleep(delay):
             sleeps.append(delay)
+            self._flatten_tracked_leg(store, state)
             raise KeyboardInterrupt
 
         flat = master_file._wait_for_shutdown_account_flat(
-            master_file.SharedMarketDataStore(),
+            store,
             client,
-            sleep=interrupted_sleep,
+            sleep=interrupted_flattening_sleep,
             max_attempts=3,
         )
 
         self.assertTrue(flat)
         self.assertEqual(sleeps, [1.0])
 
-    def test_logout_results_and_refresh_are_blocked_while_broker_is_indeterminate(self):
-        client = self._ShutdownClient([self._indeterminate_books()])
+    def test_logout_results_and_refresh_are_blocked_while_runner_exposure_open(self):
+        client = self._ShutdownClient([self._flat_books()])
+        store, _state = self._store_with_tracked_leg()
         workers = [MagicMock()]
         with (
             patch.object(master_file, "_publish_eod_summary") as summary,
@@ -6615,7 +6665,7 @@ class TestCoordinatedShutdownSupervisor(unittest.TestCase):
         ):
             finalized = master_file._finalize_flat_session(
                 workers,
-                master_file.SharedMarketDataStore(),
+                store,
                 client,
                 trade_event_queue=None,
                 natural_eod=True,
@@ -6627,12 +6677,59 @@ class TestCoordinatedShutdownSupervisor(unittest.TestCase):
         sheet.assert_not_called()
         refresh.assert_not_called()
 
+    def test_manual_account_exposure_warns_but_does_not_block_finalization(self):
+        """The operator's own positions alert loudly; results/logout proceed."""
+        from Dependencies.broker_contract import OpenPosition
+
+        client = self._ShutdownClient(
+            [
+                (
+                    BrokerQueryResult.success(()),
+                    BrokerQueryResult.success(
+                        (
+                            OpenPosition(
+                                symbol="NIFTY16JUL2622500CE",
+                                quantity=75,
+                                product_type="NRML",
+                            ),
+                        )
+                    ),
+                )
+            ]
+        )
+        store = master_file.SharedMarketDataStore()
+        store.live_session_started = True
+        event_queue = master_file.queue.Queue()
+        with (
+            patch.object(master_file, "_publish_eod_summary") as summary,
+            patch.object(master_file, "_update_pnl_google_sheet") as sheet,
+            patch.object(master_file, "_refresh_instrument_master_for_next_day") as refresh,
+        ):
+            finalized = master_file._finalize_flat_session(
+                [MagicMock()],
+                store,
+                client,
+                trade_event_queue=event_queue,
+                natural_eod=True,
+            )
+
+        self.assertTrue(finalized)
+        self.assertEqual(client.logout_calls, 1)
+        summary.assert_called_once()
+        sheet.assert_called_once_with()
+        refresh.assert_called_once_with()
+        alert = event_queue.get_nowait()
+        self.assertEqual(alert["action"], "SHUTDOWN_ACCOUNT_WARNING")
+        self.assertIn("position", alert["reason"].lower())
+        # Fixed vocabulary only: the operator's symbol never reaches the alert.
+        self.assertNotIn("NIFTY16JUL2622500CE", repr(alert))
+
     def test_interrupt_during_final_flat_audit_blocks_finalization(self):
         client = self._ShutdownClient([self._flat_books()])
         with (
             patch.object(
                 master_file,
-                "_shutdown_account_audit",
+                "_runner_exposure_audit",
                 side_effect=KeyboardInterrupt,
             ),
             patch.object(master_file, "_publish_eod_summary") as summary,

--- a/test_nifty_multi_strategy_master.py
+++ b/test_nifty_multi_strategy_master.py
@@ -3152,9 +3152,11 @@ class TestSLHuntingBnfMirror(unittest.TestCase):
             self.assertTrue(worker.enter_position("LONG", 24300.0, 24290.0, 24400.0))
             self.assertTrue(worker.pos.active)
             self.assertTrue(worker._mirror_pos.active)
-            self.assertEqual(worker._mirror_pos.quantity, 140)
+            # MAT-104 floor sizing: 10-pt stop -> floor(2500 / (10*75)) = 3
+            # NIFTY lots, mirrored as 3 BNF lots x 35 = 105 units.
+            self.assertEqual(worker._mirror_pos.quantity, 105)
             self.assertEqual(worker._mirror_pos.live_leg.confirmed_live_quantity, 35)
-            self.assertEqual(worker._mirror_pos.live_leg.risk_quantity, 140)
+            self.assertEqual(worker._mirror_pos.live_leg.risk_quantity, 105)
 
             worker.exit_position("ASYMMETRIC_ENTRY_RECOVERY")
 
@@ -3163,8 +3165,8 @@ class TestSLHuntingBnfMirror(unittest.TestCase):
             for symbol, side, quantity in fake.calls
             if "BANKNIFTY" in symbol
         ]
-        self.assertEqual(bnf_orders, [("BUY", 140), ("SELL", 35)])
-        self.assertEqual(fake.status_queries, [("BNF-ENTRY-1", 140)])
+        self.assertEqual(bnf_orders, [("BUY", 105), ("SELL", 35)])
+        self.assertEqual(fake.status_queries, [("BNF-ENTRY-1", 105)])
         self.assertFalse(worker._mirror_pos.active)
 
     def test_unknown_mirror_entry_uses_conservative_risk_quantity_for_mtm(self):
@@ -3214,17 +3216,18 @@ class TestSLHuntingBnfMirror(unittest.TestCase):
         mirror = worker._mirror_pos
         self.assertTrue(mirror.active)
         self.assertEqual(mirror.live_leg.confirmed_live_quantity, 0)
-        self.assertEqual(mirror.live_leg.risk_quantity, 140)
-        self.assertEqual(mirror.quantity, 140)
+        # MAT-104 floor sizing: 3 NIFTY lots -> 3 BNF lots x 35 = 105 units.
+        self.assertEqual(mirror.live_leg.risk_quantity, 105)
+        self.assertEqual(mirror.quantity, 105)
         store.update_ltp_map({(master_file.OPTION_EXCHANGE_SEGMENT, 3003): 490.0})
-        self.assertEqual(worker._mirror_leg_pnl(), -1400.0)
+        self.assertEqual(worker._mirror_leg_pnl(), -1050.0)
         with (
             patch.object(master_file, "execution_client", fake),
             patch.object(worker, "_start_execution_reconciliation"),
         ):
             worker.exit_bnf_mirror_only("UNKNOWN_ENTRY_RECOVERY")
         self.assertTrue(worker._mirror_pos.active)
-        self.assertEqual(worker._mirror_pos.quantity, 140)
+        self.assertEqual(worker._mirror_pos.quantity, 105)
         self.assertFalse(
             any(
                 side == "SELL" and "BANKNIFTY" in symbol

--- a/test_nifty_multi_strategy_master.py
+++ b/test_nifty_multi_strategy_master.py
@@ -4008,6 +4008,34 @@ class TestLiveOrderRouting(unittest.TestCase):
         self.assertFalse(self.worker.pos.active)
         self.assertEqual(self.store.execution_ledger.active_states(), ())
 
+    def test_worker_shutdown_blocks_only_its_own_entries(self):
+        """One strategy's shutdown must not freeze the shared account gate.
+
+        A paper strategy's max-loss stop (or the earliest 15:15 square-off)
+        blocks new entries for THAT worker through its own lifecycle gate; the
+        other live strategies keep trading. The shared freeze stays reserved
+        for genuinely account-wide conditions (indeterminate exposure, a
+        failed startup audit).
+        """
+
+        self.worker.live_trading = True
+        self.worker.request_worker_shutdown("MAX_LOSS_BREACH")
+
+        # The shared account-wide gate is untouched...
+        frozen, _reason = self.store.execution_safety.entry_freeze_snapshot()
+        self.assertFalse(frozen)
+
+        # ...but this worker's own entries are refused at the order boundary.
+        fake = _FakeShoonya()
+        with patch.object(master_file, "execution_client", fake):
+            entered = self.worker.enter_position(
+                direction="LONG",
+                entry_underlying=22500.0,
+            )
+        self.assertFalse(entered)
+        self.assertEqual(fake.calls, [])
+        self.assertFalse(self.worker.pos.active)
+
     def test_live_exit_still_reduces_after_entry_gate_is_disabled(self):
         """Turning off future entries must never suppress a known live close."""
 


### PR DESCRIPTION
## Summary

Review fixes for the MAT-101…MAT-109 stack (PRs #54, #56, #59, #60, #61, #62, #63, #64, #65). The stack passed a full re-review: the order-outcome contract, quantity ledger, lifecycle machine, sizing, data health, SL Hunting serialization, and lessons hardening are all sound. Four findings survived review and are fixed here, plus a stale-test fix and a documentation pass.

**F1 — Fill confirmation treated transient broker states as terminal (all three adapters).** A market order observed mid-fill (state `OPEN` with a partial fill count) or in one of Kotak's routine hand-off states ("validation pending", "put order req received") was returned as the FINAL outcome, freezing every live strategy's new entries over a healthy order. `_confirm_fill` now polls until the broker label is genuinely terminal (shared `TERMINAL_BROKER_STATES`, the same terminality rule the execution ledger applies) or the fill timeout expires. The timeout still ends in PARTIAL/UNKNOWN → freeze, so the fail-closed direction is unchanged.

**F2 — Any worker's shutdown froze the shared account-wide entry gate.** A paper-only strategy's max-loss stop blocked every live strategy's entries for the rest of the session, the earliest square-off froze later-cutoff workers, and the unattributed freeze defeated the basket-companion authorization (BNF mirror after a confirmed NIFTY fill). The block is now scoped to the shutting-down worker via its own lifecycle gate (enforced at both submission boundaries). Indeterminate-exposure, startup-audit, and market-data-health freezes remain account-wide. *(Operator decision.)*

**F3 — EOD finalization blocked forever on account-wide exposure.** The shutdown gate retried forever while ANY open order or NIFTY/BANKNIFTY position existed in the account — including the operator's manual positions. The hard gate is now the execution ledger (the runner's own tracked exposure, including indeterminate legs); the account-book audit still runs once per finalization but as a loud `SHUTDOWN ACCOUNT WARNING` (log + fixed-vocabulary Telegram alert) instead of an infinite block. *(Operator decision: they trade manually in this account.)*

**F4 — MAT-108 spec gap: the Dhan `--access-token` CLI flag survived.** A token typed on the command line lands in shell history and process listings. The token is now environment-only (`DHAN_TOKEN_ID`); `--client-id` (an identifier, not a secret) stays. Regression test locks the flag out.

**Stale tests — two SL Hunting mirror tests still asserted MAT-102's ceil sizing** (4 lots/140 units) after MAT-104 switched to floor sizing (3 lots/105 units). They never failed in CI because the SL Hunting SDK is absent there (the whole class skips); on the live runner's machine, with `claude-agent-sdk` installed, the suite failed. Expectations updated to MAT-104 sizing.

**F5 — Beginner-friendly documentation pass** over the stack's tersest new code (`secret_redaction`, `next_open_entry`, `execution_ledger`, `broker_contract`'s decision table, adapter session-poisoning, master-file thin spots). Comments/docstrings only — verified by comparing docstring-stripped ASTs of every touched file against HEAD (all identical).

## Verification

- `python -m unittest test_nifty_multi_strategy_master` — 313 tests, OK (with claude-agent-sdk + TA-Lib installed, i.e. no skips hiding the SL Hunting tests)
- `python -m pytest -q` (repo-wide) — 749 passed
- `python -m ruff check .` — clean
- `python -m mypy` — clean (34 files)
- `python -m compileall -q .` — clean
- CI-equivalent Bandit command — clean
- F5 proven comments-only via AST comparison (docstrings stripped) of all 8 touched files

Live flags remained off throughout; no `.env` changes.

## Notes for the operator

- **TA-Lib 0.6.8 becomes a hard runtime dependency when MAT-106 (#62) merges** — verify `pip install TA-Lib==0.6.8` on the live box before running the master.
- The stack is based 7 commits behind `main` but merges cleanly (verified with `git merge-tree`); per the backlog's own delivery gate, run one full paper session after merging before re-enabling any live flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
