### PR TITLE
SL Hunting v3m: gift-gap read + losing-side flip ban (17 Jul loss day)

### DIFF
--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -964,3 +964,65 @@ round-number magnets.
 - `OPENING_DRIVE`: SHARED-GAP REQUIREMENT condition.
 - `BNF_SPECIFIC`: the "why" clause on the leader-fails-to-lead exit.
 - Test marker: `test_system_prompt_has_v3l_closing_point_and_shared_gap_knowledge`.
+
+## Video addendum - 17 Jul flat-open loss day + gift-gap read (v3m)
+
+> Sources (full Hindi auto-transcripts from YouTube's transcript panel):
+> - `hGWenJz7Us4` (16 Jul 2026 evening, "Prediction For 17 JULY 2026", 2:43)
+> - `xTwmjkvkrQQ` (17 Jul 2026, "Live Bank Nifty Option Trading", 8:07)
+>
+> Cross-checked against the agent's journal (no 2026-07-17 rows) and the runner log
+> (`Dependencies/log_files/nifty_multi_strategy_master_front_test_dhanhq.log`).
+
+Session summary — **IH's first LOSING day in this series**:
+- Pre-open plan (prediction clip): the prior day again had small momentum with the
+  closing point uncrossed, and this time BOTH sides could be thinly present. The
+  conditional was two-sided: **gap-up -> the (thin) buyers feel "it's all mine" and
+  sit -> trap forms for THEM -> sell-side setups; gap-down -> same trap for sellers
+  -> buy-side setups; FLAT -> "whom do we target?" -> nobody -> go WITH the market
+  (sell-side)**.
+- Live session: all three indices opened FLAT. Per the plan he sold the first
+  positive push (BNF 57500 PE 1170 qty, Sensex 900, NIFTY 24100 PE 1365), naming the
+  invalidation BEFORE entry ("this resistance must not cross; BankNIFTY must not go
+  up"). The market broke out upward instead — Sensex/NIFTY first, and when BankNIFTY
+  joined, he CUT at his loss limit. The discipline segment is the day's real
+  content: "if we're wrong, the market does what we did NOT plan for"; "can we
+  control the market? Not at all — what's in our control is the limit"; "don't book
+  a small loss and hurriedly build a CALL trade — you may flip and the market turns
+  back down"; "no averaging"; "the brain only works right when the trade is going
+  right — when it's wrong, look at the limit and leave."
+
+**Agent vs IH on 17 Jul — not comparable on premise:** IH took 1 trade (a loss); the
+agent took ZERO trades because the market-data health gate blocked ALL entries (paper
+included) through the opening window. Log timeline: runner start 08:09 pre-open ->
+newest bar is yesterday's ("stale 60,032s") -> every worker logs "Blocking new
+entries" (192 lines that day) and fires the empty 30-s flatten; a worker restart
+~09:22 triggered a second flatten at 09:24 ("stale 120.4s"); entry gates reopened
+only 09:24-09:29 — after IH's ~09:16 entry. The agent's LLM ran (decision-cost lines
+from 09:16) but no order could land. The block accidentally "saved" the agent from a
+likely losing day — luck, not design. Fixed alongside this addendum: the stale-feed
+entry block and 30-s auto square-off are now scoped to LIVE workers only.
+
+**Net-new method distilled:**
+- GIFT-GAP AFTER A NOBODY'S-CROWD DAY: after a small-momentum day whose closing point
+  was never crossed, both sides are thin; a gap in EITHER direction is a gift that
+  traps its recipient (fade the gap side on confirmation), and a flat open means
+  there is nobody to hunt — go with the drift. Generalises the v3k FLAT-OPEN
+  PARTICIPATION GATE (seller-crowd case) to the two-sided thin-inventory case.
+- NO INSTANT FLIP extended to the LOSING side: booking a small loss to immediately
+  reverse into the breakout that is hurting you is the classic whipsaw; exit at the
+  limit / invalidation and let POST-LOSS SPEED LIMIT govern the next entry.
+
+**Confirmed but deliberately NOT re-encoded (already present):** limit-based loss
+exits, no averaging (structurally impossible for the agent), "control only the
+loss", the binary one-directional-day read, and the thin-crowd/closing-point entry
+premise itself (v3k/v3l — IH's entry premise WAS the encoded rule; the trade still
+lost, which is the "sound process, losing trade" case the knowledge already
+accepts). Note: IH's sell-the-first-push entry WITHOUT pattern+confirmation is what
+lost — evidence FOR keeping the agent's stricter mandatory-confirmation entry rule;
+nothing was loosened.
+
+**Knowledge changes (v3m, all prose):**
+- `RETAIL_POSITIONING`: GIFT-GAP AFTER A NOBODY'S-CROWD DAY.
+- `RISK`: NO INSTANT FLIP extended with the losing-side panic-flip ban.
+- Test marker: `test_system_prompt_has_v3m_gift_gap_and_loss_flip_knowledge`.

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
@@ -203,6 +203,18 @@ retail's stop-losses sit so you can trade where the operator will hunt them.
   go with the selling" is the asymmetry to remember after a weak-momentum down day.
   (After a genuinely one-way, high-momentum down move, MULTI-DAY ACCUMULATION still
   applies and the flat open IS the prime hunt.)
+- GIFT-GAP AFTER A NOBODY'S-CROWD DAY (the two-sided version of the gate above):
+  when the prior day had only SMALL momentum and never crossed the closing point,
+  BOTH sides are thin — nobody meaningfully positioned overnight (run the
+  CLOSING-POINT HOLD TEST). On such a day a gap in EITHER direction is a GIFT that
+  traps its own recipient: a gap-up makes the few buyers feel "it's all mine", so
+  they SIT (and add) instead of booking — they become the target; fade it with
+  sell-side setups on confirmation. A gap-down does the same to the few sellers —
+  buy-side setups. A FLAT open on such a day answers "whom do we hunt?" with
+  "nobody": go WITH the prevailing drift instead (per the participation gate above).
+  Unlike the weak-down-day case above — where a real (if thin) seller crowd makes
+  BOTH gap directions seller-hunts — here there is no pre-existing crowd at all, so
+  each gap direction traps the side it appears to reward.
 - A FLAT open that then STRUGGLES to push up is itself a tell the OTHER way: had the
   market truly meant to rise it would have gapped up or shown immediate momentum.
   A hesitant flat open that lures buyers to buy "support" expecting a breakout is a
@@ -510,7 +522,12 @@ RISK DISCIPLINE
   do not immediately reverse on the first opposing bearish/bullish pattern. Require
   enough time and distance for a fresh opposite crowd to be recruited first; a small
   pullback right after profit-booking is often a lure against the side that missed
-  the move, not proof that the whole thesis has flipped.
+  the move, not proof that the whole thesis has flipped. The same ban applies on the
+  LOSING side: while a trade is going wrong, do NOT book a small loss just to
+  instantly reverse into the move that is hurting you — that panic flip is the
+  classic whipsaw (the market often turns back right after it, losing you both
+  ways). Exit at your limit / premise-invalidation and stop; POST-LOSS SPEED LIMIT
+  then governs when the next trade may happen.
 - MOVE-EXHAUSTION — ONE MOVE PER THESIS (the same-direction twin of NO INSTANT FLIP):
   once a thesis's move has been captured and BOOKED and momentum has visibly stalled,
   that thesis is SPENT. Do NOT re-enter the SAME direction on a later, smaller pattern

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
@@ -288,3 +288,22 @@ def test_system_prompt_has_v3l_closing_point_and_shared_gap_knowledge():
     # The leader-fails-to-lead exit keeps its scope so it can't collide with RISK's
     # "SLOW-but-CONTINUOUS is the sustainable kind" rule.
     assert "SLOW-but-CONTINUOUS" in prompt
+
+
+def test_system_prompt_has_v3m_gift_gap_and_loss_flip_knowledge():
+    """v3m: 17 Jul flat-open loss day (IH's first loss in the series).
+
+    - GIFT-GAP AFTER A NOBODY'S-CROWD DAY: after a small-momentum day with the
+      closing point uncrossed, a gap in EITHER direction traps the side it appears
+      to reward (fade it); flat means there is nobody to hunt.
+    - NO INSTANT FLIP now also bans the mid-loss panic flip (booking a small loss to
+      instantly reverse into the breakout), tying into POST-LOSS SPEED LIMIT.
+    """
+    prompt = build_system_prompt()
+    assert "GIFT-GAP AFTER A NOBODY'S-CROWD DAY" in prompt
+    # Each gap direction traps the side it appears to reward on a thin day.
+    assert "traps its own recipient" in prompt
+    # The losing-side flip ban lives inside the existing NO INSTANT FLIP bullet
+    # (assert wrap-independent fragments, not exact line breaks).
+    assert "LOSING side" in prompt and "whipsaw" in prompt
+    assert "POST-LOSS SPEED LIMIT" in prompt


### PR DESCRIPTION
SL Hunting knowledge v3m — Intraday Hunter's **17 Jul** session (`xTwmjkvkrQQ` 8:07) and prediction clip (`hGWenJz7Us4` 2:43), his **first losing day in this series**, cross-checked against the agent journal and the runner log.

Knowledge-only; targets `main` (the health-gate fix motivated by the same day is [#67](https://github.com/DoRmAmMu1997/My-Algo-Trading-Code/pull/67), on the MAT chain where that code lives).

## The day

All three indices opened **flat** after another small-momentum day with the closing point uncrossed. Per his pre-open plan (flat → go WITH the prior selling) IH sold the first positive push, naming the invalidation before entry (*"this resistance must not cross; BankNIFTY must not go up"*). The market broke out upward instead — Sensex/NIFTY first, and when BankNIFTY joined, he **cut at his loss limit**. No averaging, no panic flip: *"don't book a small loss and hurriedly build a CALL trade — you may flip and the market turns back down"*; *"when you're wrong, the market does what you did NOT plan for"*; *"the brain only works right when the trade is going right — when it's wrong, look at the limit and leave."*

## Agent vs IH — not comparable on premise

IH took 1 trade (a loss). The agent took **zero** — the market-data health gate blocked ALL entries (paper included) through the opening window (gates reopened 09:24–09:29; IH entered ~09:16; the agent's LLM ran from 09:16 but no order could land). That operational bug is fixed in #67. The block accidentally "saved" the agent from a likely losing day — luck, not design.

## Net-new encoded

1. **`GIFT-GAP AFTER A NOBODY'S-CROWD DAY`** (`RETAIL_POSITIONING`, from the prediction clip). After a small-momentum day whose closing point was never crossed, BOTH sides are thin — nobody meaningfully positioned overnight. A gap in **either** direction is then a *gift that traps its own recipient*: a gap-up makes the few buyers feel "it's all mine" so they sit (and add) instead of booking — fade it with sell-side setups on confirmation; a gap-down mirrors for sellers. A **flat** open on such a day answers "whom do we hunt?" with *nobody* → go with the drift. Generalises v3k's seller-specific `FLAT-OPEN PARTICIPATION GATE` to the two-sided thin-inventory case; explicitly distinguished from it in the text.
2. **`NO INSTANT FLIP` extended to the LOSING side** (`RISK`, one clause on the existing bullet — IH's central lesson of the day). Booking a small loss to *instantly reverse* into the breakout that is hurting you is the classic whipsaw (the market often turns back right after). Exit at the limit / premise-invalidation; `POST-LOSS SPEED LIMIT` then governs the next entry.

**Deliberately NOT re-encoded:** limit-based loss exits, no averaging (structurally impossible for the agent), "control only the loss", and the thin-crowd entry premise itself (v3k/v3l — IH's premise WAS the encoded rule; the trade still lost, which is the "sound process, losing trade" case the knowledge already accepts). His pattern-free sell-the-first-push entry is what lost — evidence **for** keeping the agent's stricter mandatory pattern+confirmation entry rule; nothing was loosened.

## Verification

- `python -m pytest "Signal Generators/SL Hunting AI Agent/tests" -q` → **87 passed** (new marker `test_system_prompt_has_v3m_gift_gap_and_loss_flip_knowledge` plus every prior v2–v3l marker)
- Knowledge prose only — no schema/executor/order-path changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
