### PR TITLE
MAT-105 follow-up: market-data health gates become live-only (paper rides through)

### DIFF
--- a/Nifty Multi Strategy Front Test - Master File.py
+++ b/Nifty Multi Strategy Front Test - Master File.py
@@ -4745,8 +4745,19 @@ class BasePaperStrategyWorker(threading.Thread):
             self._wait_for_shutdown_retry()
 
     def _market_data_entries_allowed(self) -> bool:
-        """Fail closed for every entry path while the shared feed is unhealthy."""
+        """Fail closed for every REAL entry path while the shared feed is unhealthy.
 
+        Scope (operator decision, 2026-07-17): this gate protects MONEY, so it
+        applies only to live-trading workers. A paper worker keeps entering on
+        the last-good snapshot -- a virtual trade on slightly stale data is a
+        data-quality footnote, whereas blocking it costs the paper track record
+        its opening window (on 17 Jul the gate blocked every paper strategy
+        until ~09:24 while the feed warmed up, so no strategy could trade the
+        open at all).
+        """
+
+        if not self.live_trading:
+            return True
         health = self.store.market_data_health.snapshot(now=_ist_now())
         if not health.monitoring:
             return True
@@ -4768,16 +4779,41 @@ class BasePaperStrategyWorker(threading.Thread):
         return False
 
     def _handle_market_data_health(self) -> bool:
-        """Flatten tracked exposure after a feed has been unhealthy for 30s.
+        """Flatten tracked LIVE exposure after a feed has been unhealthy for 30s.
 
         This is deliberately separate from terminal daily shutdown. A feed can
         recover, but only three consecutive healthy producer cycles reopen the
         entry gate. Returning ``True`` tells the caller to consume this poll so
         no strategy logic runs alongside a safety-driven liquidation attempt.
+
+        Scope (operator decision, 2026-07-17): like the entry gate above, the
+        forced square-off exists to protect real money, so it applies only to
+        live-trading workers. A paper worker keeps its virtual position and its
+        strategy logic keeps running on the last-good snapshot. A LIVE worker
+        still flattens EVERYTHING it owns -- including a rare paper-fallback
+        position -- because its books mirror a real trading stream and
+        splitting real-vs-paper mid-liquidation would complicate
+        reconciliation.
         """
 
         health = self.store.market_data_health.snapshot(now=_ist_now())
         if not health.monitoring:
+            return False
+        if not self.live_trading:
+            # Paper worker: never force-close, never consume the poll. Log the
+            # 30s+ condition once per unhealthy episode so the operator can
+            # still see the feed outage in this worker's stream.
+            if health.liquidation_required and not self._market_data_liquidation_logged:
+                self._market_data_liquidation_logged = True
+                self.log.info(
+                    "Market data unhealthy for %.1fs; PAPER worker continues "
+                    "(square-off skipped -- no real exposure) | %s",
+                    health.unhealthy_seconds,
+                    "; ".join(health.reasons),
+                )
+            if health.entry_allowed:
+                # Reset the once-per-episode latch after recovery.
+                self._market_data_liquidation_logged = False
             return False
         if not health.entry_allowed:
             self._market_data_entries_allowed()

--- a/test_nifty_multi_strategy_master.py
+++ b/test_nifty_multi_strategy_master.py
@@ -196,7 +196,12 @@ class TestSharedMarketDataStore(unittest.TestCase):
 
 
 class TestWorkerMarketDataSafety(unittest.TestCase):
-    """Every strategy entry shares one feed gate and one stale-feed unwind path."""
+    """The feed gate and stale-feed unwind protect REAL money: live workers only.
+
+    Operator decision (2026-07-17): a paper worker keeps entering and keeps its
+    virtual position on the last-good snapshot -- the gate had blocked every
+    paper strategy through the 17 Jul opening window while the feed warmed up.
+    """
 
     def setUp(self):
         self.store = master_file.SharedMarketDataStore()
@@ -206,13 +211,26 @@ class TestWorkerMarketDataSafety(unittest.TestCase):
             MagicMock(),
         )
 
-    def test_entry_is_blocked_until_feed_recovers(self):
+    def test_live_entry_is_blocked_until_feed_recovers(self):
+        self.worker.live_trading = True
         self.store.begin_market_data_monitoring()
         with patch.object(self.worker, "_get_underlying_spot") as get_spot:
             self.assertFalse(self.worker.enter_position("LONG", 22500.0))
         get_spot.assert_not_called()
 
-    def test_thirty_second_unhealthy_state_invokes_square_off(self):
+    def test_paper_entry_allowed_while_feed_unhealthy(self):
+        """A paper (virtual) worker sails through the feed gate: the entry
+        attempt must reach the spot lookup instead of being blocked."""
+        self.assertFalse(self.worker.live_trading)
+        self.store.begin_market_data_monitoring()
+        with patch.object(self.worker, "_get_underlying_spot", return_value=0.0) as get_spot:
+            # Returns False further down (no spot LTP in this synthetic setup),
+            # but the market-data gate itself must have been passed.
+            self.assertFalse(self.worker.enter_position("LONG", 22500.0))
+        get_spot.assert_called_once()
+
+    def test_thirty_second_unhealthy_state_invokes_square_off_for_live(self):
+        self.worker.live_trading = True
         health = MagicMock(
             monitoring=True,
             entry_allowed=False,
@@ -236,7 +254,36 @@ class TestWorkerMarketDataSafety(unittest.TestCase):
         )
         self.worker._sweep_orphan_live_legs.assert_called_once_with(force=True)
 
+    def test_paper_worker_skips_market_data_square_off(self):
+        """A paper worker's virtual position must survive a 30s+ feed outage:
+        no forced close, no orphan sweep, and the poll is NOT consumed (the
+        strategy keeps running on the last-good snapshot)."""
+        self.assertFalse(self.worker.live_trading)
+        health = MagicMock(
+            monitoring=True,
+            entry_allowed=False,
+            liquidation_required=True,
+            healthy_streak=0,
+            unhealthy_seconds=31.0,
+            reasons=("LTP IDX_I/13 is stale (41.0s)",),
+        )
+        self.worker.pos.active = True
+        self.worker.exit_position = MagicMock()
+        self.worker._flatten_additional_positions = MagicMock()
+        self.worker._sweep_orphan_live_legs = MagicMock()
+
+        with patch.object(self.store.market_data_health, "snapshot", return_value=health):
+            consumed = self.worker._handle_market_data_health()
+
+        self.assertFalse(consumed)
+        self.worker.exit_position.assert_not_called()
+        self.worker._flatten_additional_positions.assert_not_called()
+        self.worker._sweep_orphan_live_legs.assert_not_called()
+        # The 30s+ outage is still logged once for the operator's audit trail.
+        self.assertTrue(self.worker._market_data_liquidation_logged)
+
     def test_unhealthy_primary_close_error_cannot_skip_other_exposure(self):
+        self.worker.live_trading = True
         health = MagicMock(
             monitoring=True,
             entry_allowed=False,


### PR DESCRIPTION
Scopes the MAT-105 market-data health protections to **live workers only**: the stale-feed **entry block** and the 30-second **auto square-off** exist to protect real money, so paper (virtual) workers now ride through on the last-good snapshot — they keep entering, and their virtual positions are never force-closed.

Based on `codex/mat-109-learning-input-hardening` (the current tip of the MAT chain, incl. the #66 review fixes), continuing the same stacking pattern.

## What 17 Jul showed (the motivating incident)

- 08:09:02 — runner starts pre-open; the newest 1-min bar is yesterday's (*"stale 60,032.4s"*), so the health gate declares the feed unhealthy: **every worker logs "Blocking new entries"** (192 such lines that day) and at 08:09:32 fires an empty *"flattening every tracked leg"*.
- ~09:22 — worker restart; 09:24:00 a second flatten (*"stale 120.4s"*).
- Entry gates only reopen **09:24–09:29** — after the opening window. **No paper strategy could trade the open at all**; the SL Hunting agent ran its LLM from 09:16 but no order could land (zero journal rows for the day).

A virtual trade on slightly stale data is a data-quality footnote; losing the paper track record's opening window every time the feed warms up is not.

## Changes

Both methods live on the shared base worker, so all 26 workers inherit the scoping:

- **`_market_data_entries_allowed`** — short-circuits to `True` for paper workers. Live workers keep the fail-closed block and the block/recovered logging (which also ends the paper-side log spam).
- **`_handle_market_data_health`** — paper workers never force-close and never consume the poll (strategy logic keeps running); the 30s+ outage is still logged **once per unhealthy episode** for the audit trail, with the latch reset on recovery. Live workers keep the flatten path **verbatim** (local close → `_flatten_additional_positions` → orphan sweep, plus the `MARKET_DATA_AUTO_SQUARE_OFF` event).
- **Documented decision** (in the docstring): a LIVE worker still flattens *everything* it owns — including a rare paper-fallback position — because its books mirror a real trading stream, and splitting real-vs-paper mid-liquidation would complicate reconciliation. "Paper" scope = `worker.live_trading == False` (the `LIVE_TRADING_ENABLED` + `<PREFIX>_LIVE_TRADING` gates in `main()`).

## Tests (`TestWorkerMarketDataSafety`)

- The live block, live square-off, and close-error-cannot-skip tests are re-pinned with `live_trading = True` (and renamed to say so).
- **NEW** `test_paper_entry_allowed_while_feed_unhealthy` — the gate is passed and the entry attempt reaches the spot lookup.
- **NEW** `test_paper_worker_skips_market_data_square_off` — no forced close, no orphan sweep, poll not consumed, one-time log latch set.

## Out of scope (noted)

The pre-open "unhealthy" noise for LIVE workers (monitoring starts at runner start while the newest bar is legitimately yesterday's) is unchanged — harmless now for paper, and a follow-up could start monitoring at 09:15.

## Verification (on this branch)

- `python -m unittest test_nifty_multi_strategy_master` → **315 tests, OK**
- `python -m ruff check .` → clean · `python -m mypy` → clean (34 files) · `compileall` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
