### PR TITLE
MAT-110: reproducible dependencies, CI, telemetry, and docs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "03:00"
+      timezone: Asia/Kolkata
+    open-pull-requests-limit: 5
+    groups:
+      python-runtime:
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "03:30"
+      timezone: Asia/Kolkata
+    open-pull-requests-limit: 5

--- a/.github/workflows/quality-and-security.yml
+++ b/.github/workflows/quality-and-security.yml
@@ -36,20 +36,33 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -r requirements.txt -r requirements-dev.txt
+          python -m pip install \
+            -r requirements.txt \
+            -r requirements-dev.txt \
+            -r requirements-ai.txt
+          python -m pip check
+
+      - name: Audit installed Python dependencies
+        # The hosted runner starts clean, so --local audits exactly the core,
+        # developer, and AI environment installed above rather than unrelated
+        # packages from a developer's system Python.
+        run: python -m pip_audit --local --progress-spinner off
 
       - name: Validate pre-commit configuration
         run: python -m pre_commit validate-config .pre-commit-config.yaml
 
-      - name: Run the master unittest suite
-        # Loads the spaced-name master file via importlib with dhanhq mocked --
-        # this suite is the correctness gate for the runner itself.
-        run: python -m unittest test_nifty_multi_strategy_master
-
-      - name: Run the pytest suites
-        # Signal-generator + SL Hunting agent + broker-helper + data-fetcher
-        # tests. SDK-gated cases skip cleanly when an optional dependency is absent.
-        run: python -m pytest "Signal Generators" "Dependencies" "Data Extractors" -q
+      - name: Run branch-enabled test coverage
+        # The master is importlib-loaded because its filename has spaces. Append
+        # every suite into one branch-enabled runtime report, then enforce the
+        # 54.7% repository baseline plus the stricter per-safety/broker budgets.
+        run: |
+          python -m coverage erase
+          python -m coverage run -m unittest test_nifty_multi_strategy_master
+          python -m coverage run --append -m unittest test_market_data_health
+          python -m coverage run --append -m pytest "Signal Generators" "Dependencies" "Data Extractors" -q
+          python -m coverage json -o coverage.json
+          python -m coverage report
+          python scripts/check_coverage_thresholds.py coverage.json
 
       - name: Compile every Python file
         # The master runner and most strategy files have SPACES in their names,
@@ -68,9 +81,44 @@ jobs:
       - name: Run Bandit security checks
         # B101 (asserts), B105 (false positives on token-URL/dict-key strings)
         # and B110 (documented best-effort fallbacks) are skipped; vendored and
-        # reference-only code is excluded. Coverage gating is a deliberate
-        # follow-up (measuring the importlib-loaded master needs its own work).
+        # reference-only code is excluded.
         run: >
           python -m bandit -r . -q
           -x "./Backtest Outputs,./My Backtest Files (For Reference),./Dependencies/Shoonya API/NorenApi.py"
           --skip B101,B105,B110
+
+  broker-dependencies:
+    name: Python ${{ matrix.python-version }} broker dependency validation
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13"]
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install exact optional broker environment
+        # Kotak v2.0.1 declares older exact pandas/requests constraints that
+        # conflict with the app's newer audited core set. Validate the official
+        # SDK in its own clean environment instead of asking pip to construct an
+        # impossible combined dependency graph.
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest==9.0.3 -r requirements-brokers.txt
+          python -m pip check
+
+      - name: Run broker contract and adapter suites
+        run: >
+          python -m pytest
+          "Dependencies/test_broker_contract.py"
+          "Dependencies/Flattrade API/test_flattrade_execution.py"
+          -q

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,10 @@ Dependencies/all_instrument*.csv
 .idea/
 .DS_Store
 Thumbs.db
+
+# Local/CI coverage artifacts
+.coverage
+.coverage.*
+coverage.json
+coverage-*.json
+htmlcov/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,14 +44,18 @@ One process, cooperating threads:
   (best-effort alerts; never blocks trading).
 - Real orders go through ONE shared, lock-guarded broker session via a broker-agnostic
   **`execution_client`** (see Broker layer). On a clean end-of-day, per-strategy P&L is written to a
-  Google Sheet. All behaviour is driven by a single `.env` — nothing is hard-coded per run.
+  Google Sheet with separate PAPER/LIVE/MIXED row labels. All behaviour is driven by a single `.env`
+  — nothing is hard-coded per run.
 
 ## Repository layout
 ```
 Nifty Multi Strategy Front Test - Master File.py   # the multithreaded paper/live runner (the "big one")
 algo.py                                             # unified CLI: fetch-data / backtest / run / setup-token / diagnose
 test_nifty_multi_strategy_master.py                # unittest suite for the master
-requirements.txt                                   # core deps (+ commented optional broker/ML deps)
+requirements.txt                                   # exact core runtime dependencies
+requirements-brokers.txt                           # exact Kotak/Shoonya optional live set
+requirements-ai.txt                                # exact optional Claude Agent SDK stack
+requirements-dev.txt                               # exact local/CI quality tools
 Data Extractors/                                   # DhanHQ 1-min OHLC downloaders (shared engine + per-index wrappers)
 My Backtest Files (For Reference)/                 # backtesting.py backtests (+ Subhamoy Strategies/)
 Signal Generators/                                 # strategy signal logic (+ CPR Strategy/, Subhamoy Strategies/,
@@ -65,6 +69,7 @@ Dependencies/
                     test_flattrade_execution.py
 pyproject.toml                                     # ruff + mypy quality-gate configuration
 .github/workflows/quality-and-security.yml         # CI: tests + compileall + ruff + mypy + bandit
+scripts/check_coverage_thresholds.py               # branch-coverage policy gate
 Backtest Outputs/                                  # generated CSVs/logs (gitignored)
 ```
 
@@ -103,10 +108,21 @@ Backtest Outputs/                                  # generated CSVs/logs (gitign
 - **Tests:** `python -m unittest test_nifty_multi_strategy_master` (loads the master via `importlib`,
   mocks `dhanhq`; broker/SDK-specific cases skip when those deps are absent). Signal-generator tests live
   under `Signal Generators/`.
-- **Dependencies:** `pip install -r requirements.txt`; optional broker/ML extras are documented (commented) inside it.
+- **Dependencies:** install core with `pip install -r requirements.txt`; add
+  `requirements-ai.txt` for SL Hunting and `requirements-dev.txt` for local
+  gates. `requirements-brokers.txt` is the isolated upstream compatibility
+  environment and must not be combined with core because Kotak pins older
+  pandas/requests; use the safe per-broker commands in README. Kotak v2 comes
+  from its official `v2.0.1` Git tag.
 - **Git / PRs:** branch off `main`; open PRs into `main` with `gh`; end commit messages with a
   `Co-Authored-By:` trailer identifying the agent that produced the change. `.env`,
   `Backtest Outputs/`, and `*.log` stay gitignored.
 - **Quality gates (run locally before pushing):** `python -m unittest test_nifty_multi_strategy_master`,
-  `python -m pytest "Signal Generators" -q`, `python -m ruff check .`, `python -m mypy`,
-  `python -m compileall -q .` — CI enforces the same set on Python 3.12 + 3.13.
+  `python -m unittest test_market_data_health`,
+  `python -m pytest "Signal Generators" "Dependencies" "Data Extractors" -q`,
+  the branch-enabled Coverage.py run plus `scripts/check_coverage_thresholds.py`,
+  pip-audit of committed pins locally plus the clean resolved CI environment,
+  `python -m ruff check .`,
+  `python -m mypy`, `python -m compileall -q .`, Bandit, and pre-commit. CI
+  enforces the same set on Python 3.12 + 3.13. Coverage floors are 54.7% overall,
+  90% for new execution/reconciliation/data-safety modules, and 80% per broker adapter.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,14 +44,18 @@ One process, cooperating threads:
   (best-effort alerts; never blocks trading).
 - Real orders go through ONE shared, lock-guarded broker session via a broker-agnostic
   **`execution_client`** (see Broker layer). On a clean end-of-day, per-strategy P&L is written to a
-  Google Sheet. All behaviour is driven by a single `.env` — nothing is hard-coded per run.
+  Google Sheet with separate PAPER/LIVE/MIXED row labels. All behaviour is driven by a single `.env`
+  — nothing is hard-coded per run.
 
 ## Repository layout
 ```
 Nifty Multi Strategy Front Test - Master File.py   # the multithreaded paper/live runner (the "big one")
 algo.py                                             # unified CLI: fetch-data / backtest / run / setup-token / diagnose
 test_nifty_multi_strategy_master.py                # unittest suite for the master
-requirements.txt                                   # core deps (+ commented optional broker/ML deps)
+requirements.txt                                   # exact core runtime dependencies
+requirements-brokers.txt                           # exact Kotak/Shoonya optional live set
+requirements-ai.txt                                # exact optional Claude Agent SDK stack
+requirements-dev.txt                               # exact local/CI quality tools
 Data Extractors/                                   # DhanHQ 1-min OHLC downloaders (shared engine + per-index wrappers)
 My Backtest Files (For Reference)/                 # backtesting.py backtests (+ Subhamoy Strategies/)
 Signal Generators/                                 # strategy signal logic (+ CPR Strategy/, Subhamoy Strategies/,
@@ -65,6 +69,7 @@ Dependencies/
                     test_flattrade_execution.py
 pyproject.toml                                     # ruff + mypy quality-gate configuration
 .github/workflows/quality-and-security.yml         # CI: tests + compileall + ruff + mypy + bandit
+scripts/check_coverage_thresholds.py               # branch-coverage policy gate
 Backtest Outputs/                                  # generated CSVs/logs (gitignored)
 ```
 
@@ -103,10 +108,21 @@ Backtest Outputs/                                  # generated CSVs/logs (gitign
 - **Tests:** `python -m unittest test_nifty_multi_strategy_master` (loads the master via `importlib`,
   mocks `dhanhq`; broker/SDK-specific cases skip when those deps are absent). Signal-generator tests live
   under `Signal Generators/`.
-- **Quality gates (run before pushing; CI enforces on Python 3.12 + 3.13):** the two test suites plus
-  `python -m ruff check .`, `python -m mypy` (scoped in `pyproject.toml` — the spaced-name master is
-  covered by `compileall` + tests instead), `python -m compileall -q .`, and `python -m bandit` per the
-  CI workflow. Dev tools install via `pip install -r requirements-dev.txt`.
-- **Dependencies:** `pip install -r requirements.txt`; optional broker/ML extras are documented (commented) inside it.
-- **Git / PRs:** branch off `main`; open PRs into `main` with `gh`; end commit messages with the
-  `Co-Authored-By: Claude <noreply@anthropic.com>` trailer. `.env`, `Backtest Outputs/`, and `*.log` stay gitignored.
+- **Quality gates (run before pushing; CI enforces on Python 3.12 + 3.13):**
+  `python -m unittest test_nifty_multi_strategy_master`,
+  `python -m unittest test_market_data_health`,
+  `python -m pytest "Signal Generators" "Dependencies" "Data Extractors" -q`,
+  the branch-enabled Coverage.py run plus `scripts/check_coverage_thresholds.py`,
+  pip-audit of committed pins locally plus the clean resolved CI environment,
+  Ruff, mypy, compileall,
+  Bandit, and pre-commit. Coverage floors are 54.7% overall, 90% for new
+  execution/reconciliation/data-safety modules, and 80% per broker adapter.
+- **Dependencies:** install core with `pip install -r requirements.txt`; add
+  `requirements-ai.txt` for SL Hunting and `requirements-dev.txt` for local
+  gates. `requirements-brokers.txt` is the isolated upstream compatibility
+  environment and must not be combined with core because Kotak pins older
+  pandas/requests; use the safe per-broker commands in README. Kotak v2 comes
+  from its official `v2.0.1` Git tag.
+- **Git / PRs:** branch off `main`; open PRs into `main` with `gh`; end commit messages with a
+  `Co-Authored-By:` trailer identifying the agent that produced the change. `.env`,
+  `Backtest Outputs/`, and `*.log` stay gitignored.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,7 @@ Dependencies/
   Shoonya API/   -> NorenApi.py (vendored client), shoonya_execution.py, diagnose_shoonya_symbol.py
   Flattrade API/ -> flattrade_execution.py, diagnose_flattrade_symbol.py,
                     test_flattrade_execution.py
+  Dhan API/      -> dhan_execution.py, diagnose_dhan_symbol.py, test_dhan_execution.py
 pyproject.toml                                     # ruff + mypy quality-gate configuration
 .github/workflows/quality-and-security.yml         # CI: tests + compileall + ruff + mypy + bandit
 scripts/check_coverage_thresholds.py               # branch-coverage policy gate
@@ -80,23 +81,34 @@ Backtest Outputs/                                  # generated CSVs/logs (gitign
   name→prefix map is `STRATEGY_ENV_PREFIX`. **Never commit secrets** — `env.example` holds blank placeholders.
 - **Live-trading safety (critical):** paper by default. A strategy trades live ONLY when the global
   `LIVE_TRADING_ENABLED` **and** that strategy's `<PREFIX>_LIVE_TRADING` are both true. `LIVE_BROKER`
-  (`KOTAK` | `SHOONYA` | `FLATTRADE`) selects the broker; an unknown value **fails closed** (live
-  disabled, paper only).
+  (`KOTAK` | `SHOONYA` | `FLATTRADE` | `DHAN`) selects the broker; an unknown value **fails closed**
+  (live disabled, paper only).
   An entry falls back to paper only after an explicit `REJECTED` result with zero fill. `PARTIAL` or
   `UNKNOWN` means exposure may exist: freeze new live entries, keep exits available, and reconcile;
   never treat an acknowledgement, truthy value, or order ID as proof of fill. A rejected live exit
   keeps the position open. Every broker network/SDK call has a ten-second deadline that includes its
-  shared lock/rate-limit wait; native HTTP timeouts remain enabled for Shoonya and Flattrade.
+  shared lock/rate-limit wait; native HTTP timeouts remain enabled for Shoonya, Flattrade and Dhan
+  (the Dhan SDK ships a 60s default that `_login_locked` overrides down to 10s).
 - **Per-strategy on/off:** each strategy also has a `<PREFIX>_VIRTUAL_TRADING` gate (default true).
   Set it false to stop that strategy's worker thread from starting at all (so it does neither paper
   nor live). Unlike live trading there is **no** global master switch — default is everything runs.
   `main()` filters the `workers` list via `_strategy_virtual_trading_enabled` before starting threads.
-- **Broker layer:** the Kotak, Shoonya, and Flattrade clients expose the SAME surface —
+- **Broker layer:** the Kotak, Shoonya, Flattrade and Dhan clients expose the SAME surface —
   `ensure_logged_in`, `preload_scrip_master`, `resolve_option_symbol`, `place_market_order`,
   `get_order_status`, `cancel_order`, `list_open_orders`, `list_open_positions`,
   `recover_after_reconciliation`, `extract_order_id`, `logout`, `is_logged_in` — so the runner only
-  touches the generic `execution_client`. The Shoonya
-  `NorenApi` client is vendored under `Dependencies/Shoonya API/`.
+  touches the generic `execution_client`. The shared result types live in
+  `Dependencies/broker_contract.py`. The Shoonya `NorenApi` client is vendored under
+  `Dependencies/Shoonya API/`. Dhan is the only broker whose SDK serves both market data and
+  execution, but the two sessions stay separate (`DhanBrokerClient` vs `dhan_execution_client`).
+  Two Dhan quirks the adapter exists to contain: its SDK returns `{'status':'failure',
+  'remarks': str(exc)}` for *transport* errors, which is shape-identical to a real rejection — so
+  `REJECTED` is never derived from the placement envelope (a `dict` `remarks` means the server
+  refused, a `str` means it is indeterminate); and `order_tag` is sent as Dhan's `correlationId`
+  so `get_order_by_correlationID` can recover an order whose response was lost. Dhan's
+  non-contract states are aliased adapter-locally (`EXPIRED`→`CANCELLED`,
+  `PART_TRADED`→`PARTIAL`); `TRANSIT`/`PENDING` stay unmapped so they remain transient.
+  Dhan resolves contracts from the local `Dependencies/all_instrument <date>.csv`, not a download.
 - **Code style:** detailed, beginner-friendly module + function docstrings and plain-English inline
   comments — match the existing density. Type hints where practical. `snake_case` functions/modules,
   `PascalCase` classes, `UPPER_SNAKE` constants and env keys. In library code use a module

--- a/Dependencies/Dhan API/dhan_execution.py
+++ b/Dependencies/Dhan API/dhan_execution.py
@@ -1,0 +1,1406 @@
+"""
+Thread-safe DhanHQ v2 execution client for the multi-strategy runner.
+
+The master runner deliberately knows almost nothing about broker APIs.  It asks
+each broker helper to log in, preload a contract master, resolve one NIFTY option
+and place a confirmed market order.  This module implements that same small
+surface for DhanHQ using the official ``dhanhq`` Python SDK.
+
+Safety rules followed here:
+
+* Importing this module never logs in or sends an order.
+* The access token is read from the environment ONLY (``DHAN_ACCESS_TOKEN``,
+  produced by ``Dependencies/dhan_token_setup.py``).  There is no browser flow
+  and no TOTP prompt, so startup never blocks on operator input.
+* Every SDK call carries a native timeout AND one total ten-second deadline that
+  also covers rate-limit wait, session-lock wait, and slow-dribble response
+  bodies.
+* ``place_market_order`` returns a typed result only after the order book
+  confirms the fill.  Rejection, partial fill, and response loss remain
+  distinct; ambiguity is ``UNKNOWN`` and poisons new submissions until explicit
+  reconciliation.
+
+Beginner's mental model -- one live order travels through this file as follows:
+
+1. ``ensure_logged_in()`` validates today's access token against the account.
+2. ``preload_scrip_master()`` loads Dhan's contract catalogue from the local
+   instrument CSV the runner already refreshes every evening.
+3. ``resolve_option_symbol()`` converts strategy details such as
+   NIFTY/14-JUL-2026/CE/24150 into Dhan's exact trading symbol.
+4. ``place_market_order()`` translates that symbol back into the numeric
+   ``securityId`` Dhan's order API actually wants, then submits the order.
+5. ``_confirm_fill()`` polls the order book; an acknowledgement alone is never
+   treated as proof that money changed hands.
+
+TWO DHAN-SPECIFIC HAZARDS THIS MODULE EXISTS TO CONTAIN
+-------------------------------------------------------
+
+**1. The SDK turns every exception into a rejection-shaped envelope.**
+``DhanHTTP._send_request`` wraps its request in a bare ``except Exception`` and
+returns ``{'status': 'failure', 'remarks': str(e), 'data': ''}``.  A socket
+timeout on an order that DID reach the exchange is therefore structurally
+identical to a genuine broker rejection.  In this repo ``REJECTED`` means
+"provably zero fill -- safe to fall back to paper", so believing that envelope
+would re-enter on paper while real exposure sits at the broker.
+
+This module NEVER derives ``REJECTED`` from the placement envelope.  It treats
+the response as an acknowledgement only, and distinguishes the two failure
+shapes the SDK can produce (see ``_classify_envelope``):
+
+* ``remarks`` is a **dict** -- Dhan's server answered and refused with a
+  structured ``errorCode``.  A candidate rejection, still confirmed before it is
+  trusted.
+* ``remarks`` is a **str** -- a transport-layer exception.  The order may have
+  reached the exchange, so the outcome is ``UNKNOWN`` and freezes new entries.
+
+Dhan gives us a recovery channel the other brokers lack: the ``order_tag`` is
+sent as ``correlationId``, so ``get_order_by_correlationID`` can find an order
+even when its POST response was lost entirely.  Both ambiguous paths try that
+lookup before concluding anything.
+
+**2. The SDK's native timeout is 60 seconds, not 10.**
+``DhanHTTP.HTTP_DEFAULT_TIME_OUT`` is 60 -- six times this repo's deadline.  It
+is a plain instance attribute, so ``_login_locked`` overrides it immediately
+after building the context.  ``DhanContext.__init__`` also swallows its own
+exceptions and can hand back a half-built object, so the attribute is verified
+rather than assumed.
+
+Small glossary:
+
+* A *scrip master* is the broker's contract catalogue: symbol, expiry, strike,
+  option type, security id, and lot size for every listed instrument.
+* ``securityId`` is Dhan's numeric instrument key.  Dhan's order API takes it
+  INSTEAD of a trading symbol, which is why this helper keeps a symbol -> id map.
+* ``correlationId`` is Dhan's name for a caller-supplied order tag, echoed back
+  in the order book and searchable through its own endpoint.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import os
+import sys
+import threading
+import time
+from collections import deque
+from collections.abc import Callable
+from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FuturesTimeoutError
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+from dhanhq import DhanContext, dhanhq
+
+# The broker helpers live in folders with spaces and are also executable as
+# standalone diagnostics.  Add their shared ``Dependencies`` parent explicitly
+# so the broker-neutral contract imports the same way in both entry points.
+_DEPENDENCIES_DIR = Path(__file__).resolve().parent.parent
+if str(_DEPENDENCIES_DIR) not in sys.path:
+    sys.path.insert(0, str(_DEPENDENCIES_DIR))
+
+from broker_contract import (  # noqa: E402
+    TERMINAL_BROKER_STATES,
+    BrokerQueryResult,
+    OpenOrder,
+    OpenPosition,
+    OrderResult,
+    OrderStatus,
+    normalize_order_result,
+)
+
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv(
+        dotenv_path=Path(__file__).resolve().parent.parent / ".env",
+        override=False,
+    )
+except Exception:
+    # ``python-dotenv`` is a core dependency, but keeping import-time behaviour
+    # harmless means paper trading can still start and report a clear login error.
+    pass
+
+
+log = logging.getLogger(__name__)
+
+# The runner refreshes this file every evening from Dhan's public detailed scrip
+# master.  Reusing it (rather than re-downloading 35 MB inside a ten-second
+# budget) also guarantees the adapter and the strategies resolve a strike to the
+# very same contract.
+_INSTRUMENT_MASTER_GLOB = "all_instrument *.csv"
+
+_API_TIMEOUT_SECONDS = 10.0
+_BROKER_CALL_DEADLINE_SECONDS = 10.0
+_FILL_TIMEOUT_SECONDS = 8.0
+_FILL_POLL_INTERVAL = 0.5
+_MAX_RATE_LIMIT_WAIT_SECONDS = 2.0
+
+# Dhan accepts these product names directly; ``NORMAL`` is this repo's neutral
+# word for a carry-forward position, which Dhan calls ``MARGIN``.
+_PRODUCT_MAP = {"INTRADAY": "INTRADAY", "NORMAL": "MARGIN", "MARGIN": "MARGIN"}
+_SIDE_MAP = {"BUY": "BUY", "SELL": "SELL"}
+
+# Dhan reports two order states the broker-neutral contract does not recognize.
+# Translating them here keeps the shared vocabulary (and the other three broker
+# adapters) untouched while still giving each state its correct meaning:
+#   EXPIRED     -- the order died without trading; that is a terminal rejection,
+#                  and leaving it unmapped would report a clean "never traded"
+#                  as UNKNOWN and needlessly freeze every live strategy.
+#   PART_TRADED -- a partial fill, which usually resolves through the quantity
+#                  comparison anyway but must not read as an unknown label when
+#                  the fill count is unavailable.
+# TRANSIT and PENDING are deliberately NOT mapped: they are transient states a
+# healthy order passes through, so they must stay UNKNOWN and keep the fill loop
+# polling rather than being reported as a final outcome.
+_DHAN_STATE_ALIASES = {"EXPIRED": "CANCELLED", "PART_TRADED": "PARTIAL"}
+
+# Dhan's order-book field names, most-specific first.  The SDK documents these
+# only in prose, so every read goes through ``_first_present`` and a casing
+# change degrades to UNKNOWN instead of a silently wrong fill count.
+_ORDER_ID_KEYS = ("orderId", "order_id", "orderid")
+_ORDER_STATE_KEYS = ("orderStatus", "order_status", "status")
+_FILLED_QTY_KEYS = ("filledQty", "filled_qty", "filledQuantity", "tradedQty")
+_ORDER_QTY_KEYS = ("quantity", "orderQuantity", "qty")
+_SYMBOL_KEYS = ("tradingSymbol", "trading_symbol", "symbol")
+_SIDE_KEYS = ("transactionType", "transaction_type")
+_PRODUCT_KEYS = ("productType", "product_type")
+_NET_QTY_KEYS = ("netQty", "net_qty", "netQuantity")
+_REASON_KEYS = ("omsErrorDescription", "oms_error_description", "errorMessage")
+
+
+def _exact_int(value: Any) -> int | None:
+    """Parse a broker quantity only when it is a finite whole number."""
+
+    if isinstance(value, bool):
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(number) or not number.is_integer():
+        return None
+    return int(number)
+
+
+def _first_present(row: dict[str, Any], keys: tuple[str, ...]) -> Any:
+    """Return the first non-empty value among ``keys``, else ``None``.
+
+    Dhan's field casing is documented only in SDK docstrings, so every order-book
+    read tolerates the plausible spellings instead of trusting one of them.
+    """
+
+    for key in keys:
+        if key in row:
+            value = row[key]
+            if value is not None and str(value).strip() != "":
+                return value
+    return None
+
+
+def _alias_state(raw_state: Any) -> str:
+    """Translate a Dhan order state into the broker-neutral vocabulary."""
+
+    state = str(raw_state or "").strip().upper().replace("-", "_").replace(" ", "_")
+    return _DHAN_STATE_ALIASES.get(state, state)
+
+
+def _env_str(name: str, default: str = "") -> str:
+    """Read one environment value and remove accidental wrapping quotes."""
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    value = str(raw).strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        value = value[1:-1].strip()
+    return value or default
+
+
+class _RollingWindowRateLimiter:
+    """Enforce per-second and per-minute request budgets across worker threads.
+
+    Short bursts wait for a slot.  A wait longer than ``max_wait_seconds`` raises
+    before the request is sent; a stale live order is more dangerous than a
+    clear indeterminate result that freezes new live entry.
+    """
+
+    def __init__(
+        self,
+        per_second: int,
+        per_minute: int,
+        max_wait_seconds: float,
+        clock: Callable[[], float] = time.monotonic,
+        sleeper: Callable[[float], None] = time.sleep,
+        label: str = "API",
+    ) -> None:
+        self.per_second = int(per_second)
+        self.per_minute = int(per_minute)
+        self.max_wait_seconds = float(max_wait_seconds)
+        self._clock = clock
+        self._sleep = sleeper
+        self.label = label
+        self._timestamps: deque[float] = deque()
+        self._lock = threading.Lock()
+
+    def acquire(self, deadline: float | None = None) -> None:
+        """Reserve one request slot or raise before a long/stale wait.
+
+        The deque stores only timestamps from the last minute.  We separately
+        count its last one-second slice because both limits apply at once.  A
+        short wait is acceptable; a long wait would make a trading decision
+        stale, so it raises *before* any broker request is sent.
+        """
+        started = self._clock()
+        if deadline is None:
+            acquired = self._lock.acquire()
+        else:
+            remaining = deadline - started
+            acquired = remaining > 0 and self._lock.acquire(timeout=remaining)
+        if not acquired:
+            raise TimeoutError(
+                f"Dhan {self.label} deadline expired waiting for the limiter lock"
+            )
+        try:
+            while True:
+                now = self._clock()
+                # Discard calls that are older than the longest (60-second)
+                # window.  Keeping the deque small also makes each check cheap.
+                minute_cutoff = now - 60.0
+                while self._timestamps and self._timestamps[0] <= minute_cutoff:
+                    self._timestamps.popleft()
+
+                # The minute deque includes the one-second window, so select its
+                # recent tail instead of maintaining a second source of truth.
+                recent_second = [
+                    stamp for stamp in self._timestamps if stamp > now - 1.0
+                ]
+                second_full = len(recent_second) >= self.per_second
+                minute_full = len(self._timestamps) >= self.per_minute
+
+                if not second_full and not minute_full:
+                    # Reserving the timestamp before returning prevents two
+                    # strategy threads from claiming the same final slot.
+                    self._timestamps.append(now)
+                    return
+
+                waits = []
+                if second_full:
+                    waits.append(1.0 - (now - recent_second[0]))
+                if minute_full:
+                    waits.append(60.0 - (now - self._timestamps[0]))
+                wait_seconds = max(0.0, max(waits))
+                elapsed = now - started
+                exceeds_call_deadline = (
+                    deadline is not None and now + wait_seconds > deadline
+                )
+                if elapsed + wait_seconds > self.max_wait_seconds or exceeds_call_deadline:
+                    raise RuntimeError(
+                        f"Dhan {self.label} rate limit exhausted; "
+                        f"safe slot needs {wait_seconds:.2f}s"
+                    )
+                self._sleep(wait_seconds)
+        finally:
+            self._lock.release()
+
+    def reset(self) -> None:
+        """Forget local request history after a session is explicitly closed."""
+        with self._lock:
+            self._timestamps.clear()
+
+
+def _classify_envelope(envelope: Any) -> tuple[str, Any, str]:
+    """Split a DhanHQ SDK reply into outcome, payload, and human reason.
+
+    Every SDK method returns ``{'status', 'remarks', 'data'}``.  Both a genuine
+    broker refusal and a local network exception arrive as ``status='failure'``,
+    so the caller cannot use that field alone without risking the "timed-out
+    order reported as rejected" bug this whole module guards against.  The
+    ``remarks`` TYPE is the discriminator:
+
+    * ``dict``  -- built by ``DhanHTTP._parse_response`` from a non-2xx reply,
+      carrying ``error_code``/``error_type``/``error_message``.  Dhan's server
+      answered and refused.
+    * ``str``   -- built by ``DhanHTTP._send_request``'s bare exception handler
+      (or a JSON decode failure).  We do not know whether the request reached
+      the exchange.
+
+    Returns:
+        ``(outcome, data, reason)`` where outcome is one of ``"ok"``,
+        ``"refused"``, or ``"indeterminate"``.
+    """
+
+    if not isinstance(envelope, dict):
+        return ("indeterminate", None, f"Malformed Dhan response: {envelope!r}")
+
+    status = str(envelope.get("status") or "").strip().lower()
+    remarks = envelope.get("remarks")
+    if status == "success":
+        return ("ok", envelope.get("data"), "")
+
+    if isinstance(remarks, dict):
+        detail = " ".join(
+            str(remarks.get(key) or "").strip()
+            for key in ("error_code", "error_type", "error_message")
+        ).strip()
+        return ("refused", envelope.get("data"), detail or "Dhan refused the request.")
+
+    return (
+        "indeterminate",
+        envelope.get("data"),
+        str(remarks or "").strip() or "Dhan response did not complete.",
+    )
+
+
+class DhanExecutionClient:
+    """One lazily authenticated, lock-guarded DhanHQ execution session.
+
+    The master creates many strategy threads but imports one singleton from the
+    bottom of this module.  All those threads therefore share one SDK client,
+    one token, one contract cache, and one pair of rate-limit counters.
+    ``RLock`` makes nested helper calls safe without allowing simultaneous
+    session writes.
+    """
+
+    def __init__(self) -> None:
+        self.client: Any = None
+        self.is_logged_in = False
+        self._lock = threading.RLock()
+        self._context: Any = None
+        self._client_code = ""
+        self._scrip_df: pd.DataFrame | None = None
+        self._symbol_cache: dict[tuple, str] = {}
+        # Dhan's order API takes a numeric securityId, but the runner's generic
+        # surface passes the human trading symbol returned by the resolver.
+        # This map bridges the two so logs and Telegram alerts stay readable.
+        self._security_id_by_symbol: dict[str, str] = {}
+        # ``requests`` timeouts are inactivity limits, not a total wall-clock
+        # budget: a slow-dribble response can otherwise run forever.  Execute one
+        # SDK call at a time and impose a caller-visible deadline around
+        # rate-limit wait, session-lock wait, and the complete response body.
+        self._sdk_executor = ThreadPoolExecutor(
+            max_workers=1,
+            thread_name_prefix="dhan-sdk",
+        )
+        self._sdk_poisoned = False
+        self._timed_out_future: Future[Any] | None = None
+        # Serialize acknowledgement plus order-book confirmation.  Without this
+        # gate another strategy can submit before a status timeout poisons the
+        # session, leaving two simultaneously indeterminate live orders.
+        self._order_submission_lock = threading.Lock()
+        # Conservative floors that sit well under Dhan's published per-second
+        # order ceiling.  With ~26 strategy threads real bursts are far smaller,
+        # so these buy safety margin rather than costing throughput.
+        self._api_limiter = _RollingWindowRateLimiter(
+            20,
+            800,
+            _MAX_RATE_LIMIT_WAIT_SECONDS,
+            label="API",
+        )
+        self._order_limiter = _RollingWindowRateLimiter(
+            10,
+            250,
+            _MAX_RATE_LIMIT_WAIT_SECONDS,
+            label="order API",
+        )
+
+    @staticmethod
+    def _remaining_broker_budget(started: float) -> float:
+        """Return seconds left in one complete broker-call wall-clock budget."""
+
+        return _BROKER_CALL_DEADLINE_SECONDS - (time.monotonic() - started)
+
+    def _run_sdk_with_deadline(
+        self,
+        operation: str,
+        call: Callable[[], Any],
+        *,
+        started: float,
+        allow_after_poison: bool = False,
+    ) -> Any:
+        """Run one SDK call without letting a slow response outlive 10s.
+
+        The caller holds ``_lock``.  If the future times out, its socket may
+        still be active inside ``requests``; poison the shared session so no
+        second request can overlap that indeterminate in-flight operation.
+        """
+
+        if self._sdk_poisoned:
+            abandoned_finished = (
+                self._timed_out_future is not None
+                and self._timed_out_future.done()
+            )
+            if not allow_after_poison or not abandoned_finished:
+                raise RuntimeError(
+                    "Dhan session is indeterminate after a broker deadline; "
+                    "new orders are blocked pending reconciliation."
+                )
+        remaining = self._remaining_broker_budget(started)
+        if remaining <= 0:
+            raise TimeoutError(f"Dhan {operation} deadline expired before submission.")
+        future = self._sdk_executor.submit(call)
+        try:
+            return future.result(timeout=remaining)
+        except FuturesTimeoutError as exc:
+            # Python aliases concurrent.futures.TimeoutError to built-in
+            # TimeoutError.  If the SDK call itself raised it, preserve that
+            # evidence rather than falsely poisoning a completed future.
+            if future.done():
+                return future.result()
+            self._sdk_poisoned = True
+            self._timed_out_future = future
+            future.cancel()
+            raise TimeoutError(
+                f"Dhan {operation} exceeded the total "
+                f"{_BROKER_CALL_DEADLINE_SECONDS:.0f}s broker deadline; "
+                "session state is indeterminate."
+            ) from exc
+
+    def _call_api(
+        self,
+        operation: str,
+        call: Callable[[Any], Any],
+        *,
+        is_order: bool = False,
+        allow_after_poison: bool = False,
+    ) -> Any:
+        """Run one SDK method under the shared limits, lock, and deadline.
+
+        Args:
+            operation: Human label used in deadline and error messages.
+            call: Receives the live ``dhanhq`` client and performs one request.
+            is_order: Also consume the stricter order budget for write calls.
+            allow_after_poison: Permit reconciliation/risk-reducing calls only
+                after the abandoned timed-out future has actually ended.
+
+        Returns:
+            The raw ``{'status', 'remarks', 'data'}`` envelope from the SDK.
+
+        Raises:
+            RuntimeError: No client, or no rate budget, is available.
+            TimeoutError: The ten-second total budget expired.
+        """
+        started = time.monotonic()
+        deadline = started + _BROKER_CALL_DEADLINE_SECONDS
+        self._api_limiter.acquire(deadline)
+        if is_order:
+            self._order_limiter.acquire(deadline)
+
+        remaining = self._remaining_broker_budget(started)
+        if remaining <= 0 or not self._lock.acquire(timeout=max(0.0, remaining)):
+            raise TimeoutError(
+                "Dhan broker deadline expired while waiting for the shared session lock."
+            )
+        try:
+            client = self.client
+            if client is None:
+                raise RuntimeError("Dhan has no authenticated SDK client.")
+            return self._run_sdk_with_deadline(
+                operation,
+                lambda: call(client),
+                started=started,
+                allow_after_poison=allow_after_poison,
+            )
+        finally:
+            self._lock.release()
+
+    def recover_after_reconciliation(self) -> bool:
+        """Explicitly clear deadline poison after the abandoned call has ended.
+
+        "Poisoned" means an earlier SDK call outlived its 10-second budget and
+        was abandoned -- but Python cannot kill a running thread, so that call
+        may STILL be dribbling a response (or completing an order) inside
+        ``requests``.  Only after (a) reconciliation has proven the account
+        state and (b) the abandoned call has actually finished is it safe to
+        accept new orders; this method refuses (returns False) until both hold.
+        """
+
+        with self._lock:
+            if self._timed_out_future is not None and not self._timed_out_future.done():
+                return False
+            self._sdk_poisoned = False
+            self._timed_out_future = None
+            return True
+
+    def ensure_logged_in(self) -> bool:
+        """Return True only when a validated DhanHQ session is available.
+
+        This method is intentionally safe to call before every operation.  The
+        normal fast path only checks in-memory state; the validation request
+        runs once when the session has not yet been established.
+        """
+        with self._lock:
+            if self.is_logged_in and self.client is not None:
+                return True
+            return self._login_locked()
+
+    def _login_locked(self) -> bool:
+        """Build and validate a DhanHQ session from environment credentials.
+
+        Unlike the other broker helpers there is no interactive step: the
+        access token is produced offline by ``dhan_token_setup.py`` and read
+        from the environment.  Returning ``False`` instead of raising lets
+        startup force every strategy back to paper mode.  The token is never
+        logged.
+
+        Note the token is NOT long-lived: DhanHQ stamps a validity into it and
+        the web console currently issues 24-hour tokens.  One that expires
+        mid-session makes orders fail, and since a rejected live EXIT leaves a
+        position open, refresh it outside market hours.
+        """
+        self.is_logged_in = False
+        self.client = None
+        self._context = None
+        self._client_code = _env_str("DHAN_CLIENT_CODE")
+        access_token = _env_str("DHAN_ACCESS_TOKEN")
+        missing = [
+            name
+            for name, value in (
+                ("DHAN_CLIENT_CODE", self._client_code),
+                ("DHAN_ACCESS_TOKEN", access_token),
+            )
+            if not value
+        ]
+        if missing:
+            log.error("Dhan login disabled: missing %s.", ", ".join(missing))
+            return False
+
+        try:
+            context = DhanContext(self._client_code, access_token)
+            # DhanContext.__init__ swallows its own exceptions and can return a
+            # half-built object, so prove the HTTP layer exists before trusting
+            # it -- otherwise the failure resurfaces as an AttributeError in the
+            # middle of a live order.
+            http = context.get_dhan_http()
+            if http is None:
+                raise RuntimeError("DhanContext produced no HTTP connection.")
+            # The SDK ships a 60-second default, six times this repo's deadline.
+            http.timeout = _API_TIMEOUT_SECONDS
+            self._context = context
+            self.client = dhanhq(context)
+        except Exception as exc:
+            self.client = None
+            self._context = None
+            log.error("Dhan session construction failed: %s", exc)
+            return False
+
+        if not self._validate_session_locked():
+            self.client = None
+            self._context = None
+            return False
+        self.is_logged_in = True
+        log.info("Dhan execution client login successful.")
+        return True
+
+    def _validate_session_locked(self) -> bool:
+        """Prove the token works with one cheap authenticated read."""
+        try:
+            envelope = self._call_api("fund limits", lambda client: client.get_fund_limits())
+        except Exception as exc:
+            log.error("Dhan session validation failed: %s", exc)
+            return False
+        outcome, _data, reason = _classify_envelope(envelope)
+        if outcome != "ok":
+            log.error(
+                "Dhan session validation rejected (%s): %s. "
+                "Re-run 'python algo.py setup-token' if the token has expired.",
+                outcome,
+                reason,
+            )
+            return False
+        return True
+
+    def preload_scrip_master(self) -> bool:
+        """Log in and cache Dhan's option catalogue from the local instrument CSV.
+
+        The master calls this once before worker threads start.  Returning
+        ``False`` makes startup disable live trading instead of discovering a
+        missing or malformed contract catalogue during the first real order.
+        """
+        if not self.ensure_logged_in():
+            return False
+        with self._lock:
+            return self._ensure_scrip_master_locked()
+
+    def _ensure_scrip_master_locked(self) -> bool:
+        """Load and normalize the contract master once; caller holds ``_lock``."""
+        if self._scrip_df is not None:
+            return not self._scrip_df.empty
+        try:
+            path = self._latest_instrument_master_path()
+            if path is None:
+                raise FileNotFoundError(
+                    f"No instrument master matching '{_INSTRUMENT_MASTER_GLOB}' in "
+                    f"{_DEPENDENCIES_DIR}. The runner refreshes this file at end of day."
+                )
+            self._scrip_df = self._prepare_scrip_master(path)
+            self._security_id_by_symbol = {
+                str(row.trading_symbol): str(row.security_id)
+                for row in self._scrip_df.itertuples(index=False)
+            }
+            log.info(
+                "Dhan NSE index-option scrip master loaded (%d rows) from %s.",
+                len(self._scrip_df),
+                path.name,
+            )
+            return True
+        except Exception as exc:
+            self._scrip_df = None
+            self._security_id_by_symbol = {}
+            log.error("Dhan scrip master load/parse failed: %s", exc)
+            return False
+
+    @staticmethod
+    def _latest_instrument_master_path() -> Path | None:
+        """Return the newest ``all_instrument <date>.csv``, or ``None``.
+
+        The filenames carry an ISO date, so a plain sort is already
+        chronological; ``max`` therefore picks the freshest catalogue.
+        """
+
+        candidates = sorted(_DEPENDENCIES_DIR.glob(_INSTRUMENT_MASTER_GLOB))
+        return candidates[-1] if candidates else None
+
+    @staticmethod
+    def _prepare_scrip_master(path: Path) -> pd.DataFrame:
+        """Read the detailed scrip master and keep only usable index options.
+
+        The filters mirror the runner's own option resolver so this adapter and
+        the strategies can never disagree about which contract a strike means:
+        NSE exchange, ``D`` (derivatives) segment, ``OPTIDX`` instrument, a real
+        CE/PE type, and a parseable expiry, strike, and security id.
+
+        Only the columns actually needed are read: the file is ~35 MB and this
+        runs while the shared session lock is held.
+
+        Raises:
+            ValueError: Required columns or usable option rows are missing.
+        """
+        required = [
+            "EXCH_ID",
+            "SEGMENT",
+            "INSTRUMENT",
+            "SYMBOL_NAME",
+            "SM_EXPIRY_DATE",
+            "SECURITY_ID",
+            "STRIKE_PRICE",
+            "OPTION_TYPE",
+            "UNDERLYING_SYMBOL",
+        ]
+        header = pd.read_csv(path, nrows=0)
+        missing = [column for column in required if column not in header.columns]
+        if missing:
+            raise ValueError(
+                f"Dhan scrip master {path.name} missing columns: " + ", ".join(missing)
+            )
+        optional = [
+            column for column in ("DISPLAY_NAME", "LOT_SIZE") if column in header.columns
+        ]
+
+        raw = pd.read_csv(
+            path,
+            usecols=required + optional,
+            dtype=str,
+            low_memory=False,
+        )
+        frame = pd.DataFrame(
+            {
+                "_exchange_u": raw["EXCH_ID"].fillna("").astype(str).str.strip().str.upper(),
+                "_segment_u": raw["SEGMENT"].fillna("").astype(str).str.strip().str.upper(),
+                "_instrument_u": raw["INSTRUMENT"].fillna("").astype(str).str.strip().str.upper(),
+                "trading_symbol": raw["SYMBOL_NAME"].fillna("").astype(str).str.strip(),
+                "display_name": (
+                    raw["DISPLAY_NAME"].fillna("").astype(str).str.strip()
+                    if "DISPLAY_NAME" in optional
+                    else ""
+                ),
+                "_underlying_u": (
+                    raw["UNDERLYING_SYMBOL"].fillna("").astype(str).str.strip().str.upper()
+                ),
+                "_option_u": raw["OPTION_TYPE"].fillna("").astype(str).str.strip().str.upper(),
+                "_expiry_date": pd.to_datetime(
+                    raw["SM_EXPIRY_DATE"], errors="coerce"
+                ).dt.date,
+                "_strike_f": pd.to_numeric(raw["STRIKE_PRICE"], errors="coerce"),
+                "security_id": pd.to_numeric(raw["SECURITY_ID"], errors="coerce"),
+                "lot_size": (
+                    pd.to_numeric(raw["LOT_SIZE"], errors="coerce")
+                    if "LOT_SIZE" in optional
+                    else 0
+                ),
+            }
+        )
+        frame = frame[
+            (frame["_exchange_u"] == "NSE")
+            & (frame["_segment_u"] == "D")
+            & (frame["_instrument_u"] == "OPTIDX")
+            & frame["_option_u"].isin(["CE", "PE"])
+            & frame["_expiry_date"].notna()
+            & frame["_strike_f"].notna()
+            & frame["security_id"].notna()
+            & frame["trading_symbol"].ne("")
+        ].copy()
+        if frame.empty:
+            raise ValueError(
+                f"Dhan scrip master {path.name} contains no usable index-option rows."
+            )
+        frame["security_id"] = frame["security_id"].astype(int)
+        return frame
+
+    def resolve_option_symbol(
+        self,
+        underlying: str,
+        expiry: Any,
+        option_type: str,
+        strike: Any,
+        exchange_segment: str = "NSE_FNO",
+    ) -> str:
+        """Return the exact Dhan trading symbol or ``""`` on a miss.
+
+        Args:
+            underlying: Index name such as ``NIFTY`` or ``BANKNIFTY``.
+            expiry: Date-like option expiry supplied by the contract lookup.
+            option_type: ``CE`` for calls or ``PE`` for puts.
+            strike: Human-scale strike such as 24150 (not a paise multiplier).
+            exchange_segment: Must be ``NSE_FNO`` for this index-options helper.
+
+        Resolution is exact rather than pattern-based: the requested expiry,
+        strike, and option type must all occur in Dhan's catalogue.  Returning
+        an empty string makes the caller skip the real order safely.
+
+        The returned value is the human symbol so logs and Telegram alerts stay
+        readable; ``place_market_order`` translates it back to the numeric
+        ``securityId`` Dhan's order API requires.
+        """
+        underlying_u = str(underlying).upper().strip()
+        option_u = str(option_type).upper().strip()
+        exchange_u = str(exchange_segment).upper().strip() or "NSE_FNO"
+        if option_u not in {"CE", "PE"} or exchange_u != "NSE_FNO":
+            log.warning(
+                "Dhan resolve skipped: unsupported option/exchange %r/%r.",
+                option_type,
+                exchange_segment,
+            )
+            return ""
+        try:
+            expiry_date = pd.Timestamp(expiry).date()
+            strike_i = round(float(strike))
+        except Exception:
+            log.warning(
+                "Dhan resolve skipped: invalid expiry/strike %r/%r.",
+                expiry,
+                strike,
+            )
+            return ""
+        cache_key = (underlying_u, expiry_date, option_u, strike_i)
+        with self._lock:
+            cached = self._symbol_cache.get(cache_key)
+            if cached:
+                return cached
+        if not self.ensure_logged_in():
+            return ""
+        with self._lock:
+            cached = self._symbol_cache.get(cache_key)
+            if cached:
+                return cached
+            if not self._ensure_scrip_master_locked():
+                return ""
+            frame = self._scrip_df
+            if frame is None:
+                return ""
+            matches = frame[
+                (frame["_underlying_u"] == underlying_u)
+                & (frame["_option_u"] == option_u)
+                & (frame["_expiry_date"] == expiry_date)
+                & (frame["_strike_f"].round().astype(int) == strike_i)
+            ]
+            if matches.empty:
+                log.warning(
+                    "Dhan symbol NOT resolved: %s/%s/%s/strike %s.",
+                    underlying_u,
+                    option_u,
+                    expiry_date,
+                    strike_i,
+                )
+                return ""
+            row = matches.iloc[0]
+            symbol = str(row["trading_symbol"]).strip()
+            self._symbol_cache[cache_key] = symbol
+            self._security_id_by_symbol[symbol] = str(int(row["security_id"]))
+            return symbol
+
+    def place_market_order(
+        self,
+        symbol: str,
+        side: str,
+        quantity: int,
+        exchange_segment: str = "NSE_FNO",
+        product_type: str = "INTRADAY",
+        *,
+        order_tag: str = "",
+    ) -> OrderResult:
+        """Serialize one order from submission through typed fill confirmation."""
+
+        quantity_i = _exact_int(quantity)
+        if quantity_i is None or quantity_i <= 0:
+            raise ValueError(f"Invalid quantity: {quantity!r}")
+        if not self._order_submission_lock.acquire(
+            timeout=_BROKER_CALL_DEADLINE_SECONDS
+        ):
+            return normalize_order_result(
+                order_id="",
+                requested_quantity=quantity_i,
+                filled_quantity=0,
+                broker_state="ORDER_GATE_TIMEOUT",
+                reason=(
+                    "Dhan order was not submitted because another order's "
+                    "outcome remained unresolved past the broker deadline."
+                ),
+            )
+        try:
+            if self._sdk_poisoned:
+                return normalize_order_result(
+                    order_id="",
+                    requested_quantity=quantity_i,
+                    filled_quantity=0,
+                    broker_state="SESSION_POISONED",
+                    reason=(
+                        "Dhan session is indeterminate after an earlier "
+                        "deadline; reconcile before submitting another order."
+                    ),
+                )
+            return self._place_market_order_serialized(
+                symbol,
+                side,
+                quantity_i,
+                exchange_segment,
+                product_type,
+                order_tag=order_tag,
+            )
+        finally:
+            self._order_submission_lock.release()
+
+    def _place_market_order_serialized(
+        self,
+        symbol: str,
+        side: str,
+        quantity: int,
+        exchange_segment: str = "NSE_FNO",
+        product_type: str = "INTRADAY",
+        *,
+        order_tag: str = "",
+    ) -> OrderResult:
+        """Place one MARKET order and return an explicit normalized outcome.
+
+        Args:
+            symbol: Exact Dhan trading symbol returned by the resolver.
+            side: Friendly ``BUY`` or ``SELL`` value used by every broker helper.
+            quantity: Number of option units, normally a whole-number lot multiple.
+            exchange_segment: ``NSE_FNO``; other segments fail closed here.
+            product_type: ``INTRADAY`` or ``NORMAL`` (Dhan ``MARGIN``).
+            order_tag: Sent as Dhan's ``correlationId`` so a lost response can
+                still be traced back to its order.
+
+        Returns:
+            An :class:`OrderResult`.  An acknowledgement followed by response
+            loss keeps its order id and becomes ``UNKNOWN`` rather than being
+            mistaken for a rejection.
+
+        Raises:
+            ValueError: A caller supplied an unsupported order value.
+
+        Important: a ``success`` envelope only means Dhan accepted the request.
+        The method still polls the order book before reporting a fill.
+        """
+        side_u = str(side).upper().strip()
+        product_u = str(product_type).upper().strip()
+        exchange_u = str(exchange_segment).upper().strip() or "NSE_FNO"
+        symbol_s = str(symbol).strip()
+        quantity_i = _exact_int(quantity)
+        if side_u not in _SIDE_MAP:
+            raise ValueError(f"Invalid side: {side!r}")
+        if product_u not in _PRODUCT_MAP:
+            raise ValueError(f"Invalid product_type: {product_type!r}")
+        if exchange_u != "NSE_FNO":
+            raise ValueError(f"Invalid exchange_segment: {exchange_segment!r}")
+        if quantity_i is None or quantity_i <= 0:
+            raise ValueError(f"Invalid quantity: {quantity!r}")
+        if not symbol_s:
+            raise ValueError("Missing trading symbol for order.")
+        if not self.ensure_logged_in():
+            return normalize_order_result(
+                order_id="",
+                requested_quantity=quantity_i,
+                filled_quantity=0,
+                broker_state="REJECTED",
+                reason="Order was not submitted because Dhan login failed.",
+            )
+
+        security_id = self._security_id_for(symbol_s)
+        if not security_id:
+            # Nothing was sent, so this is a provable zero-fill.  Guessing an id
+            # would be far worse than refusing: it could trade a different
+            # contract entirely.
+            return normalize_order_result(
+                order_id="",
+                requested_quantity=quantity_i,
+                filled_quantity=0,
+                broker_state="REJECTED",
+                reason=(
+                    f"Dhan order was not submitted: no securityId is known for "
+                    f"symbol {symbol_s!r}. Resolve the contract first."
+                ),
+            )
+
+        try:
+            envelope = self._call_api(
+                "place order",
+                lambda client: client.place_order(
+                    security_id=security_id,
+                    exchange_segment=exchange_u,
+                    transaction_type=_SIDE_MAP[side_u],
+                    quantity=quantity_i,
+                    order_type="MARKET",
+                    product_type=_PRODUCT_MAP[product_u],
+                    price=0,
+                    tag=order_tag or None,
+                ),
+                is_order=True,
+            )
+        except Exception as exc:
+            # The request may or may not have reached the exchange.  Try the
+            # correlation lookup before giving up on identifying the order.
+            return self._resolve_indeterminate_placement(
+                quantity_i,
+                order_tag,
+                f"Dhan place-order call is indeterminate: {exc}",
+            )
+
+        outcome, data, reason = _classify_envelope(envelope)
+        order_id = self.extract_order_id(data) if outcome == "ok" else ""
+        if order_id:
+            return self._confirm_fill(order_id, quantity_i)
+
+        if outcome == "refused":
+            # Dhan's server answered with a structured error.  Confirm through
+            # the correlation id that no order actually exists before calling
+            # this a provable zero fill.
+            found_id, lookup_succeeded = self._find_order_id_by_tag(order_tag)
+            if found_id:
+                return self._confirm_fill(found_id, quantity_i)
+            if lookup_succeeded or not order_tag:
+                return normalize_order_result(
+                    order_id="",
+                    requested_quantity=quantity_i,
+                    filled_quantity=0,
+                    broker_state="REJECTED",
+                    reason=f"Dhan rejected the order: {reason}",
+                )
+            return self._indeterminate_placement(
+                quantity_i,
+                f"Dhan refused the order ({reason}) but the correlation lookup "
+                "could not confirm that nothing was created.",
+            )
+
+        # "ok" with no order id, or an indeterminate transport failure.
+        return self._resolve_indeterminate_placement(
+            quantity_i,
+            order_tag,
+            reason or "Dhan acknowledged the order without an order id.",
+        )
+
+    def _security_id_for(self, symbol: str) -> str:
+        """Look up the numeric securityId cached for one trading symbol."""
+
+        with self._lock:
+            return self._security_id_by_symbol.get(symbol, "")
+
+    def _find_order_id_by_tag(self, order_tag: str) -> tuple[str, bool]:
+        """Search Dhan's order book for an order carrying ``order_tag``.
+
+        Dhan echoes the tag back as ``correlationId`` and exposes a dedicated
+        lookup, which is how a completely lost placement response can still be
+        traced to a real order.
+
+        Returns:
+            ``(order_id, lookup_succeeded)``.  The flag distinguishes "looked
+            and found nothing" (safe to call a rejection) from "could not look"
+            (must stay indeterminate).
+        """
+
+        if not order_tag:
+            return ("", False)
+        try:
+            envelope = self._call_api(
+                "order by correlation id",
+                lambda client: client.get_order_by_correlationID(str(order_tag)),
+                allow_after_poison=True,
+            )
+        except Exception as exc:
+            log.warning("Dhan correlation-id lookup failed: %s", exc)
+            return ("", False)
+        outcome, data, _reason = _classify_envelope(envelope)
+        if outcome == "ok":
+            return (self.extract_order_id(data), True)
+        if outcome == "refused":
+            # A structured refusal here means Dhan searched and found no order
+            # for this correlation id.
+            return ("", True)
+        return ("", False)
+
+    def _indeterminate_placement(self, quantity: int, reason: str) -> OrderResult:
+        """Build the UNKNOWN result used whenever exposure cannot be proven."""
+
+        return normalize_order_result(
+            order_id="",
+            requested_quantity=quantity,
+            filled_quantity=0,
+            broker_state="",
+            reason=reason,
+        )
+
+    def _resolve_indeterminate_placement(
+        self,
+        quantity: int,
+        order_tag: str,
+        reason: str,
+    ) -> OrderResult:
+        """Try the correlation lookup before accepting an unknown placement."""
+
+        found_id, _lookup_succeeded = self._find_order_id_by_tag(order_tag)
+        if found_id:
+            return self._confirm_fill(found_id, quantity)
+        return self._indeterminate_placement(quantity, reason)
+
+    def _order_status(
+        self,
+        order_id: str,
+    ) -> tuple[str | None, int | None, int | None, str]:
+        """Return normalized state, filled qty, order qty, and rejection reason."""
+        envelope = self._call_api(
+            "order status",
+            lambda client: client.get_order_by_id(str(order_id)),
+            allow_after_poison=True,
+        )
+        outcome, data, reason = _classify_envelope(envelope)
+        if outcome != "ok":
+            return (None, None, None, reason)
+        rows = data if isinstance(data, list) else [data]
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            return (
+                _alias_state(_first_present(row, _ORDER_STATE_KEYS)) or None,
+                _exact_int(_first_present(row, _FILLED_QTY_KEYS)),
+                _exact_int(_first_present(row, _ORDER_QTY_KEYS)),
+                str(_first_present(row, _REASON_KEYS) or "").strip(),
+            )
+        return (None, None, None, f"Unrecognised Dhan order-status payload: {data!r}")
+
+    def get_order_status(
+        self,
+        order_id: str,
+        requested_quantity: int = 0,
+    ) -> OrderResult:
+        """Return one normalized order-book snapshot.
+
+        Exceptions and malformed quantities are represented as ``UNKNOWN`` while
+        retaining the caller's order id.  They never become zero-fill rejection.
+        """
+        requested = _exact_int(requested_quantity)
+        if requested is None or requested < 0:
+            requested = 0
+        try:
+            state, filled, broker_qty, reason = self._order_status(str(order_id))
+        except Exception as exc:
+            return normalize_order_result(
+                order_id=order_id,
+                requested_quantity=requested,
+                filled_quantity=0,
+                broker_state="",
+                reason=f"Dhan order-status query failed: {exc}",
+            )
+
+        effective_requested = requested or broker_qty or 0
+        if requested and broker_qty not in {None, requested}:
+            return normalize_order_result(
+                order_id=order_id,
+                requested_quantity=requested,
+                filled_quantity=None,
+                broker_state=state or "",
+                reason=(
+                    f"Malformed Dhan status: broker quantity {broker_qty} "
+                    f"does not match requested quantity {requested}. {reason}"
+                ),
+            )
+        return normalize_order_result(
+            order_id=order_id,
+            requested_quantity=effective_requested,
+            filled_quantity=filled,
+            broker_state=state or "",
+            reason=reason,
+        )
+
+    def _confirm_fill(self, order_id: str, want_qty: int) -> OrderResult:
+        """Poll until the order reaches a truly terminal state, or time out.
+
+        Why the loop keeps polling on PARTIAL/UNKNOWN snapshots: a market order
+        is often observed mid-fill (Dhan state ``PART_TRADED`` with some
+        quantity already on ``filledQty``).  That is TRANSIENT -- the next 0.5s
+        poll usually shows ``TRADED`` -- so returning it as the final outcome
+        would freeze every live strategy over a perfectly healthy order.  A
+        partial/unknown snapshot becomes the real outcome only when the broker
+        label is terminal (the order can never fill further) or the timeout
+        below expires.
+        """
+        deadline = time.monotonic() + _FILL_TIMEOUT_SECONDS
+        last_result = normalize_order_result(
+            order_id=order_id,
+            requested_quantity=want_qty,
+            filled_quantity=0,
+            broker_state="",
+            reason="Dhan acknowledgement received; fill status not read yet.",
+        )
+        while time.monotonic() < deadline:
+            last_result = self.get_order_status(order_id, requested_quantity=want_qty)
+            if last_result.status in {OrderStatus.FILLED, OrderStatus.REJECTED}:
+                return last_result
+            if last_result.broker_state in TERMINAL_BROKER_STATES:
+                # Terminal label with a partial/contradictory quantity snapshot:
+                # no further fills are possible, so this IS the final outcome.
+                return last_result
+            # A failed/malformed status call is already indeterminate. Repeating
+            # it inside the same order interaction risks exceeding the deadline
+            # without adding evidence, so return immediately with the known id.
+            if "query failed" in last_result.reason.lower():
+                return last_result
+            time.sleep(_FILL_POLL_INTERVAL)
+        return normalize_order_result(
+            order_id=order_id,
+            requested_quantity=want_qty,
+            filled_quantity=last_result.filled_quantity,
+            broker_state=last_result.broker_state,
+            reason=(
+                f"Dhan order {order_id} was not terminal within "
+                f"{_FILL_TIMEOUT_SECONDS:.0f}s; exposure is indeterminate."
+            ),
+        )
+
+    def cancel_order(
+        self,
+        order_id: str,
+        requested_quantity: int = 0,
+    ) -> OrderResult:
+        """Request cancellation, then normalize the order's resulting status."""
+
+        order_id_s = str(order_id).strip()
+        requested = _exact_int(requested_quantity)
+        if not order_id_s:
+            raise ValueError("Missing order id for cancellation.")
+        if requested is None or requested < 0:
+            raise ValueError(f"Invalid requested_quantity: {requested_quantity!r}")
+        if not self.ensure_logged_in():
+            return normalize_order_result(
+                order_id=order_id_s,
+                requested_quantity=requested,
+                filled_quantity=0,
+                broker_state="",
+                reason="Dhan cancellation was not submitted because login failed.",
+            )
+        try:
+            self._call_api(
+                "cancel order",
+                lambda client: client.cancel_order(order_id_s),
+                is_order=True,
+                allow_after_poison=True,
+            )
+        except Exception as exc:
+            return normalize_order_result(
+                order_id=order_id_s,
+                requested_quantity=requested,
+                filled_quantity=0,
+                broker_state="",
+                reason=f"Dhan cancellation response is indeterminate: {exc}",
+            )
+        return self.get_order_status(order_id_s, requested_quantity=requested)
+
+    def list_open_orders(self) -> BrokerQueryResult[OpenOrder]:
+        """Return pending orders, or an explicit indeterminate query result."""
+
+        try:
+            envelope = self._call_api(
+                "order list",
+                lambda client: client.get_order_list(),
+                allow_after_poison=True,
+            )
+        except Exception as exc:
+            return BrokerQueryResult.indeterminate(
+                f"Dhan open-order query failed: {exc}"
+            )
+        outcome, data, reason = _classify_envelope(envelope)
+        if outcome != "ok":
+            return BrokerQueryResult.indeterminate(
+                f"Dhan open-order query returned {outcome}: {reason}"
+            )
+        if not isinstance(data, list):
+            return BrokerQueryResult.indeterminate(
+                f"Dhan open-order query returned malformed data: {data!r}"
+            )
+
+        orders: list[OpenOrder] = []
+        for row in data:
+            if not isinstance(row, dict):
+                return BrokerQueryResult.indeterminate(
+                    "Dhan open-order query contained a malformed row."
+                )
+            raw_state = _alias_state(_first_present(row, _ORDER_STATE_KEYS))
+            snapshot = normalize_order_result(
+                order_id=_first_present(row, _ORDER_ID_KEYS),
+                requested_quantity=_first_present(row, _ORDER_QTY_KEYS),
+                filled_quantity=_first_present(row, _FILLED_QTY_KEYS),
+                broker_state=raw_state,
+                reason="Open-order snapshot",
+            )
+            symbol = str(_first_present(row, _SYMBOL_KEYS) or "").strip()
+            if (
+                not snapshot.order_id
+                or not symbol
+                or "malformed" in snapshot.reason.lower()
+                or snapshot.requested_quantity <= 0
+            ):
+                return BrokerQueryResult.indeterminate(
+                    "Dhan open-order query contained incomplete order data."
+                )
+            if raw_state in {
+                "COMPLETE", "COMPLETED", "FILLED", "TRADED", "EXECUTED",
+                "REJECTED", "CANCELLED", "CANCELED", "CANCEL", "LAPSED",
+            }:
+                continue
+            if snapshot.remaining_quantity <= 0:
+                continue
+            orders.append(
+                OpenOrder(
+                    order_id=snapshot.order_id,
+                    symbol=symbol,
+                    side=str(_first_present(row, _SIDE_KEYS) or "").strip().upper(),
+                    requested_quantity=snapshot.requested_quantity,
+                    filled_quantity=snapshot.filled_quantity,
+                    remaining_quantity=snapshot.remaining_quantity,
+                    broker_state=snapshot.broker_state,
+                )
+            )
+        return BrokerQueryResult.success(orders)
+
+    def list_open_positions(self) -> BrokerQueryResult[OpenPosition]:
+        """Return non-flat positions, or an explicit indeterminate result."""
+
+        try:
+            envelope = self._call_api(
+                "positions",
+                lambda client: client.get_positions(),
+                allow_after_poison=True,
+            )
+        except Exception as exc:
+            return BrokerQueryResult.indeterminate(
+                f"Dhan open-position query failed: {exc}"
+            )
+        outcome, data, reason = _classify_envelope(envelope)
+        if outcome != "ok":
+            return BrokerQueryResult.indeterminate(
+                f"Dhan open-position query returned {outcome}: {reason}"
+            )
+        if not isinstance(data, list):
+            return BrokerQueryResult.indeterminate(
+                f"Dhan open-position query returned malformed data: {data!r}"
+            )
+
+        positions: list[OpenPosition] = []
+        for row in data:
+            if not isinstance(row, dict):
+                return BrokerQueryResult.indeterminate(
+                    "Dhan open-position query contained a malformed row."
+                )
+            # A flat position legitimately reports netQty 0, which
+            # ``_first_present`` skips as empty -- so read it directly.
+            raw_quantity = next(
+                (row[key] for key in _NET_QTY_KEYS if key in row),
+                None,
+            )
+            quantity = _exact_int(raw_quantity)
+            symbol = str(_first_present(row, _SYMBOL_KEYS) or "").strip()
+            if quantity is None or not symbol:
+                return BrokerQueryResult.indeterminate(
+                    "Dhan open-position query contained incomplete position data."
+                )
+            if quantity == 0:
+                continue
+            positions.append(
+                OpenPosition(
+                    symbol=symbol,
+                    quantity=quantity,
+                    product_type=str(_first_present(row, _PRODUCT_KEYS) or "").strip(),
+                    broker_state="OPEN",
+                )
+            )
+        return BrokerQueryResult.success(positions)
+
+    def extract_order_id(self, order_response: Any) -> str:
+        """Recursively find Dhan's ``orderId`` in a response payload."""
+        if isinstance(order_response, OrderResult):
+            return order_response.order_id
+        if order_response is None:
+            return ""
+        if isinstance(order_response, dict):
+            for key in ("orderId", "order_id", "orderid", "id"):
+                value = order_response.get(key)
+                if value:
+                    return str(value).strip()
+            for value in order_response.values():
+                found = self.extract_order_id(value)
+                if found:
+                    return found
+            return ""
+        if isinstance(order_response, list):
+            for value in order_response:
+                found = self.extract_order_id(value)
+                if found:
+                    return found
+            return ""
+        if isinstance(order_response, str):
+            return order_response.strip()
+        return ""
+
+    def logout(self) -> dict[str, Any]:
+        """Close the local session and erase sensitive in-memory state.
+
+        DhanHQ documents no remote logout call, so closing the SDK's connection
+        pool and clearing the client, contract cache, and rate histories is the
+        complete local logout operation.  The token itself stays valid until
+        its own expiry regardless of what this process does, which is why it
+        lives only in the environment and is never written back anywhere.
+        """
+        with self._lock:
+            context = self._context
+            if context is not None:
+                try:
+                    http = context.get_dhan_http()
+                    session = getattr(http, "session", None)
+                    if session is not None:
+                        session.close()
+                except Exception as exc:
+                    log.warning("Dhan local session close failed: %s", exc)
+            self.is_logged_in = False
+            self.client = None
+            self._context = None
+            self._client_code = ""
+            self._symbol_cache.clear()
+            self._security_id_by_symbol.clear()
+            self._scrip_df = None
+            self._api_limiter.reset()
+            self._order_limiter.reset()
+            return {"status": "success", "message": "Dhan local session cleared"}
+
+
+# The master imports and reuses this one object so all worker threads share the
+# same authenticated session, contract cache, lock, and rate-limit budgets.
+dhan_execution_client = DhanExecutionClient()

--- a/Dependencies/Dhan API/dhan_execution.py
+++ b/Dependencies/Dhan API/dhan_execution.py
@@ -96,9 +96,18 @@ from dhanhq import DhanContext, dhanhq
 # The broker helpers live in folders with spaces and are also executable as
 # standalone diagnostics.  Add their shared ``Dependencies`` parent explicitly
 # so the broker-neutral contract imports the same way in both entry points.
+#
+# The REPO ROOT goes on the path too, not just ``Dependencies``: the redaction
+# helper below is imported as ``Dependencies.secret_redaction``, which needs
+# the package's PARENT directory.  The master already has it because it is
+# launched from the repo root, but ``python <script>`` puts the SCRIPT's
+# directory on ``sys.path[0]`` and never the working directory (same fix the
+# Kotak/Shoonya helpers carry).
 _DEPENDENCIES_DIR = Path(__file__).resolve().parent.parent
-if str(_DEPENDENCIES_DIR) not in sys.path:
-    sys.path.insert(0, str(_DEPENDENCIES_DIR))
+_REPO_ROOT = _DEPENDENCIES_DIR.parent
+for _import_root in (_REPO_ROOT, _DEPENDENCIES_DIR):
+    if str(_import_root) not in sys.path:
+        sys.path.insert(0, str(_import_root))
 
 from broker_contract import (  # noqa: E402
     TERMINAL_BROKER_STATES,
@@ -109,6 +118,8 @@ from broker_contract import (  # noqa: E402
     OrderStatus,
     normalize_order_result,
 )
+
+from Dependencies.secret_redaction import redact_text  # noqa: E402
 
 try:
     from dotenv import load_dotenv
@@ -581,7 +592,12 @@ class DhanExecutionClient:
         except Exception as exc:
             self.client = None
             self._context = None
-            log.error("Dhan session construction failed: %s", exc)
+            # MAT-108: SDK construction errors can echo their arguments, and one
+            # of those arguments IS the access token -- never log the raw text.
+            log.error(
+                "Dhan session construction failed: %s",
+                redact_text(exc, (access_token,)),
+            )
             return False
 
         if not self._validate_session_locked():
@@ -597,7 +613,9 @@ class DhanExecutionClient:
         try:
             envelope = self._call_api("fund limits", lambda client: client.get_fund_limits())
         except Exception as exc:
-            log.error("Dhan session validation failed: %s", exc)
+            # MAT-108: exception/response text from an auth-adjacent call is
+            # exactly where a credential could surface -- redact before logging.
+            log.error("Dhan session validation failed: %s", redact_text(exc))
             return False
         outcome, _data, reason = _classify_envelope(envelope)
         if outcome != "ok":
@@ -605,7 +623,7 @@ class DhanExecutionClient:
                 "Dhan session validation rejected (%s): %s. "
                 "Re-run 'python algo.py setup-token' if the token has expired.",
                 outcome,
-                reason,
+                redact_text(reason),
             )
             return False
         return True

--- a/Dependencies/Dhan API/diagnose_dhan_symbol.py
+++ b/Dependencies/Dhan API/diagnose_dhan_symbol.py
@@ -33,6 +33,7 @@ from typing import Any
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import dhan_execution as de
 from broker_contract import OrderResult, OrderStatus
+from diagnostic_preflight import validate_quantity_for_lot
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -167,40 +168,6 @@ def select_contract(
         str(int(row["security_id"])),
         lot_size,
     )
-
-
-def validate_quantity_for_lot(quantity: int, lot_size: int) -> str:
-    """Return an error message when ``quantity`` is not a whole-lot multiple.
-
-    Index options trade only in exchange-defined lots, so a quantity such as 1
-    against a lot of 65 can never be accepted.  Catching that locally matters
-    because Dhan reports it as a generic ``DH-905 Input_Exception`` whose
-    ``error_message`` has been observed to read "Invalid IP" -- an error that
-    sends operators hunting a network fault that does not exist.
-
-    This validates the operator's OWN number; it deliberately does not derive
-    one.  ``--place-order`` still requires an explicit ``--qty`` because lot
-    sizes change and guessing one would risk a wrong-sized live order.
-
-    Args:
-        quantity: The explicit unit quantity supplied on the command line.
-        lot_size: Official lot size from the contract catalogue, 0 if absent.
-
-    Returns:
-        An empty string when the quantity is placeable, else the reason.
-    """
-    if lot_size <= 0:
-        # The catalogue row carried no lot size, so there is nothing to check
-        # against. The broker remains the authority.
-        return ""
-    if quantity % lot_size:
-        return (
-            f"--qty {quantity} is not a multiple of the official lot size "
-            f"{lot_size}. Index options trade in whole lots only, so Dhan "
-            f"would reject this order. Use {lot_size} for one lot "
-            f"(or {lot_size * 2} for two)."
-        )
-    return ""
 
 
 def check_entry_margin(

--- a/Dependencies/Dhan API/diagnose_dhan_symbol.py
+++ b/Dependencies/Dhan API/diagnose_dhan_symbol.py
@@ -1,0 +1,520 @@
+"""Read-only Dhan index-option diagnostic with an opt-in REAL test order.
+
+Examples from the repository root::
+
+    python "Dependencies/Dhan API/diagnose_dhan_symbol.py" CE 24150
+    python "Dependencies/Dhan API/diagnose_dhan_symbol.py" PE 24000 14JUL26
+    python "Dependencies/Dhan API/diagnose_dhan_symbol.py" --underlying BANKNIFTY CE 59500
+
+The script logs in, loads the same local instrument master used by live
+execution, prints the exact contract row, and checks the shared resolver.  It
+does not place an order unless ``--place-order`` is supplied and the operator
+supplies an explicit ``--qty`` and then types exactly ``YES``.  The real-money
+path attempts the matching SELL only after the BUY has a confirmed full fill;
+a partial or unknown entry stops for reconciliation.
+
+The normal read-only flow has five visible checkpoints: authenticate, load the
+contract list, select one exact row, ask the production resolver for the same
+symbol, and confirm that symbol maps back to the same numeric ``securityId``.
+That last step is Dhan-specific and matters: Dhan's order API is driven by the
+security id, not the symbol, so a broken mapping would silently trade the wrong
+contract.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import dhan_execution as de
+from broker_contract import OrderResult, OrderStatus
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the parser used directly and through ``algo.py diagnose``.
+
+    ``algo.py`` consumes only ``--broker dhan`` and forwards every remaining
+    argument unchanged, so this parser remains the single source of truth for the
+    broker-specific option type, strike, expiry, quantity, and real-order switch.
+    """
+    parser = argparse.ArgumentParser(
+        description=(
+            "Validate a Dhan index-option symbol. Read-only unless "
+            "--place-order is supplied and YES is typed."
+        )
+    )
+    parser.add_argument(
+        "option_type",
+        nargs="?",
+        default="CE",
+        choices=("CE", "PE"),
+        type=str.upper,
+        help="Option type (default: CE).",
+    )
+    parser.add_argument(
+        "strike",
+        nargs="?",
+        default=23950,
+        type=int,
+        help="Option strike (default: 23950).",
+    )
+    parser.add_argument(
+        "expiry",
+        nargs="?",
+        help="Optional expiry as DDMMMYY, for example 14JUL26.",
+    )
+    parser.add_argument(
+        "--underlying",
+        default="NIFTY",
+        type=str.upper,
+        help="Index name (default: NIFTY). BANKNIFTY diagnoses the mirror leg.",
+    )
+    parser.add_argument(
+        "--place-order",
+        action="store_true",
+        help="After another YES prompt, place a REAL BUY then SELL round trip.",
+    )
+    parser.add_argument(
+        "--qty",
+        type=int,
+        help="Required explicit unit quantity for the REAL test order.",
+    )
+    return parser
+
+
+def _parse_expiry(raw: str | None) -> dt.date | None:
+    """Parse the optional DDMMMYY CLI expiry with a friendly error."""
+    if not raw:
+        return None
+    try:
+        return dt.datetime.strptime(raw.upper().strip(), "%d%b%y").date()
+    except ValueError as exc:
+        raise ValueError(
+            f"Could not parse expiry {raw!r}; expected DDMMMYY like 14JUL26."
+        ) from exc
+
+
+def select_contract(
+    client: Any,
+    *,
+    underlying: str,
+    option_type: str,
+    strike: int,
+    requested_expiry: dt.date | None,
+    today: dt.date | None = None,
+) -> tuple[dt.date, str, str, int]:
+    """Select one exact catalogue row; return expiry, symbol, security id, lot.
+
+    When no expiry is supplied, the nearest non-expired contract containing the
+    requested strike is chosen.  Filtering the strike before choosing the date
+    avoids selecting an expiry that does not list that particular contract.
+
+    Args:
+        client: Logged-in DhanExecutionClient with ``_scrip_df`` preloaded.
+        underlying: Index name such as NIFTY or BANKNIFTY.
+        option_type: ``CE`` or ``PE``.
+        strike: Whole-number option strike.
+        requested_expiry: Exact date, or ``None`` to choose the nearest future row.
+        today: Injectable clock used by deterministic unit tests.
+
+    Returns:
+        ``(expiry_date, trading_symbol, security_id, lot_size)`` from one row.
+
+    Raises:
+        ValueError: The master is unavailable or no exact row exists. It never
+            guesses a symbol, a security id, or a quantity.
+    """
+    frame = getattr(client, "_scrip_df", None)
+    if frame is None or frame.empty:
+        raise ValueError("Dhan scrip master is not loaded.")
+    underlying_u = str(underlying).upper().strip()
+    option_u = str(option_type).upper().strip()
+    strike_i = round(float(strike))
+    matches = frame[
+        (frame["_underlying_u"] == underlying_u)
+        & (frame["_option_u"] == option_u)
+        & (frame["_strike_f"].round().astype(int) == strike_i)
+    ].copy()
+    if requested_expiry is not None:
+        matches = matches[matches["_expiry_date"] == requested_expiry]
+    else:
+        today = today or dt.date.today()
+        matches = matches[matches["_expiry_date"] >= today]
+        if not matches.empty:
+            nearest = min(matches["_expiry_date"])
+            matches = matches[matches["_expiry_date"] == nearest]
+    if matches.empty:
+        expiry_text = requested_expiry.isoformat() if requested_expiry else "nearest future"
+        raise ValueError(
+            f"No Dhan {underlying_u} {option_u} strike {strike_i} "
+            f"contract found for {expiry_text} expiry."
+        )
+    row = matches.sort_values(["_expiry_date", "trading_symbol"]).iloc[0]
+    # LOT_SIZE is optional in the catalogue, so report 0 rather than crashing;
+    # --place-order requires an explicit --qty regardless.
+    try:
+        lot_size = int(row["lot_size"])
+    except (TypeError, ValueError):
+        lot_size = 0
+    return (
+        row["_expiry_date"],
+        str(row["trading_symbol"]).strip(),
+        str(int(row["security_id"])),
+        lot_size,
+    )
+
+
+def validate_quantity_for_lot(quantity: int, lot_size: int) -> str:
+    """Return an error message when ``quantity`` is not a whole-lot multiple.
+
+    Index options trade only in exchange-defined lots, so a quantity such as 1
+    against a lot of 65 can never be accepted.  Catching that locally matters
+    because Dhan reports it as a generic ``DH-905 Input_Exception`` whose
+    ``error_message`` has been observed to read "Invalid IP" -- an error that
+    sends operators hunting a network fault that does not exist.
+
+    This validates the operator's OWN number; it deliberately does not derive
+    one.  ``--place-order`` still requires an explicit ``--qty`` because lot
+    sizes change and guessing one would risk a wrong-sized live order.
+
+    Args:
+        quantity: The explicit unit quantity supplied on the command line.
+        lot_size: Official lot size from the contract catalogue, 0 if absent.
+
+    Returns:
+        An empty string when the quantity is placeable, else the reason.
+    """
+    if lot_size <= 0:
+        # The catalogue row carried no lot size, so there is nothing to check
+        # against. The broker remains the authority.
+        return ""
+    if quantity % lot_size:
+        return (
+            f"--qty {quantity} is not a multiple of the official lot size "
+            f"{lot_size}. Index options trade in whole lots only, so Dhan "
+            f"would reject this order. Use {lot_size} for one lot "
+            f"(or {lot_size * 2} for two)."
+        )
+    return ""
+
+
+def check_entry_margin(
+    client: Any,
+    *,
+    security_id: str,
+    quantity: int,
+    product_type: str = "INTRADAY",
+) -> tuple[bool, str]:
+    """Ask Dhan whether the BUY entry is affordable, without placing anything.
+
+    ``margin_calculator`` validates the same contract and quantity fields as
+    ``place_order`` but creates no order, so it is a safe pre-flight.
+
+    Only the ENTRY is checked.  An exit must never be gated on a pre-flight
+    query: if a position is open, squaring it off has to stay possible even
+    when a margin lookup fails.
+
+    Returns:
+        ``(placeable, message)``.  ``placeable`` is ``False`` only when the
+        broker positively reports a shortfall.  An unavailable or malformed
+        margin reply returns ``True`` with a warning -- an advisory check that
+        cannot run must not block the operator, since the broker itself is
+        still the real gate.
+    """
+    try:
+        envelope = client._call_api(
+            "margin calculator",
+            lambda sdk: sdk.margin_calculator(
+                security_id=str(security_id),
+                exchange_segment="NSE_FNO",
+                transaction_type="BUY",
+                quantity=int(quantity),
+                product_type=product_type,
+                price=0,
+            ),
+        )
+    except Exception as exc:
+        return (True, f"Margin pre-check could not run ({exc}); continuing.")
+
+    outcome, data, reason = de._classify_envelope(envelope)
+    if outcome != "ok" or not isinstance(data, dict):
+        return (True, f"Margin pre-check was inconclusive ({outcome}: {reason}); continuing.")
+
+    # Affordability is decided by comparing the two balances DIRECTLY.
+    #
+    # Dhan's `insufficientBalance` field is deliberately ignored: despite the
+    # name it is the UNSIGNED difference, abs(totalMargin - availableBalance),
+    # so it is positive whether you are short OR have money to spare. Measured
+    # against this account (available 10000.39):
+    #
+    #   required   2808.00 -> insufficientBalance  7192.39   (surplus!)
+    #   required  11232.00 -> insufficientBalance  1231.61   (short)
+    #   required  21895.25 -> insufficientBalance 11894.86   (short)
+    #   required  87581.00 -> insufficientBalance 77580.61   (short)
+    #
+    # Reading it as a shortfall rejects every affordable order. The response
+    # carries no boolean "sufficient" flag, so the comparison below is the
+    # only reliable test.
+    required = data.get("totalMargin")
+    available = data.get("availableBalance")
+    if required is None or available is None:
+        return (True, "Margin pre-check omitted the margin/balance figures; continuing.")
+    try:
+        required_f = float(required)
+        available_f = float(available)
+    except (TypeError, ValueError):
+        return (True, "Margin pre-check returned unusable figures; continuing.")
+
+    summary = f"required {required_f:.2f}, available {available_f:.2f}"
+    if available_f < required_f:
+        return (
+            False,
+            f"Insufficient funds for this entry: {summary}, "
+            f"short by {required_f - available_f:.2f}. Fund the account or test "
+            "with a cheaper (further out-of-the-money) strike.",
+        )
+    return (True, f"Margin pre-check OK: {summary}.")
+
+
+def place_round_trip_test_order(client: Any, symbol: str, quantity: int) -> bool:
+    """Place a confirmation-gated REAL BUY then SELL; return True only if flat.
+
+    This is deliberately separate from ``main`` so tests can prove that anything
+    except uppercase ``YES`` sends zero orders. If entry or exit confirmation is
+    ambiguous, the message assumes a live position *may* exist and directs the
+    operator to Dhan; silence would be unsafe in a real-money diagnostic.
+    """
+    print("\n" + "=" * 72)
+    print("REAL ROUND-TRIP TEST ORDER on Dhan")
+    print(
+        f"  BUY {quantity} {symbol} (product=INTRADAY); after a confirmed "
+        f"full fill, attempt SELL {quantity} to flatten."
+    )
+    print("  THIS PLACES REAL ORDERS WITH REAL MONEY.")
+    try:
+        confirmation = input(
+            "  Type exactly YES to proceed (anything else aborts): "
+        ).strip()
+    except (EOFError, OSError):
+        confirmation = ""
+    if confirmation != "YES":
+        print("  Aborted (no confirmation).")
+        return False
+
+    print(f"  Placing BUY {quantity} {symbol} ...")
+    try:
+        entry = client.place_market_order(
+            symbol=symbol,
+            side="BUY",
+            quantity=quantity,
+            product_type="INTRADAY",
+        )
+    except Exception as exc:
+        print(f"  ENTRY EXPOSURE IS INDETERMINATE: client raised {exc}")
+        print(
+            f"  !! A LIVE long position in {symbol} (qty={quantity}) MAY BE OPEN. "
+            "CHECK DHAN BEFORE RETRYING OR PLACING ANOTHER ORDER."
+        )
+        return False
+    if _is_zero_fill_rejection(entry, quantity):
+        print(f"  ENTRY rejected with zero fill: {entry.reason}\n  No position opened.")
+        return False
+    if not _is_full_fill(entry, quantity):
+        _print_indeterminate("ENTRY", entry, symbol, quantity)
+        return False
+    print(f"  ENTRY filled. OrderId={entry.order_id}")
+
+    print(f"  Squaring off: SELL {quantity} {symbol} ...")
+    try:
+        exit_order = client.place_market_order(
+            symbol=symbol,
+            side="SELL",
+            quantity=quantity,
+            product_type="INTRADAY",
+        )
+    except Exception as exc:
+        print(f"  !! EXIT EXPOSURE IS INDETERMINATE: client raised {exc}")
+        print(
+            f"  !! A LIVE long position in {symbol} (qty={quantity}) MAY BE OPEN. "
+            "CHECK DHAN AND SQUARE IT OFF MANUALLY NOW."
+        )
+        return False
+    if _is_zero_fill_rejection(exit_order, quantity):
+        print(f"  !! EXIT rejected with zero fill: {exit_order.reason}")
+        print(
+            f"  !! The LIVE long {symbol} qty={quantity} remains OPEN. "
+            "Square it off manually now."
+        )
+        return False
+    if not _is_full_fill(exit_order, quantity):
+        _print_indeterminate("EXIT", exit_order, symbol, quantity)
+        return False
+    print(
+        f"  EXIT filled. OrderId={exit_order.order_id} "
+        "-> flat. Round-trip OK."
+    )
+    return True
+
+
+def _is_full_fill(result: Any, quantity: int) -> bool:
+    """Return True only for an exact, typed full-quantity fill."""
+    return (
+        isinstance(result, OrderResult)
+        and result.status is OrderStatus.FILLED
+        and result.requested_quantity == quantity
+        and result.filled_quantity == quantity
+        and result.remaining_quantity == 0
+    )
+
+
+def _is_zero_fill_rejection(result: Any, quantity: int) -> bool:
+    """Return True only when the broker explicitly proves no units traded."""
+    return (
+        isinstance(result, OrderResult)
+        and result.status is OrderStatus.REJECTED
+        and result.requested_quantity == quantity
+        and result.filled_quantity == 0
+        and result.remaining_quantity == quantity
+    )
+
+
+def _print_indeterminate(
+    stage: str,
+    result: Any,
+    symbol: str,
+    quantity: int,
+) -> None:
+    """Print typed broker evidence without claiming that exposure is flat."""
+    if isinstance(result, OrderResult):
+        evidence = (
+            f"status={result.status.value} order_id={result.order_id or 'UNKNOWN'} "
+            f"filled={result.filled_quantity}/{result.requested_quantity} "
+            f"remaining={result.remaining_quantity} reason={result.reason}"
+        )
+    else:
+        evidence = f"untyped_result={result!r}"
+    print(f"  !! {stage} EXPOSURE IS INDETERMINATE: {evidence}")
+    print(
+        f"  !! Check {symbol} qty={quantity} in Dhan before retrying or "
+        "placing another order."
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the safe symbol diagnostic and optional confirmation-gated order.
+
+    Return codes follow normal CLI convention: 0 success, 1 operational failure
+    (login/resolution/order), and 2 invalid command-line input.
+    """
+    # Parse and validate all local input before login. Typos should never touch
+    # the broker API.
+    args = build_parser().parse_args(argv)
+    if args.qty is not None and args.qty <= 0:
+        print("--qty must be a positive integer.", file=sys.stderr)
+        return 2
+    if args.place_order and args.qty is None:
+        print(
+            "--place-order requires an explicit positive --qty; the diagnostic "
+            "will not guess a live quantity from a changing exchange lot size.",
+            file=sys.stderr,
+        )
+        return 2
+    try:
+        requested_expiry = _parse_expiry(args.expiry)
+    except ValueError as exc:
+        print(exc, file=sys.stderr)
+        return 2
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s | %(levelname)s | %(message)s",
+    )
+    client = de.dhan_execution_client
+    try:
+        # ``preload_scrip_master`` authenticates first, then loads the local
+        # instrument CSV once. The production resolver below reuses the same
+        # already-normalized in-memory table.
+        print("Logging in to Dhan and loading the local instrument master...")
+        if not client.preload_scrip_master():
+            print("Could not log in / load the Dhan scrip master.")
+            return 1
+
+        expiry, csv_symbol, csv_security_id, lot_size = select_contract(
+            client,
+            underlying=args.underlying,
+            option_type=args.option_type,
+            strike=args.strike,
+            requested_expiry=requested_expiry,
+        )
+        resolved = client.resolve_option_symbol(
+            args.underlying,
+            expiry,
+            args.option_type,
+            args.strike,
+        )
+        master_rows = 0 if client._scrip_df is None else len(client._scrip_df)
+        print(f"\nContract master rows: {master_rows}")
+        print(f"Selected expiry : {expiry:%d%b%y}")
+        print(f"Trading symbol  : {csv_symbol}")
+        print(f"Security id     : {csv_security_id}")
+        print(f"Official lot    : {lot_size}")
+        print(
+            "Resolver result : "
+            f"resolve_option_symbol({args.underlying}, {expiry}, "
+            f"{args.option_type}, {args.strike}) -> {resolved!r}"
+        )
+        if not resolved or resolved != csv_symbol:
+            print("Resolver did not reproduce the exact official catalogue symbol.")
+            return 1
+
+        # Dhan-specific: the order API takes the security id, so prove the
+        # symbol the resolver returned maps back to the very same contract.
+        mapped_security_id = client._security_id_for(resolved)
+        print(f"Order-API mapping: {resolved} -> securityId {mapped_security_id!r}")
+        if mapped_security_id != csv_security_id:
+            print(
+                "Symbol does not map back to the catalogue securityId; a live "
+                "order could reach the WRONG contract. Refusing to continue."
+            )
+            return 1
+
+        # Read-only is the default. Reaching the order helper requires both the
+        # explicit flag here and its second, typed-YES confirmation inside.
+        if not args.place_order:
+            print("\nRead-only diagnostic complete. No order was placed.")
+            return 0
+
+        # Pre-flight. Both checks run BEFORE the typed-YES prompt so an order
+        # that is certain to fail never reaches the broker (and never wastes
+        # the operator's confirmation on it).
+        lot_error = validate_quantity_for_lot(args.qty, lot_size)
+        if lot_error:
+            print(f"\n{lot_error}", file=sys.stderr)
+            return 2
+
+        placeable, margin_message = check_entry_margin(
+            client,
+            security_id=csv_security_id,
+            quantity=args.qty,
+        )
+        print(f"\n{margin_message}")
+        if not placeable:
+            return 1
+
+        return 0 if place_round_trip_test_order(client, resolved, args.qty) else 1
+    except Exception as exc:
+        print(f"Dhan diagnostic failed: {exc}", file=sys.stderr)
+        return 1
+    finally:
+        # Also runs on parse/resolution/order exceptions. Dhan documents no
+        # remote logout, so this only clears local session state.
+        client.logout()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Dependencies/Dhan API/test_dhan_execution.py
+++ b/Dependencies/Dhan API/test_dhan_execution.py
@@ -345,24 +345,18 @@ def _diagnostic() -> ModuleType:
 diag = _diagnostic()
 
 
-@pytest.mark.parametrize(
-    ("quantity", "lot_size", "rejected"),
-    [
-        (1, 65, True),      # the exact case that produced "Invalid IP"
-        (64, 65, True),
-        (100, 65, True),
-        (65, 65, False),    # one lot
-        (130, 65, False),   # two lots
-        (30, 30, False),    # BankNIFTY lot
-        (1, 0, False),      # catalogue carried no lot size -> nothing to check
-    ],
-)
-def test_quantity_must_be_a_whole_lot_multiple(quantity, lot_size, rejected) -> None:
-    message = diag.validate_quantity_for_lot(quantity, lot_size)
+def test_quantity_check_is_the_shared_one_not_a_local_copy() -> None:
+    """Behaviour lives in Dependencies/test_diagnostic_preflight.py.
 
-    assert bool(message) is rejected
-    if rejected:
-        assert str(lot_size) in message
+    All four diagnostics import one implementation; this only pins that the
+    Dhan one is wired to it rather than carrying a copy that could drift.
+    """
+
+    # Imported here, not at module scope: it resolves through the sys.path the
+    # adapter sets up when this test module loads the diagnostic.
+    import diagnostic_preflight
+
+    assert diag.validate_quantity_for_lot is diagnostic_preflight.validate_quantity_for_lot
 
 
 class _MarginClient:

--- a/Dependencies/Dhan API/test_dhan_execution.py
+++ b/Dependencies/Dhan API/test_dhan_execution.py
@@ -1,0 +1,484 @@
+"""Offline unit tests for the Dhan execution helper's local logic.
+
+These cover the parts that never reach the network: rate limiting, instrument
+CSV parsing, envelope classification, order-state aliasing, and order-id
+extraction.  The broker-contract conformance tests (place/status/cancel and the
+deadline behaviour) live in ``Dependencies/test_broker_contract.py``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_module() -> ModuleType:
+    """Load the adapter from its space-containing folder."""
+
+    path = ROOT / "Dependencies" / "Dhan API" / "dhan_execution.py"
+    spec = importlib.util.spec_from_file_location("dhan_execution_unit_test", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["dhan_execution_unit_test"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+de = _load_module()
+
+
+# ---------------------------------------------------------------------------
+# Rate limiter
+# ---------------------------------------------------------------------------
+
+
+class _FakeClock:
+    """Deterministic monotonic clock whose sleeps just advance the time."""
+
+    def __init__(self) -> None:
+        self.now = 0.0
+        self.slept: list[float] = []
+
+    def __call__(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.slept.append(seconds)
+        self.now += seconds
+
+
+def _limiter(clock: _FakeClock, per_second=2, per_minute=5, max_wait=2.0):
+    return de._RollingWindowRateLimiter(
+        per_second,
+        per_minute,
+        max_wait,
+        clock=clock,
+        sleeper=clock.sleep,
+        label="test",
+    )
+
+
+def test_rate_limiter_grants_calls_inside_the_budget() -> None:
+    clock = _FakeClock()
+    limiter = _limiter(clock)
+
+    limiter.acquire()
+    limiter.acquire()
+
+    assert clock.slept == []
+
+
+def test_rate_limiter_waits_for_the_next_one_second_window() -> None:
+    clock = _FakeClock()
+    limiter = _limiter(clock)
+
+    limiter.acquire()
+    limiter.acquire()
+    limiter.acquire()
+
+    assert clock.slept and clock.slept[0] == pytest.approx(1.0)
+
+
+def test_rate_limiter_raises_rather_than_waiting_past_the_cap() -> None:
+    """A stale live order is worse than a clear, immediate refusal."""
+
+    clock = _FakeClock()
+    limiter = _limiter(clock, per_second=1, per_minute=1, max_wait=0.5)
+    limiter.acquire()
+
+    with pytest.raises(RuntimeError, match="rate limit exhausted"):
+        limiter.acquire()
+
+
+# ---------------------------------------------------------------------------
+# Envelope classification -- the safety-critical discrimination
+# ---------------------------------------------------------------------------
+
+
+def test_success_envelope_is_ok_and_carries_data() -> None:
+    outcome, data, _reason = de._classify_envelope(
+        {"status": "success", "remarks": "", "data": {"orderId": "DH-1"}}
+    )
+
+    assert outcome == "ok"
+    assert data == {"orderId": "DH-1"}
+
+
+def test_dict_remarks_means_the_server_answered_and_refused() -> None:
+    outcome, _data, reason = de._classify_envelope(
+        {
+            "status": "failure",
+            "remarks": {
+                "error_code": "DH-905",
+                "error_type": "Order_Error",
+                "error_message": "insufficient margin",
+            },
+            "data": "",
+        }
+    )
+
+    assert outcome == "refused"
+    assert "insufficient margin" in reason
+
+
+def test_str_remarks_means_indeterminate_not_refused() -> None:
+    """The SDK's bare ``except Exception`` produces this shape.
+
+    Treating it as a refusal is exactly the bug that would report a timed-out
+    but live order as a harmless rejection.
+    """
+
+    outcome, _data, reason = de._classify_envelope(
+        {"status": "failure", "remarks": "ConnectionError(read timed out)", "data": ""}
+    )
+
+    assert outcome == "indeterminate"
+    assert "timed out" in reason
+
+
+@pytest.mark.parametrize("envelope", [None, "boom", 42, [], {"unexpected": True}])
+def test_malformed_envelopes_are_indeterminate(envelope) -> None:
+    outcome, _data, _reason = de._classify_envelope(envelope)
+
+    assert outcome == "indeterminate"
+
+
+# ---------------------------------------------------------------------------
+# Order-state aliasing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("EXPIRED", "CANCELLED"),
+        ("PART_TRADED", "PARTIAL"),
+        ("part-traded", "PARTIAL"),
+        ("TRADED", "TRADED"),
+        ("REJECTED", "REJECTED"),
+        # Transient states stay themselves so the fill loop keeps polling.
+        ("PENDING", "PENDING"),
+        ("TRANSIT", "TRANSIT"),
+        (None, ""),
+    ],
+)
+def test_state_aliasing(raw, expected: str) -> None:
+    assert de._alias_state(raw) == expected
+
+
+# ---------------------------------------------------------------------------
+# Quantity and field parsing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [(75, 75), ("75", 75), (75.0, 75), ("75.5", None), (True, None), ("abc", None), (None, None)],
+)
+def test_exact_int_rejects_anything_but_whole_numbers(value, expected) -> None:
+    assert de._exact_int(value) == expected
+
+
+def test_first_present_tolerates_field_casing_differences() -> None:
+    """Dhan's field casing is documented only in prose, so reads are lenient."""
+
+    assert de._first_present({"filledQty": 25}, de._FILLED_QTY_KEYS) == 25
+    assert de._first_present({"filled_qty": 25}, de._FILLED_QTY_KEYS) == 25
+    assert de._first_present({"orderStatus": "TRADED"}, de._ORDER_STATE_KEYS) == "TRADED"
+    # Empty strings count as absent so a blank field cannot masquerade as data.
+    assert de._first_present({"filledQty": ""}, de._FILLED_QTY_KEYS) is None
+    assert de._first_present({}, de._FILLED_QTY_KEYS) is None
+
+
+def test_extract_order_id_searches_nested_payloads() -> None:
+    assert de.dhan_execution_client.extract_order_id({"orderId": " DH-1 "}) == "DH-1"
+    assert de.dhan_execution_client.extract_order_id({"data": {"orderId": "DH-2"}}) == "DH-2"
+    assert de.dhan_execution_client.extract_order_id([{"orderId": "DH-3"}]) == "DH-3"
+    assert de.dhan_execution_client.extract_order_id({}) == ""
+    assert de.dhan_execution_client.extract_order_id(None) == ""
+
+
+# ---------------------------------------------------------------------------
+# Instrument-master parsing
+# ---------------------------------------------------------------------------
+
+_HEADER = (
+    "EXCH_ID,SEGMENT,INSTRUMENT,SYMBOL_NAME,DISPLAY_NAME,SM_EXPIRY_DATE,"
+    "LOT_SIZE,SECURITY_ID,STRIKE_PRICE,OPTION_TYPE,UNDERLYING_SYMBOL\n"
+)
+_NIFTY_CE = (
+    "NSE,D,OPTIDX,NIFTY-Jul2026-24000-CE,NIFTY 24000 CALL,2026-07-21,"
+    "65,45001,24000,CE,NIFTY\n"
+)
+_NIFTY_PE = (
+    "NSE,D,OPTIDX,NIFTY-Jul2026-24000-PE,NIFTY 24000 PUT,2026-07-21,"
+    "65,45002,24000,PE,NIFTY\n"
+)
+_BNF_CE = (
+    "NSE,D,OPTIDX,BANKNIFTY-Jul2026-59500-CE,BANKNIFTY 59500 CALL,2026-07-28,"
+    "35,45003,59500,CE,BANKNIFTY\n"
+)
+# Rows that must be filtered out: a stock option, an equity row, and a future.
+_NOISE = (
+    "NSE,D,OPTSTK,RELIANCE-Jul2026-3000-CE,RELIANCE 3000 CALL,2026-07-21,"
+    "250,45004,3000,CE,RELIANCE\n"
+    "NSE,E,EQUITY,RELIANCE,Reliance Industries,,1,2885,0,,RELIANCE\n"
+    "NSE,D,FUTIDX,NIFTY-Jul2026-FUT,NIFTY FUT,2026-07-21,65,45005,0,,NIFTY\n"
+)
+
+
+def _write_master(tmp_path: Path, body: str) -> Path:
+    path = tmp_path / "all_instrument 2026-07-18.csv"
+    path.write_text(_HEADER + body, encoding="utf-8")
+    return path
+
+
+def test_prepare_scrip_master_keeps_only_index_options(tmp_path: Path) -> None:
+    frame = de.DhanExecutionClient._prepare_scrip_master(
+        _write_master(tmp_path, _NIFTY_CE + _NIFTY_PE + _BNF_CE + _NOISE)
+    )
+
+    assert len(frame) == 3
+    assert set(frame["_underlying_u"]) == {"NIFTY", "BANKNIFTY"}
+    assert set(frame["_option_u"]) == {"CE", "PE"}
+    # Security ids must survive as real integers for the order API.
+    assert sorted(frame["security_id"]) == [45001, 45002, 45003]
+    assert frame["security_id"].dtype.kind == "i"
+
+
+def test_prepare_scrip_master_raises_on_missing_columns(tmp_path: Path) -> None:
+    path = tmp_path / "all_instrument 2026-07-18.csv"
+    path.write_text("EXCH_ID,SEGMENT\nNSE,D\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="missing columns"):
+        de.DhanExecutionClient._prepare_scrip_master(path)
+
+
+def test_prepare_scrip_master_raises_when_no_option_rows_survive(tmp_path: Path) -> None:
+    """An all-noise catalogue must fail loudly, not resolve to nothing later."""
+
+    with pytest.raises(ValueError, match="no usable index-option rows"):
+        de.DhanExecutionClient._prepare_scrip_master(_write_master(tmp_path, _NOISE))
+
+
+def test_latest_instrument_master_path_picks_the_newest(tmp_path: Path, monkeypatch) -> None:
+    for name in ("all_instrument 2026-07-16.csv", "all_instrument 2026-07-18.csv"):
+        (tmp_path / name).write_text(_HEADER, encoding="utf-8")
+    monkeypatch.setattr(de, "_DEPENDENCIES_DIR", tmp_path)
+
+    picked = de.DhanExecutionClient._latest_instrument_master_path()
+
+    assert picked is not None and picked.name == "all_instrument 2026-07-18.csv"
+
+
+def test_missing_instrument_master_disables_live_trading(tmp_path: Path, monkeypatch) -> None:
+    """No catalogue means preload fails closed rather than resolving blindly."""
+
+    monkeypatch.setattr(de, "_DEPENDENCIES_DIR", tmp_path)
+    client = de.DhanExecutionClient()
+
+    assert client._ensure_scrip_master_locked() is False
+    assert client._scrip_df is None
+
+
+# ---------------------------------------------------------------------------
+# Symbol -> securityId bridge
+# ---------------------------------------------------------------------------
+
+
+def test_resolver_populates_the_security_id_map(tmp_path: Path, monkeypatch) -> None:
+    """The resolver returns a readable symbol that still maps to the right id."""
+
+    monkeypatch.setattr(de, "_DEPENDENCIES_DIR", tmp_path)
+    _write_master(tmp_path, _NIFTY_CE + _NIFTY_PE + _BNF_CE)
+    client = de.DhanExecutionClient()
+    monkeypatch.setattr(client, "ensure_logged_in", lambda: True)
+
+    symbol = client.resolve_option_symbol("NIFTY", "2026-07-21", "CE", 24000)
+
+    assert symbol == "NIFTY-Jul2026-24000-CE"
+    assert client._security_id_for(symbol) == "45001"
+    # The BankNIFTY mirror leg must resolve from the same catalogue.
+    bnf = client.resolve_option_symbol("BANKNIFTY", "2026-07-28", "CE", 59500)
+    assert bnf == "BANKNIFTY-Jul2026-59500-CE"
+    assert client._security_id_for(bnf) == "45003"
+
+
+def test_resolver_returns_empty_string_on_a_miss(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(de, "_DEPENDENCIES_DIR", tmp_path)
+    _write_master(tmp_path, _NIFTY_CE)
+    client = de.DhanExecutionClient()
+    monkeypatch.setattr(client, "ensure_logged_in", lambda: True)
+
+    assert client.resolve_option_symbol("NIFTY", "2026-07-21", "CE", 99999) == ""
+    assert client.resolve_option_symbol("NIFTY", "2026-12-31", "CE", 24000) == ""
+    assert client.resolve_option_symbol("NIFTY", "2026-07-21", "XX", 24000) == ""
+    assert client._security_id_for("NIFTY-NOT-A-SYMBOL") == ""
+
+
+# ---------------------------------------------------------------------------
+# Diagnostic pre-flight guards
+# ---------------------------------------------------------------------------
+# These exist because Dhan reports a bad quantity as a generic DH-905
+# Input_Exception whose message has been observed to read "Invalid IP",
+# which points the operator at a network fault that does not exist.
+
+
+def _diagnostic() -> ModuleType:
+    path = ROOT / "Dependencies" / "Dhan API" / "diagnose_dhan_symbol.py"
+    spec = importlib.util.spec_from_file_location("diagnose_dhan_unit_test", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["diagnose_dhan_unit_test"] = module
+    # The diagnostic imports the adapter by bare name from its own folder.
+    sys.modules.setdefault("dhan_execution", de)
+    spec.loader.exec_module(module)
+    return module
+
+
+diag = _diagnostic()
+
+
+@pytest.mark.parametrize(
+    ("quantity", "lot_size", "rejected"),
+    [
+        (1, 65, True),      # the exact case that produced "Invalid IP"
+        (64, 65, True),
+        (100, 65, True),
+        (65, 65, False),    # one lot
+        (130, 65, False),   # two lots
+        (30, 30, False),    # BankNIFTY lot
+        (1, 0, False),      # catalogue carried no lot size -> nothing to check
+    ],
+)
+def test_quantity_must_be_a_whole_lot_multiple(quantity, lot_size, rejected) -> None:
+    message = diag.validate_quantity_for_lot(quantity, lot_size)
+
+    assert bool(message) is rejected
+    if rejected:
+        assert str(lot_size) in message
+
+
+class _MarginClient:
+    """Stands in for the adapter's _call_api during margin pre-checks."""
+
+    def __init__(self, envelope) -> None:
+        self.envelope = envelope
+        self.calls: list[dict] = []
+
+    def _call_api(self, _operation, call, **_kwargs):
+        if isinstance(self.envelope, Exception):
+            raise self.envelope
+
+        class _Sdk:
+            def margin_calculator(_self, **kwargs):
+                self.calls.append(dict(kwargs))
+                return self.envelope
+
+        return call(_Sdk())
+
+
+def _margin_payload(required: float, available: float) -> dict:
+    """Build a margin reply with Dhan's real (unsigned) insufficientBalance.
+
+    Reproducing the quirk faithfully is the point: `insufficientBalance` is
+    abs(required - available), so it is positive even when the order is
+    comfortably affordable.
+    """
+
+    return {
+        "status": "success",
+        "remarks": "",
+        "data": {
+            "totalMargin": required,
+            "availableBalance": available,
+            "insufficientBalance": round(abs(required - available), 2),
+            "leverage": "1X",
+        },
+    }
+
+
+def test_margin_precheck_blocks_an_unaffordable_entry() -> None:
+    client = _MarginClient(_margin_payload(required=21895.25, available=0.39))
+
+    placeable, message = diag.check_entry_margin(client, security_id="57340", quantity=65)
+
+    assert placeable is False
+    assert "Insufficient funds" in message
+    assert "short by 21894.86" in message
+    # It must ask about the real contract and quantity, and create nothing.
+    assert client.calls[0]["security_id"] == "57340"
+    assert client.calls[0]["quantity"] == 65
+    assert client.calls[0]["transaction_type"] == "BUY"
+
+
+def test_margin_precheck_allows_an_affordable_entry() -> None:
+    """Regression: a surplus must not be misread as a shortfall.
+
+    These are the exact figures from a real Dhan reply where the order was
+    affordable (2808 needed, 10000.39 on hand) yet insufficientBalance came
+    back as 7192.39. Trusting that field blocked a perfectly valid order.
+    """
+
+    client = _MarginClient(_margin_payload(required=2808.0, available=10000.39))
+
+    placeable, message = diag.check_entry_margin(client, security_id="57360", quantity=65)
+
+    assert placeable is True
+    assert "OK" in message
+    assert "required 2808.00" in message and "available 10000.39" in message
+
+
+@pytest.mark.parametrize(
+    ("required", "available", "placeable"),
+    [
+        (2808.0, 10000.39, True),      # comfortable surplus
+        (11232.0, 10000.39, False),    # just short
+        (10000.39, 10000.39, True),    # exactly affordable
+        (10000.40, 10000.39, False),   # one paisa short
+        (0.0, 0.0, True),              # nothing required
+    ],
+)
+def test_margin_precheck_compares_balances_not_the_unsigned_field(
+    required: float,
+    available: float,
+    placeable: bool,
+) -> None:
+    client = _MarginClient(_margin_payload(required=required, available=available))
+
+    got, _message = diag.check_entry_margin(client, security_id="57360", quantity=65)
+
+    assert got is placeable
+
+
+@pytest.mark.parametrize(
+    "envelope",
+    [
+        RuntimeError("network down"),
+        {"status": "failure", "remarks": "ConnectionError(...)", "data": ""},
+        {"status": "success", "remarks": "", "data": "not-a-dict"},
+        # Missing either figure means the comparison cannot be made.
+        {"status": "success", "remarks": "", "data": {"totalMargin": 100}},
+        {"status": "success", "remarks": "", "data": {"availableBalance": 100}},
+        {"status": "success", "remarks": "", "data": {"totalMargin": "n/a", "availableBalance": 100}},
+    ],
+)
+def test_margin_precheck_that_cannot_run_does_not_block(envelope) -> None:
+    """An advisory check that fails must not stop the operator.
+
+    The broker is still the real gate, and the typed-YES confirmation is
+    still ahead -- so failing closed here would add friction without safety.
+    """
+
+    client = _MarginClient(envelope)
+
+    placeable, message = diag.check_entry_margin(client, security_id="57340", quantity=65)
+
+    assert placeable is True
+    assert "continuing" in message

--- a/Dependencies/Flattrade API/diagnose_flattrade_symbol.py
+++ b/Dependencies/Flattrade API/diagnose_flattrade_symbol.py
@@ -30,6 +30,7 @@ from typing import Any
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import flattrade_execution as fe
 from broker_contract import OrderResult, OrderStatus
+from diagnostic_preflight import validate_quantity_for_lot
 
 UNDERLYING = "NIFTY"
 
@@ -352,6 +353,14 @@ def main(argv: list[str] | None = None) -> int:
         if not args.place_order:
             print("\nRead-only diagnostic complete. No order was placed.")
             return 0
+
+        # Pre-flight before the typed-YES prompt, so an order the exchange can
+        # never accept does not reach the broker or burn a confirmation.
+        lot_error = validate_quantity_for_lot(args.qty, lot_size)
+        if lot_error:
+            print(f"\n{lot_error}", file=sys.stderr)
+            return 2
+
         return 0 if place_round_trip_test_order(client, resolved, args.qty) else 1
     except Exception as exc:
         print(f"Flattrade diagnostic failed: {exc}", file=sys.stderr)

--- a/Dependencies/Flattrade API/flattrade_execution.py
+++ b/Dependencies/Flattrade API/flattrade_execution.py
@@ -463,6 +463,10 @@ class FlattradeExecutionClient:
             log.error("Flattrade login aborted: no request_code supplied.")
             return False
 
+        # Flattrade's documented recipe: the API secret is never sent raw.
+        # Instead sha256(api_key + request_code + api_secret) proves we hold
+        # the secret while binding this exchange to THIS request code -- a
+        # replayed digest is useless once the code expires.
         digest = hashlib.sha256(
             f"{api_key}{request_code}{raw_secret}".encode()
         ).hexdigest()
@@ -533,7 +537,15 @@ class FlattradeExecutionClient:
         return True
 
     def _validate_session_locked(self) -> bool:
-        """Validate the current token and remember Flattrade's account id."""
+        """Validate the current token and remember Flattrade's account id.
+
+        ``UserDetails`` is the cheapest authenticated read, so it doubles as
+        the token check.  Two extra facts are harvested while we are here:
+        the ``exarr`` exchange list (an account without NFO enabled could log
+        in fine and then have every option order rejected -- fail that at
+        startup instead) and ``actid`` (the account id later order payloads
+        must carry, which is not always identical to the login client id).
+        """
         try:
             payload = self._post_api("UserDetails", {"uid": self._client_id})
         except Exception as exc:
@@ -546,6 +558,8 @@ class FlattradeExecutionClient:
         enabled_exchanges = {
             str(value).upper() for value in (payload.get("exarr") or [])
         }
+        # An EMPTY exarr is tolerated (some responses omit it); only a present
+        # list that excludes NFO is proof the account cannot trade options.
         if enabled_exchanges and "NFO" not in enabled_exchanges:
             log.error("Flattrade account does not report NFO access; live trading disabled.")
             return False

--- a/Dependencies/Kotak API/diagnose_kotak_symbol.py
+++ b/Dependencies/Kotak API/diagnose_kotak_symbol.py
@@ -17,6 +17,7 @@ contract. Only a confirmed full BUY fill permits the automatic SELL-to-flatten.
 Requires typing YES to confirm.
 """
 import datetime as dt
+import logging
 import sys
 from pathlib import Path
 
@@ -138,6 +139,15 @@ def place_round_trip_test_order(client, symbol, qty, broker="Kotak"):
 
 
 def main():
+    # Without this the root logger sits at WARNING, so kotak_execution's INFO
+    # diagnostics -- the scrip-master URL, download progress and byte counts --
+    # are silently dropped. They are the whole point of running this script when
+    # a download stalls, so surface them. The Flattrade and Dhan diagnostics
+    # already configure logging the same way.
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s | %(levelname)s | %(message)s",
+    )
     client = ke.kotak_execution_client
     print("Logging in (you'll be prompted for a TOTP)...")
     if not client.preload_scrip_master():

--- a/Dependencies/Kotak API/diagnose_kotak_symbol.py
+++ b/Dependencies/Kotak API/diagnose_kotak_symbol.py
@@ -24,6 +24,27 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import kotak_execution as ke  # handles sys.path to the SDK + loads .env
 from broker_contract import OrderResult, OrderStatus
+from diagnostic_preflight import validate_quantity_for_lot
+
+# Kotak's contract master spells the lot-size column differently across master
+# revisions, so try the known forms rather than hard-coding one. An unknown
+# column yields 0, which makes the shared quantity check a no-op instead of
+# blocking a good order over missing catalogue metadata.
+_LOT_SIZE_COLUMNS = ("lLotSize", "lotSize", "LotSize", "pLotSize")
+
+
+def _lot_size_for(df, trading_symbol):
+    """Return the official lot size for one resolved Kotak symbol, else 0."""
+    column = next((name for name in _LOT_SIZE_COLUMNS if name in df.columns), None)
+    if column is None:
+        return 0
+    rows = df[df["pTrdSymbol"].astype(str).str.strip() == str(trading_symbol).strip()]
+    if rows.empty:
+        return 0
+    try:
+        return int(float(rows.iloc[0][column]))
+    except (TypeError, ValueError):
+        return 0
 
 
 def _arg_val(name, default):
@@ -170,7 +191,12 @@ def main():
     # if compared as text, which looks scrambled).
     expiries = sorted(base["_expiry_str"].dropna().unique().tolist(),
                       key=lambda s: dt.datetime.strptime(s, "%d%b%Y"))
-    print(f"available expiries ({len(expiries)}):", expiries[:15])
+    # Print how many are being SHOWN as well as how many exist -- the count and
+    # the list disagreed before (18 reported, 15 printed), which reads like the
+    # resolver lost contracts rather than the display truncating them.
+    shown = expiries[:15]
+    truncated = "" if len(shown) == len(expiries) else f", showing first {len(shown)}"
+    print(f"available expiries ({len(expiries)} total{truncated}):", shown)
 
     # Show rows near our strike on the x100 scale, across the nearest expiries.
     near = base[(base["_strike_f"] >= STRIKE * 100 - 5000) & (base["_strike_f"] <= STRIKE * 100 + 5000)]
@@ -180,10 +206,14 @@ def main():
 
     # Try the actual resolver against the nearest available expiry as a demo.
     sym = ""
+    lot_size = 0
     if expiries:
         demo_exp = dt.datetime.strptime(expiries[0], "%d%b%Y").date()
         sym = client.resolve_option_symbol(UNDERLYING, demo_exp, OPT, STRIKE)
         print(f"\nresolve_option_symbol({UNDERLYING}, {demo_exp}, {OPT}, {STRIKE}) -> {sym!r}")
+        if sym:
+            lot_size = _lot_size_for(df, sym)
+            print(f"official lot    : {lot_size or 'unknown (not in this master)'}")
     print("\nIf the rows above show your strike but resolve returns '', compare the")
     print("'_expiry_str' values to the expiry your strategy actually trades.")
 
@@ -194,10 +224,16 @@ def main():
                 "\n--place-order requires an explicit positive --qty using the "
                 "current contract lot size; no order placed."
             )
-        elif sym:
-            place_round_trip_test_order(client, sym, QTY, broker="Kotak")
-        else:
+        elif not sym:
             print("\n--place-order requested but the symbol did not resolve; no order placed.")
+        else:
+            # Pre-flight before the typed-YES prompt, so an order the exchange
+            # can never accept never reaches the broker.
+            lot_error = validate_quantity_for_lot(QTY, lot_size)
+            if lot_error:
+                print(f"\n{lot_error}\nNo order placed.")
+            else:
+                place_round_trip_test_order(client, sym, QTY, broker="Kotak")
 
 
 if __name__ == "__main__":

--- a/Dependencies/Kotak API/kotak_execution.py
+++ b/Dependencies/Kotak API/kotak_execution.py
@@ -73,13 +73,21 @@ from typing import Any
 import pandas as pd
 import requests
 
-from Dependencies.secret_redaction import redact_payload, redact_text
-
 # Make the broker-neutral contract importable when this helper is loaded by the
 # master and when the sibling diagnostic executes it as a standalone script.
+#
+# The REPO ROOT has to go on the path too, not just ``Dependencies``: the
+# redaction helpers below are imported as ``Dependencies.secret_redaction``,
+# which needs the package's PARENT directory.  The master already has it because
+# it is launched from the repo root, but ``python <script>`` puts the SCRIPT's
+# directory on ``sys.path[0]`` and never the working directory -- so the sibling
+# diagnostic (directly or via ``algo.py diagnose``) used to die on import with
+# "No module named 'Dependencies'".
 _DEPENDENCIES_DIR = Path(__file__).resolve().parent.parent
-if str(_DEPENDENCIES_DIR) not in sys.path:
-    sys.path.insert(0, str(_DEPENDENCIES_DIR))
+_REPO_ROOT = _DEPENDENCIES_DIR.parent
+for _import_root in (_REPO_ROOT, _DEPENDENCIES_DIR):
+    if str(_import_root) not in sys.path:
+        sys.path.insert(0, str(_import_root))
 
 from broker_contract import (  # noqa: E402
     TERMINAL_BROKER_STATES,
@@ -90,6 +98,8 @@ from broker_contract import (  # noqa: E402
     OrderStatus,
     normalize_order_result,
 )
+
+from Dependencies.secret_redaction import redact_payload, redact_text  # noqa: E402
 
 # --- Make the downloaded "Kotak Neo API" SDK importable (if vendored) ---------
 # The SDK may live in a "Kotak Neo API" folder somewhere above this file, but the

--- a/Dependencies/Kotak API/kotak_execution.py
+++ b/Dependencies/Kotak API/kotak_execution.py
@@ -502,58 +502,27 @@ class KotakExecutionClient:
                 f"data_center={getattr(cfg, 'data_center', None)!r}"
             )
             if not server_id:
-                log.warning(
-                    "Kotak login returned NO serverId (hsServerId). The order "
-                    "endpoint needs Auth+Sid+serverId, so order placement will be rejected "
-                    "as 'unauthorized' (data + scrip lookups still work via consumer_key). "
-                    "This usually means the account/API key is not enabled for live order "
-                    "placement - check Trade API order permission / F&O segment with Kotak."
+                # An empty hsServerId does NOT block order placement, contrary
+                # to what an earlier version of this warning asserted (it told
+                # operators to go ask Kotak for order permissions they already
+                # had).  Measured against a live account returning hsServerId "":
+                #
+                #   * limits() -- a REST call that sends the SAME ``sId`` query
+                #     parameter as place_order -- returned stCode 200 / stat Ok.
+                #   * place_order reached Kotak's OMS and was rejected with
+                #     stCode 1041 "Last Traded Price (LTP) not available for
+                #     this instrument", i.e. a market-microstructure refusal
+                #     outside trading hours, NOT an authorization failure.
+                #
+                # hsServerId feeds ``NeoWebSocket(sid, token, server_id,
+                # data_center)`` -- the HS streaming socket, which this
+                # REST-only adapter never opens.  So this is informational and
+                # would only matter if live streaming were added later.
+                log.info(
+                    "Kotak login returned an empty serverId (hsServerId). REST "
+                    "order placement is unaffected: it is the HS streaming "
+                    "socket that needs it, and this adapter never opens one."
                 )
-                # Show WHAT Kotak actually sent. Until now these two responses
-                # were logged only when 2FA failed outright, so this exact case
-                # -- 2FA fine, serverId missing -- discarded the only evidence
-                # that could explain why. Everything goes through
-                # ``redact_payload`` first: tokens, session ids and the supplied
-                # credentials never reach the log.
-                secrets = (mobile, ucc, mpin, totp, consumer_key)
-                log.warning(
-                    "  totp_login    -> %s", redact_payload(login_resp, secrets)
-                )
-                log.warning(
-                    "  totp_validate -> %s", redact_payload(validate_resp, secrets)
-                )
-                log.warning(
-                    "  configuration fields present: %s",
-                    sorted(
-                        name
-                        for name in dir(cfg)
-                        if not name.startswith("_")
-                        and not callable(getattr(cfg, name, None))
-                    ),
-                )
-                # Turn the "orders will be rejected" inference into evidence
-                # WITHOUT placing an order.  ``limits`` is a read-only call that
-                # authorizes with the very same ``sId`` query parameter as
-                # place_order, so if an empty serverId is genuinely fatal this
-                # fails the same way a real order would -- and if it succeeds,
-                # the assumption was wrong and worth revisiting.
-                try:
-                    limits_probe = self._sdk_call(
-                        "limits_sid_probe",
-                        lambda: self.client.limits(
-                            segment="ALL", exchange="ALL", product="ALL"
-                        ),
-                    )
-                except Exception as exc:
-                    log.warning(
-                        "  sId probe (limits, read-only) raised: %s",
-                        redact_text(str(exc), secrets),
-                    )
-                else:
-                    log.warning(
-                        "  sId probe (limits, read-only) -> %s",
-                        redact_payload(limits_probe, secrets),
-                    )
             return True
         except Exception as exc:
             # Reset state on any failure so a stale half-session never leaks.

--- a/Dependencies/Kotak API/kotak_execution.py
+++ b/Dependencies/Kotak API/kotak_execution.py
@@ -163,7 +163,13 @@ _BROKER_DEADLINE_SECONDS = 10.0
 # this download off the order path in practice; the lazy fallback inside
 # ``resolve_option_symbol`` runs before the order-submission gate, so a slow
 # catalogue delays symbol resolution rather than an in-flight order.
-_SCRIP_MASTER_TIMEOUT_SECONDS = 20.0
+_SCRIP_MASTER_TIMEOUT_SECONDS = 60.0
+# Stream the CSV rather than reading it in one go, and report progress every few
+# seconds.  Two fixed guesses (10s, then 20s) both expired with no way to tell
+# whether the transfer was slow-but-moving or stalled outright; byte counts in
+# the log answer that directly the next time it happens.
+_SCRIP_MASTER_CHUNK_BYTES = 1 << 20
+_SCRIP_MASTER_PROGRESS_SECONDS = 5.0
 
 
 class _SdkDeadlineExceeded(TimeoutError):
@@ -525,6 +531,29 @@ class KotakExecutionClient:
                         and not callable(getattr(cfg, name, None))
                     ),
                 )
+                # Turn the "orders will be rejected" inference into evidence
+                # WITHOUT placing an order.  ``limits`` is a read-only call that
+                # authorizes with the very same ``sId`` query parameter as
+                # place_order, so if an empty serverId is genuinely fatal this
+                # fails the same way a real order would -- and if it succeeds,
+                # the assumption was wrong and worth revisiting.
+                try:
+                    limits_probe = self._sdk_call(
+                        "limits_sid_probe",
+                        lambda: self.client.limits(
+                            segment="ALL", exchange="ALL", product="ALL"
+                        ),
+                    )
+                except Exception as exc:
+                    log.warning(
+                        "  sId probe (limits, read-only) raised: %s",
+                        redact_text(str(exc), secrets),
+                    )
+                else:
+                    log.warning(
+                        "  sId probe (limits, read-only) -> %s",
+                        redact_payload(limits_probe, secrets),
+                    )
             return True
         except Exception as exc:
             # Reset state on any failure so a stale half-session never leaks.
@@ -587,14 +616,47 @@ class KotakExecutionClient:
             log.warning(f"Kotak scrip_master() returned no CSV url: {url!r}")
             return False
         # Step 2: download the CSV and load it into a pandas table (DataFrame).
+        # Log the URL so a stuck download can be reproduced with curl/a browser
+        # outside this process.  It is a plain contract-catalogue path, but it
+        # goes through redact_text in case Kotak ever signs it with a token.
+        log.info("Kotak scrip master URL: %s", redact_text(url))
         try:
             def download_scrip_master() -> str:
-                response = requests.get(
+                # Streamed, not response.text, so the log can show HOW FAR the
+                # transfer got.  A timeout that reports "0.0 MB after 60s" is a
+                # stall; one reporting steady megabytes is simply a slow link,
+                # and only the second is fixed by a longer deadline.
+                started_download = time.monotonic()
+                received = 0
+                next_report = _SCRIP_MASTER_PROGRESS_SECONDS
+                parts: list[bytes] = []
+                with requests.get(
                     url,
                     timeout=_SCRIP_MASTER_TIMEOUT_SECONDS,
-                )  # requests' timeout is retained as the native inactivity cap
-                response.raise_for_status()
-                return response.text
+                    stream=True,
+                ) as response:  # native timeout stays the inactivity cap
+                    response.raise_for_status()
+                    encoding = response.encoding or "utf-8"
+                    for chunk in response.iter_content(
+                        chunk_size=_SCRIP_MASTER_CHUNK_BYTES
+                    ):
+                        parts.append(chunk)
+                        received += len(chunk)
+                        elapsed = time.monotonic() - started_download
+                        if elapsed >= next_report:
+                            log.info(
+                                "Kotak scrip master: %.1f MB after %.0fs (%.2f MB/s).",
+                                received / 1_000_000,
+                                elapsed,
+                                received / 1_000_000 / max(elapsed, 1e-9),
+                            )
+                            next_report = elapsed + _SCRIP_MASTER_PROGRESS_SECONDS
+                log.info(
+                    "Kotak scrip master downloaded %.1f MB in %.1fs.",
+                    received / 1_000_000,
+                    time.monotonic() - started_download,
+                )
+                return b"".join(parts).decode(encoding, errors="replace")
 
             # ``requests`` alone has no total wall-clock deadline for a body
             # that keeps dribbling bytes. Reuse the isolated serial executor so

--- a/Dependencies/Kotak API/kotak_execution.py
+++ b/Dependencies/Kotak API/kotak_execution.py
@@ -152,6 +152,19 @@ _FILLED_ORDER_STATES = {"complete", "traded", "executed", "filled"}
 _FAILED_ORDER_STATES = {"rejected", "cancelled", "canceled", "cancel", "lapsed"}
 _BROKER_DEADLINE_SECONDS = 10.0
 
+# The scrip master is a multi-megabyte bulk CSV fetched once, not an order, so
+# it gets its own (longer) budget.  Holding it to the ORDER deadline was a
+# category error: ten seconds is chosen so a live order can never go stale in
+# flight, and a catalogue download simply is not that kind of call -- on a
+# slower link it was timing out and disabling live trading for the session.
+#
+# ``_BROKER_DEADLINE_SECONDS`` deliberately stays at exactly 10s: every order
+# path still uses it, and a test pins that value.  The startup preload keeps
+# this download off the order path in practice; the lazy fallback inside
+# ``resolve_option_symbol`` runs before the order-submission gate, so a slow
+# catalogue delays symbol resolution rather than an in-flight order.
+_SCRIP_MASTER_TIMEOUT_SECONDS = 20.0
+
 
 class _SdkDeadlineExceeded(TimeoutError):
     """Raised when a Kotak SDK call outlives the fixed broker deadline."""
@@ -268,13 +281,27 @@ class KotakExecutionClient:
         operation,
         *,
         block_when_poisoned: bool = False,
+        deadline_seconds: float | None = None,
     ) -> Any:
-        """Run one SDK operation serially with the fixed ten-second deadline."""
+        """Run one SDK operation serially under a total wall-clock deadline.
 
+        Args:
+            label: Operation name used in deadline messages.
+            operation: Zero-argument callable performing the SDK request.
+            block_when_poisoned: Refuse to start when the session is poisoned.
+            deadline_seconds: Override the default budget.  Only the bulk
+                scrip-master download uses this; every ORDER path keeps the
+                fixed ten-second deadline, so a live order can never go stale
+                in flight.
+        """
+
+        budget = (
+            _BROKER_DEADLINE_SECONDS if deadline_seconds is None else deadline_seconds
+        )
         started = time.monotonic()
-        if not self._sdk_call_lock.acquire(timeout=_BROKER_DEADLINE_SECONDS):
+        if not self._sdk_call_lock.acquire(timeout=budget):
             raise _SdkDeadlineExceeded(
-                f"Kotak {label} exceeded {_BROKER_DEADLINE_SECONDS:g}s "
+                f"Kotak {label} exceeded {budget:g}s "
                 "waiting for the SDK interaction gate"
             )
         try:
@@ -284,11 +311,10 @@ class KotakExecutionClient:
                         "Kotak session is poisoned; a new order cannot be submitted "
                         "before explicit reconciliation and recovery."
                     )
-            remaining = _BROKER_DEADLINE_SECONDS - (time.monotonic() - started)
+            remaining = budget - (time.monotonic() - started)
             if remaining <= 0:
                 raise _SdkDeadlineExceeded(
-                    f"Kotak {label} exceeded {_BROKER_DEADLINE_SECONDS:g}s "
-                    "before SDK submission"
+                    f"Kotak {label} exceeded {budget:g}s before SDK submission"
                 )
             future = self._sdk_executor.submit(operation)
             try:
@@ -310,7 +336,7 @@ class KotakExecutionClient:
                     if not cancelled_before_start:
                         self._timed_out_futures.add(future)
                 raise _SdkDeadlineExceeded(
-                    f"Kotak {label} exceeded {_BROKER_DEADLINE_SECONDS:g}s"
+                    f"Kotak {label} exceeded {budget:g}s"
                 ) from exc
         finally:
             self._sdk_call_lock.release()
@@ -477,6 +503,28 @@ class KotakExecutionClient:
                     "This usually means the account/API key is not enabled for live order "
                     "placement - check Trade API order permission / F&O segment with Kotak."
                 )
+                # Show WHAT Kotak actually sent. Until now these two responses
+                # were logged only when 2FA failed outright, so this exact case
+                # -- 2FA fine, serverId missing -- discarded the only evidence
+                # that could explain why. Everything goes through
+                # ``redact_payload`` first: tokens, session ids and the supplied
+                # credentials never reach the log.
+                secrets = (mobile, ucc, mpin, totp, consumer_key)
+                log.warning(
+                    "  totp_login    -> %s", redact_payload(login_resp, secrets)
+                )
+                log.warning(
+                    "  totp_validate -> %s", redact_payload(validate_resp, secrets)
+                )
+                log.warning(
+                    "  configuration fields present: %s",
+                    sorted(
+                        name
+                        for name in dir(cfg)
+                        if not name.startswith("_")
+                        and not callable(getattr(cfg, name, None))
+                    ),
+                )
             return True
         except Exception as exc:
             # Reset state on any failure so a stale half-session never leaks.
@@ -543,7 +591,7 @@ class KotakExecutionClient:
             def download_scrip_master() -> str:
                 response = requests.get(
                     url,
-                    timeout=_BROKER_DEADLINE_SECONDS,
+                    timeout=_SCRIP_MASTER_TIMEOUT_SECONDS,
                 )  # requests' timeout is retained as the native inactivity cap
                 response.raise_for_status()
                 return response.text
@@ -554,6 +602,7 @@ class KotakExecutionClient:
             csv_text = self._sdk_call(
                 "scrip_master_download",
                 download_scrip_master,
+                deadline_seconds=_SCRIP_MASTER_TIMEOUT_SECONDS,
             )
             df = pd.read_csv(io.StringIO(csv_text))
             df = df.rename(columns=lambda c: c.strip())  # trim stray spaces in headers

--- a/Dependencies/Readme.md
+++ b/Dependencies/Readme.md
@@ -30,8 +30,10 @@ The master file guarded-loads all three broker clients and then picks one with
 touches a single generic `execution_client`, so the brokers are interchangeable.
 All clients expose the **same surface**:
 `ensure_logged_in()`, `preload_scrip_master()`, `resolve_option_symbol()`,
-`place_market_order()` (with fill confirmation), `extract_order_id()`, `logout()`,
-and an `is_logged_in` flag.
+`place_market_order()` (with fill confirmation), `get_order_status()`,
+`cancel_order()`, `list_open_orders()`, `list_open_positions()`,
+`recover_after_reconciliation()`, `extract_order_id()`, `logout()`, and an
+`is_logged_in` flag.
 
 Safety gates (all in `.env`):
 - `LIVE_TRADING_ENABLED` — global kill-switch (default `false` = everything paper).
@@ -39,8 +41,13 @@ Safety gates (all in `.env`):
   (live disabled, paper only) rather than guessing a broker.
 - `<PREFIX>_LIVE_TRADING` — per strategy. A strategy goes live only when the global
   switch **and** its own flag are both true.
-- On any order failure (login, unresolved symbol, reject, unconfirmed fill) the
-  strategy falls back to paper for that trade.
+- A live entry falls back to paper only after an explicit typed `REJECTED` result
+  with zero fill. `PARTIAL` or `UNKNOWN` means broker exposure may exist: entries
+  freeze, exits remain available, and reconciliation continues. A rejected or
+  ambiguous exit keeps the leg tracked and open.
+- Startup queries open orders and relevant option positions before any live
+  worker starts. Exposure or an indeterminate broker reply blocks all live
+  workers; it is never auto-adopted or auto-flattened.
 
 Product/exchange per broker is derived from `LIVE_BROKER`: Kotak uses `nse_fo` +
 `KOTAK_PRODUCT_TYPE`; Shoonya uses `NFO` + `SHOONYA_PRODUCT_TYPE`; Flattrade uses
@@ -48,17 +55,28 @@ Product/exchange per broker is derived from `LIVE_BROKER`: Kotak uses `nse_fo` +
 
 ## Credentials (in `.env`)
 - **Kotak Neo:** `CONSUMER_KEY`, `MOBILE`, `MPIN`, `UCC`. TOTP is typed at startup
-  (not stored). Needs `pip install neo_api_client`.
+  (not stored).
 - **Shoonya:** `SHOONYA_USERID`, `SHOONYA_PASSWORD`, `SHOONYA_VENDOR_CODE`,
   `SHOONYA_API_SECRET`, `SHOONYA_IMEI`, `SHOONYA_TOTP_SECRET` (base32 seed; the TOTP
   is auto-generated via `pyotp`, or you're prompted if blank). The client is vendored
-  here; needs `pip install pyotp websocket-client`.
+  here.
 - **Flattrade:** `FLATTRADE_CLIENT_ID`, `FLATTRADE_API_KEY`, and
   `FLATTRADE_API_SECRET`. `FLATTRADE_ACCESS_TOKEN` is optional: when blank, startup
   opens Flattrade authorization and asks for the returned `request_code`. Tokens
   remain in memory unless you manually paste one into `.env`. Uses core `requests`
   and `pandas`; no extra SDK is required. Token exchange must originate from the
   static IP registered against your Flattrade API key.
+
+The exact upstream broker compatibility environment is recorded in:
+```
+pip install -r requirements-brokers.txt
+```
+Run that command only in a clean broker-validation environment: Kotak v2.0.1
+declares older exact pandas/requests constraints that conflict with the app's
+audited core runtime. In the live app environment install Shoonya with
+`pip install pyotp==2.9.0 websocket-client==1.8.0`, and install Kotak with the
+official tagged command plus `--no-deps` shown in the root README. Flattrade
+uses the pinned core `requests`/`pandas` set.
 
 > Note: Finvasia is decommissioning the legacy Shoonya QuickAuth endpoint (it returns
 > HTTP 502), so Shoonya live login needs the new OAuth API before it works again.

--- a/Dependencies/Shoonya API/diagnose_shoonya_symbol.py
+++ b/Dependencies/Shoonya API/diagnose_shoonya_symbol.py
@@ -18,12 +18,14 @@ confirmed full BUY fill permits the automatic SELL-to-flatten. Requires typing
 YES to confirm. (Needs an EXPIRY.)
 """
 import datetime as dt
+import logging
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import shoonya_execution as se  # handles sys.path to the SDK + loads .env
 from broker_contract import OrderResult, OrderStatus
+from diagnostic_preflight import validate_quantity_for_lot
 
 
 def _arg_val(name, default):
@@ -141,6 +143,14 @@ def place_round_trip_test_order(client, symbol, qty, broker="Shoonya"):
 
 
 def main():
+    # Without this the root logger sits at WARNING, so shoonya_execution's INFO
+    # diagnostics -- symbol-master load counts and lot-size availability -- are
+    # silently dropped, which is exactly what someone runs this script to see.
+    # The Kotak, Flattrade and Dhan diagnostics configure logging the same way.
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s | %(levelname)s | %(message)s",
+    )
     client = se.shoonya_execution_client
     print("Logging in to Shoonya...")
     if not client.preload_scrip_master():
@@ -181,10 +191,18 @@ def main():
                 "\n--place-order requires an explicit positive --qty using the "
                 "current contract lot size; no order placed."
             )
-        elif sym:
-            place_round_trip_test_order(client, sym, QTY, broker="Shoonya")
-        else:
+        elif not sym:
             print("\n--place-order requested but the symbol did not resolve; no order placed.")
+        else:
+            # Pre-flight before the typed-YES prompt, so an order the exchange
+            # can never accept never reaches the broker.
+            lot_size = client.lot_size_for_symbol(sym)
+            print(f"official lot    : {lot_size or 'unknown (not in this master)'}")
+            lot_error = validate_quantity_for_lot(QTY, lot_size)
+            if lot_error:
+                print(f"\n{lot_error}\nNo order placed.")
+            else:
+                place_round_trip_test_order(client, sym, QTY, broker="Shoonya")
 
 
 if __name__ == "__main__":

--- a/Dependencies/Shoonya API/shoonya_execution.py
+++ b/Dependencies/Shoonya API/shoonya_execution.py
@@ -71,13 +71,21 @@ from typing import Any
 import pandas as pd
 import requests
 
-from Dependencies.secret_redaction import redact_payload, redact_text
-
 # Make the broker-neutral contract available both when the master dynamically
 # loads this file and when the sibling diagnostic runs it as a standalone script.
+#
+# The REPO ROOT has to go on the path too, not just ``Dependencies``: the
+# redaction helpers below are imported as ``Dependencies.secret_redaction``,
+# which needs the package's PARENT directory.  The master already has it because
+# it is launched from the repo root, but ``python <script>`` puts the SCRIPT's
+# directory on ``sys.path[0]`` and never the working directory -- so the sibling
+# diagnostic (directly or via ``algo.py diagnose``) used to die on import with
+# "No module named 'Dependencies'".
 _DEPENDENCIES_DIR = Path(__file__).resolve().parent.parent
-if str(_DEPENDENCIES_DIR) not in sys.path:
-    sys.path.insert(0, str(_DEPENDENCIES_DIR))
+_REPO_ROOT = _DEPENDENCIES_DIR.parent
+for _import_root in (_REPO_ROOT, _DEPENDENCIES_DIR):
+    if str(_import_root) not in sys.path:
+        sys.path.insert(0, str(_import_root))
 
 from broker_contract import (  # noqa: E402
     TERMINAL_BROKER_STATES,
@@ -88,6 +96,8 @@ from broker_contract import (  # noqa: E402
     OrderStatus,
     normalize_order_result,
 )
+
+from Dependencies.secret_redaction import redact_payload, redact_text  # noqa: E402
 
 # --- Make the vendored "Shoonya API" SDK importable ---------------------------
 # The NorenApi client may live in a "Shoonya API" folder somewhere above this

--- a/Dependencies/Shoonya API/shoonya_execution.py
+++ b/Dependencies/Shoonya API/shoonya_execution.py
@@ -222,6 +222,9 @@ class ShoonyaExecutionClient:
         # The set of valid NFO trading symbols (uppercased), downloaded once and
         # reused for validation. Stays None until first loaded.
         self._symbol_set: set | None = None
+        # tsym -> exchange lot size, filled from the same master download. Used
+        # only by the diagnostic's pre-flight quantity check.
+        self._lot_size_by_symbol: dict[str, int] = {}
 
     @staticmethod
     def _remaining_broker_budget(started: float) -> float:
@@ -488,12 +491,43 @@ class ShoonyaExecutionClient:
             log.warning(f"Shoonya NFO symbol master missing 'TradingSymbol' column: {list(df.columns)}")
             return False
         try:
-            self._symbol_set = set(df["TradingSymbol"].astype(str).str.strip().str.upper())
+            symbols = df["TradingSymbol"].astype(str).str.strip().str.upper()
+            self._symbol_set = set(symbols)
+            # Keep the lot size alongside the symbol set. The master already
+            # carries it and the frame is discarded straight after, so this is
+            # the only chance to retain it. The sibling diagnostic uses it to
+            # refuse a --qty that is not a whole-lot multiple before any real
+            # order is submitted; live trading does not depend on it, so a
+            # master without the column simply leaves the map empty.
+            lot_column = next(
+                (name for name in ("LotSize", "Lotsize", "lotsize") if name in df.columns),
+                None,
+            )
+            if lot_column is None:
+                self._lot_size_by_symbol = {}
+                log.info("Shoonya symbol master has no lot-size column; sizes unavailable.")
+            else:
+                lots = pd.to_numeric(df[lot_column], errors="coerce").fillna(0).astype(int)
+                self._lot_size_by_symbol = {
+                    symbol: int(lot)
+                    for symbol, lot in zip(symbols, lots, strict=False)
+                    if lot > 0
+                }
             log.info(f"Shoonya NSE F&O symbol master loaded ({len(df)} rows).")
             return True
         except Exception as exc:
             log.warning(f"Shoonya NFO symbol master parse failed: {exc}")
             return False
+
+    def lot_size_for_symbol(self, trading_symbol: str) -> int:
+        """Return the exchange lot size for one tsym, or 0 when unknown.
+
+        Exposed for the sibling diagnostic's pre-flight quantity check. It never
+        triggers a download: an unloaded master just reports 0, which makes the
+        check a no-op rather than blocking on missing metadata.
+        """
+        with self._lock:
+            return self._lot_size_by_symbol.get(str(trading_symbol).strip().upper(), 0)
 
     def resolve_option_symbol(
         self,

--- a/Dependencies/dhan_token_setup.py
+++ b/Dependencies/dhan_token_setup.py
@@ -281,6 +281,17 @@ def _describe_token_expiry(access_token: str) -> str:
     leaves a position open, intraday positions can be left un-squareable
     through the API.
 
+    A weekday expiry lands in one of three situations, each with its own
+    message (a weekend expiry needs none -- no session is at risk that day):
+
+    - BETWEEN 09:15 and 15:30 -> the real danger: the token dies mid-session,
+      so the loud DURING-market-hours warning fires.
+    - BEFORE 09:15            -> nothing can fail mid-session, but that day's
+      session is not covered at all; a calmer note says to re-mint before
+      trading that day.
+    - AFTER 15:30             -> the whole session of the expiry day is
+      covered; say so, so the operator knows this is the GOOD outcome.
+
     Returns:
         A human-readable line for the operator; never raises, because a
         cosmetic decode problem must not fail an otherwise good setup run.
@@ -298,13 +309,31 @@ def _describe_token_expiry(access_token: str) -> str:
 
     hours_left = (expires_at - datetime.now().astimezone()).total_seconds() / 3600
     line = f"Token expires {expires_at:%Y-%m-%d %H:%M:%S} (about {hours_left:.0f}h from now)."
-    # 09:15-15:30 IST is the NSE equity-derivatives session.
+    if expires_at.weekday() >= 5:
+        # Weekend expiry: no session is at risk that day, and main() already
+        # prints the generic "re-run whenever it expires" advice.
+        return line
+    # 09:15-15:30 IST is the NSE equity-derivatives session. See the
+    # docstring for the three weekday situations distinguished below.
+    session_open = expires_at.replace(hour=9, minute=15, second=0, microsecond=0)
     session_close = expires_at.replace(hour=15, minute=30, second=0, microsecond=0)
-    if expires_at < session_close and expires_at.weekday() < 5:
+    if session_open <= expires_at < session_close:
         line += (
             "\n  WARNING: that is DURING market hours. If it expires while positions"
             "\n  are open you may be unable to square off through the API. Re-run this"
             "\n  script outside market hours so the window covers a whole session."
+        )
+    elif expires_at < session_open:
+        line += (
+            "\n  NOTE: that is BEFORE that day's 09:15 open, so the token does NOT"
+            "\n  cover that day's trading session at all. Nothing can fail"
+            "\n  mid-session, but re-run this script before trading that day"
+            "\n  (outside market hours)."
+        )
+    else:
+        line += (
+            "\n  Good: that is after the 15:30 close, so the token covers that"
+            "\n  day's whole trading session."
         )
     return line
 

--- a/Dependencies/dhan_token_setup.py
+++ b/Dependencies/dhan_token_setup.py
@@ -5,22 +5,35 @@ One-time DhanHQ OAuth setup script.
 
 WHAT THIS DOES (read this first if you have never run it)
 ---------------------------------------------------------
-DhanHQ's "API Key + API Secret" auth flow produces a 12-month access token
-through a 3-step OAuth process. Two of those three steps happen here in
-code; the middle step requires you to log in via a browser (DhanHQ does
-this for security so they can show you the standard login page).
+DhanHQ's "API Key + API Secret" auth flow produces an access token through a
+3-step OAuth process. Two of those three steps happen here in code; the
+middle step requires you to log in via a browser (DhanHQ does this for
+security so they can show you the standard login page).
 
 This script walks you through the whole thing and writes the resulting
 access token back into the `.env` file that sits next to it (i.e.
-`Multithreading/Dependencies/.env`). After that, the three trading scripts
-read the token from that `.env` automatically -- no more copy-pasting
-24-hour JWTs from web.dhan.co every morning.
+`Multithreading/Dependencies/.env`). After that, the trading scripts read
+the token from that `.env` automatically.
+
+HOW LONG THE TOKEN LASTS -- CHECK, DO NOT ASSUME
+------------------------------------------------
+DhanHQ decides the validity when the token is minted, and it is stamped into
+the token itself. Tokens generated from the web.dhan.co screen currently
+default to **24 hours** (that screen says so). Do not assume a long-lived
+token: this script prints the real expiry after it finishes, so read it.
+
+This matters for live trading. If the token dies mid-session, order placement
+starts failing -- and because a rejected live EXIT leaves the position open,
+you can be left holding intraday positions you cannot square off through the
+API. Mint the token OUTSIDE market hours (after the 15:30 close or before the
+09:15 open) so its window covers the whole session, never at midday.
 
 WHEN TO RUN THIS SCRIPT
 -----------------------
 - Once after you first generate the API Key / API Secret pair on
   web.dhan.co (My Profile -> DhanHQ Trading APIs -> Generate API).
-- Again whenever the 12-month access token eventually expires.
+- Again whenever the access token expires -- for a 24-hour token that means
+  before each trading day, outside market hours.
 - Again if you regenerate the API Key / Secret for any reason.
 
 WHAT YOU NEED FIRST (before running this)
@@ -44,8 +57,8 @@ to a URL that looks like:
 
 Copy the value after `tokenId=` (or the whole URL, the script tolerates
 both) and paste it into the prompt. The script then exchanges that
-short-lived `tokenId` for the 12-month `accessToken` and writes it into
-the local `.env`.
+short-lived `tokenId` for the `accessToken` and writes it into the
+local `.env`.
 
 THE 3 OAUTH STEPS, EXPLAINED FOR BEGINNERS
 ------------------------------------------
@@ -55,7 +68,7 @@ THE 3 OAUTH STEPS, EXPLAINED FOR BEGINNERS
    DhanHQ redirects the browser to a URL containing a `tokenId`.
 3. The user pastes that `tokenId` back into this script. We send it +
    our API Key/Secret back to DhanHQ. If everything matches up, DhanHQ
-   returns the long-lived `accessToken`.
+   returns the `accessToken`.
 
 This dance is essentially the same OAuth pattern you have probably seen
 when granting a third-party app access to your Google or GitHub account.
@@ -70,9 +83,12 @@ from __future__ import annotations
 # `re`     - small regex helpers for parsing the redirect URL and rewriting .env.
 # `sys`    - used to exit cleanly with an exit code on errors.
 # `Path`   - cross-platform path object for locating the sibling `.env` file.
+import base64
+import json
 import os
 import re
 import sys
+from datetime import UTC, datetime
 from getpass import getpass
 from pathlib import Path
 
@@ -251,6 +267,48 @@ def _extract_token_id(user_input: str) -> str:
     return cleaned
 
 
+def _describe_token_expiry(access_token: str) -> str:
+    """Report when this token actually dies, read from the token itself.
+
+    DhanHQ access tokens are JWTs whose middle segment carries an ``exp``
+    claim.  Decoding it (no signature check -- we are only reading a
+    timestamp we were just handed) beats assuming a validity, because the
+    web console currently mints 24-hour tokens while this flow may issue
+    something longer.
+
+    The warning matters for live trading: if the token expires during market
+    hours, order placement starts failing, and because a rejected live EXIT
+    leaves a position open, intraday positions can be left un-squareable
+    through the API.
+
+    Returns:
+        A human-readable line for the operator; never raises, because a
+        cosmetic decode problem must not fail an otherwise good setup run.
+    """
+    try:
+        segments = access_token.split(".")
+        if len(segments) != 3:
+            return "Token validity: unknown (token is not a JWT); check web.dhan.co."
+        padded = segments[1] + "=" * (-len(segments[1]) % 4)
+        expires_at = datetime.fromtimestamp(
+            json.loads(base64.urlsafe_b64decode(padded))["exp"], UTC
+        ).astimezone()
+    except Exception:
+        return "Token validity: could not be read from the token; check web.dhan.co."
+
+    hours_left = (expires_at - datetime.now().astimezone()).total_seconds() / 3600
+    line = f"Token expires {expires_at:%Y-%m-%d %H:%M:%S} (about {hours_left:.0f}h from now)."
+    # 09:15-15:30 IST is the NSE equity-derivatives session.
+    session_close = expires_at.replace(hour=15, minute=30, second=0, microsecond=0)
+    if expires_at < session_close and expires_at.weekday() < 5:
+        line += (
+            "\n  WARNING: that is DURING market hours. If it expires while positions"
+            "\n  are open you may be unable to square off through the API. Re-run this"
+            "\n  script outside market hours so the window covers a whole session."
+        )
+    return line
+
+
 def main() -> None:
     """
     Driver: walks the user through Steps 1, 2, 3 of the OAuth flow.
@@ -340,12 +398,12 @@ def main() -> None:
         print("ERROR: empty tokenId. Aborting.")
         sys.exit(2)
 
-    # --- Step 3 of 3: exchange tokenId for the long-lived access token --------
+    # --- Step 3 of 3: exchange tokenId for the access token -------------------
     # This call sends the short-lived tokenId + our API Key/Secret to
     # /app/consumeApp-consent. DhanHQ verifies the consent ID matches the
-    # one we created in Step 1 and, if all is well, returns a 12-month
-    # access token.
-    print("\nStep 3/3: exchanging tokenId for the 12-month access token...")
+    # one we created in Step 1 and, if all is well, returns the access token.
+    # DhanHQ chooses the validity; `_describe_token_expiry` reads it back.
+    print("\nStep 3/3: exchanging tokenId for the access token...")
     try:
         access_response = login.consume_token_id(token_id, api_key, api_secret)
     except Exception as exc:
@@ -406,7 +464,8 @@ def main() -> None:
     # it up on their next start.
     _write_access_token_to_env(access_token)
     print(f"\nDone. DHAN_ACCESS_TOKEN written to {ENV_PATH}")
-    print("This token is valid for 12 months. Re-run this script to refresh.")
+    print(_describe_token_expiry(access_token))
+    print("Re-run this script to refresh the token whenever it expires.")
 
 
 # Standard "only run main() when executed directly" guard. Lets other code

--- a/Dependencies/diagnostic_preflight.py
+++ b/Dependencies/diagnostic_preflight.py
@@ -1,0 +1,58 @@
+"""Local pre-flight checks shared by every broker diagnostic script.
+
+These run BEFORE a real order is submitted and BEFORE the typed-YES prompt, so
+an order that is certain to be refused never reaches the broker and never
+wastes the operator's confirmation.
+
+Why this lives in one module rather than in each diagnostic: the same rule
+applies to Kotak, Shoonya, Flattrade and Dhan, and four copies would drift.
+The checks here are deliberately broker-neutral -- they take plain numbers, not
+a client -- so nothing in this file can touch a live session.
+"""
+
+from __future__ import annotations
+
+
+def validate_quantity_for_lot(quantity: int, lot_size: int) -> str:
+    """Return an error message when ``quantity`` is not a whole-lot multiple.
+
+    Index options trade only in exchange-defined lots, so a quantity such as 1
+    against a lot of 65 can never be accepted.  Catching that locally matters
+    because brokers report it obscurely: Dhan returns a generic
+    ``DH-905 Input_Exception`` whose ``error_message`` has been observed to read
+    "Invalid IP", which sends operators hunting a network fault that does not
+    exist.
+
+    This validates the operator's OWN number; it deliberately does not derive
+    one.  ``--place-order`` still requires an explicit ``--qty`` on every
+    diagnostic, because lot sizes change and guessing one would risk a
+    wrong-sized live order.
+
+    Args:
+        quantity: The explicit unit quantity supplied on the command line.
+        lot_size: Official lot size for the contract, or 0 when the broker's
+            contract master does not expose one.
+
+    Returns:
+        An empty string when the quantity is placeable (or cannot be checked),
+        else a human-readable reason the caller should print before refusing.
+    """
+    try:
+        quantity_i = int(quantity)
+        lot_size_i = int(lot_size)
+    except (TypeError, ValueError):
+        # Nothing trustworthy to compare; the broker remains the authority.
+        return ""
+    if lot_size_i <= 0:
+        # The contract master carried no usable lot size, so there is nothing to
+        # check against. Staying silent is right: refusing here would block a
+        # perfectly good order over missing catalogue metadata.
+        return ""
+    if quantity_i % lot_size_i:
+        return (
+            f"--qty {quantity_i} is not a multiple of the official lot size "
+            f"{lot_size_i}. Index options trade in whole lots only, so the "
+            f"broker would reject this order. Use {lot_size_i} for one lot "
+            f"(or {lot_size_i * 2} for two)."
+        )
+    return ""

--- a/Dependencies/env.example
+++ b/Dependencies/env.example
@@ -995,8 +995,10 @@ GSHEET_OAUTH_TOKEN_FILE=
 # broker those orders route to (KOTAK, SHOONYA, or FLATTRADE) - all share one code path in
 # the runner (Dependencies/Kotak API/kotak_execution.py /
 # Dependencies/Shoonya API/shoonya_execution.py / Dependencies/Flattrade API/
-# flattrade_execution.py). On any order failure the
-# strategy falls back to paper for that trade.
+# flattrade_execution.py). An entry falls back to paper ONLY after an explicit
+# zero-fill REJECTED result. PARTIAL or UNKNOWN means broker exposure may exist:
+# new live entries freeze and reconciliation continues. A rejected/ambiguous
+# exit remains tracked as live exposure.
 
 # ---- Global master kill-switch (must be true for ANY live order) ----
 LIVE_TRADING_ENABLED=false
@@ -1109,7 +1111,7 @@ VOLATILITY_BREAKOUT_VIRTUAL_TRADING=true
 # =============================================================================
 # A Claude-Agent-SDK trader for the discretionary "SL Hunting" price-action method
 # on NIFTY ATM options, with BankNIFTY cross-confirmation and fail-closed
-# hard-budget sizing. Requires `pip install claude-agent-sdk pydantic`
+# hard-budget sizing. Requires `pip install -r requirements-ai.txt`
 # and a one-time `claude` CLI login. IMPORTANT: keep ANTHROPIC_API_KEY UNSET so
 # the agent draws on your Claude subscription's Agent SDK credit, not per-token
 # API billing.

--- a/Dependencies/env.example
+++ b/Dependencies/env.example
@@ -20,10 +20,12 @@
 # Authentication flow (Option A - API Key / API Secret OAuth):
 #   1. Fill in DHAN_CLIENT_CODE, DHAN_API_KEY, DHAN_API_SECRET below.
 #   2. Run `python Multithreading/Dependencies/dhan_token_setup.py` once.
-#      The script walks you through the one-time browser login and writes
-#      a fresh DHAN_ACCESS_TOKEN (valid 12 months) back into this file.
-#   3. From then on, the trading scripts read the token directly. When it
-#      eventually expires, just re-run the setup script.
+#      The script walks you through the browser login and writes a fresh
+#      DHAN_ACCESS_TOKEN back into this file, then prints its real expiry.
+#   3. From then on, the trading scripts read the token directly. Re-run the
+#      setup script whenever it expires -- tokens minted on web.dhan.co
+#      currently last only 24 HOURS, so plan on refreshing before each
+#      trading day, outside market hours.
 # ==============================================================================
 
 
@@ -41,9 +43,13 @@ DHAN_API_KEY=
 # TREAT THIS LIKE A PASSWORD. Never commit a populated .env to git.
 DHAN_API_SECRET=
 
-# 12-month access token produced by dhan_token_setup.py.
+# Access token produced by dhan_token_setup.py (or pasted from web.dhan.co).
 # Leave blank for the very first run; the setup script populates it after
 # the OAuth flow completes.
+# VALIDITY IS NOT 12 MONTHS: DhanHQ stamps the expiry into the token and the
+# web console currently issues 24-hour tokens. Generate it OUTSIDE market
+# hours -- a token that dies mid-session can leave open intraday positions
+# that cannot be squared off through the API.
 DHAN_ACCESS_TOKEN=
 
 
@@ -992,18 +998,19 @@ GSHEET_OAUTH_TOKEN_FILE=
 # By default EVERYTHING is paper: LIVE_TRADING_ENABLED=false is the global
 # kill-switch. A strategy places REAL orders only when BOTH this master switch
 # AND that strategy's own <PREFIX>_LIVE_TRADING are true. LIVE_BROKER picks which
-# broker those orders route to (KOTAK, SHOONYA, or FLATTRADE) - all share one code path in
-# the runner (Dependencies/Kotak API/kotak_execution.py /
+# broker those orders route to (KOTAK, SHOONYA, FLATTRADE, or DHAN) - all share one
+# code path in the runner (Dependencies/Kotak API/kotak_execution.py /
 # Dependencies/Shoonya API/shoonya_execution.py / Dependencies/Flattrade API/
-# flattrade_execution.py). An entry falls back to paper ONLY after an explicit
-# zero-fill REJECTED result. PARTIAL or UNKNOWN means broker exposure may exist:
-# new live entries freeze and reconciliation continues. A rejected/ambiguous
-# exit remains tracked as live exposure.
+# flattrade_execution.py / Dependencies/Dhan API/dhan_execution.py). An entry
+# falls back to paper ONLY after an explicit zero-fill REJECTED result. PARTIAL
+# or UNKNOWN means broker exposure may exist: new live entries freeze and
+# reconciliation continues. A rejected/ambiguous exit remains tracked as live
+# exposure.
 
 # ---- Global master kill-switch (must be true for ANY live order) ----
 LIVE_TRADING_ENABLED=false
 
-# ---- Active broker for live orders: KOTAK, SHOONYA, or FLATTRADE ----
+# ---- Active broker for live orders: KOTAK, SHOONYA, FLATTRADE, or DHAN ----
 LIVE_BROKER=KOTAK
 
 # ---- Kotak Neo credentials (used when LIVE_BROKER=KOTAK) ----
@@ -1042,6 +1049,18 @@ FLATTRADE_API_SECRET=
 FLATTRADE_ACCESS_TOKEN=
 FLATTRADE_PRODUCT_TYPE=INTRADAY
 FLATTRADE_MARKET_PROTECTION=5
+
+# ---- Dhan credentials (used when LIVE_BROKER=DHAN) ----
+# Dhan needs NO new secrets: live orders reuse the SAME DHAN_CLIENT_CODE and
+# DHAN_ACCESS_TOKEN already set at the top of this file for market data. The
+# token comes from `python algo.py setup-token` and is read from the
+# environment only - this helper never writes it back or prompts for one.
+# Refresh it outside market hours; see the DHAN_ACCESS_TOKEN note above.
+# Dhan also enforces a static-IP whitelist on ORDER endpoints only: reads keep
+# working while orders fail with "Invalid IP", and the token must be minted
+# AFTER the IP is registered (web.dhan.co -> Static IP Setting).
+# INTRADAY is same-day (Dhan INTRADAY); NORMAL is carry-forward (Dhan MARGIN).
+DHAN_PRODUCT_TYPE=INTRADAY
 
 # ---- Per-strategy live toggles (all default false; flip individually) ----
 # Prefixes match each strategy's existing <PREFIX>_* knobs above.

--- a/Dependencies/execution_ledger.py
+++ b/Dependencies/execution_ledger.py
@@ -467,9 +467,14 @@ class ExecutionLedger:
             raise ValueError("requested_quantity must be a positive integer")
         with self._lock:
             leg = self._legs[str(exposure_id)]
+            # One attempt at a time per leg: while the previous order may still
+            # fill, submitting more quantity could overshoot the target.
             if leg.latest_attempt is not None and not leg.latest_attempt.terminal:
                 raise RuntimeError("the previous order attempt is not terminal")
             if intent is OrderIntent.OPEN:
+                # A leg is one-directional: once closing has begun, "reopening"
+                # would blur which fills belong to the entry and which to the
+                # exit.  A fresh signal gets a fresh correlation instead.
                 if leg.closing_started:
                     raise RuntimeError(
                         "cannot open a live leg after closing has started; "
@@ -480,6 +485,9 @@ class ExecutionLedger:
             else:
                 safe_quantity = self._snapshot_leg(leg).safe_close_retry_quantity
                 phase = "X"
+            # The caller must ask for EXACTLY the quantity the ledger deems
+            # safe (see the safe-retry properties). Rejecting any other number
+            # makes it impossible to bypass the quantity maths by accident.
             if requested_quantity != safe_quantity:
                 raise ValueError(f"requested_quantity must equal safe retry quantity {safe_quantity}")
             sequence = leg.attempt_count + 1
@@ -493,6 +501,8 @@ class ExecutionLedger:
             leg.attempt_count = sequence
             if intent is OrderIntent.CLOSE:
                 leg.closing_started = True
+            # From this instant until a terminal result arrives, the leg's
+            # true exposure is unknown -- the order is (about to be) in flight.
             leg.exposure_indeterminate = True
             leg.latest_attempt = _MutableOrderAttempt(
                 intent=intent,
@@ -523,15 +533,26 @@ class ExecutionLedger:
             attempt = leg.latest_attempt
             if attempt is None:
                 raise RuntimeError("cannot apply a result before start_attempt")
+            # Identity checks: a status probe launched for attempt #1 can
+            # return AFTER a retry already started attempt #2.  The handle's
+            # sequence/tag pin the evidence to the attempt it describes, so a
+            # late reply can never be mistaken for news about the newer order.
             if attempt.sequence != handle.sequence or attempt.order_tag != handle.order_tag:
                 raise RuntimeError("stale order-attempt handle cannot mutate the current attempt")
             if result.requested_quantity != attempt.requested_quantity:
                 raise ValueError("broker result requested quantity changed within an attempt")
             if attempt.order_id and result.order_id and result.order_id != attempt.order_id:
                 raise ValueError("broker result order id changed within an attempt")
+            # Brokers report fills CUMULATIVELY per order; a count that shrank
+            # means one of the two snapshots is wrong, and guessing which
+            # would corrupt the quantity books.
             if result.filled_quantity < attempt.filled_quantity:
                 raise ValueError("broker cumulative filled quantity moved backwards")
             broker_state = str(result.broker_state).upper().strip()
+            # PARTIAL alone is not final -- the order may still be filling.
+            # It becomes terminal only alongside a terminal broker label
+            # (e.g. partially filled, then cancelled): the same rule the
+            # adapters' fill-confirmation loops poll by.
             terminal = result.status in {OrderStatus.FILLED, OrderStatus.REJECTED} or (
                 result.status is OrderStatus.PARTIAL
                 and broker_state in _TERMINAL_BROKER_STATES
@@ -546,17 +567,24 @@ class ExecutionLedger:
                 # snapshot already applied to this attempt, so it cannot reopen
                 # uncertainty or undo an entry/flat decision.
                 return self._snapshot_leg(leg)
+            # The DELTA is what this snapshot newly proves: cumulative report
+            # minus what this attempt had already been credited.  Applying
+            # deltas (never totals) is what makes a repeated or re-ordered
+            # status report unable to double-count a fill.
             fill_delta = result.filled_quantity - attempt.filled_quantity
             new_entry_filled = leg.filled_quantity
             new_entry_remaining = leg.remaining_quantity
             new_live_quantity = leg.confirmed_live_quantity
             if attempt.intent is OrderIntent.OPEN:
+                # Entry fills grow both the entry tally and the live position.
                 if leg.filled_quantity + fill_delta > leg.spec.target_quantity:
                     raise ValueError("open fills exceed the leg target quantity")
                 new_entry_filled += fill_delta
                 new_entry_remaining = leg.spec.target_quantity - new_entry_filled
                 new_live_quantity += fill_delta
             else:
+                # Close fills only shrink the live position; the entry tally
+                # keeps recording how much was ever opened.
                 if fill_delta > leg.confirmed_live_quantity:
                     raise ValueError("close fills exceed confirmed live quantity")
                 new_live_quantity -= fill_delta

--- a/Dependencies/market_data_health.py
+++ b/Dependencies/market_data_health.py
@@ -168,7 +168,12 @@ def newest_completed_minute_timestamp(
     *,
     now: datetime | None = None,
 ) -> datetime | None:
-    """Return the newest candle whose one-minute interval has completed."""
+    """Return the newest candle whose one-minute interval has completed.
+
+    Candles are stamped with their START minute, so the row stamped with the
+    CURRENT minute is still forming and is deliberately excluded -- freshness
+    is judged only on candles the market has finished printing.
+    """
 
     if frame is None or frame.empty or "timestamp" not in frame.columns:
         return None
@@ -184,7 +189,23 @@ def newest_completed_minute_timestamp(
 
 @dataclass(frozen=True)
 class MarketDataHealthSnapshot:
-    """Immutable worker-facing view of the current feed safety state."""
+    """Immutable worker-facing view of the current feed safety state.
+
+    - ``monitoring``            : False outside a live producer session; every
+                                  gate then passes so offline tools/backtests
+                                  are unaffected.
+    - ``entry_allowed``         : True only when the feed is currently healthy
+                                  AND has been healthy for the required streak
+                                  of producer refreshes (recovery hysteresis).
+    - ``liquidation_required``  : True once the feed has been continuously
+                                  unhealthy past the liquidation deadline --
+                                  live workers must start flattening.
+    - ``healthy_streak``        : consecutive healthy producer refreshes.
+    - ``unhealthy_seconds``     : how long the current unhealthy episode has
+                                  lasted (0 while healthy).
+    - ``reasons``               : operator-readable explanations, empty when
+                                  healthy.
+    """
 
     monitoring: bool
     entry_allowed: bool
@@ -195,7 +216,29 @@ class MarketDataHealthSnapshot:
 
 
 class MarketDataHealth:
-    """Track freshness, recovery hysteresis, and the liquidation deadline."""
+    """Track freshness, recovery hysteresis, and the liquidation deadline.
+
+    Beginner's map of the timing rules (all configurable via ``__init__``):
+
+    - An LTP older than **10s** or a newest completed 1-minute bar older than
+      **90s** marks the whole feed unhealthy.  90s (not 60s) for the bar
+      because a candle stamped 09:20 only COMPLETES at 09:21, and the producer
+      then needs a poll cycle to fetch it -- 90s is "one full candle plus
+      slack", while 60s would false-alarm every minute boundary.
+    - Unhealthy for **30s** continuously -> ``liquidation_required``: a blip
+      should not dump positions, but half a minute without prices means live
+      stops/targets are flying blind, so tracked exposure must come off.
+    - Recovery needs **3 consecutive healthy refreshes** before entries
+      resume.  A single good poll right after an outage is often the first
+      gasp of a flapping connection; the streak requirement stops the gate
+      from oscillating open/closed ("hysteresis").
+
+    Two entry points feed the same state: the producer calls
+    ``record_refresh`` once per fetch cycle (the only place the healthy streak
+    can ADVANCE), while workers call ``snapshot`` on their own schedule (which
+    re-evaluates ages so a silently WEDGED producer still goes stale on time
+    -- see the ``snapshot`` docstring).
+    """
 
     def __init__(
         self,
@@ -263,20 +306,36 @@ class MarketDataHealth:
             }
             reasons = self._reasons_locked(now_ist)
             if reasons:
+                # Any problem resets the recovery streak to zero and pins the
+                # START of the unhealthy episode (kept, not overwritten, so the
+                # 30s liquidation clock measures the WHOLE outage).
                 self._healthy_streak = 0
                 if self._unhealthy_since is None:
                     self._unhealthy_since = now_ist
             else:
+                # Only a producer refresh may advance the streak: three healthy
+                # WORKER polls in the same second prove nothing new about the
+                # feed, three healthy PRODUCER cycles do.
                 self._healthy_streak += 1
                 self._unhealthy_since = None
             return self._snapshot_locked(now_ist, reasons)
 
     def snapshot(self, *, now: datetime | None = None) -> MarketDataHealthSnapshot:
-        """Evaluate current ages so a silent producer becomes stale on time."""
+        """Evaluate current ages so a silent producer becomes stale on time.
+
+        This deliberately re-runs the age checks against ``now`` instead of
+        replaying the producer's last verdict: if the fetcher thread wedges and
+        never calls ``record_refresh`` again, its final (healthy) result would
+        otherwise stay "fresh" forever.  Recomputing here means the stored
+        timestamps age naturally and the gates fail closed on schedule even
+        when the producer has gone completely quiet.
+        """
 
         now_ist = _as_aware_ist(now or datetime.now(IST))
         with self._lock:
             if not self._monitoring:
+                # No live producer session: every gate passes so backtests and
+                # offline diagnostics are unaffected by freshness rules.
                 return MarketDataHealthSnapshot(
                     monitoring=False,
                     entry_allowed=True,
@@ -287,6 +346,9 @@ class MarketDataHealth:
                 )
             reasons = self._reasons_locked(now_ist)
             if reasons:
+                # Same episode bookkeeping as record_refresh -- but note the
+                # healthy branch does NOT advance the streak here: only the
+                # producer's own refreshes count as recovery evidence.
                 self._healthy_streak = 0
                 if self._unhealthy_since is None:
                     self._unhealthy_since = now_ist
@@ -295,6 +357,7 @@ class MarketDataHealth:
             return self._snapshot_locked(now_ist, reasons)
 
     def _reasons_locked(self, now: datetime) -> tuple[str, ...]:
+        """Collect every current problem; an empty tuple means healthy."""
         reasons: list[str] = []
         if not self._refresh_ok:
             reasons.append("latest OHLC refresh failed")
@@ -302,6 +365,9 @@ class MarketDataHealth:
             reasons.append("newest completed one-minute bar is unavailable")
         else:
             bar_age = (now - self._newest_completed_bar).total_seconds()
+            # A slightly future timestamp is normal clock skew; more than 5s
+            # ahead means the feed's clock (or an epoch-unit bug) cannot be
+            # trusted, which is just as unsafe as stale data.
             if bar_age < -5.0:
                 reasons.append("newest completed one-minute bar is in the future")
             elif bar_age > self._bar_max_age:
@@ -324,6 +390,7 @@ class MarketDataHealth:
         now: datetime,
         reasons: tuple[str, ...],
     ) -> MarketDataHealthSnapshot:
+        """Freeze the two gate decisions into one immutable, coherent view."""
         unhealthy_seconds = (
             max(0.0, (now - self._unhealthy_since).total_seconds())
             if self._unhealthy_since is not None
@@ -332,6 +399,10 @@ class MarketDataHealth:
         healthy = not reasons
         return MarketDataHealthSnapshot(
             monitoring=self._monitoring,
+            # Entries need BOTH currently-healthy and a full recovery streak;
+            # liquidation needs BOTH currently-unhealthy and a full 30s episode.
+            # The asymmetry is deliberate: reopening entries is the risky
+            # direction, so it carries the extra hysteresis requirement.
             entry_allowed=healthy and self._healthy_streak >= self._recovery_refreshes,
             liquidation_required=bool(
                 reasons and unhealthy_seconds >= self._liquidation_after

--- a/Dependencies/next_open_entry.py
+++ b/Dependencies/next_open_entry.py
@@ -100,6 +100,10 @@ class PendingNextOpenEntry:
         assert setup_stop is not None
         assert setup_target is not None
 
+        # Geometry check: a LONG only makes sense with the stop BELOW the
+        # entry and the target ABOVE it (mirrored for SHORT).  Anything else
+        # means the signal engine handed over levels that would fill as an
+        # instant stop-out or an instant "win" -- refuse them at the source.
         if normalized_direction == "LONG":
             valid_geometry = setup_stop < setup_entry < setup_target
             stop_distance = setup_entry - setup_stop
@@ -111,6 +115,10 @@ class PendingNextOpenEntry:
         if not valid_geometry:
             raise ValueError("setup entry/stop/target geometry is invalid")
 
+        # Candles are stamped by their START minute: the signal candle stamped
+        # 09:20 completes at 09:25, so its "next open" is the bar STAMPED
+        # 09:25 -- one full timeframe after the signal stamp.  The intent then
+        # expires one further bar later (see the module docstring).
         bar = timedelta(minutes=timeframe_minutes)
         expected_open_at = signal_at + bar
         return cls(
@@ -147,12 +155,20 @@ class PendingNextOpenEntry:
 
         if not isinstance(observed_at, datetime):
             return None
+        # EXACT slot equality, not >=: a later bar means the intended entry
+        # moment was missed (a feed gap or a slow poll), and executing on a
+        # substitute bar would be a different trade from the one the setup
+        # described.  The caller keeps the intent queued until it expires.
         if observed_at != self.expected_open_at:
             return None
         entry = _finite_price(observed_entry)
         if entry is None:
             return None
 
+        # Shift the ORIGINAL stop/target distances onto the actually observed
+        # open, then re-check geometry: a large opening gap can push the
+        # rebased stop to zero/negative territory, which the finite-positive
+        # check below turns into a refusal rather than a nonsense order.
         if self.direction == "LONG":
             stop = entry - self.stop_distance
             target = entry + self.target_distance

--- a/Dependencies/risk_sizing.py
+++ b/Dependencies/risk_sizing.py
@@ -5,6 +5,24 @@ lot.  Both behaviours can exceed the configured budget.  ``SizingDecision``
 is the single authority used by the master runner and the standalone SL
 Hunting executor: invalid inputs and one-lot-over-budget setups are explicit
 rejections, while accepted trades use ``floor`` with a configurable lot cap.
+
+Beginner's walkthrough of why floor-and-reject, with a worked example
+(budget Rs.2500, NIFTY lot 75, entry 24300, stop 24290 -> 10-point risk):
+
+- one lot risks 10 * 75 = Rs.750, so floor(2500 / 750) = **3 lots**
+  (Rs.2250 worst case, inside the budget).
+- the old ``ceil`` gave 4 lots = Rs.3000 worst case -- 20% OVER the budget
+  the operator configured, on every single trade with an awkward stop.
+- with a 40-point stop, one lot risks Rs.3000 > budget.  The old "minimum
+  one lot" still traded it; this module REJECTS it, because a budget that
+  silently stretches for wide stops is not a budget at all.  A skipped
+  setup costs an opportunity; an oversized one costs real money.
+
+The rupee-risk proxy is deliberately simple: ``|entry - stop| * lot_size``
+measures the UNDERLYING's move as if the option gained/lost point-for-point
+(delta ~= 1).  Real ATM option deltas are nearer 0.5, so this proxy usually
+OVERSTATES the risk -- conservative in exactly the direction a hard limit
+should be.
 """
 
 from __future__ import annotations
@@ -28,7 +46,13 @@ def _finite_number(value: Any) -> float | None:
 
 @dataclass(frozen=True, slots=True)
 class SizingDecision:
-    """Immutable explanation of an accepted or rejected position size."""
+    """Immutable explanation of an accepted or rejected position size.
+
+    Every field the sizing maths used is carried on the decision itself, so a
+    log line or Telegram alert can show WHY a trade was sized (or skipped)
+    without re-deriving anything.  ``accepted=False`` always comes with
+    ``lots=0``/``quantity=0`` -- callers never need to double-check.
+    """
 
     accepted: bool
     lots: int
@@ -106,6 +130,11 @@ class SizingDecision:
         The spot-distance proxy is conservative and intentionally unchanged:
         ``one_lot_risk = abs(entry - stop) * lot_size``.  What changes is the
         hard-limit policy—there is no fallback lot and no rounding upward.
+
+        The validation ladder below runs most-fundamental-first (budget, then
+        lot size, then cap, then prices, then stop distance) so the rejection
+        ``reason`` always names the FIRST thing the operator must fix, and
+        each rejection carries whatever figures were already validated.
         """
 
         normalized_budget = _finite_number(budget)

--- a/Dependencies/startup_exposure.py
+++ b/Dependencies/startup_exposure.py
@@ -56,7 +56,16 @@ def _read_typed_book[BookItem: (OpenOrder, OpenPosition)](
     query: Callable[[], object],
     item_type: type[BookItem],
 ) -> tuple[BookItem, ...] | None:
-    """Return a validated book, or ``None`` for any ambiguous outcome."""
+    """Return a validated book, or ``None`` for any ambiguous outcome.
+
+    ``None`` never means "empty" here -- an empty-but-successful book is the
+    empty tuple.  ``None`` means "could not be proven", which the caller
+    treats exactly like exposure.  The type checks below look paranoid on
+    purpose: this function is the last line between an adapter bug (or a
+    monkeypatched test double drifting from the contract) and the decision to
+    let real orders start, so any shape that is not literally the contract's
+    is refused rather than coerced.
+    """
 
     try:
         result = query()
@@ -65,6 +74,8 @@ def _read_typed_book[BookItem: (OpenOrder, OpenPosition)](
 
     if not isinstance(result, BrokerQueryResult):
         return None
+    # ``type(...) is not bool`` rather than truthiness: a mock returning a
+    # truthy non-bool (e.g. a MagicMock) must not read as "determinate".
     if type(result.is_indeterminate) is not bool:  # bool is intentional here.
         return None
     if not isinstance(result.items, tuple):
@@ -73,6 +84,8 @@ def _read_typed_book[BookItem: (OpenOrder, OpenPosition)](
         return None
     if result.is_indeterminate:
         return None
+    # Every element must be the exact typed item -- one foreign object means
+    # the whole snapshot cannot be trusted.
     if any(not isinstance(item, item_type) for item in result.items):
         return None
     return result.items

--- a/Dependencies/test_broker_contract.py
+++ b/Dependencies/test_broker_contract.py
@@ -8,14 +8,18 @@ from __future__ import annotations
 
 import importlib
 import importlib.util
+import io
 import json
 import sys
 import threading
 import time
+import zipfile
 from dataclasses import FrozenInstanceError
+from datetime import date
 from pathlib import Path
 from types import ModuleType
 
+import pandas as pd
 import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -123,6 +127,50 @@ def test_order_result_rejects_semantically_contradictory_statuses(
 
 
 @pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("requested_quantity", True, "requested_quantity"),
+        ("requested_quantity", 75.5, "requested_quantity"),
+        ("filled_quantity", -1, "filled_quantity"),
+        ("remaining_quantity", "50", "remaining_quantity"),
+        ("status", "FILLED", "OrderStatus"),
+    ],
+)
+def test_order_result_rejects_malformed_direct_fields(
+    field: str,
+    value: object,
+    message: str,
+) -> None:
+    contract = _contract_module()
+    kwargs: dict[str, object] = {
+        "order_id": "BROKEN",
+        "requested_quantity": 75,
+        "filled_quantity": 25,
+        "remaining_quantity": 50,
+        "status": contract.OrderStatus.PARTIAL,
+        "broker_state": "OPEN",
+        "reason": "malformed direct construction",
+    }
+    kwargs[field] = value
+    with pytest.raises(ValueError, match=message):
+        contract.OrderResult(**kwargs)
+
+
+def test_order_result_rejects_fill_larger_than_request() -> None:
+    contract = _contract_module()
+    with pytest.raises(ValueError, match="cannot exceed"):
+        contract.OrderResult(
+            order_id="BROKEN",
+            requested_quantity=75,
+            filled_quantity=100,
+            remaining_quantity=0,
+            status=contract.OrderStatus.UNKNOWN,
+            broker_state="OPEN",
+            reason="impossible fill",
+        )
+
+
+@pytest.mark.parametrize(
     ("broker_state", "filled", "expected"),
     [
         ("REJECTED", 0, "REJECTED"),
@@ -170,6 +218,88 @@ def test_malformed_quantity_normalizes_to_unknown_instead_of_rejected() -> None:
     assert result.filled_quantity == 0
     assert result.remaining_quantity == 75
     assert "malformed" in result.reason.lower()
+
+
+@pytest.mark.parametrize(
+    ("requested", "filled"),
+    [
+        (True, 0),
+        (-1, 0),
+        ("75.5", 0),
+        (75, True),
+        (75, -1),
+        (75, 76),
+    ],
+)
+def test_quantity_normalization_rejects_nonexact_or_impossible_values(
+    requested: object,
+    filled: object,
+) -> None:
+    contract = _contract_module()
+    result = contract.normalize_order_result(
+        order_id=None,
+        requested_quantity=requested,
+        filled_quantity=filled,
+        broker_state=None,
+    )
+    assert result.status is contract.OrderStatus.UNKNOWN
+    assert result.order_id == ""
+    assert "malformed" in result.reason.lower()
+
+
+@pytest.mark.parametrize(
+    ("state", "filled", "expected", "reason_fragment"),
+    [
+        ("PARTIAL", 25, "PARTIAL", "partial fill"),
+        ("PARTIAL", 0, "UNKNOWN", "terminal order outcome"),
+        ("COMPLETE", 75, "FILLED", "requested quantity filled"),
+        ("REJECTED", 0, "REJECTED", "terminal rejection"),
+    ],
+)
+def test_normalization_supplies_status_specific_default_reasons(
+    state: str,
+    filled: int,
+    expected: str,
+    reason_fragment: str,
+) -> None:
+    contract = _contract_module()
+    result = contract.normalize_order_result(
+        order_id="ORDER",
+        requested_quantity=75,
+        filled_quantity=filled,
+        broker_state=state,
+    )
+    assert result.status.name == expected
+    assert reason_fragment in result.reason.lower()
+
+
+def test_open_snapshot_types_reuse_contract_invariants() -> None:
+    contract = _contract_module()
+    with pytest.raises(ValueError, match="remaining_quantity"):
+        contract.OpenOrder(
+            order_id="OPEN-1",
+            symbol="NIFTY",
+            side="BUY",
+            requested_quantity=75,
+            filled_quantity=25,
+            remaining_quantity=75,
+            broker_state="OPEN",
+        )
+    with pytest.raises(ValueError, match="integer"):
+        contract.OpenPosition(
+            symbol="NIFTY",
+            quantity=True,
+            product_type="MIS",
+        )
+
+
+def test_indeterminate_query_uses_safe_defaults() -> None:
+    contract = _contract_module()
+    result = contract.BrokerQueryResult.indeterminate(" ", broker_state=" timed-out ")
+    assert result.items == ()
+    assert result.is_indeterminate is True
+    assert result.reason == "Broker query outcome is indeterminate."
+    assert result.broker_state == "timed-out"
 
 
 def test_query_failure_cannot_masquerade_as_a_successful_empty_list() -> None:
@@ -1983,6 +2113,502 @@ def test_kotak_recovery_waits_for_every_abandoned_sdk_future(
     while not first_future.done() and time.monotonic() < deadline:
         time.sleep(0.005)
     assert client.recover_after_reconciliation() is True
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (True, None),
+        ("bad", None),
+        (1.5, None),
+        (float("inf"), None),
+        ("75", 75),
+    ],
+)
+def test_broker_quantity_helpers_require_exact_finite_integers(
+    shoonya_module: ModuleType,
+    kotak_module: ModuleType,
+    flattrade_module: ModuleType,
+    value: object,
+    expected: int | None,
+) -> None:
+    """Each adapter rejects rounded or boolean quantities at its own boundary."""
+
+    assert shoonya_module._exact_int(value) == expected
+    assert kotak_module._exact_int(value) == expected
+    assert flattrade_module._exact_int(value) == expected
+
+
+def test_shoonya_login_success_and_missing_credentials_fail_closed(
+    shoonya_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """Login accepts only a typed Ok response and never keeps a half-session."""
+
+    captured: dict[str, object] = {}
+
+    class LoginNoren:
+        def login(self, **kwargs):
+            captured.update(kwargs)
+            return {"stat": "Ok", "uname": "Test Trader"}
+
+    for name, value in {
+        "SHOONYA_USERID": "USER",
+        "SHOONYA_PASSWORD": "PASSWORD",
+        "SHOONYA_VENDOR_CODE": "VENDOR",
+        "SHOONYA_API_SECRET": "SECRET",
+        "SHOONYA_TOTP_SECRET": "TOTP-SEED",
+    }.items():
+        monkeypatch.setenv(name, value)
+    monkeypatch.setattr(shoonya_module, "NorenApi", LoginNoren)
+    client = shoonya_module.ShoonyaExecutionClient()
+    monkeypatch.setattr(client, "_generate_totp", lambda _secret: "123456")
+
+    assert client.ensure_logged_in() is True
+    assert client.ensure_logged_in() is True
+    assert client.is_logged_in is True
+    assert captured["twoFA"] == "123456"
+
+    for name in (
+        "SHOONYA_USERID",
+        "SHOONYA_PASSWORD",
+        "SHOONYA_VENDOR_CODE",
+        "SHOONYA_API_SECRET",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    missing = shoonya_module.ShoonyaExecutionClient()
+    assert missing.ensure_logged_in() is False
+    assert missing.client is None
+
+
+def test_shoonya_blank_totp_and_rejected_login_clear_session(
+    shoonya_module: ModuleType,
+    monkeypatch,
+) -> None:
+    class RejectedNoren:
+        def login(self, **_kwargs):
+            return {"stat": "Not_Ok", "emsg": "bad credentials"}
+
+    for name, value in {
+        "SHOONYA_USERID": "USER",
+        "SHOONYA_PASSWORD": "PASSWORD",
+        "SHOONYA_VENDOR_CODE": "VENDOR",
+        "SHOONYA_API_SECRET": "SECRET",
+    }.items():
+        monkeypatch.setenv(name, value)
+    monkeypatch.delenv("SHOONYA_TOTP_SECRET", raising=False)
+
+    blank = shoonya_module.ShoonyaExecutionClient()
+    monkeypatch.setattr(blank, "_prompt_totp", lambda: "")
+    assert blank.ensure_logged_in() is False
+
+    monkeypatch.setenv("SHOONYA_TOTP_SECRET", "SEED")
+    monkeypatch.setattr(shoonya_module, "NorenApi", RejectedNoren)
+    rejected = shoonya_module.ShoonyaExecutionClient()
+    monkeypatch.setattr(rejected, "_generate_totp", lambda _secret: "123456")
+    assert rejected.ensure_logged_in() is False
+    assert rejected.client is None
+
+
+def test_shoonya_scrip_master_and_symbol_resolution_are_cached(
+    shoonya_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """The official master validates exact contracts without later downloads."""
+
+    archive = io.BytesIO()
+    with zipfile.ZipFile(archive, "w") as zipped:
+        zipped.writestr(
+            "NFO_symbols.txt",
+            "Exchange,Token,LotSize,Symbol,TradingSymbol\n"
+            "NFO,1,75,NIFTY,NIFTY16JUL26C22500\n",
+        )
+
+    class Response:
+        content = archive.getvalue()
+
+        @staticmethod
+        def raise_for_status() -> None:
+            return None
+
+    client = _ready_shoonya_client(
+        shoonya_module,
+        monkeypatch,
+        _FakeNorenClient(),
+    )
+    monkeypatch.setattr(shoonya_module.requests, "get", lambda *args, **kwargs: Response())
+
+    assert client.preload_scrip_master() is True
+    assert client.preload_scrip_master() is True
+    symbol = client.resolve_option_symbol("nifty", date(2026, 7, 16), "ce", 22500)
+    assert symbol == "NIFTY16JUL26C22500"
+    assert client.resolve_option_symbol("NIFTY", date(2026, 7, 16), "CE", 22500) == symbol
+    assert client.resolve_option_symbol("NIFTY", date(2026, 7, 16), "PE", 22500) == ""
+    assert client.resolve_option_symbol("NIFTY", None, "CE", 22500) == ""
+    assert client.resolve_option_symbol("NIFTY", "not-a-date", "CE", 22500) == ""
+    assert client.resolve_option_symbol("NIFTY", date(2026, 7, 16), "XX", 22500) == ""
+
+
+def test_shoonya_logout_and_recursive_order_id_extraction(
+    shoonya_module: ModuleType,
+) -> None:
+    client = shoonya_module.ShoonyaExecutionClient()
+    assert client.logout()["State"] == "NOT_OK"
+    assert client.extract_order_id({"data": [{"norenordno": "SH-NESTED"}]}) == "SH-NESTED"
+    assert client.extract_order_id([{"none": 0}, " SH-STRING "]) == "SH-STRING"
+    assert client.extract_order_id(123) == ""
+
+    class LogoutNoren:
+        @staticmethod
+        def logout():
+            return "bye"
+
+    client.client = LogoutNoren()
+    client.is_logged_in = True
+    assert client.logout() == {"State": "OK", "message": "bye"}
+    assert client.client is None
+    assert client.is_logged_in is False
+
+
+def test_kotak_login_success_normalizes_mobile_and_validates_two_factor(
+    kotak_module: ModuleType,
+    monkeypatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    class Configuration:
+        edit_token = "trade-token"
+        edit_sid = "trade-session"
+        serverId = "server"
+        base_url = "https://example.invalid"
+        data_center = "dc"
+
+    class LoginNeo:
+        def __init__(self, **kwargs):
+            captured["constructor"] = kwargs
+            self.configuration = Configuration()
+
+        def totp_login(self, **kwargs):
+            captured["login"] = kwargs
+            return {"stat": "Ok"}
+
+        def totp_validate(self, **kwargs):
+            captured["validate"] = kwargs
+            return {"stat": "Ok"}
+
+    for name, value in {
+        "CONSUMER_KEY": "CONSUMER",
+        "MOBILE": "98765-43210",
+        "MPIN": "123456",
+        "UCC": "UCC123",
+    }.items():
+        monkeypatch.setenv(name, value)
+    monkeypatch.delenv("COSNSUMER_KEY", raising=False)
+    monkeypatch.setattr(kotak_module, "NeoAPI", LoginNeo)
+    client = kotak_module.KotakExecutionClient()
+    monkeypatch.setattr(client, "_prompt_totp", lambda: "654321")
+
+    assert client.ensure_logged_in() is True
+    assert client.ensure_logged_in() is True
+    assert captured["login"]["mobile_number"] == "+919876543210"
+    assert captured["validate"] == {"mpin": "123456"}
+    assert kotak_module.KotakExecutionClient._normalize_mobile("919876543210") == "+919876543210"
+    assert kotak_module.KotakExecutionClient._normalize_mobile("+919876543210") == "+919876543210"
+    assert kotak_module.KotakExecutionClient._normalize_mobile("unexpected") == "unexpected"
+
+
+def test_kotak_login_rejects_missing_credentials_and_incomplete_two_factor(
+    kotak_module: ModuleType,
+    monkeypatch,
+) -> None:
+    for name in ("COSNSUMER_KEY", "CONSUMER_KEY", "MOBILE", "MPIN", "UCC"):
+        monkeypatch.delenv(name, raising=False)
+    assert kotak_module.KotakExecutionClient().ensure_logged_in() is False
+
+    class Configuration:
+        edit_token = ""
+        edit_sid = ""
+
+    class IncompleteNeo:
+        def __init__(self, **_kwargs):
+            self.configuration = Configuration()
+
+        @staticmethod
+        def totp_login(**_kwargs):
+            return {"stat": "Ok"}
+
+        @staticmethod
+        def totp_validate(**_kwargs):
+            return {"stat": "Not_Ok"}
+
+    for name, value in {
+        "CONSUMER_KEY": "CONSUMER",
+        "MOBILE": "9876543210",
+        "MPIN": "123456",
+        "UCC": "UCC123",
+    }.items():
+        monkeypatch.setenv(name, value)
+    monkeypatch.setattr(kotak_module, "NeoAPI", IncompleteNeo)
+    incomplete = kotak_module.KotakExecutionClient()
+    monkeypatch.setattr(incomplete, "_prompt_totp", lambda: "654321")
+    assert incomplete.ensure_logged_in() is False
+    assert incomplete.client is None
+
+
+def test_kotak_scrip_master_resolution_and_miss_diagnostics(
+    kotak_module: ModuleType,
+    monkeypatch,
+) -> None:
+    expiry = date(2026, 7, 16)
+    encoded_expiry = int(
+        (pd.Timestamp(expiry) - pd.to_timedelta(315511200, unit="s")).timestamp()
+    )
+
+    class ScripKotak(_FakeKotakSdk):
+        @staticmethod
+        def scrip_master(exchange_segment):
+            assert exchange_segment == "nse_fo"
+            return "https://example.invalid/nfo.csv"
+
+    class Response:
+        text = (
+            "pExpiryDate,pSymbolName,pOptionType,dStrikePrice;,pTrdSymbol\n"
+            f"{encoded_expiry},NIFTY,CE,2250000,NIFTY26JUL22500CE\n"
+        )
+
+        @staticmethod
+        def raise_for_status() -> None:
+            return None
+
+    client = _ready_kotak_client(kotak_module, monkeypatch, ScripKotak())
+    monkeypatch.setattr(kotak_module.requests, "get", lambda *args, **kwargs: Response())
+
+    assert client.preload_scrip_master() is True
+    assert client.preload_scrip_master() is True
+    symbol = client.resolve_option_symbol("nifty", expiry, "ce", 22500)
+    assert symbol == "NIFTY26JUL22500CE"
+    assert client.resolve_option_symbol("NIFTY", expiry, "CE", 22500) == symbol
+    assert client.resolve_option_symbol("NIFTY", expiry, "PE", 22500) == ""
+    assert client.resolve_option_symbol("NIFTY", None, "CE", 22500) == ""
+    assert client.resolve_option_symbol("NIFTY", "not-a-date", "CE", 22500) == ""
+    assert kotak_module.KotakExecutionClient._match_in_df(None, "NIFTY", "CE", "", 1) == ""
+
+
+def test_kotak_logout_and_recursive_order_id_extraction(
+    kotak_module: ModuleType,
+) -> None:
+    client = kotak_module.KotakExecutionClient()
+    assert client.logout()["State"] == "NOT_OK"
+    assert client.extract_order_id({"data": [{"nOrdNo": "KT-NESTED"}]}) == "KT-NESTED"
+    assert client.extract_order_id([{"none": 0}, " KT-STRING "]) == "KT-STRING"
+    assert client.extract_order_id(123) == ""
+
+    class LogoutKotak:
+        @staticmethod
+        def logout():
+            return "bye"
+
+    client.client = LogoutKotak()
+    client.is_logged_in = True
+    assert client.logout() == {"State": "OK", "message": "bye"}
+    assert client.client is None
+
+
+def _flattrade_master_fixture() -> pd.DataFrame:
+    """Return one valid and one filtered-out Flattrade catalogue row."""
+
+    return pd.DataFrame(
+        {
+            "Exchange": ["NFO", "NSE"],
+            "Lotsize": ["75", "1"],
+            "Symbol": ["NIFTY", "NIFTY"],
+            "Tradingsymbol": ["NIFTY16JUL26C22500", "NIFTY-SPOT"],
+            "Expiry": ["16-JUL-2026", "16-JUL-2026"],
+            "Strike": ["22500.00", "0"],
+            "Optiontype": ["CE", "XX"],
+        }
+    )
+
+
+def test_flattrade_env_parsing_session_validation_and_login_fast_path(
+    flattrade_module: ModuleType,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("MAT_TEST_QUOTED", "' value '")
+    monkeypatch.setenv("MAT_TEST_BAD_INT", "bad")
+    monkeypatch.setenv("MAT_TEST_NEGATIVE", "-1")
+    assert flattrade_module._env_str("MAT_TEST_QUOTED") == "value"
+    assert flattrade_module._env_str("MAT_TEST_MISSING", "fallback") == "fallback"
+    assert flattrade_module._env_non_negative_int("MAT_TEST_BAD_INT", 3) == 3
+    assert flattrade_module._env_non_negative_int("MAT_TEST_NEGATIVE", 3) == 3
+
+    client = flattrade_module.FlattradeExecutionClient()
+    client._client_id = "CLIENT"
+    client._access_token = "TOKEN"
+    monkeypatch.setattr(
+        client,
+        "_post_api",
+        lambda *_args, **_kwargs: {
+            "stat": "Ok",
+            "actid": "ACCOUNT",
+            "exarr": ["NFO"],
+        },
+    )
+    assert client._validate_session_locked() is True
+    assert client._account_id == "ACCOUNT"
+
+    monkeypatch.setenv("FLATTRADE_CLIENT_ID", "CLIENT")
+    monkeypatch.setenv("FLATTRADE_ACCESS_TOKEN", "TOKEN")
+    login = flattrade_module.FlattradeExecutionClient()
+    monkeypatch.setattr(login, "_validate_session_locked", lambda: True)
+    assert login.ensure_logged_in() is True
+    assert login.ensure_logged_in() is True
+
+
+def test_flattrade_browser_token_exchange_is_validated_before_login(
+    flattrade_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """The interactive flow hashes the secret and accepts only a validated token."""
+
+    captured: dict[str, object] = {}
+
+    class Response:
+        @staticmethod
+        def raise_for_status() -> None:
+            return None
+
+        @staticmethod
+        def json() -> dict[str, str]:
+            return {"status": "Ok", "token": "DAILY-TOKEN", "client": "CLIENT"}
+
+    class Session:
+        def post(self, url, **kwargs):
+            captured["url"] = url
+            captured["json"] = kwargs["json"]
+            captured["timeout"] = kwargs["timeout"]
+            return Response()
+
+    for name, value in {
+        "FLATTRADE_CLIENT_ID": "CLIENT",
+        "FLATTRADE_API_KEY": "API-KEY",
+        "FLATTRADE_API_SECRET": "API-SECRET",
+    }.items():
+        monkeypatch.setenv(name, value)
+    monkeypatch.delenv("FLATTRADE_ACCESS_TOKEN", raising=False)
+    monkeypatch.setattr("builtins.input", lambda _prompt: "REQUEST-CODE")
+    monkeypatch.setattr(flattrade_module.webbrowser, "open", lambda _url: True)
+
+    client = flattrade_module.FlattradeExecutionClient()
+    monkeypatch.setattr(client, "_ensure_session_locked", lambda: Session())
+    monkeypatch.setattr(client, "_validate_session_locked", lambda: True)
+
+    assert client.ensure_logged_in() is True
+    assert client._access_token == "DAILY-TOKEN"
+    expected_digest = flattrade_module.hashlib.sha256(
+        b"API-KEYREQUEST-CODEAPI-SECRET"
+    ).hexdigest()
+    assert captured["json"] == {
+        "api_key": "API-KEY",
+        "request_code": "REQUEST-CODE",
+        "api_secret": expected_digest,
+    }
+
+
+def test_flattrade_login_rejects_missing_identity_or_authorization_inputs(
+    flattrade_module: ModuleType,
+    monkeypatch,
+) -> None:
+    for name in (
+        "FLATTRADE_CLIENT_ID",
+        "FLATTRADE_ACCESS_TOKEN",
+        "FLATTRADE_API_KEY",
+        "FLATTRADE_API_SECRET",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    assert flattrade_module.FlattradeExecutionClient().ensure_logged_in() is False
+
+    monkeypatch.setenv("FLATTRADE_CLIENT_ID", "CLIENT")
+    assert flattrade_module.FlattradeExecutionClient().ensure_logged_in() is False
+
+    monkeypatch.setenv("FLATTRADE_API_KEY", "API-KEY")
+    monkeypatch.setenv("FLATTRADE_API_SECRET", "API-SECRET")
+    monkeypatch.setattr("builtins.input", lambda _prompt: "")
+    assert flattrade_module.FlattradeExecutionClient().ensure_logged_in() is False
+
+
+def test_flattrade_downloads_and_caches_the_official_scrip_master(
+    flattrade_module: ModuleType,
+    monkeypatch,
+) -> None:
+    csv_text = _flattrade_master_fixture().to_csv(index=False)
+
+    class Response:
+        text = csv_text
+
+        @staticmethod
+        def raise_for_status() -> None:
+            return None
+
+    class Session:
+        calls = 0
+
+        def get(self, _url, **_kwargs):
+            self.calls += 1
+            return Response()
+
+    session = Session()
+    client = _ready_flattrade_client(flattrade_module, monkeypatch)
+    client.client = session
+    assert client.preload_scrip_master() is True
+    assert client.preload_scrip_master() is True
+    assert session.calls == 1
+    assert client._scrip_df is not None
+    assert len(client._scrip_df) == 1
+
+
+def test_flattrade_scrip_preparation_resolution_and_logout(
+    flattrade_module: ModuleType,
+    monkeypatch,
+) -> None:
+    with pytest.raises(ValueError, match="missing columns"):
+        flattrade_module.FlattradeExecutionClient._prepare_scrip_master(pd.DataFrame())
+    unusable = _flattrade_master_fixture()
+    unusable["Exchange"] = "NSE"
+    with pytest.raises(ValueError, match="no usable NFO"):
+        flattrade_module.FlattradeExecutionClient._prepare_scrip_master(unusable)
+
+    prepared = flattrade_module.FlattradeExecutionClient._prepare_scrip_master(
+        _flattrade_master_fixture()
+    )
+    assert len(prepared) == 1
+    client = _ready_flattrade_client(flattrade_module, monkeypatch)
+    client._scrip_df = prepared
+    assert (
+        client.resolve_option_symbol("nifty", date(2026, 7, 16), "ce", 22500)
+        == "NIFTY16JUL26C22500"
+    )
+    assert (
+        client.resolve_option_symbol("NIFTY", date(2026, 7, 16), "CE", 22500)
+        == "NIFTY16JUL26C22500"
+    )
+    assert client.resolve_option_symbol("NIFTY", date(2026, 7, 16), "PE", 22500) == ""
+    assert client.resolve_option_symbol("NIFTY", "bad-date", "CE", "bad") == ""
+    assert client.resolve_option_symbol("NIFTY", date(2026, 7, 16), "CE", 22500, "NSE") == ""
+
+    class Session:
+        closed = False
+
+        def close(self):
+            self.closed = True
+
+    session = Session()
+    client.client = session
+    result = client.logout()
+    assert result["stat"] == "Ok"
+    assert session.closed is True
+    assert client.is_logged_in is False
+    assert client._access_token == ""
 
 
 _DIAGNOSTIC_PATHS = (

--- a/Dependencies/test_broker_contract.py
+++ b/Dependencies/test_broker_contract.py
@@ -1936,6 +1936,24 @@ def test_kotak_sdk_deadline_and_executor_are_fixed(
     assert client._sdk_executor._max_workers == 1
 
 
+def test_kotak_scrip_master_budget_is_separate_from_the_order_deadline(
+    kotak_module: ModuleType,
+) -> None:
+    """A bulk catalogue download must not be capped by the ORDER deadline.
+
+    Ten seconds exists so a live order can never go stale in flight.  The scrip
+    master is a multi-megabyte CSV fetched once, which is not that kind of call
+    -- holding it to the same budget made it time out on slower links and
+    disabled live trading for the whole session.  The two budgets are therefore
+    separate, and the order one must stay exactly ten seconds.
+    """
+
+    assert kotak_module._BROKER_DEADLINE_SECONDS == 10.0
+    assert kotak_module._SCRIP_MASTER_TIMEOUT_SECONDS > (
+        kotak_module._BROKER_DEADLINE_SECONDS
+    )
+
+
 def test_kotak_scrip_master_download_has_total_deadline(
     kotak_module: ModuleType,
     monkeypatch,
@@ -1964,6 +1982,10 @@ def test_kotak_scrip_master_download_has_total_deadline(
         return _SlowResponse()
 
     client = _ready_kotak_client(kotak_module, monkeypatch, ScripKotak())
+    # The download runs on its own budget now, so shrink THAT one; the order
+    # deadline is shrunk too so a regression that reverts to it still trips
+    # this test rather than silently waiting 20s.
+    monkeypatch.setattr(kotak_module, "_SCRIP_MASTER_TIMEOUT_SECONDS", 0.05)
     monkeypatch.setattr(kotak_module, "_BROKER_DEADLINE_SECONDS", 0.05)
     monkeypatch.setattr(kotak_module.requests, "get", slow_get)
     results = []

--- a/Dependencies/test_broker_contract.py
+++ b/Dependencies/test_broker_contract.py
@@ -2778,3 +2778,653 @@ def test_diagnostics_treat_entry_exception_as_indeterminate(
     assert flat is False
     assert "indeterminate" in output.lower()
     assert "No position opened" not in output
+
+
+# ---------------------------------------------------------------------------
+# Dhan adapter
+# ---------------------------------------------------------------------------
+# Dhan's SDK collapses BOTH a genuine broker refusal and a local network
+# exception into ``{'status': 'failure', ...}``.  Most of the tests below exist
+# to prove the adapter keeps those two apart, because mistaking a timed-out live
+# order for a rejection would send the runner back to paper while real exposure
+# sits at the broker.
+
+DHAN_SYMBOL = "NIFTY-Jul2026-24000-CE"
+DHAN_SECURITY_ID = "45022"
+
+
+@pytest.fixture(scope="module")
+def dhan_module() -> ModuleType:
+    """Return a private, network-free copy of the Dhan adapter."""
+
+    return _load_file_module(
+        "mat101_dhan_execution",
+        "Dependencies/Dhan API/dhan_execution.py",
+    )
+
+
+class _FakeDhanSdk:
+    """Minimal stand-in for the ``dhanhq`` client used by the adapter."""
+
+    def __init__(self, replies=None, correlation_reply=None) -> None:
+        self._replies = iter(replies or [])
+        self._correlation_reply = correlation_reply
+        self.place_calls: list[dict] = []
+        self.correlation_calls: list[str] = []
+        self.cancelled: list[str] = []
+
+    def _next(self):
+        return next(self._replies)
+
+    def place_order(self, **kwargs):
+        self.place_calls.append(dict(kwargs))
+        return self._next()
+
+    def get_order_by_id(self, order_id):
+        return self._next()
+
+    def get_order_by_correlationID(self, correlation_id):
+        self.correlation_calls.append(str(correlation_id))
+        if self._correlation_reply is None:
+            raise AssertionError("correlation lookup was not expected here")
+        if isinstance(self._correlation_reply, Exception):
+            raise self._correlation_reply
+        return self._correlation_reply
+
+    def cancel_order(self, order_id):
+        self.cancelled.append(str(order_id))
+        return self._next()
+
+    def get_order_list(self):
+        return self._next()
+
+    def get_positions(self):
+        return self._next()
+
+    def get_fund_limits(self):
+        return self._next()
+
+
+def _ok(data):
+    """Build the SDK's success envelope."""
+
+    return {"status": "success", "remarks": "", "data": data}
+
+
+def _refused(message="DH-905 insufficient margin"):
+    """Build the envelope Dhan returns when its SERVER answers and refuses.
+
+    ``remarks`` is a dict here -- that is the only signal distinguishing this
+    from a local transport failure.
+    """
+
+    return {
+        "status": "failure",
+        "remarks": {
+            "error_code": "DH-905",
+            "error_type": "Order_Error",
+            "error_message": message,
+        },
+        "data": "",
+    }
+
+
+def _transport_failure(message="ConnectionError(read timed out)"):
+    """Build the envelope the SDK returns when its own request RAISED.
+
+    ``remarks`` is a plain string.  The order may well have reached the
+    exchange, so this must never normalize to REJECTED.
+    """
+
+    return {"status": "failure", "remarks": message, "data": ""}
+
+
+def _status_row(state, filled, quantity=75):
+    return {
+        "orderId": "DH-1",
+        "orderStatus": state,
+        "filledQty": filled,
+        "quantity": quantity,
+        "tradingSymbol": DHAN_SYMBOL,
+        "transactionType": "BUY",
+    }
+
+
+def _ready_dhan_client(dhan_module: ModuleType, monkeypatch, fake):
+    """Build an authenticated-looking client without touching Dhan."""
+
+    client = dhan_module.DhanExecutionClient()
+    client._client_code = "TEST"
+    client.client = fake
+    client.is_logged_in = True
+    # The order API is driven by securityId, so the resolver's map must already
+    # know this symbol -- exactly as it would after preload_scrip_master().
+    client._security_id_by_symbol[DHAN_SYMBOL] = DHAN_SECURITY_ID
+    monkeypatch.setattr(client, "ensure_logged_in", lambda: True)
+    monkeypatch.setattr(dhan_module, "_FILL_POLL_INTERVAL", 0.001)
+    return client
+
+
+@pytest.mark.parametrize(
+    ("state", "filled", "expected_status", "remaining"),
+    [
+        ("REJECTED", 0, "REJECTED", 75),
+        ("TRADED", 75, "FILLED", 0),
+        ("TRADED", 25, "PARTIAL", 50),
+        # EXPIRED is not in the shared contract vocabulary; the adapter aliases
+        # it to CANCELLED so a clean "never traded" is a terminal rejection
+        # rather than an UNKNOWN that would freeze every live strategy.
+        ("EXPIRED", 0, "REJECTED", 75),
+    ],
+)
+def test_dhan_place_order_normalizes_terminal_outcomes(
+    dhan_module: ModuleType,
+    monkeypatch,
+    state: str,
+    filled: int,
+    expected_status: str,
+    remaining: int,
+) -> None:
+    """An acknowledgement is followed by a typed fill snapshot."""
+
+    fake = _FakeDhanSdk(
+        [
+            _ok({"orderId": "DH-1", "orderStatus": "TRANSIT"}),
+            _ok(_status_row(state, filled)),
+        ]
+    )
+    client = _ready_dhan_client(dhan_module, monkeypatch, fake)
+
+    result = client.place_market_order(DHAN_SYMBOL, "BUY", 75)
+
+    assert result.status.name == expected_status
+    assert result.order_id == "DH-1"
+    assert result.filled_quantity == filled
+    assert result.remaining_quantity == remaining
+
+
+def test_dhan_mid_fill_part_traded_snapshot_polls_to_completion(
+    dhan_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """A market order caught mid-fill is transient, not terminal.
+
+    Returning that first PART_TRADED snapshot as the outcome would freeze
+    every live entry over a healthy order; the loop must poll again.
+    """
+
+    fake = _FakeDhanSdk(
+        [
+            _ok({"orderId": "DH-MIDFILL", "orderStatus": "PENDING"}),
+            _ok(_status_row("PART_TRADED", 25)),
+            _ok(_status_row("TRADED", 75)),
+        ]
+    )
+    client = _ready_dhan_client(dhan_module, monkeypatch, fake)
+
+    result = client.place_market_order(DHAN_SYMBOL, "BUY", 75)
+
+    assert result.status.name == "FILLED"
+    assert result.order_id == "DH-MIDFILL"
+    assert result.filled_quantity == 75
+
+
+def test_dhan_transport_failure_is_unknown_never_rejected(
+    dhan_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """THE critical Dhan case: a lost response is not proof of a zero fill.
+
+    ``DhanHTTP._send_request`` turns a post-submission socket timeout into
+    ``{'status': 'failure', 'remarks': '<exception text>'}`` -- shape-identical
+    to a real rejection.  Believing it would re-enter on paper while a real
+    position sits at the broker.
+    """
+
+    fake = _FakeDhanSdk([_transport_failure()])
+    client = _ready_dhan_client(dhan_module, monkeypatch, fake)
+
+    result = client.place_market_order(DHAN_SYMBOL, "BUY", 75)
+
+    assert result.status.name == "UNKNOWN"
+    assert result.filled_quantity == 0
+    assert result.remaining_quantity == 75
+    # No correlation tag was supplied, so no lookup should have been attempted.
+    assert fake.correlation_calls == []
+
+
+def test_dhan_transport_failure_recovers_the_order_via_correlation_id(
+    dhan_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """A completely lost placement response is still traceable by tag.
+
+    This is the payoff of sending ``order_tag`` as Dhan's ``correlationId``:
+    the order is found and its real fill reported, instead of the runner being
+    frozen on an avoidable unknown.
+    """
+
+    fake = _FakeDhanSdk(
+        [
+            _transport_failure(),
+            _ok(_status_row("TRADED", 75)),
+        ],
+        correlation_reply=_ok({"orderId": "DH-1", "orderStatus": "TRADED"}),
+    )
+    client = _ready_dhan_client(dhan_module, monkeypatch, fake)
+
+    result = client.place_market_order(DHAN_SYMBOL, "BUY", 75, order_tag="TAG-1")
+
+    assert fake.correlation_calls == ["TAG-1"]
+    assert result.status.name == "FILLED"
+    assert result.order_id == "DH-1"
+    assert result.filled_quantity == 75
+
+
+def test_dhan_transport_failure_stays_unknown_when_lookup_also_fails(
+    dhan_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """Two failed observations still prove nothing about exposure."""
+
+    fake = _FakeDhanSdk(
+        [_transport_failure()],
+        correlation_reply=_transport_failure(),
+    )
+    client = _ready_dhan_client(dhan_module, monkeypatch, fake)
+
+    result = client.place_market_order(DHAN_SYMBOL, "BUY", 75, order_tag="TAG-2")
+
+    assert fake.correlation_calls == ["TAG-2"]
+    assert result.status.name == "UNKNOWN"
+
+
+def test_dhan_server_refusal_confirmed_by_lookup_is_rejected(
+    dhan_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """A structured refusal plus "no such order" is a provable zero fill.
+
+    Only this combination -- Dhan's server answering with an errorCode AND the
+    correlation lookup finding nothing -- earns REJECTED, which is what lets
+    the runner safely fall back to paper for that trade.
+    """
+
+    fake = _FakeDhanSdk([_refused()], correlation_reply=_refused("not found"))
+    client = _ready_dhan_client(dhan_module, monkeypatch, fake)
+
+    result = client.place_market_order(DHAN_SYMBOL, "BUY", 75, order_tag="TAG-3")
+
+    assert result.status.name == "REJECTED"
+    assert result.filled_quantity == 0
+    assert "insufficient margin" in result.reason
+
+
+def test_dhan_server_refusal_that_still_created_an_order_is_not_rejected(
+    dhan_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """If the lookup finds an order, the refusal envelope was misleading."""
+
+    fake = _FakeDhanSdk(
+        [_refused(), _ok(_status_row("TRADED", 75))],
+        correlation_reply=_ok({"orderId": "DH-1", "orderStatus": "TRADED"}),
+    )
+    client = _ready_dhan_client(dhan_module, monkeypatch, fake)
+
+    result = client.place_market_order(DHAN_SYMBOL, "BUY", 75, order_tag="TAG-4")
+
+    assert result.status.name == "FILLED"
+    assert result.order_id == "DH-1"
+
+
+def test_dhan_server_refusal_with_unverifiable_lookup_is_unknown(
+    dhan_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """A refusal we could not corroborate must not become a rejection."""
+
+    fake = _FakeDhanSdk([_refused()], correlation_reply=_transport_failure())
+    client = _ready_dhan_client(dhan_module, monkeypatch, fake)
+
+    result = client.place_market_order(DHAN_SYMBOL, "BUY", 75, order_tag="TAG-5")
+
+    assert result.status.name == "UNKNOWN"
+
+
+def test_dhan_unknown_symbol_is_rejected_without_submitting(
+    dhan_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """Refusing beats guessing: a wrong securityId would trade another contract."""
+
+    fake = _FakeDhanSdk([])
+    client = _ready_dhan_client(dhan_module, monkeypatch, fake)
+
+    result = client.place_market_order("NIFTY-NEVER-RESOLVED-CE", "BUY", 75)
+
+    assert result.status.name == "REJECTED"
+    assert fake.place_calls == []
+    assert "securityId" in result.reason
+
+
+def test_dhan_transmits_execution_ledger_tag_and_order_fields(
+    dhan_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """The tag reaches Dhan as correlationId, and the order is a MARKET order."""
+
+    fake = _FakeDhanSdk(
+        [
+            _ok({"orderId": "DH-TAG", "orderStatus": "TRANSIT"}),
+            _ok(_status_row("TRADED", 75)),
+        ]
+    )
+    client = _ready_dhan_client(dhan_module, monkeypatch, fake)
+
+    client.place_market_order(DHAN_SYMBOL, "BUY", 75, order_tag="STRAT-A1-E1")
+
+    assert len(fake.place_calls) == 1
+    sent = fake.place_calls[0]
+    assert sent["tag"] == "STRAT-A1-E1"
+    assert sent["security_id"] == DHAN_SECURITY_ID
+    assert sent["transaction_type"] == "BUY"
+    assert sent["order_type"] == "MARKET"
+    assert sent["product_type"] == "INTRADAY"
+    assert sent["exchange_segment"] == "NSE_FNO"
+    assert sent["quantity"] == 75
+
+
+def test_dhan_zero_broker_quantity_cannot_confirm_a_fill(
+    dhan_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """A status row disagreeing about size is malformed, not a fill."""
+
+    fake = _FakeDhanSdk(
+        [
+            _ok({"orderId": "DH-QTY", "orderStatus": "TRANSIT"}),
+            _ok(_status_row("TRADED", 75, quantity=10)),
+        ]
+    )
+    client = _ready_dhan_client(dhan_module, monkeypatch, fake)
+
+    result = client.place_market_order(DHAN_SYMBOL, "BUY", 75)
+
+    assert result.status.name == "UNKNOWN"
+    assert result.filled_quantity == 0
+
+
+def test_dhan_cancel_and_reconciliation_queries_are_typed(
+    dhan_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """Cancel returns a typed snapshot; book queries return typed collections."""
+
+    fake = _FakeDhanSdk(
+        [
+            _ok({"orderId": "DH-C1"}),
+            _ok(_status_row("CANCELLED", 0)),
+            _ok(
+                [
+                    {
+                        "orderId": "DH-OPEN",
+                        "orderStatus": "PENDING",
+                        "quantity": 75,
+                        "filledQty": 25,
+                        "tradingSymbol": DHAN_SYMBOL,
+                        "transactionType": "BUY",
+                    },
+                    {
+                        "orderId": "DH-DONE",
+                        "orderStatus": "TRADED",
+                        "quantity": 75,
+                        "filledQty": 75,
+                        "tradingSymbol": DHAN_SYMBOL,
+                        "transactionType": "BUY",
+                    },
+                ]
+            ),
+            _ok(
+                [
+                    {"tradingSymbol": DHAN_SYMBOL, "netQty": 75, "productType": "INTRADAY"},
+                    {"tradingSymbol": "NIFTY-FLAT-PE", "netQty": 0, "productType": "INTRADAY"},
+                ]
+            ),
+        ]
+    )
+    client = _ready_dhan_client(dhan_module, monkeypatch, fake)
+
+    cancelled = client.cancel_order("DH-C1", requested_quantity=75)
+    orders = client.list_open_orders()
+    positions = client.list_open_positions()
+
+    assert cancelled.status.name == "REJECTED"
+    assert fake.cancelled == ["DH-C1"]
+    # Only the still-working order survives; the completed one is filtered out.
+    assert orders.is_indeterminate is False
+    assert [order.order_id for order in orders.items] == ["DH-OPEN"]
+    assert orders.items[0].remaining_quantity == 50
+    # A flat (netQty 0) leg is not an open position.
+    assert positions.is_indeterminate is False
+    assert [position.symbol for position in positions.items] == [DHAN_SYMBOL]
+    assert positions.items[0].quantity == 75
+
+
+def test_dhan_query_failures_are_indeterminate_not_empty(
+    dhan_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """A failed book query must never look like a flat account."""
+
+    fake = _FakeDhanSdk([_transport_failure(), _refused()])
+    client = _ready_dhan_client(dhan_module, monkeypatch, fake)
+
+    orders = client.list_open_orders()
+    positions = client.list_open_positions()
+
+    assert orders.is_indeterminate is True
+    assert positions.is_indeterminate is True
+
+
+def test_dhan_successful_empty_queries_are_distinct_from_failure(
+    dhan_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """A genuinely empty book is a success, not an indeterminate result."""
+
+    fake = _FakeDhanSdk([_ok([]), _ok([])])
+    client = _ready_dhan_client(dhan_module, monkeypatch, fake)
+
+    orders = client.list_open_orders()
+    positions = client.list_open_positions()
+
+    assert orders.items == () and orders.is_indeterminate is False
+    assert positions.items == () and positions.is_indeterminate is False
+
+
+def test_dhan_deadline_constants_are_exactly_ten_seconds(
+    dhan_module: ModuleType,
+) -> None:
+    """The SDK boundary is ten seconds and physically single-threaded."""
+
+    client = dhan_module.DhanExecutionClient()
+    assert dhan_module._API_TIMEOUT_SECONDS == 10.0
+    assert dhan_module._BROKER_CALL_DEADLINE_SECONDS == 10.0
+    assert client._sdk_executor._max_workers == 1
+
+
+def test_dhan_login_overrides_the_sdk_sixty_second_timeout(
+    dhan_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """The SDK ships a 60s default; leaving it would blow the 10s budget.
+
+    ``DhanContext.__init__`` also swallows its own exceptions, so the adapter
+    must verify the HTTP layer exists rather than assume it.
+    """
+
+    class _Http:
+        timeout = 60
+
+    class _Context:
+        def __init__(self, client_id, access_token) -> None:
+            self.http = _Http()
+
+        def get_dhan_http(self):
+            return self.http
+
+    contexts: list[_Context] = []
+
+    def make_context(client_id, access_token):
+        context = _Context(client_id, access_token)
+        contexts.append(context)
+        return context
+
+    monkeypatch.setenv("DHAN_CLIENT_CODE", "1000000001")
+    monkeypatch.setenv("DHAN_ACCESS_TOKEN", "not-a-real-token")
+    monkeypatch.setattr(dhan_module, "DhanContext", make_context)
+    monkeypatch.setattr(dhan_module, "dhanhq", lambda context: _FakeDhanSdk([_ok({})]))
+
+    client = dhan_module.DhanExecutionClient()
+
+    assert client.ensure_logged_in() is True
+    assert contexts[0].http.timeout == 10.0
+
+
+def test_dhan_login_fails_closed_on_half_built_context(
+    dhan_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """A DhanContext that swallowed its own error must not reach an order."""
+
+    class _BrokenContext:
+        def __init__(self, client_id, access_token) -> None:
+            pass
+
+        def get_dhan_http(self):
+            return None
+
+    monkeypatch.setenv("DHAN_CLIENT_CODE", "1000000001")
+    monkeypatch.setenv("DHAN_ACCESS_TOKEN", "not-a-real-token")
+    monkeypatch.setattr(dhan_module, "DhanContext", _BrokenContext)
+
+    client = dhan_module.DhanExecutionClient()
+
+    assert client.ensure_logged_in() is False
+    assert client.client is None
+
+
+def test_dhan_login_fails_closed_without_credentials(
+    dhan_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """Missing credentials disable live trading instead of raising."""
+
+    monkeypatch.delenv("DHAN_CLIENT_CODE", raising=False)
+    monkeypatch.delenv("DHAN_ACCESS_TOKEN", raising=False)
+
+    client = dhan_module.DhanExecutionClient()
+
+    assert client.ensure_logged_in() is False
+
+
+def test_dhan_total_deadline_includes_lock_wait(
+    dhan_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """Waiting for the shared session lock cannot exceed the broker budget."""
+
+    fake = _FakeDhanSdk([_ok({})])
+    client = _ready_dhan_client(dhan_module, monkeypatch, fake)
+    monkeypatch.setattr(dhan_module, "_BROKER_CALL_DEADLINE_SECONDS", 0.05)
+    monkeypatch.setattr(client._api_limiter, "acquire", lambda *_a, **_k: None)
+
+    locked = threading.Event()
+    release = threading.Event()
+
+    def hold_lock() -> None:
+        with client._lock:
+            locked.set()
+            release.wait(0.4)
+
+    holder = threading.Thread(target=hold_lock)
+    holder.start()
+    assert locked.wait(0.2)
+    started = time.monotonic()
+    try:
+        with pytest.raises(TimeoutError, match="lock"):
+            client._call_api("fund limits", lambda sdk: sdk.get_fund_limits())
+    finally:
+        release.set()
+        holder.join(timeout=1)
+    assert time.monotonic() - started < 0.25
+
+
+def test_dhan_total_deadline_includes_rate_limiter_lock_wait(
+    dhan_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """A stuck limiter mutex cannot postpone dispatch past the deadline."""
+
+    class _NeverCalled(_FakeDhanSdk):
+        def get_fund_limits(self):
+            raise AssertionError("SDK must not start after limiter deadline")
+
+    fake = _NeverCalled([])
+    client = _ready_dhan_client(dhan_module, monkeypatch, fake)
+    monkeypatch.setattr(dhan_module, "_BROKER_CALL_DEADLINE_SECONDS", 0.05)
+
+    locked = threading.Event()
+    release = threading.Event()
+
+    def hold_limiter_lock() -> None:
+        with client._api_limiter._lock:
+            locked.set()
+            release.wait(0.4)
+
+    holder = threading.Thread(target=hold_limiter_lock)
+    holder.start()
+    assert locked.wait(0.2)
+    started = time.monotonic()
+    try:
+        with pytest.raises(TimeoutError, match="limiter lock"):
+            client._call_api("fund limits", lambda sdk: sdk.get_fund_limits())
+    finally:
+        release.set()
+        holder.join(timeout=1)
+    assert time.monotonic() - started < 0.25
+
+
+def test_dhan_slow_response_poisons_the_session_until_reconciliation(
+    dhan_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """An abandoned in-flight call blocks new orders until it has ended."""
+
+    release = threading.Event()
+
+    class _SlowSdk(_FakeDhanSdk):
+        def get_fund_limits(self):
+            release.wait(0.5)
+            return _ok({})
+
+    fake = _SlowSdk([])
+    client = _ready_dhan_client(dhan_module, monkeypatch, fake)
+    monkeypatch.setattr(dhan_module, "_BROKER_CALL_DEADLINE_SECONDS", 0.05)
+    monkeypatch.setattr(client._api_limiter, "acquire", lambda *_a, **_k: None)
+
+    try:
+        with pytest.raises(TimeoutError, match="broker deadline"):
+            client._call_api("fund limits", lambda sdk: sdk.get_fund_limits())
+        assert client._sdk_poisoned is True
+        # A poisoned session refuses new orders outright.
+        blocked = client.place_market_order(DHAN_SYMBOL, "BUY", 75)
+        assert blocked.status.name == "UNKNOWN"
+        assert blocked.broker_state == "SESSION_POISONED"
+        # Recovery is refused while the abandoned call is still running.
+        assert client.recover_after_reconciliation() is False
+    finally:
+        release.set()
+    client._timed_out_future.result(timeout=1)
+    assert client.recover_after_reconciliation() is True

--- a/Dependencies/test_broker_contract.py
+++ b/Dependencies/test_broker_contract.py
@@ -1603,6 +1603,35 @@ def test_vendored_noren_preserves_non_ok_payloads(
     assert positions == payload
 
 
+class _FakeStreamingResponse:
+    """Model a streamed ``requests`` response, not the old ``.text`` shape.
+
+    The Kotak scrip-master download streams so it can log how far a transfer
+    got before a deadline expired, which means the doubles have to support the
+    context-manager + ``iter_content`` protocol the real response provides.
+    """
+
+    encoding = "utf-8"
+
+    def __init__(self, body: str, chunk_size: int = 64) -> None:
+        self._payload = body.encode("utf-8")
+        self._chunk_size = chunk_size
+
+    def __enter__(self) -> _FakeStreamingResponse:
+        return self
+
+    def __exit__(self, *_exc_info: object) -> bool:
+        return False
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def iter_content(self, chunk_size: int = 0):
+        step = chunk_size or self._chunk_size
+        for start in range(0, len(self._payload), step):
+            yield self._payload[start : start + step]
+
+
 @pytest.fixture(scope="module")
 def kotak_module() -> ModuleType:
     """Return a private copy of the Kotak adapter; calls use behavioral fakes."""
@@ -1967,19 +1996,13 @@ def test_kotak_scrip_master_download_has_total_deadline(
         def scrip_master(self, exchange_segment):
             return "https://example.invalid/nfo.csv"
 
-    class _SlowResponse:
-        text = (
-            "pExpiryDate,pSymbolName,pOptionType,dStrikePrice;,pTrdSymbol\n"
-            "0,NIFTY,CE,2250000,NIFTY-TEST\n"
-        )
-
-        def raise_for_status(self):
-            return None
-
     def slow_get(*args, **kwargs):
         started.set()
         release.wait(0.5)
-        return _SlowResponse()
+        return _FakeStreamingResponse(
+            "pExpiryDate,pSymbolName,pOptionType,dStrikePrice;,pTrdSymbol\n"
+            "0,NIFTY,CE,2250000,NIFTY-TEST\n"
+        )
 
     client = _ready_kotak_client(kotak_module, monkeypatch, ScripKotak())
     # The download runs on its own budget now, so shrink THAT one; the order
@@ -2492,18 +2515,17 @@ def test_kotak_scrip_master_resolution_and_miss_diagnostics(
             assert exchange_segment == "nse_fo"
             return "https://example.invalid/nfo.csv"
 
-    class Response:
-        text = (
-            "pExpiryDate,pSymbolName,pOptionType,dStrikePrice;,pTrdSymbol\n"
-            f"{encoded_expiry},NIFTY,CE,2250000,NIFTY26JUL22500CE\n"
-        )
-
-        @staticmethod
-        def raise_for_status() -> None:
-            return None
+    csv_body = (
+        "pExpiryDate,pSymbolName,pOptionType,dStrikePrice;,pTrdSymbol\n"
+        f"{encoded_expiry},NIFTY,CE,2250000,NIFTY26JUL22500CE\n"
+    )
 
     client = _ready_kotak_client(kotak_module, monkeypatch, ScripKotak())
-    monkeypatch.setattr(kotak_module.requests, "get", lambda *args, **kwargs: Response())
+    monkeypatch.setattr(
+        kotak_module.requests,
+        "get",
+        lambda *args, **kwargs: _FakeStreamingResponse(csv_body),
+    )
 
     assert client.preload_scrip_master() is True
     assert client.preload_scrip_master() is True

--- a/Dependencies/test_broker_contract.py
+++ b/Dependencies/test_broker_contract.py
@@ -42,6 +42,31 @@ _neo_api_test_module.NeoAPI = _NeoApiTestDouble
 sys.modules["neo_api_client"] = _neo_api_test_module
 
 
+class _DhanhqTestDouble:
+    """Import-only stand-in; behavioral tests inject their own SDK clients."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        self.args = args
+        self.kwargs = kwargs
+
+
+# ``dhanhq`` differs from Kotak's SDK: it is a CORE dependency (it also serves
+# market data), so the main quality job HAS the real package and other suites in
+# the same pytest process bind names from it.  The isolated broker-dependency
+# job installs requirements-brokers.txt alone, where it is deliberately absent.
+#
+# Hence the conditional: stand in only when the real package is genuinely
+# missing.  Clobbering an installed core dependency for every run would be a
+# latent trap for whichever suite happens to import it next.
+try:  # pragma: no cover - which branch runs depends on the CI environment
+    import dhanhq as _installed_dhanhq  # noqa: F401
+except ModuleNotFoundError:
+    _dhanhq_test_module = ModuleType("dhanhq")
+    _dhanhq_test_module.DhanContext = _DhanhqTestDouble
+    _dhanhq_test_module.dhanhq = _DhanhqTestDouble
+    sys.modules["dhanhq"] = _dhanhq_test_module
+
+
 def _load_file_module(name: str, relative_path: str) -> ModuleType:
     """Load a broker helper whose parent folder contains spaces."""
 
@@ -2903,6 +2928,22 @@ def _ready_dhan_client(dhan_module: ModuleType, monkeypatch, fake):
     monkeypatch.setattr(client, "ensure_logged_in", lambda: True)
     monkeypatch.setattr(dhan_module, "_FILL_POLL_INTERVAL", 0.001)
     return client
+
+
+def test_dhan_adapter_loads_without_an_installed_sdk(
+    dhan_module: ModuleType,
+) -> None:
+    """The adapter must import in the SDK-free broker-dependency job.
+
+    That job installs requirements-brokers.txt alone, so ``dhanhq`` is absent
+    and the import-only double above stands in; the core quality job has the
+    real package and uses it as-is.  Either way the module must load, because
+    every behavioral test replaces ``client`` with its own broker-shaped fake
+    and none of them exercise the real SDK.
+    """
+
+    assert dhan_module.DhanContext is sys.modules["dhanhq"].DhanContext
+    assert callable(dhan_module.dhanhq)
 
 
 @pytest.mark.parametrize(

--- a/Dependencies/test_broker_contract.py
+++ b/Dependencies/test_broker_contract.py
@@ -16,6 +16,7 @@ import importlib
 import importlib.util
 import io
 import json
+import logging
 import re
 import subprocess  # nosec B404 - used only to import this repo's own adapters
 import sys
@@ -3487,6 +3488,98 @@ def test_dhan_login_fails_closed_without_credentials(
     client = dhan_module.DhanExecutionClient()
 
     assert client.ensure_logged_in() is False
+
+
+def test_dhan_login_failure_never_logs_the_access_token(
+    dhan_module: ModuleType,
+    monkeypatch,
+    caplog,
+) -> None:
+    """MAT-108 parity: a token-bearing construction error must be redacted.
+
+    The exception message here deliberately does NOT look like a
+    ``token=value`` assignment, so only the known-secret replacement can
+    scrub it -- proving the adapter passes the real token to ``redact_text``
+    rather than relying on the pattern pass getting lucky.
+    """
+
+    canary = "CANARY-DHAN-ACCESS-TOKEN"
+
+    class _LeakyContext:
+        def __init__(self, client_id, access_token) -> None:
+            raise RuntimeError(f"handshake rejected for {access_token} by gateway")
+
+    monkeypatch.setenv("DHAN_CLIENT_CODE", "1000000001")
+    monkeypatch.setenv("DHAN_ACCESS_TOKEN", canary)
+    monkeypatch.setattr(dhan_module, "DhanContext", _LeakyContext)
+
+    client = dhan_module.DhanExecutionClient()
+    with caplog.at_level(logging.ERROR):
+        assert client.ensure_logged_in() is False
+
+    assert canary not in caplog.text
+    assert "<redacted>" in caplog.text
+
+
+def test_dhan_logout_clears_local_session_state(
+    dhan_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """Logout is local-only: close the pool and erase every session cache."""
+
+    class _Session:
+        def __init__(self) -> None:
+            self.closed = 0
+
+        def close(self) -> None:
+            self.closed += 1
+
+    class _Http:
+        def __init__(self) -> None:
+            self.session = _Session()
+
+    class _Context:
+        def __init__(self) -> None:
+            self.http = _Http()
+
+        def get_dhan_http(self):
+            return self.http
+
+    client = _ready_dhan_client(dhan_module, monkeypatch, _FakeDhanSdk([]))
+    context = _Context()
+    client._context = context
+    client._symbol_cache[("NIFTY",)] = DHAN_SYMBOL
+
+    result = client.logout()
+
+    assert result["status"] == "success"
+    assert context.http.session.closed == 1
+    assert client.is_logged_in is False
+    assert client.client is None
+    assert client._context is None
+    assert client._symbol_cache == {}
+    assert client._security_id_by_symbol == {}
+    assert client._scrip_df is None
+
+
+def test_dhan_logout_survives_a_failing_session_close(
+    dhan_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """A pool that will not close still ends with a cleared local session."""
+
+    class _BrokenContext:
+        def get_dhan_http(self):
+            raise RuntimeError("connection pool already torn down")
+
+    client = _ready_dhan_client(dhan_module, monkeypatch, _FakeDhanSdk([]))
+    client._context = _BrokenContext()
+
+    result = client.logout()
+
+    assert result["status"] == "success"
+    assert client.client is None
+    assert client.is_logged_in is False
 
 
 def test_dhan_total_deadline_includes_lock_wait(

--- a/Dependencies/test_broker_contract.py
+++ b/Dependencies/test_broker_contract.py
@@ -2,6 +2,12 @@
 
 These tests stay entirely in memory.  They never construct a real broker
 session, enable a live-trading flag, or make a network request.
+
+One deliberate exception: ``test_adapter_imports_under_its_diagnostic_search_path``
+spawns a short-lived subprocess per adapter.  ``sys.path`` semantics cannot be
+tested faithfully in-process without polluting the running interpreter, and that
+search path is precisely what the test exists to pin down.  Those subprocesses
+still only import a module -- no session, no flag, no network.
 """
 
 from __future__ import annotations
@@ -10,6 +16,8 @@ import importlib
 import importlib.util
 import io
 import json
+import re
+import subprocess
 import sys
 import threading
 import time
@@ -392,6 +400,71 @@ def test_execution_client_protocol_covers_reconciliation_surface() -> None:
             return {}
 
     assert isinstance(CompleteFakeClient(), contract.ExecutionClient)
+
+
+@pytest.mark.parametrize(
+    ("relative_dir", "module_name"),
+    [
+        ("Dependencies/Kotak API", "kotak_execution"),
+        ("Dependencies/Shoonya API", "shoonya_execution"),
+        ("Dependencies/Flattrade API", "flattrade_execution"),
+        ("Dependencies/Dhan API", "dhan_execution"),
+    ],
+)
+def test_adapter_imports_under_its_diagnostic_search_path(
+    relative_dir: str,
+    module_name: str,
+) -> None:
+    """Every adapter must import the way its sibling diagnostic launches it.
+
+    ``python <script>`` puts the SCRIPT's directory on ``sys.path[0]`` and never
+    the working directory.  So an adapter that reaches for ``Dependencies.<x>``
+    has to put the repo ROOT on the path itself -- adding only ``Dependencies``
+    is not enough, because that import needs the package's PARENT.
+
+    This is a regression guard: MAT-108 added
+    ``from Dependencies.secret_redaction import ...`` to the Kotak and Shoonya
+    adapters ABOVE their ``sys.path`` setup, which broke both diagnostics -- run
+    directly and through ``algo.py diagnose`` -- with "No module named
+    'Dependencies'".  The runner never noticed because it is launched from the
+    repo root, and no test imported an adapter under a diagnostic's search path.
+
+    A genuinely absent optional broker SDK is a different thing and is
+    tolerated: CI deliberately runs one job without ``dhanhq`` and another
+    without ``neo_api_client``.
+    """
+
+    # Rebuild the interpreter's search path exactly as `python <script>` would:
+    # the script's own directory first, with '' and the CWD removed so the repo
+    # root cannot leak in and mask the bug.
+    probe = (
+        "import os, sys\n"
+        "cwd = os.getcwd()\n"
+        f"sys.path[:] = [{str(ROOT / relative_dir)!r}]"
+        " + [p for p in sys.path if p not in ('', cwd)]\n"
+        f"import {module_name}\n"
+        "print('IMPORT OK')\n"
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", probe],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    output = completed.stdout + completed.stderr
+
+    assert "No module named 'Dependencies'" not in output, (
+        f"{module_name} cannot import under its diagnostic's search path; the "
+        f"repo root is missing from sys.path.\n{output}"
+    )
+    if "IMPORT OK" in output:
+        return
+    absent_module = re.search(r"No module named '([\w.]+)'", output)
+    if absent_module is None:
+        pytest.fail(f"{module_name} failed to import:\n{output}")
+    pytest.skip(f"optional broker SDK {absent_module.group(1)!r} is not installed")
 
 
 @pytest.fixture(scope="module")

--- a/Dependencies/test_broker_contract.py
+++ b/Dependencies/test_broker_contract.py
@@ -17,7 +17,7 @@ import importlib.util
 import io
 import json
 import re
-import subprocess
+import subprocess  # nosec B404 - used only to import this repo's own adapters
 import sys
 import threading
 import time
@@ -445,7 +445,9 @@ def test_adapter_imports_under_its_diagnostic_search_path(
         f"import {module_name}\n"
         "print('IMPORT OK')\n"
     )
-    completed = subprocess.run(
+    # nosec B603 - argv is [sys.executable, "-c", <literal built from ROOT and a
+    # hard-coded parametrize entry>]; no shell, and no external input reaches it.
+    completed = subprocess.run(  # nosec B603
         [sys.executable, "-c", probe],
         cwd=ROOT,
         capture_output=True,

--- a/Dependencies/test_dhan_token_setup.py
+++ b/Dependencies/test_dhan_token_setup.py
@@ -1,0 +1,69 @@
+"""Tests for the token-expiry advisory in the Dhan OAuth setup script.
+
+The three weekday messages steer a live operator's next action, so each case
+is locked in: mid-session expiry warns loudly, pre-open expiry gets the calmer
+"session not covered" note, and post-close expiry is reported as the good
+outcome.  Timestamps are built from the LOCAL clock (the same clock the helper
+renders with), which keeps the tests deterministic on an IST box and on a UTC
+CI runner alike.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from datetime import datetime, timedelta
+
+from Dependencies.dhan_token_setup import _describe_token_expiry
+
+
+def _token_with_exp(expires_at: datetime) -> str:
+    """Build a JWT-shaped token whose middle segment carries ``exp``."""
+    payload = (
+        base64.urlsafe_b64encode(
+            json.dumps({"exp": int(expires_at.timestamp())}).encode("utf-8")
+        )
+        .decode("ascii")
+        .rstrip("=")
+    )
+    return f"header.{payload}.signature"
+
+
+def _upcoming_weekday_at(hour: int, minute: int, *, weekday: int = 0) -> datetime:
+    """Return the NEXT occurrence of ``weekday`` (0=Monday) at HH:MM local time."""
+    now = datetime.now().astimezone()
+    days_ahead = (weekday - now.weekday()) % 7 or 7
+    return (now + timedelta(days=days_ahead)).replace(
+        hour=hour, minute=minute, second=0, microsecond=0
+    )
+
+
+def test_mid_session_weekday_expiry_warns_during_market_hours():
+    expiry = _upcoming_weekday_at(11, 0)
+    text = _describe_token_expiry(_token_with_exp(expiry))
+    assert "DURING market hours" in text
+
+
+def test_pre_open_weekday_expiry_notes_uncovered_session_not_market_hours():
+    expiry = _upcoming_weekday_at(8, 0)
+    text = _describe_token_expiry(_token_with_exp(expiry))
+    assert "DURING market hours" not in text
+    assert "BEFORE that day's 09:15 open" in text
+
+
+def test_post_close_weekday_expiry_reports_the_session_as_covered():
+    expiry = _upcoming_weekday_at(17, 0)
+    text = _describe_token_expiry(_token_with_exp(expiry))
+    assert "DURING market hours" not in text
+    assert "covers that" in text
+
+
+def test_weekend_expiry_carries_no_session_message():
+    expiry = _upcoming_weekday_at(11, 0, weekday=6)  # next Sunday, mid-day
+    text = _describe_token_expiry(_token_with_exp(expiry))
+    assert text.startswith("Token expires ")
+    assert "\n" not in text
+
+
+def test_non_jwt_token_degrades_to_an_unknown_validity_note():
+    assert "unknown" in _describe_token_expiry("not-a-jwt")

--- a/Dependencies/test_diagnostic_preflight.py
+++ b/Dependencies/test_diagnostic_preflight.py
@@ -1,0 +1,113 @@
+"""Tests for the pre-flight checks shared by every broker diagnostic.
+
+Entirely in memory: these helpers take plain numbers and never touch a broker
+session, which is the point of keeping them separate from the adapters.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load(name: str, relative_path: str) -> ModuleType:
+    """Load a module whose folder may contain spaces."""
+
+    spec = importlib.util.spec_from_file_location(name, ROOT / relative_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+preflight = _load("preflight_under_test", "Dependencies/diagnostic_preflight.py")
+
+
+@pytest.mark.parametrize(
+    ("quantity", "lot_size", "rejected"),
+    [
+        # The exact case that produced Dhan's misleading "Invalid IP" message.
+        (1, 65, True),
+        (64, 65, True),
+        (66, 65, True),
+        (100, 65, True),
+        (65, 65, False),      # one lot
+        (130, 65, False),     # two lots
+        (30, 30, False),      # BankNIFTY lot
+        (75, 25, False),      # three lots of a smaller contract
+    ],
+)
+def test_quantity_must_be_a_whole_lot_multiple(
+    quantity: int,
+    lot_size: int,
+    rejected: bool,
+) -> None:
+    message = preflight.validate_quantity_for_lot(quantity, lot_size)
+
+    assert bool(message) is rejected
+    if rejected:
+        # The operator needs the lot size to fix the command, not just a refusal.
+        assert str(lot_size) in message
+        assert str(lot_size * 2) in message
+
+
+@pytest.mark.parametrize("lot_size", [0, -1, -65])
+def test_unknown_lot_size_never_blocks_an_order(lot_size: int) -> None:
+    """Missing catalogue metadata must not veto a good order.
+
+    Kotak's lot column name varies by master revision and a Shoonya master
+    without one leaves the map empty; in both cases the broker stays the
+    authority rather than this local check.
+    """
+
+    assert preflight.validate_quantity_for_lot(1, lot_size) == ""
+    assert preflight.validate_quantity_for_lot(65, lot_size) == ""
+
+
+@pytest.mark.parametrize(
+    ("quantity", "lot_size"),
+    [("65", 65), (65, "65"), ("abc", 65), (65, "abc"), (None, 65), (65, None)],
+)
+def test_unparseable_values_are_not_treated_as_violations(
+    quantity: object,
+    lot_size: object,
+) -> None:
+    """Garbage in means "cannot check", never a false refusal.
+
+    Each diagnostic parses --qty its own way (argparse for Flattrade/Dhan, hand
+    rolled for Kotak/Shoonya), so this helper takes whatever they hand it.
+    """
+
+    message = preflight.validate_quantity_for_lot(quantity, lot_size)  # type: ignore[arg-type]
+
+    assert message == "" or "not a multiple" in message
+
+
+def test_every_diagnostic_uses_the_shared_check() -> None:
+    """All four diagnostics must share one implementation, not copies.
+
+    The guard existed only in the Dhan diagnostic first; duplicating it per
+    broker is exactly how the four would drift apart.
+    """
+
+    diagnostics = {
+        "kotak": "Dependencies/Kotak API/diagnose_kotak_symbol.py",
+        "shoonya": "Dependencies/Shoonya API/diagnose_shoonya_symbol.py",
+        "flattrade": "Dependencies/Flattrade API/diagnose_flattrade_symbol.py",
+        "dhan": "Dependencies/Dhan API/diagnose_dhan_symbol.py",
+    }
+    for broker, relative_path in diagnostics.items():
+        source = (ROOT / relative_path).read_text(encoding="utf-8")
+        assert "from diagnostic_preflight import validate_quantity_for_lot" in source, (
+            f"{broker} diagnostic does not import the shared quantity check"
+        )
+        assert "validate_quantity_for_lot(" in source, (
+            f"{broker} diagnostic imports the shared check but never calls it"
+        )

--- a/Dependencies/test_execution_ledger.py
+++ b/Dependencies/test_execution_ledger.py
@@ -12,6 +12,7 @@ from Dependencies.broker_contract import OrderResult, OrderStatus
 from Dependencies.execution_ledger import (
     ExecutionLedger,
     LegSpec,
+    OrderAttemptHandle,
     OrderIntent,
     build_order_tag,
 )
@@ -513,3 +514,189 @@ def test_public_states_are_immutable_coherent_snapshots() -> None:
     assert filled.confirmed_live_quantity == 50
     assert ledger.get(filled.exposure_id) == filled
     assert ledger.active_states() == (filled,)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("strategy", " ", "strategy"),
+        ("correlation_id", "SHORT", "correlation_id"),
+        ("role", "NN", "role"),
+        ("role", "_", "role"),
+        ("underlying", "", "underlying and symbol"),
+        ("symbol", "", "underlying and symbol"),
+        ("option_type", "CALL", "option_type"),
+        ("opening_side", "HOLD", "opening_side"),
+        ("owner_id", "SHORT", "owner_id"),
+    ],
+)
+def test_leg_identity_fields_fail_closed(
+    field: str,
+    value: object,
+    message: str,
+) -> None:
+    kwargs: dict[str, object] = {
+        "strategy": " HeikinAshi ",
+        "correlation_id": "4f8d2q7j",
+        "role": "n",
+        "underlying": "nifty",
+        "symbol": " NIFTY-22500-CE ",
+        "option_type": "ce",
+        "strike": 22500.0,
+        "expiry": date(2026, 7, 16),
+        "opening_side": "buy",
+        "target_quantity": 50,
+        "owner_id": "",
+    }
+    kwargs[field] = value
+    with pytest.raises(ValueError, match=message):
+        LegSpec(**kwargs)  # type: ignore[arg-type]
+
+
+def test_leg_identity_is_normalized_once_at_registration() -> None:
+    spec = LegSpec(
+        strategy=" HeikinAshi ",
+        correlation_id="4f8d2q7j",
+        role="n",
+        underlying="nifty",
+        symbol=" NIFTY-22500-CE ",
+        option_type="ce",
+        strike=22500.0,
+        expiry=date(2026, 7, 16),
+        opening_side="buy",
+        target_quantity=50,
+        owner_id="8a7b6c5d",
+    )
+    assert spec.strategy == "HeikinAshi"
+    assert spec.correlation_id == "4F8D2Q7J"
+    assert spec.role == "N"
+    assert spec.underlying == "NIFTY"
+    assert spec.symbol == "NIFTY-22500-CE"
+    assert spec.option_type == "CE"
+    assert spec.opening_side == "BUY"
+    assert spec.owner_id == "8A7B6C5D"
+
+
+def test_registered_state_has_no_attempt_handle_and_no_safe_close() -> None:
+    state = ExecutionLedger().register(_spec())
+    assert state.latest_attempt_handle is None
+    assert state.safe_close_retry_quantity == 0
+
+
+@pytest.mark.parametrize(
+    ("args", "message"),
+    [
+        (("", "4F8D2Q7J", "N", "E", 1), "strategy"),
+        (("HeikinAshi", "SHORT", "N", "E", 1), "correlation_id"),
+        (("HeikinAshi", "4F8D2Q7J", "NN", "E", 1), "role"),
+        (("HeikinAshi", "4F8D2Q7J", "N", "_", 1), "phase"),
+        (("HeikinAshi", "4F8D2Q7J", "N", "E", True), "attempt"),
+        (("HeikinAshi", "4F8D2Q7J", "N", "E", 0), "attempt"),
+    ],
+)
+def test_order_tag_inputs_are_strict(
+    args: tuple[object, ...],
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        build_order_tag(*args)  # type: ignore[arg-type]
+
+
+def test_completed_correlation_cannot_be_reused() -> None:
+    ledger = ExecutionLedger()
+    leg = ledger.register(_spec())
+    attempt = ledger.start_attempt(leg.exposure_id, OrderIntent.OPEN, 50)
+    ledger.apply_result(
+        attempt,
+        _result(
+            order_id="REJECTED",
+            requested=50,
+            filled=0,
+            status=OrderStatus.REJECTED,
+            broker_state="REJECTED",
+        ),
+    )
+    with pytest.raises(ValueError, match="already belongs"):
+        ledger.register(_spec())
+
+
+def test_start_attempt_rejects_invalid_intent_quantity_and_overlap() -> None:
+    ledger = ExecutionLedger()
+    leg = ledger.register(_spec())
+    with pytest.raises(ValueError, match="intent"):
+        ledger.start_attempt(leg.exposure_id, "OPEN", 50)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="safe retry quantity"):
+        ledger.start_attempt(leg.exposure_id, OrderIntent.OPEN, 25)
+
+    ledger.start_attempt(leg.exposure_id, OrderIntent.OPEN, 50)
+    with pytest.raises(RuntimeError, match="previous order attempt"):
+        ledger.start_attempt(leg.exposure_id, OrderIntent.OPEN, 50)
+
+
+def test_apply_result_rejects_wrong_types_and_missing_attempt() -> None:
+    ledger = ExecutionLedger()
+    leg = ledger.register(_spec())
+    handle = OrderAttemptHandle(leg.exposure_id, 1, "M2-ABC-4F8D2Q7J-NE01")
+    result = _result(
+        order_id="OPEN",
+        requested=50,
+        filled=0,
+        status=OrderStatus.UNKNOWN,
+        broker_state="OPEN",
+    )
+    with pytest.raises(ValueError, match="handle"):
+        ledger.apply_result("bad", result)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="result"):
+        ledger.apply_result(handle, object())  # type: ignore[arg-type]
+    with pytest.raises(RuntimeError, match="before start_attempt"):
+        ledger.apply_result(handle, result)
+
+
+def test_apply_result_rejects_changed_request_order_id_and_backwards_fill() -> None:
+    ledger = ExecutionLedger()
+    leg = ledger.register(_spec())
+    attempt = ledger.start_attempt(leg.exposure_id, OrderIntent.OPEN, 50)
+    ledger.apply_result(
+        attempt,
+        _result(
+            order_id="OPEN-1",
+            requested=50,
+            filled=20,
+            status=OrderStatus.PARTIAL,
+            broker_state="PARTIAL",
+        ),
+    )
+
+    with pytest.raises(ValueError, match="requested quantity changed"):
+        ledger.apply_result(
+            attempt,
+            _result(
+                order_id="OPEN-1",
+                requested=40,
+                filled=20,
+                status=OrderStatus.PARTIAL,
+                broker_state="PARTIAL",
+            ),
+        )
+    with pytest.raises(ValueError, match="order id changed"):
+        ledger.apply_result(
+            attempt,
+            _result(
+                order_id="OPEN-2",
+                requested=50,
+                filled=20,
+                status=OrderStatus.PARTIAL,
+                broker_state="PARTIAL",
+            ),
+        )
+    with pytest.raises(ValueError, match="moved backwards"):
+        ledger.apply_result(
+            attempt,
+            _result(
+                order_id="OPEN-1",
+                requested=50,
+                filled=10,
+                status=OrderStatus.PARTIAL,
+                broker_state="PARTIAL",
+            ),
+        )

--- a/Dependencies/test_next_open_entry.py
+++ b/Dependencies/test_next_open_entry.py
@@ -132,3 +132,77 @@ def test_nonfinite_observed_open_is_not_rebased() -> None:
         is None
     )
     assert pending.expires_at - pending.expected_open_at == timedelta(minutes=5)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("direction", "SIDEWAYS", "direction"),
+        ("signal_at", "2026-07-16", "signal_at"),
+        ("timeframe_minutes", True, "timeframe_minutes"),
+        ("timeframe_minutes", 0, "timeframe_minutes"),
+        ("entry", True, "finite positive"),
+        ("stop", "bad", "finite positive"),
+        ("target", float("nan"), "finite positive"),
+    ],
+)
+def test_invalid_setup_types_and_prices_fail_closed(
+    field: str,
+    value: object,
+    message: str,
+) -> None:
+    kwargs: dict[str, object] = {
+        "direction": "LONG",
+        "signal_at": datetime(2026, 7, 16, 10, 0),
+        "entry": 100.0,
+        "stop": 95.0,
+        "target": 110.0,
+        "timeframe_minutes": 5,
+    }
+    kwargs[field] = value
+    with pytest.raises(ValueError, match=message):
+        PendingNextOpenEntry.from_setup(**kwargs)  # type: ignore[arg-type]
+
+
+def test_expiry_rejects_a_nondatetime_observation() -> None:
+    pending = PendingNextOpenEntry.from_setup(
+        direction="LONG",
+        signal_at=datetime(2026, 7, 16, 10, 0),
+        entry=100.0,
+        stop=95.0,
+        target=110.0,
+        timeframe_minutes=5,
+    )
+    with pytest.raises(ValueError, match="observed_at"):
+        pending.expired_as_of("2026-07-16")  # type: ignore[arg-type]
+
+
+def test_rebase_rejects_nondatetime_and_nonpositive_observed_open() -> None:
+    pending = PendingNextOpenEntry.from_setup(
+        direction="LONG",
+        signal_at=datetime(2026, 7, 16, 10, 0),
+        entry=100.0,
+        stop=95.0,
+        target=110.0,
+        timeframe_minutes=5,
+    )
+    assert pending.rebase_at_open(observed_at="bad", observed_entry=100.0) is None  # type: ignore[arg-type]
+    assert pending.rebase_at_open(observed_at=pending.expected_open_at, observed_entry=0) is None
+
+
+def test_large_gap_that_would_create_a_nonpositive_stop_is_rejected() -> None:
+    pending = PendingNextOpenEntry.from_setup(
+        direction="LONG",
+        signal_at=datetime(2026, 7, 16, 10, 0),
+        entry=100.0,
+        stop=1.0,
+        target=110.0,
+        timeframe_minutes=5,
+    )
+    assert (
+        pending.rebase_at_open(
+            observed_at=pending.expected_open_at,
+            observed_entry=50.0,
+        )
+        is None
+    )

--- a/Dependencies/test_repository_policy.py
+++ b/Dependencies/test_repository_policy.py
@@ -1,0 +1,113 @@
+"""Regression tests for MAT-110 dependency and CI policy.
+
+These checks keep the safety controls reviewable in ordinary pytest runs. They
+do not contact package indexes or GitHub; they only validate committed policy.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tomllib
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def _requirement_lines(name: str) -> list[str]:
+    return [
+        line.strip()
+        for line in (ROOT / name).read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+
+
+def test_optional_dependency_sets_are_exact_and_kotak_uses_official_tag():
+    core = _requirement_lines("requirements.txt")
+    ai = _requirement_lines("requirements-ai.txt")
+    brokers = _requirement_lines("requirements-brokers.txt")
+
+    assert "requests==2.33.0" in core
+    assert "python-dotenv==1.2.2" in core
+    # The full quality job imports the vendored Shoonya client while measuring
+    # broker-adapter coverage, so its import-time WebSocket dependency belongs
+    # in the core test/runtime environment as well as the isolated broker set.
+    assert "websocket-client==1.8.0" in core
+    assert "claude-agent-sdk==0.2.115" in ai
+    assert "pydantic==2.13.4" in ai
+    assert all("==" in line for line in ai)
+    assert "pyotp==2.9.0" in brokers
+    assert "websocket-client==1.8.0" in brokers
+    assert any(
+        line == (
+            "neo_api_client @ git+https://github.com/Kotak-Neo/"
+            "Kotak-neo-api-v2.git@v2.0.1"
+        )
+        for line in brokers
+    )
+    assert all("==" in line or " @ git+" in line for line in brokers)
+
+
+def test_ci_runs_audit_branch_coverage_and_every_exact_dependency_set():
+    workflow = (ROOT / ".github/workflows/quality-and-security.yml").read_text(encoding="utf-8")
+    parsed = yaml.safe_load(workflow)
+    core_job = workflow.split("\n  broker-dependencies:", maxsplit=1)[0]
+
+    assert set(parsed["jobs"]) == {"verify", "broker-dependencies"}
+    assert "requirements-ai.txt" in workflow
+    assert "requirements-brokers.txt" in workflow
+    assert "broker-dependencies:" in workflow
+    assert "requirements-brokers.txt" not in core_job
+    assert "python -m pip_audit" in workflow
+    assert "python -m coverage run" in workflow
+    assert "scripts/check_coverage_thresholds.py" in workflow
+
+
+def test_dependabot_updates_python_and_github_actions_weekly():
+    config = yaml.safe_load((ROOT / ".github/dependabot.yml").read_text(encoding="utf-8"))
+    ecosystems = {
+        item["package-ecosystem"]: item["schedule"]["interval"]
+        for item in config["updates"]
+    }
+
+    assert ecosystems == {"pip": "weekly", "github-actions": "weekly"}
+
+
+def test_coverage_config_is_branch_enabled_and_preserves_overall_baseline():
+    config = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+
+    assert config["tool"]["coverage"]["run"]["branch"] is True
+    assert config["tool"]["coverage"]["report"]["fail_under"] == 54.7
+
+
+def test_coverage_threshold_checker_enforces_safety_and_broker_budgets():
+    path = ROOT / "scripts/check_coverage_thresholds.py"
+    spec = importlib.util.spec_from_file_location("check_coverage_thresholds", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+
+    safety_path = next(iter(module.SAFETY_THRESHOLDS))
+    broker_path = next(iter(module.BROKER_THRESHOLDS))
+    report = {
+        "files": {
+            safety_path: {
+                "summary": {"percent_covered": 89.99, "num_branches": 2},
+            },
+            broker_path.replace("/", "\\"): {
+                "summary": {"percent_covered": 80.0, "num_branches": 2},
+            },
+        }
+    }
+
+    failures = module.evaluate_coverage(
+        report,
+        safety_thresholds={safety_path: 90.0},
+        broker_thresholds={broker_path: 80.0},
+    )
+
+    assert len(failures) == 1
+    assert safety_path in failures[0]

--- a/Dependencies/test_risk_sizing.py
+++ b/Dependencies/test_risk_sizing.py
@@ -117,3 +117,48 @@ def test_invalid_sizing_inputs_fail_closed(
 
     assert decision.accepted is False
     assert decision.quantity == 0
+
+
+@pytest.mark.parametrize("lots", (True, 0, 1.5))
+def test_fixed_sizing_rejects_invalid_lot_counts(lots: object) -> None:
+    decision = SizingDecision.fixed(lots=lots, lot_size=50)  # type: ignore[arg-type]
+    assert decision.accepted is False
+    assert decision.quantity == 0
+
+
+@pytest.mark.parametrize("lot_size", (True, 0, 50.5))
+def test_fixed_sizing_rejects_invalid_exchange_lot_sizes(lot_size: object) -> None:
+    decision = SizingDecision.fixed(lots=2, lot_size=lot_size)  # type: ignore[arg-type]
+    assert decision.accepted is False
+    assert decision.max_lots == 2
+
+
+def test_fixed_sizing_returns_a_complete_decision() -> None:
+    decision = SizingDecision.fixed(lots=2, lot_size=50)
+    assert decision.accepted is True
+    assert decision.lots == 2
+    assert decision.quantity == 100
+    assert decision.total_risk == 0.0
+
+
+@pytest.mark.parametrize("budget", (True, "not-a-budget", None))
+def test_budget_rejects_booleans_and_conversion_failures(budget: object) -> None:
+    decision = SizingDecision.from_risk_budget(
+        entry=100.0,
+        stop=99.0,
+        lot_size=50,
+        budget=budget,  # type: ignore[arg-type]
+    )
+    assert decision.accepted is False
+    assert "budget" in decision.reason.lower()
+
+
+def test_overflowing_one_lot_risk_is_rejected() -> None:
+    decision = SizingDecision.from_risk_budget(
+        entry=1e308,
+        stop=1.0,
+        lot_size=2,
+        budget=1e308,
+    )
+    assert decision.accepted is False
+    assert "one-lot risk" in decision.reason.lower()

--- a/Dependencies/test_secret_redaction.py
+++ b/Dependencies/test_secret_redaction.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 import io
 import logging
 
-from Dependencies.secret_redaction import REDACTED, RedactingFilter, redact_payload, redact_text
+from Dependencies.secret_redaction import (
+    REDACTED,
+    RedactingFilter,
+    install_redaction_filter,
+    redact_payload,
+    redact_text,
+)
 
 
 def test_recursive_redaction_covers_broker_and_identity_fields():
@@ -47,3 +53,38 @@ def test_debug_and_exception_records_never_emit_canary_secrets():
     output = stream.getvalue()
     assert secret not in output
     assert REDACTED in output
+
+
+def test_redaction_reaches_secrets_inside_tuples_and_sets():
+    """Broker payloads can nest sequences; every container type is walked."""
+    payload = (
+        "password=CANARY-TUPLE",
+        {"CANARY-SET-SECRET", "harmless"},
+        ["token=CANARY-LIST"],
+    )
+    safe = redact_payload(payload, ("CANARY-SET-SECRET",))
+    rendered = repr(safe)
+    assert "CANARY" not in rendered
+    assert isinstance(safe, tuple)
+    assert isinstance(safe[1], set)
+
+
+def test_install_redaction_filter_covers_logger_and_existing_handlers():
+    """One install call must guard both the logger and its current handlers."""
+    secret = "CANARY-INSTALL-SECRET"
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    logger = logging.getLogger("mat110.install.canary")
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+
+    install_redaction_filter(logger, [secret])
+    logger.debug("session token is %s somewhere in this line", secret)
+
+    output = stream.getvalue()
+    assert secret not in output
+    assert REDACTED in output
+    # The guard sits on the handler too, so records that reach the handler
+    # directly (propagated from child loggers) are also scrubbed.
+    assert any(isinstance(f, RedactingFilter) for f in handler.filters)

--- a/Dependencies/trading_lifecycle.py
+++ b/Dependencies/trading_lifecycle.py
@@ -147,6 +147,10 @@ class TradingLifecycle:
                 self._state = LifecycleState.FLAT
                 self._next_retry_at = None
             elif self._next_retry_at is None:
+                # Capped backoff: attempt 1 retries after 1s, attempt 2 after
+                # 2s, attempt 3 AND EVERY LATER attempt after 5s.  The cap is
+                # deliberate -- unlike a network backoff this loop is trying to
+                # CLOSE live exposure, so it must never back off into minutes.
                 delay_index = min(
                     self._flatten_attempts - 1,
                     len(_RETRY_DELAYS_SECONDS) - 1,

--- a/Nifty Multi Strategy Front Test - Master File.py
+++ b/Nifty Multi Strategy Front Test - Master File.py
@@ -385,8 +385,11 @@ def _env_bool(name: str, default: bool = False) -> bool:
 # DHAN_CLIENT_CODE  : 10-digit dhanClientId (e.g. "1100000000").
 # DHAN_API_KEY      : long-lived "app_id" used by the OAuth setup script.
 # DHAN_API_SECRET   : long-lived "app_secret" pair to DHAN_API_KEY.
-# DHAN_ACCESS_TOKEN : 12-month token produced by the setup script. This is
-#                     what the dhanhq SDK actually authenticates with.
+# DHAN_ACCESS_TOKEN : token produced by the setup script. This is what the
+#                     dhanhq SDK actually authenticates with. Its validity is
+#                     stamped into the token by DhanHQ and is NOT 12 months --
+#                     web.dhan.co currently issues 24-hour tokens, so refresh
+#                     it outside market hours before each trading day.
 CLIENT_CODE = _env_str("DHAN_CLIENT_CODE", "")
 API_KEY = _env_str("DHAN_API_KEY", "")
 API_SECRET = _env_str("DHAN_API_SECRET", "")
@@ -1002,15 +1005,15 @@ CPR_ALGO3_LOGIC = load_module(
 )
 
 # -----------------------------------------------------------------------------
-# Live-execution layer (optional) - Kotak Neo, Shoonya, or Flattrade.
+# Live-execution layer (optional) - Kotak Neo, Shoonya, Flattrade, or Dhan.
 # -----------------------------------------------------------------------------
-# This is how real (non-paper) orders reach the broker. All three helpers expose
+# This is how real (non-paper) orders reach the broker. All four helpers expose
 # the SAME contract: login/symbol resolution, typed place/status/cancel results,
 # determinate-or-indeterminate open order/position queries, and logout. The runner
 # uses whichever one LIVE_BROKER selects via a single generic `execution_client`.
 # Each import is
 # wrapped in try/except on purpose: if a broker's SDK/deps are missing, that
-# client is set to None and the runner keeps working (the OTHER broker, or
+# client is set to None and the runner keeps working (the OTHER brokers, or
 # paper-only). main() forces any "live" strategy back to paper when the selected
 # client is None.
 try:
@@ -1052,6 +1055,19 @@ except Exception as _flattrade_import_exc:
         _flattrade_import_exc,
     )
 
+try:
+    _dhan_execution_module = load_module(
+        "master_dhan_execution",
+        Path(__file__).resolve().parent / "Dependencies" / "Dhan API" / "dhan_execution.py",
+    )
+    dhan_execution_client = _dhan_execution_module.dhan_execution_client
+except Exception as _dhan_import_exc:
+    dhan_execution_client = None
+    logging.getLogger(LOGGER_NAME).warning(
+        "Dhan execution layer unavailable (%s); Dhan live trading disabled.",
+        _dhan_import_exc,
+    )
+
 
 def _select_execution_client(broker_name: str):
     """Return client, exchange, and product for one explicit broker selection.
@@ -1074,8 +1090,11 @@ def _select_execution_client(broker_name: str):
     if broker == "FLATTRADE":
         product = _env_str("FLATTRADE_PRODUCT_TYPE", "INTRADAY").upper().strip() or "INTRADAY"
         return flattrade_execution_client, "NFO", product
+    if broker == "DHAN":
+        product = _env_str("DHAN_PRODUCT_TYPE", "INTRADAY").upper().strip() or "INTRADAY"
+        return dhan_execution_client, "NSE_FNO", product
     logging.getLogger(LOGGER_NAME).error(
-        "Unknown LIVE_BROKER=%r (expected KOTAK, SHOONYA, or FLATTRADE); "
+        "Unknown LIVE_BROKER=%r (expected KOTAK, SHOONYA, FLATTRADE, or DHAN); "
         "live trading DISABLED (paper only).",
         broker_name,
     )

--- a/Nifty Multi Strategy Front Test - Master File.py
+++ b/Nifty Multi Strategy Front Test - Master File.py
@@ -3272,6 +3272,12 @@ class BasePaperStrategyWorker(threading.Thread):
         # real orders on the active broker (see `_place_real_leg`) in addition to
         # the usual paper bookkeeping.
         self.live_trading = False
+        # Actual session provenance is derived from order outcomes, not merely
+        # from the live configuration flag. A live-enabled worker can execute a
+        # confirmed broker fill and later take an explicit zero-fill paper
+        # fallback, which makes that strategy's daily result MIXED.
+        self._execution_modes_seen: set[str] = set()
+        self._execution_mode_lock = threading.Lock()
         # Distinguish otherwise-identical legs owned by different worker
         # instances.  A frozen worker may finish its own partial order, but a
         # second worker must never adopt that continuation merely because its
@@ -4575,17 +4581,32 @@ class BasePaperStrategyWorker(threading.Thread):
         (TelegramMessageWorker) owns all formatting and network I/O, so the
         trading threads are never exposed to Telegram latency or failures.
         """
-        event_queue = getattr(self, "trade_event_queue", None)
-        if event_queue is None:
-            return
         try:
             event.setdefault("strategy", self.strategy_name)
             event.setdefault("ts", datetime.now().strftime("%Y-%m-%d %H:%M:%S"))
-            event.setdefault("mode", "PAPER")
+            event.setdefault("mode", "LIVE" if self.live_trading else "PAPER")
+            mode_parts = _execution_mode_parts(event["mode"])
+            with self._execution_mode_lock:
+                self._execution_modes_seen.update(mode_parts)
+            event_queue = getattr(self, "trade_event_queue", None)
+            if event_queue is None:
+                return
             event_queue.put_nowait(event)
         except Exception:
             # A failed enqueue must never disturb the trading loop.
             pass
+
+    def session_execution_mode(self) -> str:
+        """Return PAPER, LIVE, or MIXED from this worker's actual outcomes."""
+        with self._execution_mode_lock:
+            observed = set(self._execution_modes_seen)
+        if len(observed) > 1:
+            return "MIXED"
+        if observed:
+            return next(iter(observed))
+        # A no-trade day has no order outcome. Report the mode in which the
+        # strategy was armed rather than falsely claiming a paper execution.
+        return "LIVE" if self.live_trading else "PAPER"
 
     # ------------------------------------------------------------------
     # Helpers
@@ -4917,7 +4938,11 @@ class BasePaperStrategyWorker(threading.Thread):
             return
         if not self._shutdown_summary_logged:
             self._shutdown_summary_logged = True
-            self.log.info("Paper summary | %s", self.summary_text())
+            self.log.info(
+                "Result summary | Mode=%s | %s",
+                self.session_execution_mode(),
+                self.summary_text(),
+            )
             self.log.info(
                 "Strategy stopped only after broker-confirmed flat lifecycle completion."
             )
@@ -12021,6 +12046,28 @@ def _format_inr(value) -> str:
     return f"{sign}₹{abs(amount):,.2f}"
 
 
+def _execution_mode_parts(mode) -> set[str]:
+    """Normalize detailed order tags into daily PAPER/LIVE provenance parts."""
+    normalized = str(mode or "").strip().upper()
+    if normalized == "MIXED":
+        return {"PAPER", "LIVE"}
+    if normalized in {"LIVE", "LIVE_REJECTED", "LIVE_INDETERMINATE"}:
+        return {"LIVE"}
+    # PAPER_FALLBACK is deliberately paper provenance: the broker explicitly
+    # rejected the entry with zero fill and the simulated trade was opened.
+    return {"PAPER"}
+
+
+def _combined_execution_mode(modes) -> str:
+    """Combine worker/session modes into one PAPER, LIVE, or MIXED label."""
+    parts: set[str] = set()
+    for mode in modes:
+        parts.update(_execution_mode_parts(mode))
+    if len(parts) > 1:
+        return "MIXED"
+    return next(iter(parts), "PAPER")
+
+
 def _format_eod_summary(event: dict) -> str:
     """
     Build the end-of-day cumulative P&L message: one line per strategy worker
@@ -12035,8 +12082,12 @@ def _format_eod_summary(event: dict) -> str:
         lines.append(f"<i>{ts}</i>")
     for row in sorted(rows, key=lambda r: _safe_float(r.get("pnl", 0.0), 0.0), reverse=True):
         strat = html.escape(str(row.get("strategy", "?")))
+        row_mode = html.escape(str(row.get("mode", "PAPER")))
         trades = _to_int_safe(row.get("trades", 0), 0)
-        lines.append(f"{strat}: <b>{_format_inr(row.get('pnl', 0.0))}</b> ({trades} trade(s))")
+        lines.append(
+            f"{strat} [{row_mode}]: <b>{_format_inr(row.get('pnl', 0.0))}</b> "
+            f"({trades} trade(s))"
+        )
     lines.append("──────────")
     lines.append(
         f"<b>Total: {_format_inr(event.get('total_pnl', 0.0))} "
@@ -12268,12 +12319,21 @@ def _publish_eod_summary(workers, event_queue) -> None:
     for worker in workers:
         pnl = _safe_float(getattr(worker, "realized_pnl", 0.0), 0.0)
         trades = _to_int_safe(getattr(worker, "completed_trades", 0), 0)
-        rows.append({"strategy": worker.strategy_name, "pnl": pnl, "trades": trades})
+        mode_getter = getattr(worker, "session_execution_mode", None)
+        if callable(mode_getter):
+            worker_mode = mode_getter()
+        else:
+            worker_mode = "LIVE" if getattr(worker, "live_trading", False) else "PAPER"
+        rows.append(
+            {"strategy": worker.strategy_name, "pnl": pnl, "trades": trades, "mode": worker_mode}
+        )
         total_pnl += pnl
         total_trades += trades
 
+    overall_mode = _combined_execution_mode(row["mode"] for row in rows)
     logger.info(
-        "END-OF-DAY cumulative paper P&L across %d workers = %.2f over %d trade(s).",
+        "END-OF-DAY cumulative %s P&L across %d workers = %.2f over %d trade(s).",
+        overall_mode,
         len(workers),
         total_pnl,
         total_trades,
@@ -12288,7 +12348,7 @@ def _publish_eod_summary(workers, event_queue) -> None:
                 "total_pnl": total_pnl,
                 "total_trades": total_trades,
                 "ts": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
-                "mode": "PAPER",
+                "mode": overall_mode,
             }
         )
     except Exception:
@@ -12345,7 +12405,8 @@ _PNL_SHEET_ROW_LABELS = {
 }
 
 _PNL_LOG_LINE_RE = re.compile(r"RealizedPnL=(-?\d+(?:\.\d+)?)")
-# Only Paper-summary lines inside this window are used for the sheet. Covers
+_PNL_MODE_RE = re.compile(r"\bMode=(PAPER|LIVE|MIXED)\b")
+# Only result-summary lines inside this window are used for the sheet. Covers
 # max-loss during the session (from 9:15) through the last square-off (15:20)
 # while ignoring after-market test runs that log fresh summaries at 17:00+.
 _PNL_LOG_WINDOW_START = (9, 15)
@@ -12383,8 +12444,9 @@ def _parse_eod_pnl_by_day(log_path) -> dict:
     """
     Parse the runner's log for each strategy's end-of-day realised P&L per day.
 
-    Reads the per-strategy "Paper summary | ... RealizedPnL=<pnl>" lines that
-    every worker logs at square-off / max-loss. The log format is
+    Reads the per-strategy "Result summary | Mode=<mode> | ... RealizedPnL=<pnl>"
+    lines that every worker logs at square-off / max-loss. Legacy "Paper summary"
+    rows remain readable as PAPER. The log format is
     "<asctime> | <level> | <threadName> | <message>", and threadName is
     "<strategy_name>Thread", so we recover the date (from asctime), the strategy
     (from the thread name), and the figure. Returns {"YYYY-MM-DD":
@@ -12405,7 +12467,9 @@ def _parse_eod_pnl_by_day(log_path) -> dict:
             for line in handle:
                 # Cheap pre-filter: skip everything that isn't a P&L summary line
                 # before doing the costlier split/regex work below.
-                if "Paper summary" not in line or "RealizedPnL=" not in line:
+                is_legacy_paper = "Paper summary" in line
+                is_mode_result = "Result summary" in line
+                if (not is_legacy_paper and not is_mode_result) or "RealizedPnL=" not in line:
                     continue
                 # Break into the 4 log fields. maxsplit=3 keeps the message intact
                 # even if the message itself contains " | ".
@@ -12433,10 +12497,19 @@ def _parse_eod_pnl_by_day(log_path) -> dict:
                 match = _PNL_LOG_LINE_RE.search(message)
                 if not match:
                     continue
+                mode = "PAPER"
+                if is_mode_result:
+                    mode_match = _PNL_MODE_RE.search(message)
+                    if not mode_match:
+                        continue
+                    mode = mode_match.group(1)
                 try:
                     # Last write wins: a later summary for the same strategy/day
                     # (e.g. a re-entry's final line) overwrites the earlier one.
-                    result.setdefault(date_str, {})[strategy] = float(match.group(1))
+                    result.setdefault(date_str, {})[strategy] = {
+                        "pnl": float(match.group(1)),
+                        "mode": mode,
+                    }
                 except ValueError:
                     continue
     except Exception as exc:  # pragma: no cover - defensive
@@ -12492,11 +12565,31 @@ def _compute_pnl_sheet_updates(values, pnl_by_day, today_str):
         if date_str[:7] != current_month or date_str not in date_to_col:
             continue
         col_idx = date_to_col[date_str]
-        for strategy, pnl in per_strategy.items():
+        for strategy, result_record in per_strategy.items():
             # Map the code's strategy name to the sheet's exact row label.
-            label = _PNL_SHEET_ROW_LABELS.get(strategy)
-            if label is None or label not in label_to_row:
+            base_label = _PNL_SHEET_ROW_LABELS.get(strategy)
+            if isinstance(result_record, dict):
+                pnl = result_record.get("pnl")
+                mode = str(result_record.get("mode", "")).strip().upper()
+                if mode not in {"PAPER", "LIVE", "MIXED"}:
+                    unmatched.add(strategy)
+                    continue
+            else:
+                # Backward-compatible input for older callers/tests: numeric
+                # records came from the legacy Paper-summary parser.
+                pnl = result_record
+                mode = "PAPER"
+            # Keep the existing paper rows intact. Live and mixed results require
+            # distinct numeric rows so broker P&L can never contaminate the paper
+            # tracker's historical series.
+            if base_label is None:
                 # No mapping, or the sheet is missing that row -> report it.
+                unmatched.add(strategy)
+                continue
+            label = base_label if mode == "PAPER" else f"{base_label} [{mode}]"
+            if label not in label_to_row:
+                # Live and mixed modes use dedicated rows. If the operator has
+                # not added that row yet, warn instead of overwriting paper P&L.
                 unmatched.add(strategy)
                 continue
             row_idx = label_to_row[label]

--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ Although I own the code, the coding itself was done entirely using GPT-5.4-xhigh
 
 # Recent additions
 - **Per-strategy "off" switch — `<PREFIX>_VIRTUAL_TRADING`.** Every strategy now has a virtual (paper) toggle that **defaults to true**. Set it false to stop that strategy's worker thread from starting at all — so it does no paper trading (and, since the thread never runs, no live trading either). Unlike live trading there is **no** global master switch: the default is that everything runs, and you silence individual strategies. Lets you run just the strategies you want on a given day instead of the whole roster.
-- **Quality gates & CI.** A GitHub Actions workflow (`.github/workflows/quality-and-security.yml`) runs the full gate on every push/PR across Python 3.12 + 3.13: both test suites, `compileall`, **ruff**, **mypy** (scoped in `pyproject.toml`), and **bandit**. Config lives in `pyproject.toml` + `requirements-dev.txt`, with a `.pre-commit-config.yaml` for local checks. Install the dev tools with `pip install -r requirements-dev.txt`.
+- **Quality gates & CI.** A GitHub Actions workflow (`.github/workflows/quality-and-security.yml`) runs the full gate on every push/PR across Python 3.12 + 3.13: all repository suites, branch-coverage budgets, `pip-audit`, `compileall`, **Ruff**, **mypy** (scoped in `pyproject.toml`), **Bandit**, and pre-commit validation. Exact tooling lives in `requirements-dev.txt`.
 - **SL Hunting AI Agent — BankNIFTY mirror basket + newer knowledge (v3c–v3e).** The agent now trades Intraday Hunter's multi-index style: every NIFTY entry is mirrored with an **equal-lot BankNIFTY ATM** leg (`SL_HUNTING_BNF_MIRROR`, default true). The two legs are **tied for hard risk** (stop/target, max-loss, 15:15 square-off close both) but the agent evaluates each leg's **premise independently** and can cut one alone via the EXIT `exit_leg` selector (`NIFTY` | `BNF` | `BOTH`). Entry stays NIFTY-only (the mirror copies it). Its knowledge also grew several distilled-from-video layers — a scoped **gap-up opening-drive**, a **2-week verbatim transcript sweep**, and a **live-day match** against the agent's own journal (details in `Signal Generators/SL Hunting AI Agent/README.md`).
-- **Optional LLM trading agent — the "SL Hunting AI Agent" (opt-in 27th worker).** A Claude agent (via the [`claude-agent-sdk`](https://pypi.org/project/claude-agent-sdk/) on your Claude subscription — **no API key**) trades the discretionary *SL Hunting* price-action method on NIFTY ATM options. Once per completed 1-min bar (the method's native timeframe) it reads the NIFTY chart (with **BankNIFTY cross-confirmation**) and — only on a confirmed setup at a real level — acts through the SAME tested `enter_position`/`exit_position` path as every other worker. Position sizing floors affordable whole lots, never exceeds `SL_HUNTING_RISK_BUDGET`, skips one-lot-over-budget setups, and caps at `SL_HUNTING_MAX_LOTS` (default 5); the equal-lot BankNIFTY mirror can roughly double basket risk. It **stops opening new positions after noon** (`SL_HUNTING_NO_NEW_ENTRY_HOUR`, default 12:00) — *not* a square-off: open positions, their stops/targets, and the 15:15 square-off are unaffected. It is **off by default** (`SL_HUNTING_ENABLED`), trades **paper** unless both `LIVE_TRADING_ENABLED` and `SL_HUNTING_LIVE_TRADING` are set, and is **fail-soft** — any agent/SDK error becomes a safe HOLD (never an exception into the trading loop), and its extra deps are lazily imported so a missing dep just disables this one worker. It can also **learn from its own trades**: a per-trade journal feeds an off-loop reflection *coach* that proposes lessons, which the operator human-gates into the prompt (paper-first, off by default). Needs `pip install claude-agent-sdk pydantic` and a one-time `claude setup-token` (keep `ANTHROPIC_API_KEY` **UNSET** so it bills your Claude plan, not per-token API). Full details — knowledge, tools, safety model, the learning loop — are in `Signal Generators/SL Hunting AI Agent/README.md`. This is the optional **27th** worker.
+- **Optional LLM trading agent — the "SL Hunting AI Agent" (opt-in 27th worker).** A Claude agent (via the [`claude-agent-sdk`](https://pypi.org/project/claude-agent-sdk/) on your Claude subscription — **no API key**) trades the discretionary *SL Hunting* price-action method on NIFTY ATM options. Once per completed 1-min bar (the method's native timeframe) it reads the NIFTY chart (with **BankNIFTY cross-confirmation**) and — only on a confirmed setup at a real level — acts through the SAME tested `enter_position`/`exit_position` path as every other worker. Position sizing floors affordable whole lots, never exceeds `SL_HUNTING_RISK_BUDGET`, skips one-lot-over-budget setups, and caps at `SL_HUNTING_MAX_LOTS` (default 5); the equal-lot BankNIFTY mirror can roughly double basket risk. It **stops opening new positions after noon** (`SL_HUNTING_NO_NEW_ENTRY_HOUR`, default 12:00) — *not* a square-off: open positions, their stops/targets, and the 15:15 square-off are unaffected. It is **off by default** (`SL_HUNTING_ENABLED`), trades **paper** unless both `LIVE_TRADING_ENABLED` and `SL_HUNTING_LIVE_TRADING` are set, and is **fail-soft** — any agent/SDK error becomes a safe HOLD while its separate mechanical risk loop keeps checking stop, target, max-loss, stale data, and square-off. It can also **learn from its own trades** through a tool-free, schema-validated reflection coach with digest-bound human approval (paper-first, off by default). Install the exact optional stack with `pip install -r requirements-ai.txt` and run one-time `claude setup-token` (keep `ANTHROPIC_API_KEY` **UNSET** so it bills your Claude plan, not per-token API). Full details — knowledge, tools, safety model, the learning loop — are in `Signal Generators/SL Hunting AI Agent/README.md`. This is the optional **27th** worker.
 - **CPR Algo 3 (multi-instrument) is now wired into the front test.** A new `CPRAlgo3StrategyWorker` runs the "CPR basic setup" strategy, which watches THREE charts at once — the NIFTY spot plus a ~ITM CE and a ~ITM PE of the current-week expiry — and only fires when VWAP and the CPR band align across all three (RSI/ARSI on spot). The two ITM options are **observation only**: a signal still BUYS the ATM CE/PE of the next-next expiry through the same tested path as the other directional workers, so it shares CPR's risk knobs (tunable via `CPR_ALGO3_*` in `.env`, including `CPR_ALGO3_ITM_OFFSET`). It fetches the two option 1-min OHLC feeds on demand and drives its own spot target/stop exit. This brings the runner to **26 workers**. (The standalone Algo 3 signal generator + its unit tests live under `Signal Generators/CPR Strategy/`.)
 - **Code-quality pass.** Added a `requirements.txt`; gave every Shoonya broker HTTP call a timeout (a hung call could otherwise stall a worker thread and the shared broker lock); removed hardcoded credentials from the vendored Shoonya client; routed the execution layer's status/errors through `logging` instead of `print()`; and ported the master test suite into the repo (`test_nifty_multi_strategy_master.py` — see Tests below).
 - **Live broker execution is broker-selectable (Kotak Neo, Shoonya, or Flattrade).** `LIVE_BROKER` picks `KOTAK`, `SHOONYA`, or `FLATTRADE`, and every real order goes through one generic `execution_client`. The global `LIVE_TRADING_ENABLED` kill-switch and each strategy's `<PREFIX>_LIVE_TRADING` flag must both be true; unknown broker names fail closed to paper. Each broker folder contains an execution client and a read-only diagnostic with an optional, typed-`YES`, round-trip test order. Flattrade uses its official Pi v2 browser-token flow, exact NFO index scrip master, documented request limits, market-order protection, and `SingleOrdHist` fill confirmation. Everything still defaults to paper. (Shoonya's legacy QuickAuth endpoint is being decommissioned by Finvasia.)
 - **End-of-day P&L is now written to a Google Sheet.** When all workers exit on a clean end of day, the master parses the run's log for each strategy's realised P&L and writes it into a tracker sheet — one row per strategy, one column per calendar day — overwriting today's cell and backfilling any blank earlier-this-month cells from the (append-mode) log. Auth is OAuth user-token via `gspread`; configure `GSHEET_ID` + an OAuth client in `.env` (see Setup). It's a safe no-op when unconfigured, so it never disturbs shutdown.
-- **13 TradingBot signal-generator ports added — the front test now runs 24 workers.** Thirteen more ATM single-leg strategies were ported into `Signal Generators/` (SMA Crossover, Bollinger Bands, Keltner Squeeze, Mean Reversion Z-Score, ML Ensemble, Multi-Timeframe, Opening Range Breakout, Parabolic SAR, RSI Divergence, RSI Reversal, Stochastic, Supertrend, Volatility Breakout), all sharing `misc_strategy_common.py` (the mandatory TA-Lib 0.6.8 indicator backend). They're wired into the master via one shared factory as `AtmSingleLegStrategyWorker`s — the same family as Renko/Goldmine/CPR — and each is fully tunable from `.env` by its own prefix (e.g. `SMA_CROSSOVER_*`, `KELTNER_SQUEEZE_*`). This brings the runner to **24 workers** (21 ATM single-leg + 2 Hedged Puts + 1 Delta-0.2). ML Ensemble needs `scikit-learn`.
+- **13 TradingBot signal-generator ports.** Thirteen ATM single-leg strategies were ported into `Signal Generators/` (SMA Crossover, Bollinger Bands, Keltner Squeeze, Mean Reversion Z-Score, ML Ensemble, Multi-Timeframe, Opening Range Breakout, Parabolic SAR, RSI Divergence, RSI Reversal, Stochastic, Supertrend, Volatility Breakout), all sharing `misc_strategy_common.py` and the mandatory TA-Lib 0.6.8 indicator backend. They're wired through the shared `AtmSingleLegStrategyWorker` factory and each is tunable from `.env` by its own prefix. ML Ensemble needs `scikit-learn`.
 - **CPR (Central Pivot Range) strategy is now live in the front test.** It runs as an ATM single-leg worker (`CPRStrategyWorker`) alongside the other strategies: the master file feeds it 1-min OHLC, the CPR logic resamples to complete 5-min candles internally, and a LONG/SHORT signal buys the ATM CE/PE of the next-next expiry. Tunable via `CPR_*` knobs in the `.env` (lots, max-loss, poll, 09:25-15:15 window). (This brought the master file to nine workers at the time; see the latest addition at the top of this list for the current total.)
 - **Telegram trade notifications.** A queue-based `TelegramMessageWorker` posts a message to a Telegram group/channel on every entry and exit from *any* worker. Each alert shows the strategy, the exact option instrument(s), lot size, entry and exit price, and P&L (hedged spreads show both legs). It runs on its own thread so Telegram latency or downtime never blocks the trading loop, and it's a cheap no-op when disabled. See Setup below to switch it on.
 
@@ -37,7 +37,7 @@ You might have to adjust the import addresses from which the files are to be imp
 # Repository structure
 ```
 .
-├── Nifty Multi Strategy Front Test - Master File.py   # multithreaded paper + live runner (26 strategies + 1 optional LLM agent)
+├── Nifty Multi Strategy Front Test - Master File.py   # multithreaded paper/live runner (~26 + optional LLM worker)
 ├── Data Extractors/                                   # 1m OHLC downloaders + shared helper
 ├── My Backtest Files (For Reference)/                 # backtesting.py-based backtests
 ├── Signal Generators/                                 # strategy / signal logic modules
@@ -56,7 +56,18 @@ Each subfolder has its own `Readme.md` with the details.
    ```
    pip install -r requirements.txt
    ```
-   That covers the core (data fetch, backtests, runner). For live trading also install your broker's client — see the commented "Live trading (optional)" section in `requirements.txt`: Kotak Neo (`neo_api_client`) and/or Shoonya (`pyotp` + `websocket-client`; the NorenApi client itself is vendored). Flattrade uses the core `requests` and `pandas` dependencies, so it needs no extra SDK.
+   That covers the core (data fetch, backtests, runner). Install exact optional sets only when needed:
+   ```
+   pip install -r requirements-ai.txt        # SL Hunting Claude SDK stack
+   pip install -r requirements-dev.txt       # local quality/security gates
+   pip install pyotp==2.9.0 websocket-client==1.8.0  # Shoonya runtime
+   pip install --no-deps "git+https://github.com/Kotak-Neo/Kotak-neo-api-v2.git@v2.0.1#egg=neo_api_client"
+   ```
+   Flattrade uses the core `requests` and `pandas` dependencies. Shoonya's NorenApi
+   client is vendored. Kotak's official tag declares older exact pandas/requests
+   versions, so `--no-deps` prevents it from silently downgrading the audited core
+   runtime. `requirements-brokers.txt` records and tests the upstream broker
+   dependency environment separately in CI; do not combine it with `requirements.txt`.
 3. Configure credentials. Copy `Dependencies/env.example` to `Dependencies/.env` and fill it in (`.env` is git-ignored). Set your Dhan credentials there, then run the one-time token setup:
    ```
    python "Dependencies/dhan_token_setup.py"
@@ -76,7 +87,7 @@ Each subfolder has its own `Readme.md` with the details.
    GSHEET_OAUTH_CLIENT_FILE=Dependencies/gsheet_oauth_client.json
    GSHEET_OAUTH_TOKEN_FILE=Dependencies/gsheet_oauth_token.json
    ```
-   Auth is OAuth user-token via `gspread`: in Google Cloud enable the Sheets API, create an OAuth client of type **Desktop app**, download its JSON to `GSHEET_OAUTH_CLIENT_FILE`, and share the sheet with your Google account. The first run opens a browser once for consent and caches a token at `GSHEET_OAUTH_TOKEN_FILE`. The sheet needs one row per strategy in column A with exact labels (e.g. `Renko Strategy`, `SMA Crossover Strategy`, `Stochastic Oscillator Strategy`, `Supertrend Strategy`, …); unmatched strategies are skipped with a warning. Leave `GSHEET_ID` blank to disable (safe no-op).
+   Auth is OAuth user-token via `gspread`: in Google Cloud enable the Sheets API, create an OAuth client of type **Desktop app**, download its JSON to `GSHEET_OAUTH_CLIENT_FILE`, and share the sheet with your Google account. The first run opens a browser once for consent and caches a token at `GSHEET_OAUTH_TOKEN_FILE`. PAPER results use the existing row labels in column A (e.g. `Renko Strategy`); LIVE and MIXED results use separate `Renko Strategy [LIVE]` and `Renko Strategy [MIXED]` rows so real-money outcomes cannot contaminate paper history. Unmatched strategies are skipped with a warning. Leave `GSHEET_ID` blank to disable (safe no-op).
 
 6. (Optional) Live broker execution. Everything is paper by default. To place REAL orders, set in `Dependencies/.env`:
    ```
@@ -84,7 +95,7 @@ Each subfolder has its own `Readme.md` with the details.
    LIVE_BROKER=KOTAK                # KOTAK, SHOONYA, or FLATTRADE
    RENKO_LIVE_TRADING=true          # flip the specific strategies you want live
    ```
-   Then fill the selected broker's credential block. Flattrade needs `FLATTRADE_CLIENT_ID`, `FLATTRADE_API_KEY`, and `FLATTRADE_API_SECRET`; its optional `FLATTRADE_ACCESS_TOKEN` is validated when supplied, otherwise startup opens browser authorization and asks for the returned `request_code`. A strategy trades live only when `LIVE_TRADING_ENABLED` **and** its own `<PREFIX>_LIVE_TRADING` are both true; any order failure falls back to paper for that trade. Check connectivity first with the read-only diagnostics — they can place a confirmation-gated round-trip (buy + auto square-off) test order via `--place-order`:
+   Then fill the selected broker's credential block. Flattrade needs `FLATTRADE_CLIENT_ID`, `FLATTRADE_API_KEY`, and `FLATTRADE_API_SECRET`; its optional `FLATTRADE_ACCESS_TOKEN` is validated when supplied, otherwise startup opens browser authorization and asks for the returned `request_code`. A strategy trades live only when `LIVE_TRADING_ENABLED` **and** its own `<PREFIX>_LIVE_TRADING` are both true. An entry falls back to paper only after a typed zero-fill `REJECTED`; `PARTIAL` or `UNKNOWN` means exposure may exist, freezes new live entries, and starts reconciliation. Check connectivity first with the read-only diagnostics — they can place a confirmation-gated round-trip (buy + auto square-off) test order via `--place-order`:
    ```
    python "Dependencies/Kotak API/diagnose_kotak_symbol.py" CE 23950 --place-order
    python "Dependencies/Shoonya API/diagnose_shoonya_symbol.py" CE 23950 26JUN25 --place-order
@@ -118,19 +129,30 @@ The front-test master has a unittest suite — env toggles, broker paper/live ro
 ```
 python -m unittest test_nifty_multi_strategy_master
 ```
-175 tests; broker/SDK-specific cases skip automatically when optional dependencies are absent, and all Flattrade HTTP/browser/order behaviour is mocked. (The CPR, Subhamoy, and SL Hunting AI Agent signal generators have their own tests under `Signal Generators/`.) CI runs the whole quality gate on every push/PR — see "Quality gates & CI" below.
+Broker/SDK-specific cases skip automatically when optional dependencies are absent, and all broker HTTP/browser/order behaviour is mocked. Signal generators, execution/reconciliation primitives, data extractors, and repository-policy checks have focused suites under their respective folders. CI runs the whole quality gate on every push/PR — see "Quality gates & CI" below.
 
 # Quality gates & CI
 A GitHub Actions workflow (`.github/workflows/quality-and-security.yml`) runs on every push and pull request across Python 3.12 and 3.13. Locally, the same gate is:
 ```
-pip install -r requirements-dev.txt          # ruff, mypy, bandit, pre-commit, pytest
+pip install -r requirements-dev.txt
+pip install -r requirements-ai.txt
 python -m unittest test_nifty_multi_strategy_master
-python -m pytest "Signal Generators" "Dependencies" -q
+python -m unittest test_market_data_health
+python -m pytest "Signal Generators" "Dependencies" "Data Extractors" -q
+python -m coverage erase
+python -m coverage run -m unittest test_nifty_multi_strategy_master
+python -m coverage run --append -m unittest test_market_data_health
+python -m coverage run --append -m pytest "Signal Generators" "Dependencies" "Data Extractors" -q
+python -m coverage json -o coverage.json
+python scripts/check_coverage_thresholds.py coverage.json
+python -m pip_audit -r requirements.txt --no-deps --progress-spinner off
+python -m pip_audit -r requirements-ai.txt --no-deps --progress-spinner off
+python -m pip_audit -r requirements-dev.txt --no-deps --progress-spinner off
 python -m compileall -q .
 python -m ruff check .
 python -m mypy
 ```
-`pyproject.toml` holds the ruff + mypy config (mypy is scoped to the identifier-named modules — the spaced-name master file is covered by `compileall` + the unittest suite instead). `.pre-commit-config.yaml` wires the check-only hooks; install them once with `pre-commit install`.
+Coverage is branch-enabled: overall runtime coverage may not fall below 54.7%, new execution/reconciliation/data-safety modules require 90%, and every broker adapter requires 80%. The three local audit commands check committed direct pins; CI additionally audits the complete resolved dependency tree in a clean hosted environment. `pyproject.toml` holds the coverage, Ruff, and mypy config (mypy is scoped to the identifier-named modules — the spaced-name master file is covered by `compileall` + the unittest suite instead). `.pre-commit-config.yaml` wires the check-only hooks; install them once with `pre-commit install`.
 
 # License
 Released under the MIT License — see [LICENSE](LICENSE).

--- a/Signal Generators/SL Hunting AI Agent/README.md
+++ b/Signal Generators/SL Hunting AI Agent/README.md
@@ -51,7 +51,7 @@ one NIFTY lot is unaffordable, and caps at `SL_HUNTING_MAX_LOTS` (default 5).
 
 ## Setup (one-time)
 ```bash
-pip install claude-agent-sdk pydantic
+pip install -r requirements-ai.txt
 # Authenticate to your Claude SUBSCRIPTION. For an UNATTENDED live runner prefer a
 # long-lived token; interactive `claude login` also works but its OAuth login expires.
 claude setup-token
@@ -92,7 +92,7 @@ SL_HUNTING_MODEL=claude-opus-4-8 # or claude-sonnet-4-6 to cut cost
 ```
 Then run the master as usual (`python algo.py run`). It trades on **paper** unless
 both `LIVE_TRADING_ENABLED` and `SL_HUNTING_LIVE_TRADING` are `true`; the live
-broker is the existing `LIVE_BROKER` (`KOTAK`/`SHOONYA`). Live orders go through the
+broker is the existing `LIVE_BROKER` (`KOTAK`/`SHOONYA`/`FLATTRADE`). Live orders go through the
 master's one shared, lock-guarded broker session and its `enter_position` /
 `exit_position` (so max-loss, square-off and Telegram all apply). See the
 `SL_HUNTING_*` block in `Dependencies/env.example` for all knobs.
@@ -105,19 +105,19 @@ cutoff the agent isn't called at all, so it makes **no LLM calls for the rest of
 
 ## Safety
 - **Paper by default.** The agent is given exactly **one** order tool, chosen by
-  the env (`place_paper_order` / `place_kotak_order` / `place_shoonya_order`) — it
+  the env (`place_paper_order` / `place_kotak_order` / `place_shoonya_order` /
+  `place_flattrade_order`) — it
   can never pick paper-vs-real or the broker.
 - The agent **never raises** into the trading loop: any failure (SDK missing,
   malformed output, **auth 401 / usage-limit 429**, …) returns a safe `HOLD`, and the
   warning log names the cause (e.g. "authentication failed (HTTP 401) — run
   `claude setup-token`") so it's actionable.
-- Each SDK call is **time-bounded** (`SL_HUNTING_SDK_TIMEOUT_SECONDS`, default 90s).
-  The per-bar decision blocks the worker thread that also enforces stop/target,
-  max-loss and the 15:15 square-off, so a hung CLI call is abandoned at the budget:
-  that bar's order tool is disarmed (a late-waking loop cannot fire a zombie order)
-  and the agent records a fail-soft `HOLD`. If the CLI stays hung, subsequent bars
-  are **gated** until the abandoned call finishes — so at most one hung agent
-  call/subprocess exists at a time instead of one accumulating per bar.
+- Each SDK call is **time-bounded** (`SL_HUNTING_SDK_TIMEOUT_SECONDS`, default 90s;
+  accepted range 5–120s). Inference runs outside the mechanical risk loop, so
+  stop/target, max-loss, stale-feed, and 15:15 square-off checks continue while
+  one agent call is in flight. A timed-out or late result is disarmed inside the
+  final execution lock and becomes a fail-soft `HOLD`; at most one inference can
+  be active, so hung subprocesses cannot accumulate or place zombie orders.
 - Entry **stop/target are sanity-checked at the order tool** against the live price
   (correct side; stop within ~3%, target within ~10%) and bounded in the schema —
   a hallucinated level cannot silently disable the mechanical stop; the rejected
@@ -162,10 +162,14 @@ human-reviewed loop:
    when `SL_HUNTING_LESSONS_ENABLED=true`** (default off), loaded once per session so
    prompt caching holds. Validate first on paper: `sl_hunting_runner.py --lessons on|off`.
 
-**Safety/ML guardrails:** lessons are **human-gated, paper-first, and off by default**;
-the coach runs off the live loop; lessons are phrased as tendencies (not laws), require a
-minimum sample, separate process from outcome (a sound setup that lost ≠ a mistake), and
-the store is bounded/de-duplicated. Fine-tuning/RL and auto-promotion are out of scope.
+**Safety/ML guardrails:** lessons are **human-gated, paper-first, and off by default**.
+The coach runs off the live loop with `tools=[]`; journal rows are delimited untrusted
+data projected through strict schemas and length/row limits. Proposed and approved
+lessons use typed bounded schemas, promotion binds the approved content to a SHA-256
+digest, and atomic writes prevent a partial store. Modified approved content fails
+digest verification. Lessons remain tendencies (not laws), require a minimum sample,
+separate process from outcome (a sound setup that lost ≠ a mistake), and are
+bounded/de-duplicated. Fine-tuning/RL and auto-promotion are out of scope.
 
 ## Bank Nifty methodology (v3a)
 Knowledge-only drop distilled from 9 "Intraday Hunter" live-trading videos. General lessons

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_coach.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_coach.py
@@ -258,6 +258,13 @@ def summarize_journal(rows: list[dict[str, Any]], limit: int = 60) -> str:
     )
 
     # Build newest-first against the total character budget, then restore chronology.
+    #
+    # How the loop works: each iteration PREPENDS one older trade to the
+    # candidate list and renders the whole block.  If that render busts the
+    # character budget, the loop stops and keeps ``included`` -- the largest
+    # set that fit.  Walking newest-first means the trades sacrificed to the
+    # budget are always the OLDEST ones, and because each accepted candidate
+    # was prepended, ``included`` is already back in chronological order.
     included: list[dict[str, Any]] = []
     for trade in reversed(recent):
         candidate = [trade.model_dump(mode="json"), *included]
@@ -286,7 +293,14 @@ def summarize_journal(rows: list[dict[str, Any]], limit: int = 60) -> str:
 
 
 def _build_read_only_options(model: str, system_prompt: str, max_turns: int) -> dict[str, Any]:
-    """Build the coach SDK options with every tool surface explicitly disabled."""
+    """Build the coach SDK options with every tool surface explicitly disabled.
+
+    Both ``tools`` and ``allowed_tools`` are empty ON PURPOSE (belt and
+    braces): the journal text the coach reads is untrusted, so even a
+    perfectly injected "run this tool" instruction has no tool to run.
+    ``setting_sources`` is empty so no local settings file can quietly
+    re-enable one.
+    """
     return {
         "model": model,
         "system_prompt": system_prompt,

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_lessons.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_lessons.py
@@ -215,7 +215,21 @@ def _now() -> str:
 
 
 def lesson_content_digest(record: StoredLesson | dict[str, Any]) -> str:
-    """Return the canonical digest that binds operator approval to lesson content."""
+    """Return the canonical digest that binds operator approval to lesson content.
+
+    What the digest is FOR: the operator approves a lesson by reading its exact
+    text.  If the stored file were later edited (by a bug, a merge, or a
+    prompt-injection-shaped payload), the approved id would silently point at
+    words the operator never reviewed -- and those words are injected into the
+    live agent's prompt.  ``StoredLesson`` therefore recomputes this digest on
+    every load and rejects any approved record whose content no longer matches.
+
+    Only the reviewed CONTENT participates (id, scope, lesson, rationale,
+    evidence, confidence).  Timestamps and status are deliberately excluded so
+    a harmless metadata touch cannot invalidate a genuine approval.  The
+    canonical JSON form (sorted keys, fixed separators) makes the digest
+    stable regardless of dict ordering or formatting.
+    """
     source = record.model_dump(mode="json") if isinstance(record, StoredLesson) else record
     evidence = source.get("evidence") or {}
     content = {
@@ -296,6 +310,8 @@ def save_lessons(path: str, lessons: list[dict[str, Any]]) -> None:
     see either the previous complete store or the new complete store, never a partially
     written JSON document after a crash.
     """
+    # Validate BEFORE opening any file: a malformed record must fail loudly
+    # here rather than half-replace the store.
     validated = [
         StoredLesson.model_validate(record).model_dump(mode="json", exclude_none=True)
         for record in lessons
@@ -303,6 +319,9 @@ def save_lessons(path: str, lessons: list[dict[str, Any]]) -> None:
     parent = os.path.dirname(path)
     if parent:
         os.makedirs(parent, exist_ok=True)
+    # The temp file must live in the SAME directory as the target: os.replace
+    # is atomic only within one filesystem, and a cross-device rename would
+    # degrade to the copy-then-delete window this function exists to remove.
     directory = parent or "."
     descriptor, temporary_path = tempfile.mkstemp(
         prefix=f".{os.path.basename(path)}.", suffix=".tmp", dir=directory, text=True
@@ -311,10 +330,15 @@ def save_lessons(path: str, lessons: list[dict[str, Any]]) -> None:
         with os.fdopen(descriptor, "w", encoding="utf-8") as file_handle:
             json.dump(validated, file_handle, indent=2, ensure_ascii=False)
             file_handle.write("\n")
+            # flush() pushes Python's buffer to the OS; fsync() pushes the OS
+            # buffer to disk. Only after BOTH is the temp file guaranteed
+            # complete on disk, making the replace below crash-safe.
             file_handle.flush()
             os.fsync(file_handle.fileno())
         os.replace(temporary_path, path)
     finally:
+        # On success the temp path no longer exists (it BECAME the store); on
+        # any failure this removes the orphaned partial file.
         if os.path.exists(temporary_path):
             os.unlink(temporary_path)
 
@@ -328,14 +352,23 @@ def consolidate(lessons: list[dict[str, Any]], max_lessons: int = MAX_LIVE_LESSO
     """De-duplicate by id (keep the better-evidenced copy), rank by sample size then
     recency, and cap at `max_lessons` — so the store stays bounded and non-contradictory."""
     by_id: dict[str, dict[str, Any]] = {}
+    # Strict validation first: consolidation is a write-path chokepoint (both
+    # add_proposed and promote funnel through it), so a malformed record dies
+    # here instead of ever reaching the saved store.
     validated, _rejected = _validated_records(lessons)
     for lesson in validated:
         lid = lesson.get("id")
         if not lid:
             continue
+        # Same slug = same lesson text seen across coach runs.  Keep the copy
+        # backed by MORE trades: growing evidence should win, and a rerun on a
+        # shrunken journal must not downgrade a well-supported lesson.
         prev = by_id.get(lid)
         if prev is None or _sample(lesson) > _sample(prev):
             by_id[lid] = lesson
+    # Rank best-evidenced first (recency breaks ties), then cap: with a
+    # bounded list, a new well-supported lesson naturally evicts the weakest
+    # one, keeping the prompt block a stable size forever.
     ranked = sorted(
         by_id.values(),
         key=lambda rec: (_sample(rec), str(rec.get("updated_at", ""))),

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_tools.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_tools.py
@@ -99,7 +99,23 @@ CONTEXT_TOOL_NAMES = [
 
 
 class ToolContextState(StrEnum):
-    """Lifecycle of the one side-effect capability granted to an agent pass."""
+    """Lifecycle of the one side-effect capability granted to an agent pass.
+
+    The transitions, in plain English:
+
+    - ``ACTIVE``    : the pass may still place its one order.  Rejected
+                      validation attempts return here so the model can
+                      correct its levels within the same pass.
+    - ``EXECUTING`` : an order is inside the executor right now -- a second
+                      call arriving mid-flight is refused, never queued.
+    - ``CONSUMED``  : an ACCEPTED side effect happened.  Terminal: one pass
+                      gets at most one accepted ENTER or EXIT, ever.
+    - ``EXPIRED``   : the decision window closed (deadline, stale generation,
+                      mechanical exit, or the pass simply finished) before an
+                      accepted action.  Terminal: a late tool call from an
+                      abandoned SDK loop finds a dead capability, not a
+                      market order.
+    """
 
     ACTIVE = "ACTIVE"
     EXECUTING = "EXECUTING"
@@ -283,6 +299,13 @@ class SLHuntingToolContext:
         else:
             return {"accepted": False, "reason": f"unknown action {action!r}; expected ENTER_LONG, ENTER_SHORT or EXIT"}
 
+        # The final gate.  The freshness checks (state, generation, deadline)
+        # run INSIDE the same lock that serializes the executor call, because
+        # checking first and locking second would leave a gap: the mechanical
+        # risk loop could invalidate this pass between the check and the
+        # order.  Inside the lock, what was checked is what executes.  This is
+        # also the lock the worker's stop/target/square-off paths hold while
+        # THEY act, so an agent order and a mechanical exit can never race.
         with self._execution_lock:
             refusal = self._refusal_inside_lock()
             if refusal is not None:
@@ -291,6 +314,8 @@ class SLHuntingToolContext:
             try:
                 result = executor_call()
             except BaseException:
+                # An executor that blew up mid-order leaves unknown exposure;
+                # this pass must not get a second try at it.
                 self.expired_reason = "executor raised"
                 self.state = ToolContextState.EXPIRED
                 raise

--- a/algo.py
+++ b/algo.py
@@ -95,6 +95,7 @@ BACKTEST_SCRIPTS = {
 # these keys automatically; each value is the script that receives the remaining
 # CE/PE, strike, expiry, and --place-order arguments unchanged.
 BROKER_DIAGNOSTICS = {
+    "dhan": "Dependencies/Dhan API/diagnose_dhan_symbol.py",
     "flattrade": "Dependencies/Flattrade API/diagnose_flattrade_symbol.py",
     "kotak": "Dependencies/Kotak API/diagnose_kotak_symbol.py",
     "shoonya": "Dependencies/Shoonya API/diagnose_shoonya_symbol.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,3 +132,32 @@ ignore_missing_imports = true
 # The vendored Shoonya SDK is third-party code; type-check our wrappers, not it.
 module = ["NorenApi"]
 ignore_errors = true
+
+[tool.coverage.run]
+# Measure branch exits as well as statements. ``thread`` matters because the
+# master runner and several fault-injection tests execute safety paths in worker
+# threads. Relative paths keep the JSON report identical on Windows and Linux.
+branch = true
+relative_files = true
+concurrency = ["thread"]
+source = ["."]
+omit = [
+    "*/test_*.py",
+    "*/tests/*",
+    "Backtest Outputs/*",
+    "My Backtest Files (For Reference)/*",
+    "Dependencies/Shoonya API/NorenApi.py",
+]
+
+[tool.coverage.report]
+# MAT-110 measured the branch-enabled runtime baseline before installing this
+# gate. Per-module 90%/80% budgets are enforced from coverage.json by the small
+# policy script because Coverage.py has only one global fail-under setting.
+fail_under = 54.7
+precision = 1
+show_missing = true
+skip_covered = false
+exclude_also = [
+    "if TYPE_CHECKING:",
+    "if __name__ == .__main__.:",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ files = [
     "algo.py",
     "Data Extractors/index_1m_5y_data_fetch_dhan_common.py",
     "Dependencies/broker_contract.py",
+    "Dependencies/diagnostic_preflight.py",
     "Dependencies/next_open_entry.py",
     "Dependencies/market_data_health.py",
     "Dependencies/risk_sizing.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,8 @@ files = [
     "Dependencies/Shoonya API/diagnose_shoonya_symbol.py",
     "Dependencies/Flattrade API/flattrade_execution.py",
     "Dependencies/Flattrade API/diagnose_flattrade_symbol.py",
+    "Dependencies/Dhan API/dhan_execution.py",
+    "Dependencies/Dhan API/diagnose_dhan_symbol.py",
     "Signal Generators/ema_trend_strategy_logic.py",
     "Signal Generators/heikin_ashi_strategy_logic.py",
     "Signal Generators/renko_strategy_logic.py",

--- a/requirements-ai.txt
+++ b/requirements-ai.txt
@@ -1,0 +1,10 @@
+# Exact optional runtime set for the SL Hunting Claude agent.
+#
+# These versions are the Python 3.12/3.13 set validated by the MAT safety stack.
+# The first three packages are the Claude Agent SDK's direct runtime dependencies;
+# pinning them prevents a fresh install from silently changing the agent transport.
+claude-agent-sdk==0.2.115
+anyio==4.14.1
+mcp==1.28.1
+sniffio==1.3.1
+pydantic==2.13.4

--- a/requirements-brokers.txt
+++ b/requirements-brokers.txt
@@ -1,0 +1,15 @@
+# Exact optional broker dependency environment validated on Python 3.12/3.13.
+#
+# Kotak does not publish the required v2.0.1 instruction as a usable PyPI release.
+# Install the official repository tag exactly as Kotak documents. Shoonya's client
+# is vendored, but it needs the pinned TOTP and WebSocket packages below. Flattrade
+# uses requests/pandas from requirements.txt and needs no extra SDK.
+#
+# IMPORTANT: Kotak's tag declares older exact pandas/requests constraints, so this
+# full file is an isolated compatibility/CI environment and must not be combined
+# with requirements.txt. For the live app environment, follow README.md: install
+# Shoonya's two pins directly and install the tagged Kotak package with --no-deps
+# so pip cannot silently downgrade the audited core runtime.
+neo_api_client @ git+https://github.com/Kotak-Neo/Kotak-neo-api-v2.git@v2.0.1
+pyotp==2.9.0
+websocket-client==1.8.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,14 +5,11 @@ ruff==0.15.1
 mypy==1.19.1
 bandit==1.9.4
 pre-commit==4.6.0
+coverage==7.14.1
+pytest-cov==7.1.0
+pip-audit==2.10.1
 # Type stubs for typed third-party usage in the mypy scope. pandas-stubs is
 # pinned so local and CI mypy see the exact same pandas typing (an out-of-band
 # stubs install once made local mypy fail while CI stayed green).
 types-requests==2.33.0.20260518
 pandas-stubs==2.3.3.260113
-# Optional runtime deps installed in CI so the SL Hunting and Shoonya suites
-# run fully instead of skipping (they stay optional for live operation).
-pydantic
-claude-agent-sdk
-pyotp
-websocket-client

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,29 +9,33 @@ dhanhq==2.2.0
 pandas==3.0.3
 numpy==2.4.6
 backtesting==0.6.5
-python-dotenv==1.0.0
+python-dotenv==1.2.2
 gspread==6.2.1
 pytz==2026.2
-# 2.32.4 fixes CVE-2024-47081 (.netrc credential leak) present in 2.32.3; the
-# broker, symbol-master and Telegram HTTP paths all use requests.
-requests==2.32.4
+# The broker, symbol-master and Telegram HTTP paths all use requests. Keep this
+# at the first release that clears the repository audit after PYSEC-2026-2275.
+requests==2.33.0
+# The vendored Shoonya client imports websocket at module load. Keep this
+# harmless, conflict-free import dependency in the core set so diagnostics and
+# the broker coverage suite work even before optional live credentials exist.
+websocket-client==1.8.0
 TA-Lib==0.6.8
 
-# ---- Live trading (optional) — install only for the broker you use ----
-# The commented pins below are the versions verified on the live runner; keep
-# them when installing an extra so the whole box stays on one verified set.
-# Kotak Neo:
-#   neo_api_client
-# Shoonya (Finvasia) — the NorenApi client is vendored in "Dependencies/Shoonya API/",
-# but it needs these at runtime:
-#   pyotp==2.9.0
-#   websocket-client==1.8.0
+# ---- Exact optional dependency sets -----------------------------------------
+# Live broker compatibility manifest:
+#   requirements-brokers.txt
+# Kotak's official v2.0.1 tag declares dependencies that conflict with this
+# audited core set, so do not install both files together. README.md gives the
+# safe per-broker commands. Shoonya's NorenApi client remains vendored under
+# "Dependencies/Shoonya API/".
+#
+# SL Hunting AI Agent:
+#   pip install -r requirements-ai.txt
+# This pins the Claude Agent SDK and the exact transitive SDK/schema stack
+# validated together. The strategy stays disabled when this set is absent.
+#
+# Development and CI:
+#   pip install -r requirements-dev.txt
+#
 # ML Ensemble signal generator:
 #   scikit-learn==1.8.0
-# SL Hunting AI Agent (optional, LLM-driven strategy under "Signal Generators/
-# SL Hunting AI Agent/") — only needed when SL_HUNTING_ENABLED=true. The Claude
-# Agent SDK runs on your Claude subscription (bundled Claude CLI login; keep
-# ANTHROPIC_API_KEY UNSET). pydantic validates the agent's JSON decisions. Both
-# are lazily imported, so the master and its test suite run fine without them:
-#   claude-agent-sdk==0.2.87
-#   pydantic==2.13.4

--- a/scripts/check_coverage_thresholds.py
+++ b/scripts/check_coverage_thresholds.py
@@ -20,12 +20,20 @@ SAFETY_THRESHOLDS = {
     "Dependencies/market_data_health.py": 90.0,
     "Dependencies/next_open_entry.py": 90.0,
     "Dependencies/risk_sizing.py": 90.0,
+    # MAT-108's redaction layer is data-safety code: a regression here leaks
+    # credentials into logs, so it carries the same 90% budget.
+    "Dependencies/secret_redaction.py": 90.0,
 }
 
+# EVERY live execution adapter belongs in this dict. A broker added without a
+# row here silently escapes the "80% per broker adapter" policy that
+# CLAUDE.md/AGENTS.md promise (exactly what happened when the Dhan adapter
+# first landed), so treat this list as part of adding a broker.
 BROKER_THRESHOLDS = {
     "Dependencies/Kotak API/kotak_execution.py": 80.0,
     "Dependencies/Shoonya API/shoonya_execution.py": 80.0,
     "Dependencies/Flattrade API/flattrade_execution.py": 80.0,
+    "Dependencies/Dhan API/dhan_execution.py": 80.0,
 }
 
 

--- a/scripts/check_coverage_thresholds.py
+++ b/scripts/check_coverage_thresholds.py
@@ -1,0 +1,87 @@
+"""Enforce MAT-110's per-module branch-enabled coverage budgets.
+
+Coverage.py's ``percent_covered`` combines statements and measured branch exits.
+The CI run enables branch measurement globally, then this script applies stricter
+budgets to the live-money safety core and each broker adapter.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+SAFETY_THRESHOLDS = {
+    "Dependencies/broker_contract.py": 90.0,
+    "Dependencies/execution_ledger.py": 90.0,
+    "Dependencies/startup_exposure.py": 90.0,
+    "Dependencies/trading_lifecycle.py": 90.0,
+    "Dependencies/market_data_health.py": 90.0,
+    "Dependencies/next_open_entry.py": 90.0,
+    "Dependencies/risk_sizing.py": 90.0,
+}
+
+BROKER_THRESHOLDS = {
+    "Dependencies/Kotak API/kotak_execution.py": 80.0,
+    "Dependencies/Shoonya API/shoonya_execution.py": 80.0,
+    "Dependencies/Flattrade API/flattrade_execution.py": 80.0,
+}
+
+
+def _portable_path(value: str) -> str:
+    """Normalize Coverage.py paths from Windows or POSIX runners."""
+    return str(value).replace("\\", "/").lstrip("./")
+
+
+def evaluate_coverage(
+    report: dict[str, Any],
+    *,
+    safety_thresholds: dict[str, float] | None = None,
+    broker_thresholds: dict[str, float] | None = None,
+) -> list[str]:
+    """Return deterministic failure messages for missing/under-budget modules."""
+    files = {
+        _portable_path(path): details
+        for path, details in (report.get("files") or {}).items()
+    }
+    thresholds = {
+        **(SAFETY_THRESHOLDS if safety_thresholds is None else safety_thresholds),
+        **(BROKER_THRESHOLDS if broker_thresholds is None else broker_thresholds),
+    }
+    failures: list[str] = []
+    for raw_path, threshold in sorted(thresholds.items()):
+        path = _portable_path(raw_path)
+        details = files.get(path)
+        if details is None:
+            failures.append(f"{path}: missing from coverage report")
+            continue
+        summary = details.get("summary") or {}
+        if int(summary.get("num_branches", 0)) <= 0:
+            failures.append(f"{path}: branch data was not measured")
+            continue
+        measured = float(summary.get("percent_covered", 0.0))
+        if measured + 1e-9 < float(threshold):
+            failures.append(
+                f"{path}: {measured:.2f}% is below the {float(threshold):.1f}% budget"
+            )
+    return failures
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("report", nargs="?", default="coverage.json")
+    args = parser.parse_args(argv)
+    report = json.loads(Path(args.report).read_text(encoding="utf-8"))
+    failures = evaluate_coverage(report)
+    if failures:
+        print("Coverage policy failed:")
+        for failure in failures:
+            print(f"- {failure}")
+        return 1
+    print("Coverage policy passed for all safety and broker modules.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_coverage_thresholds.py
+++ b/scripts/check_coverage_thresholds.py
@@ -3,6 +3,13 @@
 Coverage.py's ``percent_covered`` combines statements and measured branch exits.
 The CI run enables branch measurement globally, then this script applies stricter
 budgets to the live-money safety core and each broker adapter.
+
+Why this script exists at all: Coverage.py has exactly ONE global
+``fail_under`` setting (pyproject pins it to the repository's 54.7% baseline),
+so the stricter 90%/80% per-module budgets have to be enforced from the JSON
+report by hand.  The split is deliberate -- the global floor stops overall
+erosion, while these budgets stop a specific safety module from quietly losing
+its tests.
 """
 
 from __future__ import annotations
@@ -62,13 +69,21 @@ def evaluate_coverage(
         path = _portable_path(raw_path)
         details = files.get(path)
         if details is None:
+            # A renamed/deleted module must FAIL the gate, not silently drop
+            # out of it -- otherwise moving a file would retire its budget.
             failures.append(f"{path}: missing from coverage report")
             continue
         summary = details.get("summary") or {}
         if int(summary.get("num_branches", 0)) <= 0:
+            # Percent alone can look fine while branch measurement was never
+            # switched on (a broken [tool.coverage.run] branch=true would
+            # silently weaken every budget). Zero measured branches in modules
+            # this size is only ever a measurement failure.
             failures.append(f"{path}: branch data was not measured")
             continue
         measured = float(summary.get("percent_covered", 0.0))
+        # The epsilon keeps an exactly-on-budget module passing despite float
+        # representation (e.g. a true 80.0 stored as 79.999...).
         if measured + 1e-9 < float(threshold):
             failures.append(
                 f"{path}: {measured:.2f}% is below the {float(threshold):.1f}% budget"

--- a/test_market_data_health.py
+++ b/test_market_data_health.py
@@ -12,6 +12,7 @@ from Dependencies.market_data_health import (
     MarketDataHealth,
     MarketDataValidationError,
     complete_minute_bucket_mask,
+    newest_completed_minute_timestamp,
     validate_ohlc_frame,
 )
 
@@ -43,6 +44,43 @@ class TestOHLCValidation(unittest.TestCase):
         frame.loc[0, "close"] = float("inf")
         with self.assertRaises(MarketDataValidationError):
             validate_ohlc_frame(frame, now=self.now)
+
+    def test_rejects_empty_or_incomplete_snapshots(self) -> None:
+        for frame in (None, pd.DataFrame()):
+            with self.subTest(frame=frame), self.assertRaises(
+                MarketDataValidationError, msg="empty"
+            ):
+                validate_ohlc_frame(frame, now=self.now)  # type: ignore[arg-type]
+
+        with self.assertRaises(MarketDataValidationError, msg="missing"):
+            validate_ohlc_frame(pd.DataFrame({"timestamp": [self.now]}), now=self.now)
+
+    def test_rejects_invalid_or_misaligned_timestamps(self) -> None:
+        for timestamp in (pd.NaT, datetime(2026, 7, 16, 9, 59, 1)):
+            with self.subTest(timestamp=timestamp), self.assertRaises(
+                MarketDataValidationError
+            ):
+                validate_ohlc_frame(_frame([timestamp]), now=self.now)
+
+    def test_rejects_nonnumeric_price_and_each_geometry_violation(self) -> None:
+        nonnumeric = _frame([datetime(2026, 7, 16, 9, 59)])
+        nonnumeric["open"] = pd.Series(["not-a-price"], dtype=object)
+        with self.assertRaises(MarketDataValidationError):
+            validate_ohlc_frame(nonnumeric, now=self.now)
+
+        mutations = (
+            ("low", 101.5),   # low above open
+            ("low", 101.5),   # low above close
+            ("high", 99.5),   # high below open/close
+            ("low", 103.0),   # low above high
+        )
+        for column, value in mutations:
+            frame = _frame([datetime(2026, 7, 16, 9, 59)])
+            frame.loc[0, column] = value
+            with self.subTest(column=column, value=value), self.assertRaises(
+                MarketDataValidationError
+            ):
+                validate_ohlc_frame(frame, now=self.now)
 
         frame.loc[0, "close"] = 0.0
         with self.assertRaises(MarketDataValidationError):
@@ -107,6 +145,43 @@ class TestCompleteMinuteBuckets(unittest.TestCase):
         )
         self.assertEqual(complete_minute_bucket_mask(wrong_slots, 5).tolist(), [False] * 5)
 
+    def test_rejects_invalid_timeframes_and_handles_empty_or_partial_buckets(self) -> None:
+        with self.assertRaises(ValueError, msg="positive"):
+            complete_minute_bucket_mask(pd.DatetimeIndex([]), 0)
+
+        self.assertEqual(
+            complete_minute_bucket_mask(pd.DatetimeIndex([]), 5).tolist(),
+            [],
+        )
+        partial = pd.DatetimeIndex(["2026-07-16 09:15", "2026-07-16 09:16"])
+        self.assertEqual(complete_minute_bucket_mask(partial, 5).tolist(), [False, False])
+
+
+class TestCompletedMinuteTimestamp(unittest.TestCase):
+    """Only completed one-minute bars may drive freshness decisions."""
+
+    def test_returns_none_for_missing_inputs(self) -> None:
+        now = datetime(2026, 7, 16, 10, 0, 30, tzinfo=IST)
+        self.assertIsNone(newest_completed_minute_timestamp(None, now=now))  # type: ignore[arg-type]
+        self.assertIsNone(newest_completed_minute_timestamp(pd.DataFrame(), now=now))
+        self.assertIsNone(
+            newest_completed_minute_timestamp(pd.DataFrame({"open": [100]}), now=now)
+        )
+
+    def test_excludes_current_minute_and_returns_latest_completed_bar(self) -> None:
+        now = datetime(2026, 7, 16, 10, 0, 30, tzinfo=IST)
+        frame = _frame(
+            [
+                datetime(2026, 7, 16, 9, 58),
+                datetime(2026, 7, 16, 9, 59),
+                datetime(2026, 7, 16, 10, 0),
+            ]
+        )
+        self.assertEqual(
+            newest_completed_minute_timestamp(frame, now=now),
+            datetime(2026, 7, 16, 9, 59, tzinfo=IST),
+        )
+
 
 class TestMarketDataHealth(unittest.TestCase):
     """Live entry and liquidation state must follow explicit freshness rules."""
@@ -166,6 +241,47 @@ class TestMarketDataHealth(unittest.TestCase):
         snapshot = health.snapshot(now=self.now)
         self.assertFalse(snapshot.monitoring)
         self.assertTrue(snapshot.entry_allowed)
+
+    def test_stop_monitoring_restores_offline_entry_behavior(self) -> None:
+        self.health.stop_monitoring()
+        snapshot = self.health.snapshot(now=self.now)
+        self.assertFalse(snapshot.monitoring)
+        self.assertTrue(snapshot.entry_allowed)
+
+    def test_failed_refresh_and_missing_inputs_report_each_reason(self) -> None:
+        snapshot = self.health.record_refresh(
+            ohlc_ok=False,
+            newest_completed_bar=None,
+            ltp_fetched_at={},
+            required_ltp_keys={self.key},
+            now=self.now,
+        )
+        self.assertFalse(snapshot.entry_allowed)
+        self.assertEqual(snapshot.healthy_streak, 0)
+        self.assertTrue(any("refresh failed" in reason for reason in snapshot.reasons))
+        self.assertTrue(any("unavailable" in reason for reason in snapshot.reasons))
+
+    def test_future_bar_and_future_ltp_are_unhealthy(self) -> None:
+        snapshot = self.health.record_refresh(
+            ohlc_ok=True,
+            newest_completed_bar=self.now + timedelta(seconds=6),
+            ltp_fetched_at={self.key: self.now + timedelta(seconds=6)},
+            required_ltp_keys={self.key},
+            now=self.now,
+        )
+        self.assertTrue(any("bar is in the future" in reason for reason in snapshot.reasons))
+        self.assertTrue(any("future-dated" in reason for reason in snapshot.reasons))
+
+    def test_unhealthy_clock_starts_when_snapshot_first_observes_silence(self) -> None:
+        for offset in (0, 2, 4):
+            self._record_healthy(self.now + timedelta(seconds=offset))
+
+        first_stale = self.now + timedelta(seconds=20)
+        first = self.health.snapshot(now=first_stale)
+        later = self.health.snapshot(now=first_stale + timedelta(seconds=31))
+        self.assertEqual(first.unhealthy_seconds, 0.0)
+        self.assertGreaterEqual(later.unhealthy_seconds, 31.0)
+        self.assertTrue(later.liquidation_required)
 
 
 if __name__ == "__main__":

--- a/test_nifty_multi_strategy_master.py
+++ b/test_nifty_multi_strategy_master.py
@@ -6,6 +6,7 @@ import sys
 import tempfile
 import threading
 import unittest
+from contextlib import ExitStack
 from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -2056,6 +2057,70 @@ class TestEnvBool(unittest.TestCase):
             self.assertTrue(master_file._env_bool("X_FLAG", True))
         os.environ.pop("X_FLAG", None)
         self.assertFalse(master_file._env_bool("X_FLAG", False))
+
+
+class TestSelectExecutionClient(unittest.TestCase):
+    """`_select_execution_client` routes brokers and fails closed on a typo.
+
+    Its own docstring calls this out as the reason the decision lives in one
+    small function: a typo must never route real-money orders to another
+    broker, and an unrecognised name must disable live trading entirely.
+    """
+
+    def _select(self, broker, **clients):
+        """Run the selector with every broker client patched to a sentinel."""
+        defaults = {
+            "kotak_execution_client": "KOTAK-CLIENT",
+            "shoonya_execution_client": "SHOONYA-CLIENT",
+            "flattrade_execution_client": "FLATTRADE-CLIENT",
+            "dhan_execution_client": "DHAN-CLIENT",
+        }
+        defaults.update(clients)
+        with ExitStack() as stack:
+            for name, value in defaults.items():
+                stack.enter_context(patch.object(master_file, name, value))
+            return master_file._select_execution_client(broker)
+
+    def test_each_broker_routes_to_its_own_client_and_segment(self):
+        # The exchange-segment string is broker-specific and is passed straight
+        # through to the order call, so a wrong value would reject every order.
+        expected = {
+            "KOTAK": ("KOTAK-CLIENT", "nse_fo"),
+            "SHOONYA": ("SHOONYA-CLIENT", "NFO"),
+            "FLATTRADE": ("FLATTRADE-CLIENT", "NFO"),
+            "DHAN": ("DHAN-CLIENT", "NSE_FNO"),
+        }
+        for broker, (client, segment) in expected.items():
+            with self.subTest(broker=broker), patch.dict(os.environ, {}, clear=False):
+                got_client, got_segment, got_product = self._select(broker)
+                self.assertEqual(got_client, client)
+                self.assertEqual(got_segment, segment)
+                self.assertEqual(got_product, "INTRADAY")
+
+    def test_broker_name_is_case_and_whitespace_insensitive(self):
+        client, segment, _product = self._select("  dhan  ")
+        self.assertEqual(client, "DHAN-CLIENT")
+        self.assertEqual(segment, "NSE_FNO")
+
+    def test_product_type_comes_from_the_brokers_own_env_key(self):
+        with patch.dict(os.environ, {"DHAN_PRODUCT_TYPE": "normal"}):
+            _client, _segment, product = self._select("DHAN")
+        self.assertEqual(product, "NORMAL")
+
+    def test_unknown_broker_fails_closed(self):
+        for broker in ("ZERODHA", "", "dhann", None):
+            with self.subTest(broker=broker):
+                self.assertEqual(
+                    self._select(broker),
+                    (None, "", "INTRADAY"),
+                )
+
+    def test_missing_client_yields_none_so_startup_forces_paper(self):
+        # A broker whose SDK failed to import is None; the selector still
+        # returns it so `_configure_startup_live_trading` disables live mode.
+        client, segment, _product = self._select("DHAN", dhan_execution_client=None)
+        self.assertIsNone(client)
+        self.assertEqual(segment, "NSE_FNO")
 
 
 class TestTimezoneAssumption(unittest.TestCase):

--- a/test_nifty_multi_strategy_master.py
+++ b/test_nifty_multi_strategy_master.py
@@ -1397,6 +1397,17 @@ class TestBasePaperStrategyWorker(unittest.TestCase):
         self.assertNotEqual(oid1, oid2)
         self.assertTrue(oid2.endswith("-0002"))
 
+    def test_session_execution_mode_tracks_live_and_paper_fallbacks_without_telegram(self):
+        """Mode telemetry is trading state, not a side effect of enabling Telegram."""
+        self.assertEqual(self.worker.session_execution_mode(), "PAPER")
+
+        self.worker.live_trading = True
+        self.worker.publish_trade_event({"action": "ENTRY", "mode": "LIVE"})
+        self.assertEqual(self.worker.session_execution_mode(), "LIVE")
+
+        self.worker.publish_trade_event({"action": "ENTRY", "mode": "PAPER_FALLBACK"})
+        self.assertEqual(self.worker.session_execution_mode(), "MIXED")
+
     def test_stop_event_flattens_before_worker_reaches_stopped(self):
         """A pre-set terminal event is translated into flatten-then-stop."""
 
@@ -2133,6 +2144,73 @@ class TestGoogleSheetRetry(unittest.TestCase):
         self._run_writer(fake)                          # must not raise
         self.assertEqual(calls["oauth"], 3)             # bounded attempts
         self.assertEqual(calls["updates"], [])
+
+
+class TestExecutionModeResults(unittest.TestCase):
+    """End-of-day logs, Telegram, and Sheet rows must retain execution provenance."""
+
+    @staticmethod
+    def _worker(name: str, mode: str, pnl: float, trades: int):
+        worker = MagicMock()
+        worker.strategy_name = name
+        worker.realized_pnl = pnl
+        worker.completed_trades = trades
+        worker.session_execution_mode.return_value = mode
+        return worker
+
+    def test_eod_summary_reports_mixed_mode_and_per_strategy_modes(self):
+        event_queue = master_file.queue.Queue()
+        workers = [
+            self._worker("Renko", "LIVE", 100.0, 1),
+            self._worker("EMA", "PAPER", -25.0, 2),
+        ]
+
+        master_file._publish_eod_summary(workers, event_queue)
+
+        event = event_queue.get_nowait()
+        self.assertEqual(event["mode"], "MIXED")
+        self.assertEqual([row["mode"] for row in event["rows"]], ["LIVE", "PAPER"])
+        self.assertIn("[MIXED]", master_file.format_trade_message(event))
+
+    def test_log_parser_keeps_new_modes_and_legacy_paper_rows(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "runner.log"
+            path.write_text(
+                "2026-07-16 15:15:00,000 | INFO | RenkoThread | "
+                "Result summary | Mode=LIVE | Trades=1 | RealizedPnL=100.00\n"
+                "2026-07-16 15:16:00,000 | INFO | EMAThread | "
+                "Result summary | Mode=MIXED | Trades=2 | RealizedPnL=-25.00\n"
+                "2026-07-15 15:15:00,000 | INFO | RenkoThread | "
+                "Paper summary | Trades=1 | RealizedPnL=50.00\n",
+                encoding="utf-8",
+            )
+
+            parsed = master_file._parse_eod_pnl_by_day(path)
+
+        self.assertEqual(parsed["2026-07-16"]["Renko"], {"pnl": 100.0, "mode": "LIVE"})
+        self.assertEqual(parsed["2026-07-16"]["EMA"], {"pnl": -25.0, "mode": "MIXED"})
+        self.assertEqual(parsed["2026-07-15"]["Renko"], {"pnl": 50.0, "mode": "PAPER"})
+
+    def test_sheet_uses_mode_specific_labels_without_turning_pnl_into_text(self):
+        values = [
+            ["Strategy", "2026-07-16"],
+            ["Renko Strategy [LIVE]", ""],
+            ["EMA Strategy [MIXED]", ""],
+            ["Renko Strategy", ""],
+        ]
+        pnl_by_day = {
+            "2026-07-16": {
+                "Renko": {"pnl": 100.0, "mode": "LIVE"},
+                "EMA": {"pnl": -25.0, "mode": "MIXED"},
+            }
+        }
+
+        updates, unmatched = master_file._compute_pnl_sheet_updates(
+            values, pnl_by_day, "2026-07-16"
+        )
+
+        self.assertEqual(updates, [(1, 1, 100.0), (2, 1, -25.0)])
+        self.assertEqual(unmatched, [])
 
 
 class TestStrategyEnvPrefixMap(unittest.TestCase):


### PR DESCRIPTION
## MAT-110

This final stacked ticket makes the safety backlog reproducible and observable:

- pins exact broker and Claude-agent dependency sets, including Kotak v2.0.1 from its official VCS tag;
- adds clean-environment `pip-audit`, Dependabot policy, and Python 3.12/3.13 broker dependency checks;
- enforces the measured 54.7% runtime branch-coverage floor, 90% for new safety modules, and 80% for each broker adapter;
- distinguishes PAPER, LIVE, and MIXED strategy telemetry in logs, Telegram summaries, and Google Sheet rows;
- expands fault/boundary coverage and aligns README, AGENTS.md, CLAUDE.md, env templates, and broker/SL Hunting documentation;
- installs Shoonya's pinned import-time `websocket-client` dependency in the core quality environment, with a repository-policy regression guard.

The branch is one exact MAT-110 commit on the current MAT-109 tip. The complete ten-ticket stack is rebased onto current `main` (`f8ad804`) with each adjacent slice exactly one commit ahead and zero behind. It preserves the upstream SL Hunting v3j-v3m, Profit Shooter 5-minute, journal-fidelity, and live-only market-data changes. This PR contains 23 intended files and no publication/bootstrap artifacts.

## Verification

- 320 master unittests passed (25 expected optional-SDK skips)
- 20 focused market-data-health tests passed
- 515 Signal Generator, Dependency, and Data Extractor pytest cases passed
- total runtime branch coverage: 65.1%; every safety/broker module budget passed
- Ruff, mypy (34 source files), compileall, Bandit, pre-commit configuration, and diff checks passed locally
- final focused security rerun: 144 credential/redaction, Dhan, broker-contract, and repository-policy tests plus 5 journal/lesson injection/schema/digest/atomicity tests passed
- GitHub Actions run `29634151149` passed all four jobs:
  - Python 3.12 and 3.13 quality checks, including clean-environment `pip-audit`, branch coverage, Ruff, mypy, compileall, and Bandit
  - Python 3.12 and 3.13 isolated broker-dependency validation
- GitHub Actions runs 94-103 passed for every ticket head in the rebuilt stack
- final formal Codex Security validation and attack-path analysis found no reportable or deferred finding; CRED-001, AGENT-001, and LESSON-001 remain suppressed after final-tree revalidation

Live flags remained off throughout implementation. Before re-enabling live trading, run the locked full-market-session paper soak and confirm there are no stale-data, reconciliation, sizing, or shutdown alerts.

Codex authored and verified this change; the commit includes the requested co-author trailer.