### PR TITLE
Add DhanHQ live execution client (LIVE_BROKER=DHAN)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,7 @@ Dependencies/
   Shoonya API/   -> NorenApi.py (vendored client), shoonya_execution.py, diagnose_shoonya_symbol.py
   Flattrade API/ -> flattrade_execution.py, diagnose_flattrade_symbol.py,
                     test_flattrade_execution.py
+  Dhan API/      -> dhan_execution.py, diagnose_dhan_symbol.py, test_dhan_execution.py
 pyproject.toml                                     # ruff + mypy quality-gate configuration
 .github/workflows/quality-and-security.yml         # CI: tests + compileall + ruff + mypy + bandit
 scripts/check_coverage_thresholds.py               # branch-coverage policy gate
@@ -80,23 +81,34 @@ Backtest Outputs/                                  # generated CSVs/logs (gitign
   name→prefix map is `STRATEGY_ENV_PREFIX`. **Never commit secrets** — `env.example` holds blank placeholders.
 - **Live-trading safety (critical):** paper by default. A strategy trades live ONLY when the global
   `LIVE_TRADING_ENABLED` **and** that strategy's `<PREFIX>_LIVE_TRADING` are both true. `LIVE_BROKER`
-  (`KOTAK` | `SHOONYA` | `FLATTRADE`) selects the broker; an unknown value **fails closed** (live
-  disabled, paper only).
+  (`KOTAK` | `SHOONYA` | `FLATTRADE` | `DHAN`) selects the broker; an unknown value **fails closed**
+  (live disabled, paper only).
   An entry falls back to paper only after an explicit `REJECTED` result with zero fill. `PARTIAL` or
   `UNKNOWN` means exposure may exist: freeze new live entries, keep exits available, and reconcile;
   never treat an acknowledgement, truthy value, or order ID as proof of fill. A rejected live exit
   keeps the position open. Every broker network/SDK call has a ten-second deadline that includes its
-  shared lock/rate-limit wait; native HTTP timeouts remain enabled for Shoonya and Flattrade.
+  shared lock/rate-limit wait; native HTTP timeouts remain enabled for Shoonya, Flattrade and Dhan
+  (the Dhan SDK ships a 60s default that `_login_locked` overrides down to 10s).
 - **Per-strategy on/off:** each strategy also has a `<PREFIX>_VIRTUAL_TRADING` gate (default true).
   Set it false to stop that strategy's worker thread from starting at all (so it does neither paper
   nor live). Unlike live trading there is **no** global master switch — default is everything runs.
   `main()` filters the `workers` list via `_strategy_virtual_trading_enabled` before starting threads.
-- **Broker layer:** the Kotak, Shoonya, and Flattrade clients expose the SAME surface —
+- **Broker layer:** the Kotak, Shoonya, Flattrade and Dhan clients expose the SAME surface —
   `ensure_logged_in`, `preload_scrip_master`, `resolve_option_symbol`, `place_market_order`,
   `get_order_status`, `cancel_order`, `list_open_orders`, `list_open_positions`,
   `recover_after_reconciliation`, `extract_order_id`, `logout`, `is_logged_in` — so the runner only
-  touches the generic `execution_client`. The Shoonya
-  `NorenApi` client is vendored under `Dependencies/Shoonya API/`.
+  touches the generic `execution_client`. The shared result types live in
+  `Dependencies/broker_contract.py`. The Shoonya `NorenApi` client is vendored under
+  `Dependencies/Shoonya API/`. Dhan is the only broker whose SDK serves both market data and
+  execution, but the two sessions stay separate (`DhanBrokerClient` vs `dhan_execution_client`).
+  Two Dhan quirks the adapter exists to contain: its SDK returns `{'status':'failure',
+  'remarks': str(exc)}` for *transport* errors, which is shape-identical to a real rejection — so
+  `REJECTED` is never derived from the placement envelope (a `dict` `remarks` means the server
+  refused, a `str` means it is indeterminate); and `order_tag` is sent as Dhan's `correlationId`
+  so `get_order_by_correlationID` can recover an order whose response was lost. Dhan's
+  non-contract states are aliased adapter-locally (`EXPIRED`→`CANCELLED`,
+  `PART_TRADED`→`PARTIAL`); `TRANSIT`/`PENDING` stay unmapped so they remain transient.
+  Dhan resolves contracts from the local `Dependencies/all_instrument <date>.csv`, not a download.
 - **Code style:** detailed, beginner-friendly module + function docstrings and plain-English inline
   comments — match the existing density. Type hints where practical. `snake_case` functions/modules,
   `PascalCase` classes, `UPPER_SNAKE` constants and env keys. In library code use a module

--- a/Dependencies/Dhan API/dhan_execution.py
+++ b/Dependencies/Dhan API/dhan_execution.py
@@ -1,0 +1,1406 @@
+"""
+Thread-safe DhanHQ v2 execution client for the multi-strategy runner.
+
+The master runner deliberately knows almost nothing about broker APIs.  It asks
+each broker helper to log in, preload a contract master, resolve one NIFTY option
+and place a confirmed market order.  This module implements that same small
+surface for DhanHQ using the official ``dhanhq`` Python SDK.
+
+Safety rules followed here:
+
+* Importing this module never logs in or sends an order.
+* The access token is read from the environment ONLY (``DHAN_ACCESS_TOKEN``,
+  produced by ``Dependencies/dhan_token_setup.py``).  There is no browser flow
+  and no TOTP prompt, so startup never blocks on operator input.
+* Every SDK call carries a native timeout AND one total ten-second deadline that
+  also covers rate-limit wait, session-lock wait, and slow-dribble response
+  bodies.
+* ``place_market_order`` returns a typed result only after the order book
+  confirms the fill.  Rejection, partial fill, and response loss remain
+  distinct; ambiguity is ``UNKNOWN`` and poisons new submissions until explicit
+  reconciliation.
+
+Beginner's mental model -- one live order travels through this file as follows:
+
+1. ``ensure_logged_in()`` validates today's access token against the account.
+2. ``preload_scrip_master()`` loads Dhan's contract catalogue from the local
+   instrument CSV the runner already refreshes every evening.
+3. ``resolve_option_symbol()`` converts strategy details such as
+   NIFTY/14-JUL-2026/CE/24150 into Dhan's exact trading symbol.
+4. ``place_market_order()`` translates that symbol back into the numeric
+   ``securityId`` Dhan's order API actually wants, then submits the order.
+5. ``_confirm_fill()`` polls the order book; an acknowledgement alone is never
+   treated as proof that money changed hands.
+
+TWO DHAN-SPECIFIC HAZARDS THIS MODULE EXISTS TO CONTAIN
+-------------------------------------------------------
+
+**1. The SDK turns every exception into a rejection-shaped envelope.**
+``DhanHTTP._send_request`` wraps its request in a bare ``except Exception`` and
+returns ``{'status': 'failure', 'remarks': str(e), 'data': ''}``.  A socket
+timeout on an order that DID reach the exchange is therefore structurally
+identical to a genuine broker rejection.  In this repo ``REJECTED`` means
+"provably zero fill -- safe to fall back to paper", so believing that envelope
+would re-enter on paper while real exposure sits at the broker.
+
+This module NEVER derives ``REJECTED`` from the placement envelope.  It treats
+the response as an acknowledgement only, and distinguishes the two failure
+shapes the SDK can produce (see ``_classify_envelope``):
+
+* ``remarks`` is a **dict** -- Dhan's server answered and refused with a
+  structured ``errorCode``.  A candidate rejection, still confirmed before it is
+  trusted.
+* ``remarks`` is a **str** -- a transport-layer exception.  The order may have
+  reached the exchange, so the outcome is ``UNKNOWN`` and freezes new entries.
+
+Dhan gives us a recovery channel the other brokers lack: the ``order_tag`` is
+sent as ``correlationId``, so ``get_order_by_correlationID`` can find an order
+even when its POST response was lost entirely.  Both ambiguous paths try that
+lookup before concluding anything.
+
+**2. The SDK's native timeout is 60 seconds, not 10.**
+``DhanHTTP.HTTP_DEFAULT_TIME_OUT`` is 60 -- six times this repo's deadline.  It
+is a plain instance attribute, so ``_login_locked`` overrides it immediately
+after building the context.  ``DhanContext.__init__`` also swallows its own
+exceptions and can hand back a half-built object, so the attribute is verified
+rather than assumed.
+
+Small glossary:
+
+* A *scrip master* is the broker's contract catalogue: symbol, expiry, strike,
+  option type, security id, and lot size for every listed instrument.
+* ``securityId`` is Dhan's numeric instrument key.  Dhan's order API takes it
+  INSTEAD of a trading symbol, which is why this helper keeps a symbol -> id map.
+* ``correlationId`` is Dhan's name for a caller-supplied order tag, echoed back
+  in the order book and searchable through its own endpoint.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import os
+import sys
+import threading
+import time
+from collections import deque
+from collections.abc import Callable
+from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FuturesTimeoutError
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+from dhanhq import DhanContext, dhanhq
+
+# The broker helpers live in folders with spaces and are also executable as
+# standalone diagnostics.  Add their shared ``Dependencies`` parent explicitly
+# so the broker-neutral contract imports the same way in both entry points.
+_DEPENDENCIES_DIR = Path(__file__).resolve().parent.parent
+if str(_DEPENDENCIES_DIR) not in sys.path:
+    sys.path.insert(0, str(_DEPENDENCIES_DIR))
+
+from broker_contract import (  # noqa: E402
+    TERMINAL_BROKER_STATES,
+    BrokerQueryResult,
+    OpenOrder,
+    OpenPosition,
+    OrderResult,
+    OrderStatus,
+    normalize_order_result,
+)
+
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv(
+        dotenv_path=Path(__file__).resolve().parent.parent / ".env",
+        override=False,
+    )
+except Exception:
+    # ``python-dotenv`` is a core dependency, but keeping import-time behaviour
+    # harmless means paper trading can still start and report a clear login error.
+    pass
+
+
+log = logging.getLogger(__name__)
+
+# The runner refreshes this file every evening from Dhan's public detailed scrip
+# master.  Reusing it (rather than re-downloading 35 MB inside a ten-second
+# budget) also guarantees the adapter and the strategies resolve a strike to the
+# very same contract.
+_INSTRUMENT_MASTER_GLOB = "all_instrument *.csv"
+
+_API_TIMEOUT_SECONDS = 10.0
+_BROKER_CALL_DEADLINE_SECONDS = 10.0
+_FILL_TIMEOUT_SECONDS = 8.0
+_FILL_POLL_INTERVAL = 0.5
+_MAX_RATE_LIMIT_WAIT_SECONDS = 2.0
+
+# Dhan accepts these product names directly; ``NORMAL`` is this repo's neutral
+# word for a carry-forward position, which Dhan calls ``MARGIN``.
+_PRODUCT_MAP = {"INTRADAY": "INTRADAY", "NORMAL": "MARGIN", "MARGIN": "MARGIN"}
+_SIDE_MAP = {"BUY": "BUY", "SELL": "SELL"}
+
+# Dhan reports two order states the broker-neutral contract does not recognize.
+# Translating them here keeps the shared vocabulary (and the other three broker
+# adapters) untouched while still giving each state its correct meaning:
+#   EXPIRED     -- the order died without trading; that is a terminal rejection,
+#                  and leaving it unmapped would report a clean "never traded"
+#                  as UNKNOWN and needlessly freeze every live strategy.
+#   PART_TRADED -- a partial fill, which usually resolves through the quantity
+#                  comparison anyway but must not read as an unknown label when
+#                  the fill count is unavailable.
+# TRANSIT and PENDING are deliberately NOT mapped: they are transient states a
+# healthy order passes through, so they must stay UNKNOWN and keep the fill loop
+# polling rather than being reported as a final outcome.
+_DHAN_STATE_ALIASES = {"EXPIRED": "CANCELLED", "PART_TRADED": "PARTIAL"}
+
+# Dhan's order-book field names, most-specific first.  The SDK documents these
+# only in prose, so every read goes through ``_first_present`` and a casing
+# change degrades to UNKNOWN instead of a silently wrong fill count.
+_ORDER_ID_KEYS = ("orderId", "order_id", "orderid")
+_ORDER_STATE_KEYS = ("orderStatus", "order_status", "status")
+_FILLED_QTY_KEYS = ("filledQty", "filled_qty", "filledQuantity", "tradedQty")
+_ORDER_QTY_KEYS = ("quantity", "orderQuantity", "qty")
+_SYMBOL_KEYS = ("tradingSymbol", "trading_symbol", "symbol")
+_SIDE_KEYS = ("transactionType", "transaction_type")
+_PRODUCT_KEYS = ("productType", "product_type")
+_NET_QTY_KEYS = ("netQty", "net_qty", "netQuantity")
+_REASON_KEYS = ("omsErrorDescription", "oms_error_description", "errorMessage")
+
+
+def _exact_int(value: Any) -> int | None:
+    """Parse a broker quantity only when it is a finite whole number."""
+
+    if isinstance(value, bool):
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(number) or not number.is_integer():
+        return None
+    return int(number)
+
+
+def _first_present(row: dict[str, Any], keys: tuple[str, ...]) -> Any:
+    """Return the first non-empty value among ``keys``, else ``None``.
+
+    Dhan's field casing is documented only in SDK docstrings, so every order-book
+    read tolerates the plausible spellings instead of trusting one of them.
+    """
+
+    for key in keys:
+        if key in row:
+            value = row[key]
+            if value is not None and str(value).strip() != "":
+                return value
+    return None
+
+
+def _alias_state(raw_state: Any) -> str:
+    """Translate a Dhan order state into the broker-neutral vocabulary."""
+
+    state = str(raw_state or "").strip().upper().replace("-", "_").replace(" ", "_")
+    return _DHAN_STATE_ALIASES.get(state, state)
+
+
+def _env_str(name: str, default: str = "") -> str:
+    """Read one environment value and remove accidental wrapping quotes."""
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    value = str(raw).strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        value = value[1:-1].strip()
+    return value or default
+
+
+class _RollingWindowRateLimiter:
+    """Enforce per-second and per-minute request budgets across worker threads.
+
+    Short bursts wait for a slot.  A wait longer than ``max_wait_seconds`` raises
+    before the request is sent; a stale live order is more dangerous than a
+    clear indeterminate result that freezes new live entry.
+    """
+
+    def __init__(
+        self,
+        per_second: int,
+        per_minute: int,
+        max_wait_seconds: float,
+        clock: Callable[[], float] = time.monotonic,
+        sleeper: Callable[[float], None] = time.sleep,
+        label: str = "API",
+    ) -> None:
+        self.per_second = int(per_second)
+        self.per_minute = int(per_minute)
+        self.max_wait_seconds = float(max_wait_seconds)
+        self._clock = clock
+        self._sleep = sleeper
+        self.label = label
+        self._timestamps: deque[float] = deque()
+        self._lock = threading.Lock()
+
+    def acquire(self, deadline: float | None = None) -> None:
+        """Reserve one request slot or raise before a long/stale wait.
+
+        The deque stores only timestamps from the last minute.  We separately
+        count its last one-second slice because both limits apply at once.  A
+        short wait is acceptable; a long wait would make a trading decision
+        stale, so it raises *before* any broker request is sent.
+        """
+        started = self._clock()
+        if deadline is None:
+            acquired = self._lock.acquire()
+        else:
+            remaining = deadline - started
+            acquired = remaining > 0 and self._lock.acquire(timeout=remaining)
+        if not acquired:
+            raise TimeoutError(
+                f"Dhan {self.label} deadline expired waiting for the limiter lock"
+            )
+        try:
+            while True:
+                now = self._clock()
+                # Discard calls that are older than the longest (60-second)
+                # window.  Keeping the deque small also makes each check cheap.
+                minute_cutoff = now - 60.0
+                while self._timestamps and self._timestamps[0] <= minute_cutoff:
+                    self._timestamps.popleft()
+
+                # The minute deque includes the one-second window, so select its
+                # recent tail instead of maintaining a second source of truth.
+                recent_second = [
+                    stamp for stamp in self._timestamps if stamp > now - 1.0
+                ]
+                second_full = len(recent_second) >= self.per_second
+                minute_full = len(self._timestamps) >= self.per_minute
+
+                if not second_full and not minute_full:
+                    # Reserving the timestamp before returning prevents two
+                    # strategy threads from claiming the same final slot.
+                    self._timestamps.append(now)
+                    return
+
+                waits = []
+                if second_full:
+                    waits.append(1.0 - (now - recent_second[0]))
+                if minute_full:
+                    waits.append(60.0 - (now - self._timestamps[0]))
+                wait_seconds = max(0.0, max(waits))
+                elapsed = now - started
+                exceeds_call_deadline = (
+                    deadline is not None and now + wait_seconds > deadline
+                )
+                if elapsed + wait_seconds > self.max_wait_seconds or exceeds_call_deadline:
+                    raise RuntimeError(
+                        f"Dhan {self.label} rate limit exhausted; "
+                        f"safe slot needs {wait_seconds:.2f}s"
+                    )
+                self._sleep(wait_seconds)
+        finally:
+            self._lock.release()
+
+    def reset(self) -> None:
+        """Forget local request history after a session is explicitly closed."""
+        with self._lock:
+            self._timestamps.clear()
+
+
+def _classify_envelope(envelope: Any) -> tuple[str, Any, str]:
+    """Split a DhanHQ SDK reply into outcome, payload, and human reason.
+
+    Every SDK method returns ``{'status', 'remarks', 'data'}``.  Both a genuine
+    broker refusal and a local network exception arrive as ``status='failure'``,
+    so the caller cannot use that field alone without risking the "timed-out
+    order reported as rejected" bug this whole module guards against.  The
+    ``remarks`` TYPE is the discriminator:
+
+    * ``dict``  -- built by ``DhanHTTP._parse_response`` from a non-2xx reply,
+      carrying ``error_code``/``error_type``/``error_message``.  Dhan's server
+      answered and refused.
+    * ``str``   -- built by ``DhanHTTP._send_request``'s bare exception handler
+      (or a JSON decode failure).  We do not know whether the request reached
+      the exchange.
+
+    Returns:
+        ``(outcome, data, reason)`` where outcome is one of ``"ok"``,
+        ``"refused"``, or ``"indeterminate"``.
+    """
+
+    if not isinstance(envelope, dict):
+        return ("indeterminate", None, f"Malformed Dhan response: {envelope!r}")
+
+    status = str(envelope.get("status") or "").strip().lower()
+    remarks = envelope.get("remarks")
+    if status == "success":
+        return ("ok", envelope.get("data"), "")
+
+    if isinstance(remarks, dict):
+        detail = " ".join(
+            str(remarks.get(key) or "").strip()
+            for key in ("error_code", "error_type", "error_message")
+        ).strip()
+        return ("refused", envelope.get("data"), detail or "Dhan refused the request.")
+
+    return (
+        "indeterminate",
+        envelope.get("data"),
+        str(remarks or "").strip() or "Dhan response did not complete.",
+    )
+
+
+class DhanExecutionClient:
+    """One lazily authenticated, lock-guarded DhanHQ execution session.
+
+    The master creates many strategy threads but imports one singleton from the
+    bottom of this module.  All those threads therefore share one SDK client,
+    one token, one contract cache, and one pair of rate-limit counters.
+    ``RLock`` makes nested helper calls safe without allowing simultaneous
+    session writes.
+    """
+
+    def __init__(self) -> None:
+        self.client: Any = None
+        self.is_logged_in = False
+        self._lock = threading.RLock()
+        self._context: Any = None
+        self._client_code = ""
+        self._scrip_df: pd.DataFrame | None = None
+        self._symbol_cache: dict[tuple, str] = {}
+        # Dhan's order API takes a numeric securityId, but the runner's generic
+        # surface passes the human trading symbol returned by the resolver.
+        # This map bridges the two so logs and Telegram alerts stay readable.
+        self._security_id_by_symbol: dict[str, str] = {}
+        # ``requests`` timeouts are inactivity limits, not a total wall-clock
+        # budget: a slow-dribble response can otherwise run forever.  Execute one
+        # SDK call at a time and impose a caller-visible deadline around
+        # rate-limit wait, session-lock wait, and the complete response body.
+        self._sdk_executor = ThreadPoolExecutor(
+            max_workers=1,
+            thread_name_prefix="dhan-sdk",
+        )
+        self._sdk_poisoned = False
+        self._timed_out_future: Future[Any] | None = None
+        # Serialize acknowledgement plus order-book confirmation.  Without this
+        # gate another strategy can submit before a status timeout poisons the
+        # session, leaving two simultaneously indeterminate live orders.
+        self._order_submission_lock = threading.Lock()
+        # Conservative floors that sit well under Dhan's published per-second
+        # order ceiling.  With ~26 strategy threads real bursts are far smaller,
+        # so these buy safety margin rather than costing throughput.
+        self._api_limiter = _RollingWindowRateLimiter(
+            20,
+            800,
+            _MAX_RATE_LIMIT_WAIT_SECONDS,
+            label="API",
+        )
+        self._order_limiter = _RollingWindowRateLimiter(
+            10,
+            250,
+            _MAX_RATE_LIMIT_WAIT_SECONDS,
+            label="order API",
+        )
+
+    @staticmethod
+    def _remaining_broker_budget(started: float) -> float:
+        """Return seconds left in one complete broker-call wall-clock budget."""
+
+        return _BROKER_CALL_DEADLINE_SECONDS - (time.monotonic() - started)
+
+    def _run_sdk_with_deadline(
+        self,
+        operation: str,
+        call: Callable[[], Any],
+        *,
+        started: float,
+        allow_after_poison: bool = False,
+    ) -> Any:
+        """Run one SDK call without letting a slow response outlive 10s.
+
+        The caller holds ``_lock``.  If the future times out, its socket may
+        still be active inside ``requests``; poison the shared session so no
+        second request can overlap that indeterminate in-flight operation.
+        """
+
+        if self._sdk_poisoned:
+            abandoned_finished = (
+                self._timed_out_future is not None
+                and self._timed_out_future.done()
+            )
+            if not allow_after_poison or not abandoned_finished:
+                raise RuntimeError(
+                    "Dhan session is indeterminate after a broker deadline; "
+                    "new orders are blocked pending reconciliation."
+                )
+        remaining = self._remaining_broker_budget(started)
+        if remaining <= 0:
+            raise TimeoutError(f"Dhan {operation} deadline expired before submission.")
+        future = self._sdk_executor.submit(call)
+        try:
+            return future.result(timeout=remaining)
+        except FuturesTimeoutError as exc:
+            # Python aliases concurrent.futures.TimeoutError to built-in
+            # TimeoutError.  If the SDK call itself raised it, preserve that
+            # evidence rather than falsely poisoning a completed future.
+            if future.done():
+                return future.result()
+            self._sdk_poisoned = True
+            self._timed_out_future = future
+            future.cancel()
+            raise TimeoutError(
+                f"Dhan {operation} exceeded the total "
+                f"{_BROKER_CALL_DEADLINE_SECONDS:.0f}s broker deadline; "
+                "session state is indeterminate."
+            ) from exc
+
+    def _call_api(
+        self,
+        operation: str,
+        call: Callable[[Any], Any],
+        *,
+        is_order: bool = False,
+        allow_after_poison: bool = False,
+    ) -> Any:
+        """Run one SDK method under the shared limits, lock, and deadline.
+
+        Args:
+            operation: Human label used in deadline and error messages.
+            call: Receives the live ``dhanhq`` client and performs one request.
+            is_order: Also consume the stricter order budget for write calls.
+            allow_after_poison: Permit reconciliation/risk-reducing calls only
+                after the abandoned timed-out future has actually ended.
+
+        Returns:
+            The raw ``{'status', 'remarks', 'data'}`` envelope from the SDK.
+
+        Raises:
+            RuntimeError: No client, or no rate budget, is available.
+            TimeoutError: The ten-second total budget expired.
+        """
+        started = time.monotonic()
+        deadline = started + _BROKER_CALL_DEADLINE_SECONDS
+        self._api_limiter.acquire(deadline)
+        if is_order:
+            self._order_limiter.acquire(deadline)
+
+        remaining = self._remaining_broker_budget(started)
+        if remaining <= 0 or not self._lock.acquire(timeout=max(0.0, remaining)):
+            raise TimeoutError(
+                "Dhan broker deadline expired while waiting for the shared session lock."
+            )
+        try:
+            client = self.client
+            if client is None:
+                raise RuntimeError("Dhan has no authenticated SDK client.")
+            return self._run_sdk_with_deadline(
+                operation,
+                lambda: call(client),
+                started=started,
+                allow_after_poison=allow_after_poison,
+            )
+        finally:
+            self._lock.release()
+
+    def recover_after_reconciliation(self) -> bool:
+        """Explicitly clear deadline poison after the abandoned call has ended.
+
+        "Poisoned" means an earlier SDK call outlived its 10-second budget and
+        was abandoned -- but Python cannot kill a running thread, so that call
+        may STILL be dribbling a response (or completing an order) inside
+        ``requests``.  Only after (a) reconciliation has proven the account
+        state and (b) the abandoned call has actually finished is it safe to
+        accept new orders; this method refuses (returns False) until both hold.
+        """
+
+        with self._lock:
+            if self._timed_out_future is not None and not self._timed_out_future.done():
+                return False
+            self._sdk_poisoned = False
+            self._timed_out_future = None
+            return True
+
+    def ensure_logged_in(self) -> bool:
+        """Return True only when a validated DhanHQ session is available.
+
+        This method is intentionally safe to call before every operation.  The
+        normal fast path only checks in-memory state; the validation request
+        runs once when the session has not yet been established.
+        """
+        with self._lock:
+            if self.is_logged_in and self.client is not None:
+                return True
+            return self._login_locked()
+
+    def _login_locked(self) -> bool:
+        """Build and validate a DhanHQ session from environment credentials.
+
+        Unlike the other broker helpers there is no interactive step: the
+        access token is produced offline by ``dhan_token_setup.py`` and read
+        from the environment.  Returning ``False`` instead of raising lets
+        startup force every strategy back to paper mode.  The token is never
+        logged.
+
+        Note the token is NOT long-lived: DhanHQ stamps a validity into it and
+        the web console currently issues 24-hour tokens.  One that expires
+        mid-session makes orders fail, and since a rejected live EXIT leaves a
+        position open, refresh it outside market hours.
+        """
+        self.is_logged_in = False
+        self.client = None
+        self._context = None
+        self._client_code = _env_str("DHAN_CLIENT_CODE")
+        access_token = _env_str("DHAN_ACCESS_TOKEN")
+        missing = [
+            name
+            for name, value in (
+                ("DHAN_CLIENT_CODE", self._client_code),
+                ("DHAN_ACCESS_TOKEN", access_token),
+            )
+            if not value
+        ]
+        if missing:
+            log.error("Dhan login disabled: missing %s.", ", ".join(missing))
+            return False
+
+        try:
+            context = DhanContext(self._client_code, access_token)
+            # DhanContext.__init__ swallows its own exceptions and can return a
+            # half-built object, so prove the HTTP layer exists before trusting
+            # it -- otherwise the failure resurfaces as an AttributeError in the
+            # middle of a live order.
+            http = context.get_dhan_http()
+            if http is None:
+                raise RuntimeError("DhanContext produced no HTTP connection.")
+            # The SDK ships a 60-second default, six times this repo's deadline.
+            http.timeout = _API_TIMEOUT_SECONDS
+            self._context = context
+            self.client = dhanhq(context)
+        except Exception as exc:
+            self.client = None
+            self._context = None
+            log.error("Dhan session construction failed: %s", exc)
+            return False
+
+        if not self._validate_session_locked():
+            self.client = None
+            self._context = None
+            return False
+        self.is_logged_in = True
+        log.info("Dhan execution client login successful.")
+        return True
+
+    def _validate_session_locked(self) -> bool:
+        """Prove the token works with one cheap authenticated read."""
+        try:
+            envelope = self._call_api("fund limits", lambda client: client.get_fund_limits())
+        except Exception as exc:
+            log.error("Dhan session validation failed: %s", exc)
+            return False
+        outcome, _data, reason = _classify_envelope(envelope)
+        if outcome != "ok":
+            log.error(
+                "Dhan session validation rejected (%s): %s. "
+                "Re-run 'python algo.py setup-token' if the token has expired.",
+                outcome,
+                reason,
+            )
+            return False
+        return True
+
+    def preload_scrip_master(self) -> bool:
+        """Log in and cache Dhan's option catalogue from the local instrument CSV.
+
+        The master calls this once before worker threads start.  Returning
+        ``False`` makes startup disable live trading instead of discovering a
+        missing or malformed contract catalogue during the first real order.
+        """
+        if not self.ensure_logged_in():
+            return False
+        with self._lock:
+            return self._ensure_scrip_master_locked()
+
+    def _ensure_scrip_master_locked(self) -> bool:
+        """Load and normalize the contract master once; caller holds ``_lock``."""
+        if self._scrip_df is not None:
+            return not self._scrip_df.empty
+        try:
+            path = self._latest_instrument_master_path()
+            if path is None:
+                raise FileNotFoundError(
+                    f"No instrument master matching '{_INSTRUMENT_MASTER_GLOB}' in "
+                    f"{_DEPENDENCIES_DIR}. The runner refreshes this file at end of day."
+                )
+            self._scrip_df = self._prepare_scrip_master(path)
+            self._security_id_by_symbol = {
+                str(row.trading_symbol): str(row.security_id)
+                for row in self._scrip_df.itertuples(index=False)
+            }
+            log.info(
+                "Dhan NSE index-option scrip master loaded (%d rows) from %s.",
+                len(self._scrip_df),
+                path.name,
+            )
+            return True
+        except Exception as exc:
+            self._scrip_df = None
+            self._security_id_by_symbol = {}
+            log.error("Dhan scrip master load/parse failed: %s", exc)
+            return False
+
+    @staticmethod
+    def _latest_instrument_master_path() -> Path | None:
+        """Return the newest ``all_instrument <date>.csv``, or ``None``.
+
+        The filenames carry an ISO date, so a plain sort is already
+        chronological; ``max`` therefore picks the freshest catalogue.
+        """
+
+        candidates = sorted(_DEPENDENCIES_DIR.glob(_INSTRUMENT_MASTER_GLOB))
+        return candidates[-1] if candidates else None
+
+    @staticmethod
+    def _prepare_scrip_master(path: Path) -> pd.DataFrame:
+        """Read the detailed scrip master and keep only usable index options.
+
+        The filters mirror the runner's own option resolver so this adapter and
+        the strategies can never disagree about which contract a strike means:
+        NSE exchange, ``D`` (derivatives) segment, ``OPTIDX`` instrument, a real
+        CE/PE type, and a parseable expiry, strike, and security id.
+
+        Only the columns actually needed are read: the file is ~35 MB and this
+        runs while the shared session lock is held.
+
+        Raises:
+            ValueError: Required columns or usable option rows are missing.
+        """
+        required = [
+            "EXCH_ID",
+            "SEGMENT",
+            "INSTRUMENT",
+            "SYMBOL_NAME",
+            "SM_EXPIRY_DATE",
+            "SECURITY_ID",
+            "STRIKE_PRICE",
+            "OPTION_TYPE",
+            "UNDERLYING_SYMBOL",
+        ]
+        header = pd.read_csv(path, nrows=0)
+        missing = [column for column in required if column not in header.columns]
+        if missing:
+            raise ValueError(
+                f"Dhan scrip master {path.name} missing columns: " + ", ".join(missing)
+            )
+        optional = [
+            column for column in ("DISPLAY_NAME", "LOT_SIZE") if column in header.columns
+        ]
+
+        raw = pd.read_csv(
+            path,
+            usecols=required + optional,
+            dtype=str,
+            low_memory=False,
+        )
+        frame = pd.DataFrame(
+            {
+                "_exchange_u": raw["EXCH_ID"].fillna("").astype(str).str.strip().str.upper(),
+                "_segment_u": raw["SEGMENT"].fillna("").astype(str).str.strip().str.upper(),
+                "_instrument_u": raw["INSTRUMENT"].fillna("").astype(str).str.strip().str.upper(),
+                "trading_symbol": raw["SYMBOL_NAME"].fillna("").astype(str).str.strip(),
+                "display_name": (
+                    raw["DISPLAY_NAME"].fillna("").astype(str).str.strip()
+                    if "DISPLAY_NAME" in optional
+                    else ""
+                ),
+                "_underlying_u": (
+                    raw["UNDERLYING_SYMBOL"].fillna("").astype(str).str.strip().str.upper()
+                ),
+                "_option_u": raw["OPTION_TYPE"].fillna("").astype(str).str.strip().str.upper(),
+                "_expiry_date": pd.to_datetime(
+                    raw["SM_EXPIRY_DATE"], errors="coerce"
+                ).dt.date,
+                "_strike_f": pd.to_numeric(raw["STRIKE_PRICE"], errors="coerce"),
+                "security_id": pd.to_numeric(raw["SECURITY_ID"], errors="coerce"),
+                "lot_size": (
+                    pd.to_numeric(raw["LOT_SIZE"], errors="coerce")
+                    if "LOT_SIZE" in optional
+                    else 0
+                ),
+            }
+        )
+        frame = frame[
+            (frame["_exchange_u"] == "NSE")
+            & (frame["_segment_u"] == "D")
+            & (frame["_instrument_u"] == "OPTIDX")
+            & frame["_option_u"].isin(["CE", "PE"])
+            & frame["_expiry_date"].notna()
+            & frame["_strike_f"].notna()
+            & frame["security_id"].notna()
+            & frame["trading_symbol"].ne("")
+        ].copy()
+        if frame.empty:
+            raise ValueError(
+                f"Dhan scrip master {path.name} contains no usable index-option rows."
+            )
+        frame["security_id"] = frame["security_id"].astype(int)
+        return frame
+
+    def resolve_option_symbol(
+        self,
+        underlying: str,
+        expiry: Any,
+        option_type: str,
+        strike: Any,
+        exchange_segment: str = "NSE_FNO",
+    ) -> str:
+        """Return the exact Dhan trading symbol or ``""`` on a miss.
+
+        Args:
+            underlying: Index name such as ``NIFTY`` or ``BANKNIFTY``.
+            expiry: Date-like option expiry supplied by the contract lookup.
+            option_type: ``CE`` for calls or ``PE`` for puts.
+            strike: Human-scale strike such as 24150 (not a paise multiplier).
+            exchange_segment: Must be ``NSE_FNO`` for this index-options helper.
+
+        Resolution is exact rather than pattern-based: the requested expiry,
+        strike, and option type must all occur in Dhan's catalogue.  Returning
+        an empty string makes the caller skip the real order safely.
+
+        The returned value is the human symbol so logs and Telegram alerts stay
+        readable; ``place_market_order`` translates it back to the numeric
+        ``securityId`` Dhan's order API requires.
+        """
+        underlying_u = str(underlying).upper().strip()
+        option_u = str(option_type).upper().strip()
+        exchange_u = str(exchange_segment).upper().strip() or "NSE_FNO"
+        if option_u not in {"CE", "PE"} or exchange_u != "NSE_FNO":
+            log.warning(
+                "Dhan resolve skipped: unsupported option/exchange %r/%r.",
+                option_type,
+                exchange_segment,
+            )
+            return ""
+        try:
+            expiry_date = pd.Timestamp(expiry).date()
+            strike_i = round(float(strike))
+        except Exception:
+            log.warning(
+                "Dhan resolve skipped: invalid expiry/strike %r/%r.",
+                expiry,
+                strike,
+            )
+            return ""
+        cache_key = (underlying_u, expiry_date, option_u, strike_i)
+        with self._lock:
+            cached = self._symbol_cache.get(cache_key)
+            if cached:
+                return cached
+        if not self.ensure_logged_in():
+            return ""
+        with self._lock:
+            cached = self._symbol_cache.get(cache_key)
+            if cached:
+                return cached
+            if not self._ensure_scrip_master_locked():
+                return ""
+            frame = self._scrip_df
+            if frame is None:
+                return ""
+            matches = frame[
+                (frame["_underlying_u"] == underlying_u)
+                & (frame["_option_u"] == option_u)
+                & (frame["_expiry_date"] == expiry_date)
+                & (frame["_strike_f"].round().astype(int) == strike_i)
+            ]
+            if matches.empty:
+                log.warning(
+                    "Dhan symbol NOT resolved: %s/%s/%s/strike %s.",
+                    underlying_u,
+                    option_u,
+                    expiry_date,
+                    strike_i,
+                )
+                return ""
+            row = matches.iloc[0]
+            symbol = str(row["trading_symbol"]).strip()
+            self._symbol_cache[cache_key] = symbol
+            self._security_id_by_symbol[symbol] = str(int(row["security_id"]))
+            return symbol
+
+    def place_market_order(
+        self,
+        symbol: str,
+        side: str,
+        quantity: int,
+        exchange_segment: str = "NSE_FNO",
+        product_type: str = "INTRADAY",
+        *,
+        order_tag: str = "",
+    ) -> OrderResult:
+        """Serialize one order from submission through typed fill confirmation."""
+
+        quantity_i = _exact_int(quantity)
+        if quantity_i is None or quantity_i <= 0:
+            raise ValueError(f"Invalid quantity: {quantity!r}")
+        if not self._order_submission_lock.acquire(
+            timeout=_BROKER_CALL_DEADLINE_SECONDS
+        ):
+            return normalize_order_result(
+                order_id="",
+                requested_quantity=quantity_i,
+                filled_quantity=0,
+                broker_state="ORDER_GATE_TIMEOUT",
+                reason=(
+                    "Dhan order was not submitted because another order's "
+                    "outcome remained unresolved past the broker deadline."
+                ),
+            )
+        try:
+            if self._sdk_poisoned:
+                return normalize_order_result(
+                    order_id="",
+                    requested_quantity=quantity_i,
+                    filled_quantity=0,
+                    broker_state="SESSION_POISONED",
+                    reason=(
+                        "Dhan session is indeterminate after an earlier "
+                        "deadline; reconcile before submitting another order."
+                    ),
+                )
+            return self._place_market_order_serialized(
+                symbol,
+                side,
+                quantity_i,
+                exchange_segment,
+                product_type,
+                order_tag=order_tag,
+            )
+        finally:
+            self._order_submission_lock.release()
+
+    def _place_market_order_serialized(
+        self,
+        symbol: str,
+        side: str,
+        quantity: int,
+        exchange_segment: str = "NSE_FNO",
+        product_type: str = "INTRADAY",
+        *,
+        order_tag: str = "",
+    ) -> OrderResult:
+        """Place one MARKET order and return an explicit normalized outcome.
+
+        Args:
+            symbol: Exact Dhan trading symbol returned by the resolver.
+            side: Friendly ``BUY`` or ``SELL`` value used by every broker helper.
+            quantity: Number of option units, normally a whole-number lot multiple.
+            exchange_segment: ``NSE_FNO``; other segments fail closed here.
+            product_type: ``INTRADAY`` or ``NORMAL`` (Dhan ``MARGIN``).
+            order_tag: Sent as Dhan's ``correlationId`` so a lost response can
+                still be traced back to its order.
+
+        Returns:
+            An :class:`OrderResult`.  An acknowledgement followed by response
+            loss keeps its order id and becomes ``UNKNOWN`` rather than being
+            mistaken for a rejection.
+
+        Raises:
+            ValueError: A caller supplied an unsupported order value.
+
+        Important: a ``success`` envelope only means Dhan accepted the request.
+        The method still polls the order book before reporting a fill.
+        """
+        side_u = str(side).upper().strip()
+        product_u = str(product_type).upper().strip()
+        exchange_u = str(exchange_segment).upper().strip() or "NSE_FNO"
+        symbol_s = str(symbol).strip()
+        quantity_i = _exact_int(quantity)
+        if side_u not in _SIDE_MAP:
+            raise ValueError(f"Invalid side: {side!r}")
+        if product_u not in _PRODUCT_MAP:
+            raise ValueError(f"Invalid product_type: {product_type!r}")
+        if exchange_u != "NSE_FNO":
+            raise ValueError(f"Invalid exchange_segment: {exchange_segment!r}")
+        if quantity_i is None or quantity_i <= 0:
+            raise ValueError(f"Invalid quantity: {quantity!r}")
+        if not symbol_s:
+            raise ValueError("Missing trading symbol for order.")
+        if not self.ensure_logged_in():
+            return normalize_order_result(
+                order_id="",
+                requested_quantity=quantity_i,
+                filled_quantity=0,
+                broker_state="REJECTED",
+                reason="Order was not submitted because Dhan login failed.",
+            )
+
+        security_id = self._security_id_for(symbol_s)
+        if not security_id:
+            # Nothing was sent, so this is a provable zero-fill.  Guessing an id
+            # would be far worse than refusing: it could trade a different
+            # contract entirely.
+            return normalize_order_result(
+                order_id="",
+                requested_quantity=quantity_i,
+                filled_quantity=0,
+                broker_state="REJECTED",
+                reason=(
+                    f"Dhan order was not submitted: no securityId is known for "
+                    f"symbol {symbol_s!r}. Resolve the contract first."
+                ),
+            )
+
+        try:
+            envelope = self._call_api(
+                "place order",
+                lambda client: client.place_order(
+                    security_id=security_id,
+                    exchange_segment=exchange_u,
+                    transaction_type=_SIDE_MAP[side_u],
+                    quantity=quantity_i,
+                    order_type="MARKET",
+                    product_type=_PRODUCT_MAP[product_u],
+                    price=0,
+                    tag=order_tag or None,
+                ),
+                is_order=True,
+            )
+        except Exception as exc:
+            # The request may or may not have reached the exchange.  Try the
+            # correlation lookup before giving up on identifying the order.
+            return self._resolve_indeterminate_placement(
+                quantity_i,
+                order_tag,
+                f"Dhan place-order call is indeterminate: {exc}",
+            )
+
+        outcome, data, reason = _classify_envelope(envelope)
+        order_id = self.extract_order_id(data) if outcome == "ok" else ""
+        if order_id:
+            return self._confirm_fill(order_id, quantity_i)
+
+        if outcome == "refused":
+            # Dhan's server answered with a structured error.  Confirm through
+            # the correlation id that no order actually exists before calling
+            # this a provable zero fill.
+            found_id, lookup_succeeded = self._find_order_id_by_tag(order_tag)
+            if found_id:
+                return self._confirm_fill(found_id, quantity_i)
+            if lookup_succeeded or not order_tag:
+                return normalize_order_result(
+                    order_id="",
+                    requested_quantity=quantity_i,
+                    filled_quantity=0,
+                    broker_state="REJECTED",
+                    reason=f"Dhan rejected the order: {reason}",
+                )
+            return self._indeterminate_placement(
+                quantity_i,
+                f"Dhan refused the order ({reason}) but the correlation lookup "
+                "could not confirm that nothing was created.",
+            )
+
+        # "ok" with no order id, or an indeterminate transport failure.
+        return self._resolve_indeterminate_placement(
+            quantity_i,
+            order_tag,
+            reason or "Dhan acknowledged the order without an order id.",
+        )
+
+    def _security_id_for(self, symbol: str) -> str:
+        """Look up the numeric securityId cached for one trading symbol."""
+
+        with self._lock:
+            return self._security_id_by_symbol.get(symbol, "")
+
+    def _find_order_id_by_tag(self, order_tag: str) -> tuple[str, bool]:
+        """Search Dhan's order book for an order carrying ``order_tag``.
+
+        Dhan echoes the tag back as ``correlationId`` and exposes a dedicated
+        lookup, which is how a completely lost placement response can still be
+        traced to a real order.
+
+        Returns:
+            ``(order_id, lookup_succeeded)``.  The flag distinguishes "looked
+            and found nothing" (safe to call a rejection) from "could not look"
+            (must stay indeterminate).
+        """
+
+        if not order_tag:
+            return ("", False)
+        try:
+            envelope = self._call_api(
+                "order by correlation id",
+                lambda client: client.get_order_by_correlationID(str(order_tag)),
+                allow_after_poison=True,
+            )
+        except Exception as exc:
+            log.warning("Dhan correlation-id lookup failed: %s", exc)
+            return ("", False)
+        outcome, data, _reason = _classify_envelope(envelope)
+        if outcome == "ok":
+            return (self.extract_order_id(data), True)
+        if outcome == "refused":
+            # A structured refusal here means Dhan searched and found no order
+            # for this correlation id.
+            return ("", True)
+        return ("", False)
+
+    def _indeterminate_placement(self, quantity: int, reason: str) -> OrderResult:
+        """Build the UNKNOWN result used whenever exposure cannot be proven."""
+
+        return normalize_order_result(
+            order_id="",
+            requested_quantity=quantity,
+            filled_quantity=0,
+            broker_state="",
+            reason=reason,
+        )
+
+    def _resolve_indeterminate_placement(
+        self,
+        quantity: int,
+        order_tag: str,
+        reason: str,
+    ) -> OrderResult:
+        """Try the correlation lookup before accepting an unknown placement."""
+
+        found_id, _lookup_succeeded = self._find_order_id_by_tag(order_tag)
+        if found_id:
+            return self._confirm_fill(found_id, quantity)
+        return self._indeterminate_placement(quantity, reason)
+
+    def _order_status(
+        self,
+        order_id: str,
+    ) -> tuple[str | None, int | None, int | None, str]:
+        """Return normalized state, filled qty, order qty, and rejection reason."""
+        envelope = self._call_api(
+            "order status",
+            lambda client: client.get_order_by_id(str(order_id)),
+            allow_after_poison=True,
+        )
+        outcome, data, reason = _classify_envelope(envelope)
+        if outcome != "ok":
+            return (None, None, None, reason)
+        rows = data if isinstance(data, list) else [data]
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            return (
+                _alias_state(_first_present(row, _ORDER_STATE_KEYS)) or None,
+                _exact_int(_first_present(row, _FILLED_QTY_KEYS)),
+                _exact_int(_first_present(row, _ORDER_QTY_KEYS)),
+                str(_first_present(row, _REASON_KEYS) or "").strip(),
+            )
+        return (None, None, None, f"Unrecognised Dhan order-status payload: {data!r}")
+
+    def get_order_status(
+        self,
+        order_id: str,
+        requested_quantity: int = 0,
+    ) -> OrderResult:
+        """Return one normalized order-book snapshot.
+
+        Exceptions and malformed quantities are represented as ``UNKNOWN`` while
+        retaining the caller's order id.  They never become zero-fill rejection.
+        """
+        requested = _exact_int(requested_quantity)
+        if requested is None or requested < 0:
+            requested = 0
+        try:
+            state, filled, broker_qty, reason = self._order_status(str(order_id))
+        except Exception as exc:
+            return normalize_order_result(
+                order_id=order_id,
+                requested_quantity=requested,
+                filled_quantity=0,
+                broker_state="",
+                reason=f"Dhan order-status query failed: {exc}",
+            )
+
+        effective_requested = requested or broker_qty or 0
+        if requested and broker_qty not in {None, requested}:
+            return normalize_order_result(
+                order_id=order_id,
+                requested_quantity=requested,
+                filled_quantity=None,
+                broker_state=state or "",
+                reason=(
+                    f"Malformed Dhan status: broker quantity {broker_qty} "
+                    f"does not match requested quantity {requested}. {reason}"
+                ),
+            )
+        return normalize_order_result(
+            order_id=order_id,
+            requested_quantity=effective_requested,
+            filled_quantity=filled,
+            broker_state=state or "",
+            reason=reason,
+        )
+
+    def _confirm_fill(self, order_id: str, want_qty: int) -> OrderResult:
+        """Poll until the order reaches a truly terminal state, or time out.
+
+        Why the loop keeps polling on PARTIAL/UNKNOWN snapshots: a market order
+        is often observed mid-fill (Dhan state ``PART_TRADED`` with some
+        quantity already on ``filledQty``).  That is TRANSIENT -- the next 0.5s
+        poll usually shows ``TRADED`` -- so returning it as the final outcome
+        would freeze every live strategy over a perfectly healthy order.  A
+        partial/unknown snapshot becomes the real outcome only when the broker
+        label is terminal (the order can never fill further) or the timeout
+        below expires.
+        """
+        deadline = time.monotonic() + _FILL_TIMEOUT_SECONDS
+        last_result = normalize_order_result(
+            order_id=order_id,
+            requested_quantity=want_qty,
+            filled_quantity=0,
+            broker_state="",
+            reason="Dhan acknowledgement received; fill status not read yet.",
+        )
+        while time.monotonic() < deadline:
+            last_result = self.get_order_status(order_id, requested_quantity=want_qty)
+            if last_result.status in {OrderStatus.FILLED, OrderStatus.REJECTED}:
+                return last_result
+            if last_result.broker_state in TERMINAL_BROKER_STATES:
+                # Terminal label with a partial/contradictory quantity snapshot:
+                # no further fills are possible, so this IS the final outcome.
+                return last_result
+            # A failed/malformed status call is already indeterminate. Repeating
+            # it inside the same order interaction risks exceeding the deadline
+            # without adding evidence, so return immediately with the known id.
+            if "query failed" in last_result.reason.lower():
+                return last_result
+            time.sleep(_FILL_POLL_INTERVAL)
+        return normalize_order_result(
+            order_id=order_id,
+            requested_quantity=want_qty,
+            filled_quantity=last_result.filled_quantity,
+            broker_state=last_result.broker_state,
+            reason=(
+                f"Dhan order {order_id} was not terminal within "
+                f"{_FILL_TIMEOUT_SECONDS:.0f}s; exposure is indeterminate."
+            ),
+        )
+
+    def cancel_order(
+        self,
+        order_id: str,
+        requested_quantity: int = 0,
+    ) -> OrderResult:
+        """Request cancellation, then normalize the order's resulting status."""
+
+        order_id_s = str(order_id).strip()
+        requested = _exact_int(requested_quantity)
+        if not order_id_s:
+            raise ValueError("Missing order id for cancellation.")
+        if requested is None or requested < 0:
+            raise ValueError(f"Invalid requested_quantity: {requested_quantity!r}")
+        if not self.ensure_logged_in():
+            return normalize_order_result(
+                order_id=order_id_s,
+                requested_quantity=requested,
+                filled_quantity=0,
+                broker_state="",
+                reason="Dhan cancellation was not submitted because login failed.",
+            )
+        try:
+            self._call_api(
+                "cancel order",
+                lambda client: client.cancel_order(order_id_s),
+                is_order=True,
+                allow_after_poison=True,
+            )
+        except Exception as exc:
+            return normalize_order_result(
+                order_id=order_id_s,
+                requested_quantity=requested,
+                filled_quantity=0,
+                broker_state="",
+                reason=f"Dhan cancellation response is indeterminate: {exc}",
+            )
+        return self.get_order_status(order_id_s, requested_quantity=requested)
+
+    def list_open_orders(self) -> BrokerQueryResult[OpenOrder]:
+        """Return pending orders, or an explicit indeterminate query result."""
+
+        try:
+            envelope = self._call_api(
+                "order list",
+                lambda client: client.get_order_list(),
+                allow_after_poison=True,
+            )
+        except Exception as exc:
+            return BrokerQueryResult.indeterminate(
+                f"Dhan open-order query failed: {exc}"
+            )
+        outcome, data, reason = _classify_envelope(envelope)
+        if outcome != "ok":
+            return BrokerQueryResult.indeterminate(
+                f"Dhan open-order query returned {outcome}: {reason}"
+            )
+        if not isinstance(data, list):
+            return BrokerQueryResult.indeterminate(
+                f"Dhan open-order query returned malformed data: {data!r}"
+            )
+
+        orders: list[OpenOrder] = []
+        for row in data:
+            if not isinstance(row, dict):
+                return BrokerQueryResult.indeterminate(
+                    "Dhan open-order query contained a malformed row."
+                )
+            raw_state = _alias_state(_first_present(row, _ORDER_STATE_KEYS))
+            snapshot = normalize_order_result(
+                order_id=_first_present(row, _ORDER_ID_KEYS),
+                requested_quantity=_first_present(row, _ORDER_QTY_KEYS),
+                filled_quantity=_first_present(row, _FILLED_QTY_KEYS),
+                broker_state=raw_state,
+                reason="Open-order snapshot",
+            )
+            symbol = str(_first_present(row, _SYMBOL_KEYS) or "").strip()
+            if (
+                not snapshot.order_id
+                or not symbol
+                or "malformed" in snapshot.reason.lower()
+                or snapshot.requested_quantity <= 0
+            ):
+                return BrokerQueryResult.indeterminate(
+                    "Dhan open-order query contained incomplete order data."
+                )
+            if raw_state in {
+                "COMPLETE", "COMPLETED", "FILLED", "TRADED", "EXECUTED",
+                "REJECTED", "CANCELLED", "CANCELED", "CANCEL", "LAPSED",
+            }:
+                continue
+            if snapshot.remaining_quantity <= 0:
+                continue
+            orders.append(
+                OpenOrder(
+                    order_id=snapshot.order_id,
+                    symbol=symbol,
+                    side=str(_first_present(row, _SIDE_KEYS) or "").strip().upper(),
+                    requested_quantity=snapshot.requested_quantity,
+                    filled_quantity=snapshot.filled_quantity,
+                    remaining_quantity=snapshot.remaining_quantity,
+                    broker_state=snapshot.broker_state,
+                )
+            )
+        return BrokerQueryResult.success(orders)
+
+    def list_open_positions(self) -> BrokerQueryResult[OpenPosition]:
+        """Return non-flat positions, or an explicit indeterminate result."""
+
+        try:
+            envelope = self._call_api(
+                "positions",
+                lambda client: client.get_positions(),
+                allow_after_poison=True,
+            )
+        except Exception as exc:
+            return BrokerQueryResult.indeterminate(
+                f"Dhan open-position query failed: {exc}"
+            )
+        outcome, data, reason = _classify_envelope(envelope)
+        if outcome != "ok":
+            return BrokerQueryResult.indeterminate(
+                f"Dhan open-position query returned {outcome}: {reason}"
+            )
+        if not isinstance(data, list):
+            return BrokerQueryResult.indeterminate(
+                f"Dhan open-position query returned malformed data: {data!r}"
+            )
+
+        positions: list[OpenPosition] = []
+        for row in data:
+            if not isinstance(row, dict):
+                return BrokerQueryResult.indeterminate(
+                    "Dhan open-position query contained a malformed row."
+                )
+            # A flat position legitimately reports netQty 0, which
+            # ``_first_present`` skips as empty -- so read it directly.
+            raw_quantity = next(
+                (row[key] for key in _NET_QTY_KEYS if key in row),
+                None,
+            )
+            quantity = _exact_int(raw_quantity)
+            symbol = str(_first_present(row, _SYMBOL_KEYS) or "").strip()
+            if quantity is None or not symbol:
+                return BrokerQueryResult.indeterminate(
+                    "Dhan open-position query contained incomplete position data."
+                )
+            if quantity == 0:
+                continue
+            positions.append(
+                OpenPosition(
+                    symbol=symbol,
+                    quantity=quantity,
+                    product_type=str(_first_present(row, _PRODUCT_KEYS) or "").strip(),
+                    broker_state="OPEN",
+                )
+            )
+        return BrokerQueryResult.success(positions)
+
+    def extract_order_id(self, order_response: Any) -> str:
+        """Recursively find Dhan's ``orderId`` in a response payload."""
+        if isinstance(order_response, OrderResult):
+            return order_response.order_id
+        if order_response is None:
+            return ""
+        if isinstance(order_response, dict):
+            for key in ("orderId", "order_id", "orderid", "id"):
+                value = order_response.get(key)
+                if value:
+                    return str(value).strip()
+            for value in order_response.values():
+                found = self.extract_order_id(value)
+                if found:
+                    return found
+            return ""
+        if isinstance(order_response, list):
+            for value in order_response:
+                found = self.extract_order_id(value)
+                if found:
+                    return found
+            return ""
+        if isinstance(order_response, str):
+            return order_response.strip()
+        return ""
+
+    def logout(self) -> dict[str, Any]:
+        """Close the local session and erase sensitive in-memory state.
+
+        DhanHQ documents no remote logout call, so closing the SDK's connection
+        pool and clearing the client, contract cache, and rate histories is the
+        complete local logout operation.  The token itself stays valid until
+        its own expiry regardless of what this process does, which is why it
+        lives only in the environment and is never written back anywhere.
+        """
+        with self._lock:
+            context = self._context
+            if context is not None:
+                try:
+                    http = context.get_dhan_http()
+                    session = getattr(http, "session", None)
+                    if session is not None:
+                        session.close()
+                except Exception as exc:
+                    log.warning("Dhan local session close failed: %s", exc)
+            self.is_logged_in = False
+            self.client = None
+            self._context = None
+            self._client_code = ""
+            self._symbol_cache.clear()
+            self._security_id_by_symbol.clear()
+            self._scrip_df = None
+            self._api_limiter.reset()
+            self._order_limiter.reset()
+            return {"status": "success", "message": "Dhan local session cleared"}
+
+
+# The master imports and reuses this one object so all worker threads share the
+# same authenticated session, contract cache, lock, and rate-limit budgets.
+dhan_execution_client = DhanExecutionClient()

--- a/Dependencies/Dhan API/diagnose_dhan_symbol.py
+++ b/Dependencies/Dhan API/diagnose_dhan_symbol.py
@@ -1,0 +1,520 @@
+"""Read-only Dhan index-option diagnostic with an opt-in REAL test order.
+
+Examples from the repository root::
+
+    python "Dependencies/Dhan API/diagnose_dhan_symbol.py" CE 24150
+    python "Dependencies/Dhan API/diagnose_dhan_symbol.py" PE 24000 14JUL26
+    python "Dependencies/Dhan API/diagnose_dhan_symbol.py" --underlying BANKNIFTY CE 59500
+
+The script logs in, loads the same local instrument master used by live
+execution, prints the exact contract row, and checks the shared resolver.  It
+does not place an order unless ``--place-order`` is supplied and the operator
+supplies an explicit ``--qty`` and then types exactly ``YES``.  The real-money
+path attempts the matching SELL only after the BUY has a confirmed full fill;
+a partial or unknown entry stops for reconciliation.
+
+The normal read-only flow has five visible checkpoints: authenticate, load the
+contract list, select one exact row, ask the production resolver for the same
+symbol, and confirm that symbol maps back to the same numeric ``securityId``.
+That last step is Dhan-specific and matters: Dhan's order API is driven by the
+security id, not the symbol, so a broken mapping would silently trade the wrong
+contract.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import dhan_execution as de
+from broker_contract import OrderResult, OrderStatus
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the parser used directly and through ``algo.py diagnose``.
+
+    ``algo.py`` consumes only ``--broker dhan`` and forwards every remaining
+    argument unchanged, so this parser remains the single source of truth for the
+    broker-specific option type, strike, expiry, quantity, and real-order switch.
+    """
+    parser = argparse.ArgumentParser(
+        description=(
+            "Validate a Dhan index-option symbol. Read-only unless "
+            "--place-order is supplied and YES is typed."
+        )
+    )
+    parser.add_argument(
+        "option_type",
+        nargs="?",
+        default="CE",
+        choices=("CE", "PE"),
+        type=str.upper,
+        help="Option type (default: CE).",
+    )
+    parser.add_argument(
+        "strike",
+        nargs="?",
+        default=23950,
+        type=int,
+        help="Option strike (default: 23950).",
+    )
+    parser.add_argument(
+        "expiry",
+        nargs="?",
+        help="Optional expiry as DDMMMYY, for example 14JUL26.",
+    )
+    parser.add_argument(
+        "--underlying",
+        default="NIFTY",
+        type=str.upper,
+        help="Index name (default: NIFTY). BANKNIFTY diagnoses the mirror leg.",
+    )
+    parser.add_argument(
+        "--place-order",
+        action="store_true",
+        help="After another YES prompt, place a REAL BUY then SELL round trip.",
+    )
+    parser.add_argument(
+        "--qty",
+        type=int,
+        help="Required explicit unit quantity for the REAL test order.",
+    )
+    return parser
+
+
+def _parse_expiry(raw: str | None) -> dt.date | None:
+    """Parse the optional DDMMMYY CLI expiry with a friendly error."""
+    if not raw:
+        return None
+    try:
+        return dt.datetime.strptime(raw.upper().strip(), "%d%b%y").date()
+    except ValueError as exc:
+        raise ValueError(
+            f"Could not parse expiry {raw!r}; expected DDMMMYY like 14JUL26."
+        ) from exc
+
+
+def select_contract(
+    client: Any,
+    *,
+    underlying: str,
+    option_type: str,
+    strike: int,
+    requested_expiry: dt.date | None,
+    today: dt.date | None = None,
+) -> tuple[dt.date, str, str, int]:
+    """Select one exact catalogue row; return expiry, symbol, security id, lot.
+
+    When no expiry is supplied, the nearest non-expired contract containing the
+    requested strike is chosen.  Filtering the strike before choosing the date
+    avoids selecting an expiry that does not list that particular contract.
+
+    Args:
+        client: Logged-in DhanExecutionClient with ``_scrip_df`` preloaded.
+        underlying: Index name such as NIFTY or BANKNIFTY.
+        option_type: ``CE`` or ``PE``.
+        strike: Whole-number option strike.
+        requested_expiry: Exact date, or ``None`` to choose the nearest future row.
+        today: Injectable clock used by deterministic unit tests.
+
+    Returns:
+        ``(expiry_date, trading_symbol, security_id, lot_size)`` from one row.
+
+    Raises:
+        ValueError: The master is unavailable or no exact row exists. It never
+            guesses a symbol, a security id, or a quantity.
+    """
+    frame = getattr(client, "_scrip_df", None)
+    if frame is None or frame.empty:
+        raise ValueError("Dhan scrip master is not loaded.")
+    underlying_u = str(underlying).upper().strip()
+    option_u = str(option_type).upper().strip()
+    strike_i = round(float(strike))
+    matches = frame[
+        (frame["_underlying_u"] == underlying_u)
+        & (frame["_option_u"] == option_u)
+        & (frame["_strike_f"].round().astype(int) == strike_i)
+    ].copy()
+    if requested_expiry is not None:
+        matches = matches[matches["_expiry_date"] == requested_expiry]
+    else:
+        today = today or dt.date.today()
+        matches = matches[matches["_expiry_date"] >= today]
+        if not matches.empty:
+            nearest = min(matches["_expiry_date"])
+            matches = matches[matches["_expiry_date"] == nearest]
+    if matches.empty:
+        expiry_text = requested_expiry.isoformat() if requested_expiry else "nearest future"
+        raise ValueError(
+            f"No Dhan {underlying_u} {option_u} strike {strike_i} "
+            f"contract found for {expiry_text} expiry."
+        )
+    row = matches.sort_values(["_expiry_date", "trading_symbol"]).iloc[0]
+    # LOT_SIZE is optional in the catalogue, so report 0 rather than crashing;
+    # --place-order requires an explicit --qty regardless.
+    try:
+        lot_size = int(row["lot_size"])
+    except (TypeError, ValueError):
+        lot_size = 0
+    return (
+        row["_expiry_date"],
+        str(row["trading_symbol"]).strip(),
+        str(int(row["security_id"])),
+        lot_size,
+    )
+
+
+def validate_quantity_for_lot(quantity: int, lot_size: int) -> str:
+    """Return an error message when ``quantity`` is not a whole-lot multiple.
+
+    Index options trade only in exchange-defined lots, so a quantity such as 1
+    against a lot of 65 can never be accepted.  Catching that locally matters
+    because Dhan reports it as a generic ``DH-905 Input_Exception`` whose
+    ``error_message`` has been observed to read "Invalid IP" -- an error that
+    sends operators hunting a network fault that does not exist.
+
+    This validates the operator's OWN number; it deliberately does not derive
+    one.  ``--place-order`` still requires an explicit ``--qty`` because lot
+    sizes change and guessing one would risk a wrong-sized live order.
+
+    Args:
+        quantity: The explicit unit quantity supplied on the command line.
+        lot_size: Official lot size from the contract catalogue, 0 if absent.
+
+    Returns:
+        An empty string when the quantity is placeable, else the reason.
+    """
+    if lot_size <= 0:
+        # The catalogue row carried no lot size, so there is nothing to check
+        # against. The broker remains the authority.
+        return ""
+    if quantity % lot_size:
+        return (
+            f"--qty {quantity} is not a multiple of the official lot size "
+            f"{lot_size}. Index options trade in whole lots only, so Dhan "
+            f"would reject this order. Use {lot_size} for one lot "
+            f"(or {lot_size * 2} for two)."
+        )
+    return ""
+
+
+def check_entry_margin(
+    client: Any,
+    *,
+    security_id: str,
+    quantity: int,
+    product_type: str = "INTRADAY",
+) -> tuple[bool, str]:
+    """Ask Dhan whether the BUY entry is affordable, without placing anything.
+
+    ``margin_calculator`` validates the same contract and quantity fields as
+    ``place_order`` but creates no order, so it is a safe pre-flight.
+
+    Only the ENTRY is checked.  An exit must never be gated on a pre-flight
+    query: if a position is open, squaring it off has to stay possible even
+    when a margin lookup fails.
+
+    Returns:
+        ``(placeable, message)``.  ``placeable`` is ``False`` only when the
+        broker positively reports a shortfall.  An unavailable or malformed
+        margin reply returns ``True`` with a warning -- an advisory check that
+        cannot run must not block the operator, since the broker itself is
+        still the real gate.
+    """
+    try:
+        envelope = client._call_api(
+            "margin calculator",
+            lambda sdk: sdk.margin_calculator(
+                security_id=str(security_id),
+                exchange_segment="NSE_FNO",
+                transaction_type="BUY",
+                quantity=int(quantity),
+                product_type=product_type,
+                price=0,
+            ),
+        )
+    except Exception as exc:
+        return (True, f"Margin pre-check could not run ({exc}); continuing.")
+
+    outcome, data, reason = de._classify_envelope(envelope)
+    if outcome != "ok" or not isinstance(data, dict):
+        return (True, f"Margin pre-check was inconclusive ({outcome}: {reason}); continuing.")
+
+    # Affordability is decided by comparing the two balances DIRECTLY.
+    #
+    # Dhan's `insufficientBalance` field is deliberately ignored: despite the
+    # name it is the UNSIGNED difference, abs(totalMargin - availableBalance),
+    # so it is positive whether you are short OR have money to spare. Measured
+    # against this account (available 10000.39):
+    #
+    #   required   2808.00 -> insufficientBalance  7192.39   (surplus!)
+    #   required  11232.00 -> insufficientBalance  1231.61   (short)
+    #   required  21895.25 -> insufficientBalance 11894.86   (short)
+    #   required  87581.00 -> insufficientBalance 77580.61   (short)
+    #
+    # Reading it as a shortfall rejects every affordable order. The response
+    # carries no boolean "sufficient" flag, so the comparison below is the
+    # only reliable test.
+    required = data.get("totalMargin")
+    available = data.get("availableBalance")
+    if required is None or available is None:
+        return (True, "Margin pre-check omitted the margin/balance figures; continuing.")
+    try:
+        required_f = float(required)
+        available_f = float(available)
+    except (TypeError, ValueError):
+        return (True, "Margin pre-check returned unusable figures; continuing.")
+
+    summary = f"required {required_f:.2f}, available {available_f:.2f}"
+    if available_f < required_f:
+        return (
+            False,
+            f"Insufficient funds for this entry: {summary}, "
+            f"short by {required_f - available_f:.2f}. Fund the account or test "
+            "with a cheaper (further out-of-the-money) strike.",
+        )
+    return (True, f"Margin pre-check OK: {summary}.")
+
+
+def place_round_trip_test_order(client: Any, symbol: str, quantity: int) -> bool:
+    """Place a confirmation-gated REAL BUY then SELL; return True only if flat.
+
+    This is deliberately separate from ``main`` so tests can prove that anything
+    except uppercase ``YES`` sends zero orders. If entry or exit confirmation is
+    ambiguous, the message assumes a live position *may* exist and directs the
+    operator to Dhan; silence would be unsafe in a real-money diagnostic.
+    """
+    print("\n" + "=" * 72)
+    print("REAL ROUND-TRIP TEST ORDER on Dhan")
+    print(
+        f"  BUY {quantity} {symbol} (product=INTRADAY); after a confirmed "
+        f"full fill, attempt SELL {quantity} to flatten."
+    )
+    print("  THIS PLACES REAL ORDERS WITH REAL MONEY.")
+    try:
+        confirmation = input(
+            "  Type exactly YES to proceed (anything else aborts): "
+        ).strip()
+    except (EOFError, OSError):
+        confirmation = ""
+    if confirmation != "YES":
+        print("  Aborted (no confirmation).")
+        return False
+
+    print(f"  Placing BUY {quantity} {symbol} ...")
+    try:
+        entry = client.place_market_order(
+            symbol=symbol,
+            side="BUY",
+            quantity=quantity,
+            product_type="INTRADAY",
+        )
+    except Exception as exc:
+        print(f"  ENTRY EXPOSURE IS INDETERMINATE: client raised {exc}")
+        print(
+            f"  !! A LIVE long position in {symbol} (qty={quantity}) MAY BE OPEN. "
+            "CHECK DHAN BEFORE RETRYING OR PLACING ANOTHER ORDER."
+        )
+        return False
+    if _is_zero_fill_rejection(entry, quantity):
+        print(f"  ENTRY rejected with zero fill: {entry.reason}\n  No position opened.")
+        return False
+    if not _is_full_fill(entry, quantity):
+        _print_indeterminate("ENTRY", entry, symbol, quantity)
+        return False
+    print(f"  ENTRY filled. OrderId={entry.order_id}")
+
+    print(f"  Squaring off: SELL {quantity} {symbol} ...")
+    try:
+        exit_order = client.place_market_order(
+            symbol=symbol,
+            side="SELL",
+            quantity=quantity,
+            product_type="INTRADAY",
+        )
+    except Exception as exc:
+        print(f"  !! EXIT EXPOSURE IS INDETERMINATE: client raised {exc}")
+        print(
+            f"  !! A LIVE long position in {symbol} (qty={quantity}) MAY BE OPEN. "
+            "CHECK DHAN AND SQUARE IT OFF MANUALLY NOW."
+        )
+        return False
+    if _is_zero_fill_rejection(exit_order, quantity):
+        print(f"  !! EXIT rejected with zero fill: {exit_order.reason}")
+        print(
+            f"  !! The LIVE long {symbol} qty={quantity} remains OPEN. "
+            "Square it off manually now."
+        )
+        return False
+    if not _is_full_fill(exit_order, quantity):
+        _print_indeterminate("EXIT", exit_order, symbol, quantity)
+        return False
+    print(
+        f"  EXIT filled. OrderId={exit_order.order_id} "
+        "-> flat. Round-trip OK."
+    )
+    return True
+
+
+def _is_full_fill(result: Any, quantity: int) -> bool:
+    """Return True only for an exact, typed full-quantity fill."""
+    return (
+        isinstance(result, OrderResult)
+        and result.status is OrderStatus.FILLED
+        and result.requested_quantity == quantity
+        and result.filled_quantity == quantity
+        and result.remaining_quantity == 0
+    )
+
+
+def _is_zero_fill_rejection(result: Any, quantity: int) -> bool:
+    """Return True only when the broker explicitly proves no units traded."""
+    return (
+        isinstance(result, OrderResult)
+        and result.status is OrderStatus.REJECTED
+        and result.requested_quantity == quantity
+        and result.filled_quantity == 0
+        and result.remaining_quantity == quantity
+    )
+
+
+def _print_indeterminate(
+    stage: str,
+    result: Any,
+    symbol: str,
+    quantity: int,
+) -> None:
+    """Print typed broker evidence without claiming that exposure is flat."""
+    if isinstance(result, OrderResult):
+        evidence = (
+            f"status={result.status.value} order_id={result.order_id or 'UNKNOWN'} "
+            f"filled={result.filled_quantity}/{result.requested_quantity} "
+            f"remaining={result.remaining_quantity} reason={result.reason}"
+        )
+    else:
+        evidence = f"untyped_result={result!r}"
+    print(f"  !! {stage} EXPOSURE IS INDETERMINATE: {evidence}")
+    print(
+        f"  !! Check {symbol} qty={quantity} in Dhan before retrying or "
+        "placing another order."
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the safe symbol diagnostic and optional confirmation-gated order.
+
+    Return codes follow normal CLI convention: 0 success, 1 operational failure
+    (login/resolution/order), and 2 invalid command-line input.
+    """
+    # Parse and validate all local input before login. Typos should never touch
+    # the broker API.
+    args = build_parser().parse_args(argv)
+    if args.qty is not None and args.qty <= 0:
+        print("--qty must be a positive integer.", file=sys.stderr)
+        return 2
+    if args.place_order and args.qty is None:
+        print(
+            "--place-order requires an explicit positive --qty; the diagnostic "
+            "will not guess a live quantity from a changing exchange lot size.",
+            file=sys.stderr,
+        )
+        return 2
+    try:
+        requested_expiry = _parse_expiry(args.expiry)
+    except ValueError as exc:
+        print(exc, file=sys.stderr)
+        return 2
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s | %(levelname)s | %(message)s",
+    )
+    client = de.dhan_execution_client
+    try:
+        # ``preload_scrip_master`` authenticates first, then loads the local
+        # instrument CSV once. The production resolver below reuses the same
+        # already-normalized in-memory table.
+        print("Logging in to Dhan and loading the local instrument master...")
+        if not client.preload_scrip_master():
+            print("Could not log in / load the Dhan scrip master.")
+            return 1
+
+        expiry, csv_symbol, csv_security_id, lot_size = select_contract(
+            client,
+            underlying=args.underlying,
+            option_type=args.option_type,
+            strike=args.strike,
+            requested_expiry=requested_expiry,
+        )
+        resolved = client.resolve_option_symbol(
+            args.underlying,
+            expiry,
+            args.option_type,
+            args.strike,
+        )
+        master_rows = 0 if client._scrip_df is None else len(client._scrip_df)
+        print(f"\nContract master rows: {master_rows}")
+        print(f"Selected expiry : {expiry:%d%b%y}")
+        print(f"Trading symbol  : {csv_symbol}")
+        print(f"Security id     : {csv_security_id}")
+        print(f"Official lot    : {lot_size}")
+        print(
+            "Resolver result : "
+            f"resolve_option_symbol({args.underlying}, {expiry}, "
+            f"{args.option_type}, {args.strike}) -> {resolved!r}"
+        )
+        if not resolved or resolved != csv_symbol:
+            print("Resolver did not reproduce the exact official catalogue symbol.")
+            return 1
+
+        # Dhan-specific: the order API takes the security id, so prove the
+        # symbol the resolver returned maps back to the very same contract.
+        mapped_security_id = client._security_id_for(resolved)
+        print(f"Order-API mapping: {resolved} -> securityId {mapped_security_id!r}")
+        if mapped_security_id != csv_security_id:
+            print(
+                "Symbol does not map back to the catalogue securityId; a live "
+                "order could reach the WRONG contract. Refusing to continue."
+            )
+            return 1
+
+        # Read-only is the default. Reaching the order helper requires both the
+        # explicit flag here and its second, typed-YES confirmation inside.
+        if not args.place_order:
+            print("\nRead-only diagnostic complete. No order was placed.")
+            return 0
+
+        # Pre-flight. Both checks run BEFORE the typed-YES prompt so an order
+        # that is certain to fail never reaches the broker (and never wastes
+        # the operator's confirmation on it).
+        lot_error = validate_quantity_for_lot(args.qty, lot_size)
+        if lot_error:
+            print(f"\n{lot_error}", file=sys.stderr)
+            return 2
+
+        placeable, margin_message = check_entry_margin(
+            client,
+            security_id=csv_security_id,
+            quantity=args.qty,
+        )
+        print(f"\n{margin_message}")
+        if not placeable:
+            return 1
+
+        return 0 if place_round_trip_test_order(client, resolved, args.qty) else 1
+    except Exception as exc:
+        print(f"Dhan diagnostic failed: {exc}", file=sys.stderr)
+        return 1
+    finally:
+        # Also runs on parse/resolution/order exceptions. Dhan documents no
+        # remote logout, so this only clears local session state.
+        client.logout()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Dependencies/Dhan API/test_dhan_execution.py
+++ b/Dependencies/Dhan API/test_dhan_execution.py
@@ -1,0 +1,484 @@
+"""Offline unit tests for the Dhan execution helper's local logic.
+
+These cover the parts that never reach the network: rate limiting, instrument
+CSV parsing, envelope classification, order-state aliasing, and order-id
+extraction.  The broker-contract conformance tests (place/status/cancel and the
+deadline behaviour) live in ``Dependencies/test_broker_contract.py``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_module() -> ModuleType:
+    """Load the adapter from its space-containing folder."""
+
+    path = ROOT / "Dependencies" / "Dhan API" / "dhan_execution.py"
+    spec = importlib.util.spec_from_file_location("dhan_execution_unit_test", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["dhan_execution_unit_test"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+de = _load_module()
+
+
+# ---------------------------------------------------------------------------
+# Rate limiter
+# ---------------------------------------------------------------------------
+
+
+class _FakeClock:
+    """Deterministic monotonic clock whose sleeps just advance the time."""
+
+    def __init__(self) -> None:
+        self.now = 0.0
+        self.slept: list[float] = []
+
+    def __call__(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.slept.append(seconds)
+        self.now += seconds
+
+
+def _limiter(clock: _FakeClock, per_second=2, per_minute=5, max_wait=2.0):
+    return de._RollingWindowRateLimiter(
+        per_second,
+        per_minute,
+        max_wait,
+        clock=clock,
+        sleeper=clock.sleep,
+        label="test",
+    )
+
+
+def test_rate_limiter_grants_calls_inside_the_budget() -> None:
+    clock = _FakeClock()
+    limiter = _limiter(clock)
+
+    limiter.acquire()
+    limiter.acquire()
+
+    assert clock.slept == []
+
+
+def test_rate_limiter_waits_for_the_next_one_second_window() -> None:
+    clock = _FakeClock()
+    limiter = _limiter(clock)
+
+    limiter.acquire()
+    limiter.acquire()
+    limiter.acquire()
+
+    assert clock.slept and clock.slept[0] == pytest.approx(1.0)
+
+
+def test_rate_limiter_raises_rather_than_waiting_past_the_cap() -> None:
+    """A stale live order is worse than a clear, immediate refusal."""
+
+    clock = _FakeClock()
+    limiter = _limiter(clock, per_second=1, per_minute=1, max_wait=0.5)
+    limiter.acquire()
+
+    with pytest.raises(RuntimeError, match="rate limit exhausted"):
+        limiter.acquire()
+
+
+# ---------------------------------------------------------------------------
+# Envelope classification -- the safety-critical discrimination
+# ---------------------------------------------------------------------------
+
+
+def test_success_envelope_is_ok_and_carries_data() -> None:
+    outcome, data, _reason = de._classify_envelope(
+        {"status": "success", "remarks": "", "data": {"orderId": "DH-1"}}
+    )
+
+    assert outcome == "ok"
+    assert data == {"orderId": "DH-1"}
+
+
+def test_dict_remarks_means_the_server_answered_and_refused() -> None:
+    outcome, _data, reason = de._classify_envelope(
+        {
+            "status": "failure",
+            "remarks": {
+                "error_code": "DH-905",
+                "error_type": "Order_Error",
+                "error_message": "insufficient margin",
+            },
+            "data": "",
+        }
+    )
+
+    assert outcome == "refused"
+    assert "insufficient margin" in reason
+
+
+def test_str_remarks_means_indeterminate_not_refused() -> None:
+    """The SDK's bare ``except Exception`` produces this shape.
+
+    Treating it as a refusal is exactly the bug that would report a timed-out
+    but live order as a harmless rejection.
+    """
+
+    outcome, _data, reason = de._classify_envelope(
+        {"status": "failure", "remarks": "ConnectionError(read timed out)", "data": ""}
+    )
+
+    assert outcome == "indeterminate"
+    assert "timed out" in reason
+
+
+@pytest.mark.parametrize("envelope", [None, "boom", 42, [], {"unexpected": True}])
+def test_malformed_envelopes_are_indeterminate(envelope) -> None:
+    outcome, _data, _reason = de._classify_envelope(envelope)
+
+    assert outcome == "indeterminate"
+
+
+# ---------------------------------------------------------------------------
+# Order-state aliasing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("EXPIRED", "CANCELLED"),
+        ("PART_TRADED", "PARTIAL"),
+        ("part-traded", "PARTIAL"),
+        ("TRADED", "TRADED"),
+        ("REJECTED", "REJECTED"),
+        # Transient states stay themselves so the fill loop keeps polling.
+        ("PENDING", "PENDING"),
+        ("TRANSIT", "TRANSIT"),
+        (None, ""),
+    ],
+)
+def test_state_aliasing(raw, expected: str) -> None:
+    assert de._alias_state(raw) == expected
+
+
+# ---------------------------------------------------------------------------
+# Quantity and field parsing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [(75, 75), ("75", 75), (75.0, 75), ("75.5", None), (True, None), ("abc", None), (None, None)],
+)
+def test_exact_int_rejects_anything_but_whole_numbers(value, expected) -> None:
+    assert de._exact_int(value) == expected
+
+
+def test_first_present_tolerates_field_casing_differences() -> None:
+    """Dhan's field casing is documented only in prose, so reads are lenient."""
+
+    assert de._first_present({"filledQty": 25}, de._FILLED_QTY_KEYS) == 25
+    assert de._first_present({"filled_qty": 25}, de._FILLED_QTY_KEYS) == 25
+    assert de._first_present({"orderStatus": "TRADED"}, de._ORDER_STATE_KEYS) == "TRADED"
+    # Empty strings count as absent so a blank field cannot masquerade as data.
+    assert de._first_present({"filledQty": ""}, de._FILLED_QTY_KEYS) is None
+    assert de._first_present({}, de._FILLED_QTY_KEYS) is None
+
+
+def test_extract_order_id_searches_nested_payloads() -> None:
+    assert de.dhan_execution_client.extract_order_id({"orderId": " DH-1 "}) == "DH-1"
+    assert de.dhan_execution_client.extract_order_id({"data": {"orderId": "DH-2"}}) == "DH-2"
+    assert de.dhan_execution_client.extract_order_id([{"orderId": "DH-3"}]) == "DH-3"
+    assert de.dhan_execution_client.extract_order_id({}) == ""
+    assert de.dhan_execution_client.extract_order_id(None) == ""
+
+
+# ---------------------------------------------------------------------------
+# Instrument-master parsing
+# ---------------------------------------------------------------------------
+
+_HEADER = (
+    "EXCH_ID,SEGMENT,INSTRUMENT,SYMBOL_NAME,DISPLAY_NAME,SM_EXPIRY_DATE,"
+    "LOT_SIZE,SECURITY_ID,STRIKE_PRICE,OPTION_TYPE,UNDERLYING_SYMBOL\n"
+)
+_NIFTY_CE = (
+    "NSE,D,OPTIDX,NIFTY-Jul2026-24000-CE,NIFTY 24000 CALL,2026-07-21,"
+    "65,45001,24000,CE,NIFTY\n"
+)
+_NIFTY_PE = (
+    "NSE,D,OPTIDX,NIFTY-Jul2026-24000-PE,NIFTY 24000 PUT,2026-07-21,"
+    "65,45002,24000,PE,NIFTY\n"
+)
+_BNF_CE = (
+    "NSE,D,OPTIDX,BANKNIFTY-Jul2026-59500-CE,BANKNIFTY 59500 CALL,2026-07-28,"
+    "35,45003,59500,CE,BANKNIFTY\n"
+)
+# Rows that must be filtered out: a stock option, an equity row, and a future.
+_NOISE = (
+    "NSE,D,OPTSTK,RELIANCE-Jul2026-3000-CE,RELIANCE 3000 CALL,2026-07-21,"
+    "250,45004,3000,CE,RELIANCE\n"
+    "NSE,E,EQUITY,RELIANCE,Reliance Industries,,1,2885,0,,RELIANCE\n"
+    "NSE,D,FUTIDX,NIFTY-Jul2026-FUT,NIFTY FUT,2026-07-21,65,45005,0,,NIFTY\n"
+)
+
+
+def _write_master(tmp_path: Path, body: str) -> Path:
+    path = tmp_path / "all_instrument 2026-07-18.csv"
+    path.write_text(_HEADER + body, encoding="utf-8")
+    return path
+
+
+def test_prepare_scrip_master_keeps_only_index_options(tmp_path: Path) -> None:
+    frame = de.DhanExecutionClient._prepare_scrip_master(
+        _write_master(tmp_path, _NIFTY_CE + _NIFTY_PE + _BNF_CE + _NOISE)
+    )
+
+    assert len(frame) == 3
+    assert set(frame["_underlying_u"]) == {"NIFTY", "BANKNIFTY"}
+    assert set(frame["_option_u"]) == {"CE", "PE"}
+    # Security ids must survive as real integers for the order API.
+    assert sorted(frame["security_id"]) == [45001, 45002, 45003]
+    assert frame["security_id"].dtype.kind == "i"
+
+
+def test_prepare_scrip_master_raises_on_missing_columns(tmp_path: Path) -> None:
+    path = tmp_path / "all_instrument 2026-07-18.csv"
+    path.write_text("EXCH_ID,SEGMENT\nNSE,D\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="missing columns"):
+        de.DhanExecutionClient._prepare_scrip_master(path)
+
+
+def test_prepare_scrip_master_raises_when_no_option_rows_survive(tmp_path: Path) -> None:
+    """An all-noise catalogue must fail loudly, not resolve to nothing later."""
+
+    with pytest.raises(ValueError, match="no usable index-option rows"):
+        de.DhanExecutionClient._prepare_scrip_master(_write_master(tmp_path, _NOISE))
+
+
+def test_latest_instrument_master_path_picks_the_newest(tmp_path: Path, monkeypatch) -> None:
+    for name in ("all_instrument 2026-07-16.csv", "all_instrument 2026-07-18.csv"):
+        (tmp_path / name).write_text(_HEADER, encoding="utf-8")
+    monkeypatch.setattr(de, "_DEPENDENCIES_DIR", tmp_path)
+
+    picked = de.DhanExecutionClient._latest_instrument_master_path()
+
+    assert picked is not None and picked.name == "all_instrument 2026-07-18.csv"
+
+
+def test_missing_instrument_master_disables_live_trading(tmp_path: Path, monkeypatch) -> None:
+    """No catalogue means preload fails closed rather than resolving blindly."""
+
+    monkeypatch.setattr(de, "_DEPENDENCIES_DIR", tmp_path)
+    client = de.DhanExecutionClient()
+
+    assert client._ensure_scrip_master_locked() is False
+    assert client._scrip_df is None
+
+
+# ---------------------------------------------------------------------------
+# Symbol -> securityId bridge
+# ---------------------------------------------------------------------------
+
+
+def test_resolver_populates_the_security_id_map(tmp_path: Path, monkeypatch) -> None:
+    """The resolver returns a readable symbol that still maps to the right id."""
+
+    monkeypatch.setattr(de, "_DEPENDENCIES_DIR", tmp_path)
+    _write_master(tmp_path, _NIFTY_CE + _NIFTY_PE + _BNF_CE)
+    client = de.DhanExecutionClient()
+    monkeypatch.setattr(client, "ensure_logged_in", lambda: True)
+
+    symbol = client.resolve_option_symbol("NIFTY", "2026-07-21", "CE", 24000)
+
+    assert symbol == "NIFTY-Jul2026-24000-CE"
+    assert client._security_id_for(symbol) == "45001"
+    # The BankNIFTY mirror leg must resolve from the same catalogue.
+    bnf = client.resolve_option_symbol("BANKNIFTY", "2026-07-28", "CE", 59500)
+    assert bnf == "BANKNIFTY-Jul2026-59500-CE"
+    assert client._security_id_for(bnf) == "45003"
+
+
+def test_resolver_returns_empty_string_on_a_miss(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(de, "_DEPENDENCIES_DIR", tmp_path)
+    _write_master(tmp_path, _NIFTY_CE)
+    client = de.DhanExecutionClient()
+    monkeypatch.setattr(client, "ensure_logged_in", lambda: True)
+
+    assert client.resolve_option_symbol("NIFTY", "2026-07-21", "CE", 99999) == ""
+    assert client.resolve_option_symbol("NIFTY", "2026-12-31", "CE", 24000) == ""
+    assert client.resolve_option_symbol("NIFTY", "2026-07-21", "XX", 24000) == ""
+    assert client._security_id_for("NIFTY-NOT-A-SYMBOL") == ""
+
+
+# ---------------------------------------------------------------------------
+# Diagnostic pre-flight guards
+# ---------------------------------------------------------------------------
+# These exist because Dhan reports a bad quantity as a generic DH-905
+# Input_Exception whose message has been observed to read "Invalid IP",
+# which points the operator at a network fault that does not exist.
+
+
+def _diagnostic() -> ModuleType:
+    path = ROOT / "Dependencies" / "Dhan API" / "diagnose_dhan_symbol.py"
+    spec = importlib.util.spec_from_file_location("diagnose_dhan_unit_test", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["diagnose_dhan_unit_test"] = module
+    # The diagnostic imports the adapter by bare name from its own folder.
+    sys.modules.setdefault("dhan_execution", de)
+    spec.loader.exec_module(module)
+    return module
+
+
+diag = _diagnostic()
+
+
+@pytest.mark.parametrize(
+    ("quantity", "lot_size", "rejected"),
+    [
+        (1, 65, True),      # the exact case that produced "Invalid IP"
+        (64, 65, True),
+        (100, 65, True),
+        (65, 65, False),    # one lot
+        (130, 65, False),   # two lots
+        (30, 30, False),    # BankNIFTY lot
+        (1, 0, False),      # catalogue carried no lot size -> nothing to check
+    ],
+)
+def test_quantity_must_be_a_whole_lot_multiple(quantity, lot_size, rejected) -> None:
+    message = diag.validate_quantity_for_lot(quantity, lot_size)
+
+    assert bool(message) is rejected
+    if rejected:
+        assert str(lot_size) in message
+
+
+class _MarginClient:
+    """Stands in for the adapter's _call_api during margin pre-checks."""
+
+    def __init__(self, envelope) -> None:
+        self.envelope = envelope
+        self.calls: list[dict] = []
+
+    def _call_api(self, _operation, call, **_kwargs):
+        if isinstance(self.envelope, Exception):
+            raise self.envelope
+
+        class _Sdk:
+            def margin_calculator(_self, **kwargs):
+                self.calls.append(dict(kwargs))
+                return self.envelope
+
+        return call(_Sdk())
+
+
+def _margin_payload(required: float, available: float) -> dict:
+    """Build a margin reply with Dhan's real (unsigned) insufficientBalance.
+
+    Reproducing the quirk faithfully is the point: `insufficientBalance` is
+    abs(required - available), so it is positive even when the order is
+    comfortably affordable.
+    """
+
+    return {
+        "status": "success",
+        "remarks": "",
+        "data": {
+            "totalMargin": required,
+            "availableBalance": available,
+            "insufficientBalance": round(abs(required - available), 2),
+            "leverage": "1X",
+        },
+    }
+
+
+def test_margin_precheck_blocks_an_unaffordable_entry() -> None:
+    client = _MarginClient(_margin_payload(required=21895.25, available=0.39))
+
+    placeable, message = diag.check_entry_margin(client, security_id="57340", quantity=65)
+
+    assert placeable is False
+    assert "Insufficient funds" in message
+    assert "short by 21894.86" in message
+    # It must ask about the real contract and quantity, and create nothing.
+    assert client.calls[0]["security_id"] == "57340"
+    assert client.calls[0]["quantity"] == 65
+    assert client.calls[0]["transaction_type"] == "BUY"
+
+
+def test_margin_precheck_allows_an_affordable_entry() -> None:
+    """Regression: a surplus must not be misread as a shortfall.
+
+    These are the exact figures from a real Dhan reply where the order was
+    affordable (2808 needed, 10000.39 on hand) yet insufficientBalance came
+    back as 7192.39. Trusting that field blocked a perfectly valid order.
+    """
+
+    client = _MarginClient(_margin_payload(required=2808.0, available=10000.39))
+
+    placeable, message = diag.check_entry_margin(client, security_id="57360", quantity=65)
+
+    assert placeable is True
+    assert "OK" in message
+    assert "required 2808.00" in message and "available 10000.39" in message
+
+
+@pytest.mark.parametrize(
+    ("required", "available", "placeable"),
+    [
+        (2808.0, 10000.39, True),      # comfortable surplus
+        (11232.0, 10000.39, False),    # just short
+        (10000.39, 10000.39, True),    # exactly affordable
+        (10000.40, 10000.39, False),   # one paisa short
+        (0.0, 0.0, True),              # nothing required
+    ],
+)
+def test_margin_precheck_compares_balances_not_the_unsigned_field(
+    required: float,
+    available: float,
+    placeable: bool,
+) -> None:
+    client = _MarginClient(_margin_payload(required=required, available=available))
+
+    got, _message = diag.check_entry_margin(client, security_id="57360", quantity=65)
+
+    assert got is placeable
+
+
+@pytest.mark.parametrize(
+    "envelope",
+    [
+        RuntimeError("network down"),
+        {"status": "failure", "remarks": "ConnectionError(...)", "data": ""},
+        {"status": "success", "remarks": "", "data": "not-a-dict"},
+        # Missing either figure means the comparison cannot be made.
+        {"status": "success", "remarks": "", "data": {"totalMargin": 100}},
+        {"status": "success", "remarks": "", "data": {"availableBalance": 100}},
+        {"status": "success", "remarks": "", "data": {"totalMargin": "n/a", "availableBalance": 100}},
+    ],
+)
+def test_margin_precheck_that_cannot_run_does_not_block(envelope) -> None:
+    """An advisory check that fails must not stop the operator.
+
+    The broker is still the real gate, and the typed-YES confirmation is
+    still ahead -- so failing closed here would add friction without safety.
+    """
+
+    client = _MarginClient(envelope)
+
+    placeable, message = diag.check_entry_margin(client, security_id="57340", quantity=65)
+
+    assert placeable is True
+    assert "continuing" in message

--- a/Dependencies/dhan_token_setup.py
+++ b/Dependencies/dhan_token_setup.py
@@ -5,22 +5,35 @@ One-time DhanHQ OAuth setup script.
 
 WHAT THIS DOES (read this first if you have never run it)
 ---------------------------------------------------------
-DhanHQ's "API Key + API Secret" auth flow produces a 12-month access token
-through a 3-step OAuth process. Two of those three steps happen here in
-code; the middle step requires you to log in via a browser (DhanHQ does
-this for security so they can show you the standard login page).
+DhanHQ's "API Key + API Secret" auth flow produces an access token through a
+3-step OAuth process. Two of those three steps happen here in code; the
+middle step requires you to log in via a browser (DhanHQ does this for
+security so they can show you the standard login page).
 
 This script walks you through the whole thing and writes the resulting
 access token back into the `.env` file that sits next to it (i.e.
-`Multithreading/Dependencies/.env`). After that, the three trading scripts
-read the token from that `.env` automatically -- no more copy-pasting
-24-hour JWTs from web.dhan.co every morning.
+`Multithreading/Dependencies/.env`). After that, the trading scripts read
+the token from that `.env` automatically.
+
+HOW LONG THE TOKEN LASTS -- CHECK, DO NOT ASSUME
+------------------------------------------------
+DhanHQ decides the validity when the token is minted, and it is stamped into
+the token itself. Tokens generated from the web.dhan.co screen currently
+default to **24 hours** (that screen says so). Do not assume a long-lived
+token: this script prints the real expiry after it finishes, so read it.
+
+This matters for live trading. If the token dies mid-session, order placement
+starts failing -- and because a rejected live EXIT leaves the position open,
+you can be left holding intraday positions you cannot square off through the
+API. Mint the token OUTSIDE market hours (after the 15:30 close or before the
+09:15 open) so its window covers the whole session, never at midday.
 
 WHEN TO RUN THIS SCRIPT
 -----------------------
 - Once after you first generate the API Key / API Secret pair on
   web.dhan.co (My Profile -> DhanHQ Trading APIs -> Generate API).
-- Again whenever the 12-month access token eventually expires.
+- Again whenever the access token expires -- for a 24-hour token that means
+  before each trading day, outside market hours.
 - Again if you regenerate the API Key / Secret for any reason.
 
 WHAT YOU NEED FIRST (before running this)
@@ -44,8 +57,8 @@ to a URL that looks like:
 
 Copy the value after `tokenId=` (or the whole URL, the script tolerates
 both) and paste it into the prompt. The script then exchanges that
-short-lived `tokenId` for the 12-month `accessToken` and writes it into
-the local `.env`.
+short-lived `tokenId` for the `accessToken` and writes it into the
+local `.env`.
 
 THE 3 OAUTH STEPS, EXPLAINED FOR BEGINNERS
 ------------------------------------------
@@ -55,7 +68,7 @@ THE 3 OAUTH STEPS, EXPLAINED FOR BEGINNERS
    DhanHQ redirects the browser to a URL containing a `tokenId`.
 3. The user pastes that `tokenId` back into this script. We send it +
    our API Key/Secret back to DhanHQ. If everything matches up, DhanHQ
-   returns the long-lived `accessToken`.
+   returns the `accessToken`.
 
 This dance is essentially the same OAuth pattern you have probably seen
 when granting a third-party app access to your Google or GitHub account.
@@ -70,9 +83,12 @@ from __future__ import annotations
 # `re`     - small regex helpers for parsing the redirect URL and rewriting .env.
 # `sys`    - used to exit cleanly with an exit code on errors.
 # `Path`   - cross-platform path object for locating the sibling `.env` file.
+import base64
+import json
 import os
 import re
 import sys
+from datetime import UTC, datetime
 from getpass import getpass
 from pathlib import Path
 
@@ -251,6 +267,48 @@ def _extract_token_id(user_input: str) -> str:
     return cleaned
 
 
+def _describe_token_expiry(access_token: str) -> str:
+    """Report when this token actually dies, read from the token itself.
+
+    DhanHQ access tokens are JWTs whose middle segment carries an ``exp``
+    claim.  Decoding it (no signature check -- we are only reading a
+    timestamp we were just handed) beats assuming a validity, because the
+    web console currently mints 24-hour tokens while this flow may issue
+    something longer.
+
+    The warning matters for live trading: if the token expires during market
+    hours, order placement starts failing, and because a rejected live EXIT
+    leaves a position open, intraday positions can be left un-squareable
+    through the API.
+
+    Returns:
+        A human-readable line for the operator; never raises, because a
+        cosmetic decode problem must not fail an otherwise good setup run.
+    """
+    try:
+        segments = access_token.split(".")
+        if len(segments) != 3:
+            return "Token validity: unknown (token is not a JWT); check web.dhan.co."
+        padded = segments[1] + "=" * (-len(segments[1]) % 4)
+        expires_at = datetime.fromtimestamp(
+            json.loads(base64.urlsafe_b64decode(padded))["exp"], UTC
+        ).astimezone()
+    except Exception:
+        return "Token validity: could not be read from the token; check web.dhan.co."
+
+    hours_left = (expires_at - datetime.now().astimezone()).total_seconds() / 3600
+    line = f"Token expires {expires_at:%Y-%m-%d %H:%M:%S} (about {hours_left:.0f}h from now)."
+    # 09:15-15:30 IST is the NSE equity-derivatives session.
+    session_close = expires_at.replace(hour=15, minute=30, second=0, microsecond=0)
+    if expires_at < session_close and expires_at.weekday() < 5:
+        line += (
+            "\n  WARNING: that is DURING market hours. If it expires while positions"
+            "\n  are open you may be unable to square off through the API. Re-run this"
+            "\n  script outside market hours so the window covers a whole session."
+        )
+    return line
+
+
 def main() -> None:
     """
     Driver: walks the user through Steps 1, 2, 3 of the OAuth flow.
@@ -340,12 +398,12 @@ def main() -> None:
         print("ERROR: empty tokenId. Aborting.")
         sys.exit(2)
 
-    # --- Step 3 of 3: exchange tokenId for the long-lived access token --------
+    # --- Step 3 of 3: exchange tokenId for the access token -------------------
     # This call sends the short-lived tokenId + our API Key/Secret to
     # /app/consumeApp-consent. DhanHQ verifies the consent ID matches the
-    # one we created in Step 1 and, if all is well, returns a 12-month
-    # access token.
-    print("\nStep 3/3: exchanging tokenId for the 12-month access token...")
+    # one we created in Step 1 and, if all is well, returns the access token.
+    # DhanHQ chooses the validity; `_describe_token_expiry` reads it back.
+    print("\nStep 3/3: exchanging tokenId for the access token...")
     try:
         access_response = login.consume_token_id(token_id, api_key, api_secret)
     except Exception as exc:
@@ -406,7 +464,8 @@ def main() -> None:
     # it up on their next start.
     _write_access_token_to_env(access_token)
     print(f"\nDone. DHAN_ACCESS_TOKEN written to {ENV_PATH}")
-    print("This token is valid for 12 months. Re-run this script to refresh.")
+    print(_describe_token_expiry(access_token))
+    print("Re-run this script to refresh the token whenever it expires.")
 
 
 # Standard "only run main() when executed directly" guard. Lets other code

--- a/Dependencies/env.example
+++ b/Dependencies/env.example
@@ -20,10 +20,12 @@
 # Authentication flow (Option A - API Key / API Secret OAuth):
 #   1. Fill in DHAN_CLIENT_CODE, DHAN_API_KEY, DHAN_API_SECRET below.
 #   2. Run `python Multithreading/Dependencies/dhan_token_setup.py` once.
-#      The script walks you through the one-time browser login and writes
-#      a fresh DHAN_ACCESS_TOKEN (valid 12 months) back into this file.
-#   3. From then on, the trading scripts read the token directly. When it
-#      eventually expires, just re-run the setup script.
+#      The script walks you through the browser login and writes a fresh
+#      DHAN_ACCESS_TOKEN back into this file, then prints its real expiry.
+#   3. From then on, the trading scripts read the token directly. Re-run the
+#      setup script whenever it expires -- tokens minted on web.dhan.co
+#      currently last only 24 HOURS, so plan on refreshing before each
+#      trading day, outside market hours.
 # ==============================================================================
 
 
@@ -41,9 +43,13 @@ DHAN_API_KEY=
 # TREAT THIS LIKE A PASSWORD. Never commit a populated .env to git.
 DHAN_API_SECRET=
 
-# 12-month access token produced by dhan_token_setup.py.
+# Access token produced by dhan_token_setup.py (or pasted from web.dhan.co).
 # Leave blank for the very first run; the setup script populates it after
 # the OAuth flow completes.
+# VALIDITY IS NOT 12 MONTHS: DhanHQ stamps the expiry into the token and the
+# web console currently issues 24-hour tokens. Generate it OUTSIDE market
+# hours -- a token that dies mid-session can leave open intraday positions
+# that cannot be squared off through the API.
 DHAN_ACCESS_TOKEN=
 
 
@@ -992,18 +998,19 @@ GSHEET_OAUTH_TOKEN_FILE=
 # By default EVERYTHING is paper: LIVE_TRADING_ENABLED=false is the global
 # kill-switch. A strategy places REAL orders only when BOTH this master switch
 # AND that strategy's own <PREFIX>_LIVE_TRADING are true. LIVE_BROKER picks which
-# broker those orders route to (KOTAK, SHOONYA, or FLATTRADE) - all share one code path in
-# the runner (Dependencies/Kotak API/kotak_execution.py /
+# broker those orders route to (KOTAK, SHOONYA, FLATTRADE, or DHAN) - all share one
+# code path in the runner (Dependencies/Kotak API/kotak_execution.py /
 # Dependencies/Shoonya API/shoonya_execution.py / Dependencies/Flattrade API/
-# flattrade_execution.py). An entry falls back to paper ONLY after an explicit
-# zero-fill REJECTED result. PARTIAL or UNKNOWN means broker exposure may exist:
-# new live entries freeze and reconciliation continues. A rejected/ambiguous
-# exit remains tracked as live exposure.
+# flattrade_execution.py / Dependencies/Dhan API/dhan_execution.py). An entry
+# falls back to paper ONLY after an explicit zero-fill REJECTED result. PARTIAL
+# or UNKNOWN means broker exposure may exist: new live entries freeze and
+# reconciliation continues. A rejected/ambiguous exit remains tracked as live
+# exposure.
 
 # ---- Global master kill-switch (must be true for ANY live order) ----
 LIVE_TRADING_ENABLED=false
 
-# ---- Active broker for live orders: KOTAK, SHOONYA, or FLATTRADE ----
+# ---- Active broker for live orders: KOTAK, SHOONYA, FLATTRADE, or DHAN ----
 LIVE_BROKER=KOTAK
 
 # ---- Kotak Neo credentials (used when LIVE_BROKER=KOTAK) ----
@@ -1042,6 +1049,18 @@ FLATTRADE_API_SECRET=
 FLATTRADE_ACCESS_TOKEN=
 FLATTRADE_PRODUCT_TYPE=INTRADAY
 FLATTRADE_MARKET_PROTECTION=5
+
+# ---- Dhan credentials (used when LIVE_BROKER=DHAN) ----
+# Dhan needs NO new secrets: live orders reuse the SAME DHAN_CLIENT_CODE and
+# DHAN_ACCESS_TOKEN already set at the top of this file for market data. The
+# token comes from `python algo.py setup-token` and is read from the
+# environment only - this helper never writes it back or prompts for one.
+# Refresh it outside market hours; see the DHAN_ACCESS_TOKEN note above.
+# Dhan also enforces a static-IP whitelist on ORDER endpoints only: reads keep
+# working while orders fail with "Invalid IP", and the token must be minted
+# AFTER the IP is registered (web.dhan.co -> Static IP Setting).
+# INTRADAY is same-day (Dhan INTRADAY); NORMAL is carry-forward (Dhan MARGIN).
+DHAN_PRODUCT_TYPE=INTRADAY
 
 # ---- Per-strategy live toggles (all default false; flip individually) ----
 # Prefixes match each strategy's existing <PREFIX>_* knobs above.

--- a/Dependencies/test_broker_contract.py
+++ b/Dependencies/test_broker_contract.py
@@ -2778,3 +2778,653 @@ def test_diagnostics_treat_entry_exception_as_indeterminate(
     assert flat is False
     assert "indeterminate" in output.lower()
     assert "No position opened" not in output
+
+
+# ---------------------------------------------------------------------------
+# Dhan adapter
+# ---------------------------------------------------------------------------
+# Dhan's SDK collapses BOTH a genuine broker refusal and a local network
+# exception into ``{'status': 'failure', ...}``.  Most of the tests below exist
+# to prove the adapter keeps those two apart, because mistaking a timed-out live
+# order for a rejection would send the runner back to paper while real exposure
+# sits at the broker.
+
+DHAN_SYMBOL = "NIFTY-Jul2026-24000-CE"
+DHAN_SECURITY_ID = "45022"
+
+
+@pytest.fixture(scope="module")
+def dhan_module() -> ModuleType:
+    """Return a private, network-free copy of the Dhan adapter."""
+
+    return _load_file_module(
+        "mat101_dhan_execution",
+        "Dependencies/Dhan API/dhan_execution.py",
+    )
+
+
+class _FakeDhanSdk:
+    """Minimal stand-in for the ``dhanhq`` client used by the adapter."""
+
+    def __init__(self, replies=None, correlation_reply=None) -> None:
+        self._replies = iter(replies or [])
+        self._correlation_reply = correlation_reply
+        self.place_calls: list[dict] = []
+        self.correlation_calls: list[str] = []
+        self.cancelled: list[str] = []
+
+    def _next(self):
+        return next(self._replies)
+
+    def place_order(self, **kwargs):
+        self.place_calls.append(dict(kwargs))
+        return self._next()
+
+    def get_order_by_id(self, order_id):
+        return self._next()
+
+    def get_order_by_correlationID(self, correlation_id):
+        self.correlation_calls.append(str(correlation_id))
+        if self._correlation_reply is None:
+            raise AssertionError("correlation lookup was not expected here")
+        if isinstance(self._correlation_reply, Exception):
+            raise self._correlation_reply
+        return self._correlation_reply
+
+    def cancel_order(self, order_id):
+        self.cancelled.append(str(order_id))
+        return self._next()
+
+    def get_order_list(self):
+        return self._next()
+
+    def get_positions(self):
+        return self._next()
+
+    def get_fund_limits(self):
+        return self._next()
+
+
+def _ok(data):
+    """Build the SDK's success envelope."""
+
+    return {"status": "success", "remarks": "", "data": data}
+
+
+def _refused(message="DH-905 insufficient margin"):
+    """Build the envelope Dhan returns when its SERVER answers and refuses.
+
+    ``remarks`` is a dict here -- that is the only signal distinguishing this
+    from a local transport failure.
+    """
+
+    return {
+        "status": "failure",
+        "remarks": {
+            "error_code": "DH-905",
+            "error_type": "Order_Error",
+            "error_message": message,
+        },
+        "data": "",
+    }
+
+
+def _transport_failure(message="ConnectionError(read timed out)"):
+    """Build the envelope the SDK returns when its own request RAISED.
+
+    ``remarks`` is a plain string.  The order may well have reached the
+    exchange, so this must never normalize to REJECTED.
+    """
+
+    return {"status": "failure", "remarks": message, "data": ""}
+
+
+def _status_row(state, filled, quantity=75):
+    return {
+        "orderId": "DH-1",
+        "orderStatus": state,
+        "filledQty": filled,
+        "quantity": quantity,
+        "tradingSymbol": DHAN_SYMBOL,
+        "transactionType": "BUY",
+    }
+
+
+def _ready_dhan_client(dhan_module: ModuleType, monkeypatch, fake):
+    """Build an authenticated-looking client without touching Dhan."""
+
+    client = dhan_module.DhanExecutionClient()
+    client._client_code = "TEST"
+    client.client = fake
+    client.is_logged_in = True
+    # The order API is driven by securityId, so the resolver's map must already
+    # know this symbol -- exactly as it would after preload_scrip_master().
+    client._security_id_by_symbol[DHAN_SYMBOL] = DHAN_SECURITY_ID
+    monkeypatch.setattr(client, "ensure_logged_in", lambda: True)
+    monkeypatch.setattr(dhan_module, "_FILL_POLL_INTERVAL", 0.001)
+    return client
+
+
+@pytest.mark.parametrize(
+    ("state", "filled", "expected_status", "remaining"),
+    [
+        ("REJECTED", 0, "REJECTED", 75),
+        ("TRADED", 75, "FILLED", 0),
+        ("TRADED", 25, "PARTIAL", 50),
+        # EXPIRED is not in the shared contract vocabulary; the adapter aliases
+        # it to CANCELLED so a clean "never traded" is a terminal rejection
+        # rather than an UNKNOWN that would freeze every live strategy.
+        ("EXPIRED", 0, "REJECTED", 75),
+    ],
+)
+def test_dhan_place_order_normalizes_terminal_outcomes(
+    dhan_module: ModuleType,
+    monkeypatch,
+    state: str,
+    filled: int,
+    expected_status: str,
+    remaining: int,
+) -> None:
+    """An acknowledgement is followed by a typed fill snapshot."""
+
+    fake = _FakeDhanSdk(
+        [
+            _ok({"orderId": "DH-1", "orderStatus": "TRANSIT"}),
+            _ok(_status_row(state, filled)),
+        ]
+    )
+    client = _ready_dhan_client(dhan_module, monkeypatch, fake)
+
+    result = client.place_market_order(DHAN_SYMBOL, "BUY", 75)
+
+    assert result.status.name == expected_status
+    assert result.order_id == "DH-1"
+    assert result.filled_quantity == filled
+    assert result.remaining_quantity == remaining
+
+
+def test_dhan_mid_fill_part_traded_snapshot_polls_to_completion(
+    dhan_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """A market order caught mid-fill is transient, not terminal.
+
+    Returning that first PART_TRADED snapshot as the outcome would freeze
+    every live entry over a healthy order; the loop must poll again.
+    """
+
+    fake = _FakeDhanSdk(
+        [
+            _ok({"orderId": "DH-MIDFILL", "orderStatus": "PENDING"}),
+            _ok(_status_row("PART_TRADED", 25)),
+            _ok(_status_row("TRADED", 75)),
+        ]
+    )
+    client = _ready_dhan_client(dhan_module, monkeypatch, fake)
+
+    result = client.place_market_order(DHAN_SYMBOL, "BUY", 75)
+
+    assert result.status.name == "FILLED"
+    assert result.order_id == "DH-MIDFILL"
+    assert result.filled_quantity == 75
+
+
+def test_dhan_transport_failure_is_unknown_never_rejected(
+    dhan_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """THE critical Dhan case: a lost response is not proof of a zero fill.
+
+    ``DhanHTTP._send_request`` turns a post-submission socket timeout into
+    ``{'status': 'failure', 'remarks': '<exception text>'}`` -- shape-identical
+    to a real rejection.  Believing it would re-enter on paper while a real
+    position sits at the broker.
+    """
+
+    fake = _FakeDhanSdk([_transport_failure()])
+    client = _ready_dhan_client(dhan_module, monkeypatch, fake)
+
+    result = client.place_market_order(DHAN_SYMBOL, "BUY", 75)
+
+    assert result.status.name == "UNKNOWN"
+    assert result.filled_quantity == 0
+    assert result.remaining_quantity == 75
+    # No correlation tag was supplied, so no lookup should have been attempted.
+    assert fake.correlation_calls == []
+
+
+def test_dhan_transport_failure_recovers_the_order_via_correlation_id(
+    dhan_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """A completely lost placement response is still traceable by tag.
+
+    This is the payoff of sending ``order_tag`` as Dhan's ``correlationId``:
+    the order is found and its real fill reported, instead of the runner being
+    frozen on an avoidable unknown.
+    """
+
+    fake = _FakeDhanSdk(
+        [
+            _transport_failure(),
+            _ok(_status_row("TRADED", 75)),
+        ],
+        correlation_reply=_ok({"orderId": "DH-1", "orderStatus": "TRADED"}),
+    )
+    client = _ready_dhan_client(dhan_module, monkeypatch, fake)
+
+    result = client.place_market_order(DHAN_SYMBOL, "BUY", 75, order_tag="TAG-1")
+
+    assert fake.correlation_calls == ["TAG-1"]
+    assert result.status.name == "FILLED"
+    assert result.order_id == "DH-1"
+    assert result.filled_quantity == 75
+
+
+def test_dhan_transport_failure_stays_unknown_when_lookup_also_fails(
+    dhan_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """Two failed observations still prove nothing about exposure."""
+
+    fake = _FakeDhanSdk(
+        [_transport_failure()],
+        correlation_reply=_transport_failure(),
+    )
+    client = _ready_dhan_client(dhan_module, monkeypatch, fake)
+
+    result = client.place_market_order(DHAN_SYMBOL, "BUY", 75, order_tag="TAG-2")
+
+    assert fake.correlation_calls == ["TAG-2"]
+    assert result.status.name == "UNKNOWN"
+
+
+def test_dhan_server_refusal_confirmed_by_lookup_is_rejected(
+    dhan_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """A structured refusal plus "no such order" is a provable zero fill.
+
+    Only this combination -- Dhan's server answering with an errorCode AND the
+    correlation lookup finding nothing -- earns REJECTED, which is what lets
+    the runner safely fall back to paper for that trade.
+    """
+
+    fake = _FakeDhanSdk([_refused()], correlation_reply=_refused("not found"))
+    client = _ready_dhan_client(dhan_module, monkeypatch, fake)
+
+    result = client.place_market_order(DHAN_SYMBOL, "BUY", 75, order_tag="TAG-3")
+
+    assert result.status.name == "REJECTED"
+    assert result.filled_quantity == 0
+    assert "insufficient margin" in result.reason
+
+
+def test_dhan_server_refusal_that_still_created_an_order_is_not_rejected(
+    dhan_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """If the lookup finds an order, the refusal envelope was misleading."""
+
+    fake = _FakeDhanSdk(
+        [_refused(), _ok(_status_row("TRADED", 75))],
+        correlation_reply=_ok({"orderId": "DH-1", "orderStatus": "TRADED"}),
+    )
+    client = _ready_dhan_client(dhan_module, monkeypatch, fake)
+
+    result = client.place_market_order(DHAN_SYMBOL, "BUY", 75, order_tag="TAG-4")
+
+    assert result.status.name == "FILLED"
+    assert result.order_id == "DH-1"
+
+
+def test_dhan_server_refusal_with_unverifiable_lookup_is_unknown(
+    dhan_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """A refusal we could not corroborate must not become a rejection."""
+
+    fake = _FakeDhanSdk([_refused()], correlation_reply=_transport_failure())
+    client = _ready_dhan_client(dhan_module, monkeypatch, fake)
+
+    result = client.place_market_order(DHAN_SYMBOL, "BUY", 75, order_tag="TAG-5")
+
+    assert result.status.name == "UNKNOWN"
+
+
+def test_dhan_unknown_symbol_is_rejected_without_submitting(
+    dhan_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """Refusing beats guessing: a wrong securityId would trade another contract."""
+
+    fake = _FakeDhanSdk([])
+    client = _ready_dhan_client(dhan_module, monkeypatch, fake)
+
+    result = client.place_market_order("NIFTY-NEVER-RESOLVED-CE", "BUY", 75)
+
+    assert result.status.name == "REJECTED"
+    assert fake.place_calls == []
+    assert "securityId" in result.reason
+
+
+def test_dhan_transmits_execution_ledger_tag_and_order_fields(
+    dhan_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """The tag reaches Dhan as correlationId, and the order is a MARKET order."""
+
+    fake = _FakeDhanSdk(
+        [
+            _ok({"orderId": "DH-TAG", "orderStatus": "TRANSIT"}),
+            _ok(_status_row("TRADED", 75)),
+        ]
+    )
+    client = _ready_dhan_client(dhan_module, monkeypatch, fake)
+
+    client.place_market_order(DHAN_SYMBOL, "BUY", 75, order_tag="STRAT-A1-E1")
+
+    assert len(fake.place_calls) == 1
+    sent = fake.place_calls[0]
+    assert sent["tag"] == "STRAT-A1-E1"
+    assert sent["security_id"] == DHAN_SECURITY_ID
+    assert sent["transaction_type"] == "BUY"
+    assert sent["order_type"] == "MARKET"
+    assert sent["product_type"] == "INTRADAY"
+    assert sent["exchange_segment"] == "NSE_FNO"
+    assert sent["quantity"] == 75
+
+
+def test_dhan_zero_broker_quantity_cannot_confirm_a_fill(
+    dhan_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """A status row disagreeing about size is malformed, not a fill."""
+
+    fake = _FakeDhanSdk(
+        [
+            _ok({"orderId": "DH-QTY", "orderStatus": "TRANSIT"}),
+            _ok(_status_row("TRADED", 75, quantity=10)),
+        ]
+    )
+    client = _ready_dhan_client(dhan_module, monkeypatch, fake)
+
+    result = client.place_market_order(DHAN_SYMBOL, "BUY", 75)
+
+    assert result.status.name == "UNKNOWN"
+    assert result.filled_quantity == 0
+
+
+def test_dhan_cancel_and_reconciliation_queries_are_typed(
+    dhan_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """Cancel returns a typed snapshot; book queries return typed collections."""
+
+    fake = _FakeDhanSdk(
+        [
+            _ok({"orderId": "DH-C1"}),
+            _ok(_status_row("CANCELLED", 0)),
+            _ok(
+                [
+                    {
+                        "orderId": "DH-OPEN",
+                        "orderStatus": "PENDING",
+                        "quantity": 75,
+                        "filledQty": 25,
+                        "tradingSymbol": DHAN_SYMBOL,
+                        "transactionType": "BUY",
+                    },
+                    {
+                        "orderId": "DH-DONE",
+                        "orderStatus": "TRADED",
+                        "quantity": 75,
+                        "filledQty": 75,
+                        "tradingSymbol": DHAN_SYMBOL,
+                        "transactionType": "BUY",
+                    },
+                ]
+            ),
+            _ok(
+                [
+                    {"tradingSymbol": DHAN_SYMBOL, "netQty": 75, "productType": "INTRADAY"},
+                    {"tradingSymbol": "NIFTY-FLAT-PE", "netQty": 0, "productType": "INTRADAY"},
+                ]
+            ),
+        ]
+    )
+    client = _ready_dhan_client(dhan_module, monkeypatch, fake)
+
+    cancelled = client.cancel_order("DH-C1", requested_quantity=75)
+    orders = client.list_open_orders()
+    positions = client.list_open_positions()
+
+    assert cancelled.status.name == "REJECTED"
+    assert fake.cancelled == ["DH-C1"]
+    # Only the still-working order survives; the completed one is filtered out.
+    assert orders.is_indeterminate is False
+    assert [order.order_id for order in orders.items] == ["DH-OPEN"]
+    assert orders.items[0].remaining_quantity == 50
+    # A flat (netQty 0) leg is not an open position.
+    assert positions.is_indeterminate is False
+    assert [position.symbol for position in positions.items] == [DHAN_SYMBOL]
+    assert positions.items[0].quantity == 75
+
+
+def test_dhan_query_failures_are_indeterminate_not_empty(
+    dhan_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """A failed book query must never look like a flat account."""
+
+    fake = _FakeDhanSdk([_transport_failure(), _refused()])
+    client = _ready_dhan_client(dhan_module, monkeypatch, fake)
+
+    orders = client.list_open_orders()
+    positions = client.list_open_positions()
+
+    assert orders.is_indeterminate is True
+    assert positions.is_indeterminate is True
+
+
+def test_dhan_successful_empty_queries_are_distinct_from_failure(
+    dhan_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """A genuinely empty book is a success, not an indeterminate result."""
+
+    fake = _FakeDhanSdk([_ok([]), _ok([])])
+    client = _ready_dhan_client(dhan_module, monkeypatch, fake)
+
+    orders = client.list_open_orders()
+    positions = client.list_open_positions()
+
+    assert orders.items == () and orders.is_indeterminate is False
+    assert positions.items == () and positions.is_indeterminate is False
+
+
+def test_dhan_deadline_constants_are_exactly_ten_seconds(
+    dhan_module: ModuleType,
+) -> None:
+    """The SDK boundary is ten seconds and physically single-threaded."""
+
+    client = dhan_module.DhanExecutionClient()
+    assert dhan_module._API_TIMEOUT_SECONDS == 10.0
+    assert dhan_module._BROKER_CALL_DEADLINE_SECONDS == 10.0
+    assert client._sdk_executor._max_workers == 1
+
+
+def test_dhan_login_overrides_the_sdk_sixty_second_timeout(
+    dhan_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """The SDK ships a 60s default; leaving it would blow the 10s budget.
+
+    ``DhanContext.__init__`` also swallows its own exceptions, so the adapter
+    must verify the HTTP layer exists rather than assume it.
+    """
+
+    class _Http:
+        timeout = 60
+
+    class _Context:
+        def __init__(self, client_id, access_token) -> None:
+            self.http = _Http()
+
+        def get_dhan_http(self):
+            return self.http
+
+    contexts: list[_Context] = []
+
+    def make_context(client_id, access_token):
+        context = _Context(client_id, access_token)
+        contexts.append(context)
+        return context
+
+    monkeypatch.setenv("DHAN_CLIENT_CODE", "1000000001")
+    monkeypatch.setenv("DHAN_ACCESS_TOKEN", "not-a-real-token")
+    monkeypatch.setattr(dhan_module, "DhanContext", make_context)
+    monkeypatch.setattr(dhan_module, "dhanhq", lambda context: _FakeDhanSdk([_ok({})]))
+
+    client = dhan_module.DhanExecutionClient()
+
+    assert client.ensure_logged_in() is True
+    assert contexts[0].http.timeout == 10.0
+
+
+def test_dhan_login_fails_closed_on_half_built_context(
+    dhan_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """A DhanContext that swallowed its own error must not reach an order."""
+
+    class _BrokenContext:
+        def __init__(self, client_id, access_token) -> None:
+            pass
+
+        def get_dhan_http(self):
+            return None
+
+    monkeypatch.setenv("DHAN_CLIENT_CODE", "1000000001")
+    monkeypatch.setenv("DHAN_ACCESS_TOKEN", "not-a-real-token")
+    monkeypatch.setattr(dhan_module, "DhanContext", _BrokenContext)
+
+    client = dhan_module.DhanExecutionClient()
+
+    assert client.ensure_logged_in() is False
+    assert client.client is None
+
+
+def test_dhan_login_fails_closed_without_credentials(
+    dhan_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """Missing credentials disable live trading instead of raising."""
+
+    monkeypatch.delenv("DHAN_CLIENT_CODE", raising=False)
+    monkeypatch.delenv("DHAN_ACCESS_TOKEN", raising=False)
+
+    client = dhan_module.DhanExecutionClient()
+
+    assert client.ensure_logged_in() is False
+
+
+def test_dhan_total_deadline_includes_lock_wait(
+    dhan_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """Waiting for the shared session lock cannot exceed the broker budget."""
+
+    fake = _FakeDhanSdk([_ok({})])
+    client = _ready_dhan_client(dhan_module, monkeypatch, fake)
+    monkeypatch.setattr(dhan_module, "_BROKER_CALL_DEADLINE_SECONDS", 0.05)
+    monkeypatch.setattr(client._api_limiter, "acquire", lambda *_a, **_k: None)
+
+    locked = threading.Event()
+    release = threading.Event()
+
+    def hold_lock() -> None:
+        with client._lock:
+            locked.set()
+            release.wait(0.4)
+
+    holder = threading.Thread(target=hold_lock)
+    holder.start()
+    assert locked.wait(0.2)
+    started = time.monotonic()
+    try:
+        with pytest.raises(TimeoutError, match="lock"):
+            client._call_api("fund limits", lambda sdk: sdk.get_fund_limits())
+    finally:
+        release.set()
+        holder.join(timeout=1)
+    assert time.monotonic() - started < 0.25
+
+
+def test_dhan_total_deadline_includes_rate_limiter_lock_wait(
+    dhan_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """A stuck limiter mutex cannot postpone dispatch past the deadline."""
+
+    class _NeverCalled(_FakeDhanSdk):
+        def get_fund_limits(self):
+            raise AssertionError("SDK must not start after limiter deadline")
+
+    fake = _NeverCalled([])
+    client = _ready_dhan_client(dhan_module, monkeypatch, fake)
+    monkeypatch.setattr(dhan_module, "_BROKER_CALL_DEADLINE_SECONDS", 0.05)
+
+    locked = threading.Event()
+    release = threading.Event()
+
+    def hold_limiter_lock() -> None:
+        with client._api_limiter._lock:
+            locked.set()
+            release.wait(0.4)
+
+    holder = threading.Thread(target=hold_limiter_lock)
+    holder.start()
+    assert locked.wait(0.2)
+    started = time.monotonic()
+    try:
+        with pytest.raises(TimeoutError, match="limiter lock"):
+            client._call_api("fund limits", lambda sdk: sdk.get_fund_limits())
+    finally:
+        release.set()
+        holder.join(timeout=1)
+    assert time.monotonic() - started < 0.25
+
+
+def test_dhan_slow_response_poisons_the_session_until_reconciliation(
+    dhan_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """An abandoned in-flight call blocks new orders until it has ended."""
+
+    release = threading.Event()
+
+    class _SlowSdk(_FakeDhanSdk):
+        def get_fund_limits(self):
+            release.wait(0.5)
+            return _ok({})
+
+    fake = _SlowSdk([])
+    client = _ready_dhan_client(dhan_module, monkeypatch, fake)
+    monkeypatch.setattr(dhan_module, "_BROKER_CALL_DEADLINE_SECONDS", 0.05)
+    monkeypatch.setattr(client._api_limiter, "acquire", lambda *_a, **_k: None)
+
+    try:
+        with pytest.raises(TimeoutError, match="broker deadline"):
+            client._call_api("fund limits", lambda sdk: sdk.get_fund_limits())
+        assert client._sdk_poisoned is True
+        # A poisoned session refuses new orders outright.
+        blocked = client.place_market_order(DHAN_SYMBOL, "BUY", 75)
+        assert blocked.status.name == "UNKNOWN"
+        assert blocked.broker_state == "SESSION_POISONED"
+        # Recovery is refused while the abandoned call is still running.
+        assert client.recover_after_reconciliation() is False
+    finally:
+        release.set()
+    client._timed_out_future.result(timeout=1)
+    assert client.recover_after_reconciliation() is True

--- a/Dependencies/test_broker_contract.py
+++ b/Dependencies/test_broker_contract.py
@@ -42,6 +42,31 @@ _neo_api_test_module.NeoAPI = _NeoApiTestDouble
 sys.modules["neo_api_client"] = _neo_api_test_module
 
 
+class _DhanhqTestDouble:
+    """Import-only stand-in; behavioral tests inject their own SDK clients."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        self.args = args
+        self.kwargs = kwargs
+
+
+# ``dhanhq`` differs from Kotak's SDK: it is a CORE dependency (it also serves
+# market data), so the main quality job HAS the real package and other suites in
+# the same pytest process bind names from it.  The isolated broker-dependency
+# job installs requirements-brokers.txt alone, where it is deliberately absent.
+#
+# Hence the conditional: stand in only when the real package is genuinely
+# missing.  Clobbering an installed core dependency for every run would be a
+# latent trap for whichever suite happens to import it next.
+try:  # pragma: no cover - which branch runs depends on the CI environment
+    import dhanhq as _installed_dhanhq  # noqa: F401
+except ModuleNotFoundError:
+    _dhanhq_test_module = ModuleType("dhanhq")
+    _dhanhq_test_module.DhanContext = _DhanhqTestDouble
+    _dhanhq_test_module.dhanhq = _DhanhqTestDouble
+    sys.modules["dhanhq"] = _dhanhq_test_module
+
+
 def _load_file_module(name: str, relative_path: str) -> ModuleType:
     """Load a broker helper whose parent folder contains spaces."""
 
@@ -2903,6 +2928,22 @@ def _ready_dhan_client(dhan_module: ModuleType, monkeypatch, fake):
     monkeypatch.setattr(client, "ensure_logged_in", lambda: True)
     monkeypatch.setattr(dhan_module, "_FILL_POLL_INTERVAL", 0.001)
     return client
+
+
+def test_dhan_adapter_loads_without_an_installed_sdk(
+    dhan_module: ModuleType,
+) -> None:
+    """The adapter must import in the SDK-free broker-dependency job.
+
+    That job installs requirements-brokers.txt alone, so ``dhanhq`` is absent
+    and the import-only double above stands in; the core quality job has the
+    real package and uses it as-is.  Either way the module must load, because
+    every behavioral test replaces ``client`` with its own broker-shaped fake
+    and none of them exercise the real SDK.
+    """
+
+    assert dhan_module.DhanContext is sys.modules["dhanhq"].DhanContext
+    assert callable(dhan_module.dhanhq)
 
 
 @pytest.mark.parametrize(

--- a/Nifty Multi Strategy Front Test - Master File.py
+++ b/Nifty Multi Strategy Front Test - Master File.py
@@ -385,8 +385,11 @@ def _env_bool(name: str, default: bool = False) -> bool:
 # DHAN_CLIENT_CODE  : 10-digit dhanClientId (e.g. "1100000000").
 # DHAN_API_KEY      : long-lived "app_id" used by the OAuth setup script.
 # DHAN_API_SECRET   : long-lived "app_secret" pair to DHAN_API_KEY.
-# DHAN_ACCESS_TOKEN : 12-month token produced by the setup script. This is
-#                     what the dhanhq SDK actually authenticates with.
+# DHAN_ACCESS_TOKEN : token produced by the setup script. This is what the
+#                     dhanhq SDK actually authenticates with. Its validity is
+#                     stamped into the token by DhanHQ and is NOT 12 months --
+#                     web.dhan.co currently issues 24-hour tokens, so refresh
+#                     it outside market hours before each trading day.
 CLIENT_CODE = _env_str("DHAN_CLIENT_CODE", "")
 API_KEY = _env_str("DHAN_API_KEY", "")
 API_SECRET = _env_str("DHAN_API_SECRET", "")
@@ -1002,15 +1005,15 @@ CPR_ALGO3_LOGIC = load_module(
 )
 
 # -----------------------------------------------------------------------------
-# Live-execution layer (optional) - Kotak Neo, Shoonya, or Flattrade.
+# Live-execution layer (optional) - Kotak Neo, Shoonya, Flattrade, or Dhan.
 # -----------------------------------------------------------------------------
-# This is how real (non-paper) orders reach the broker. All three helpers expose
+# This is how real (non-paper) orders reach the broker. All four helpers expose
 # the SAME contract: login/symbol resolution, typed place/status/cancel results,
 # determinate-or-indeterminate open order/position queries, and logout. The runner
 # uses whichever one LIVE_BROKER selects via a single generic `execution_client`.
 # Each import is
 # wrapped in try/except on purpose: if a broker's SDK/deps are missing, that
-# client is set to None and the runner keeps working (the OTHER broker, or
+# client is set to None and the runner keeps working (the OTHER brokers, or
 # paper-only). main() forces any "live" strategy back to paper when the selected
 # client is None.
 try:
@@ -1052,6 +1055,19 @@ except Exception as _flattrade_import_exc:
         _flattrade_import_exc,
     )
 
+try:
+    _dhan_execution_module = load_module(
+        "master_dhan_execution",
+        Path(__file__).resolve().parent / "Dependencies" / "Dhan API" / "dhan_execution.py",
+    )
+    dhan_execution_client = _dhan_execution_module.dhan_execution_client
+except Exception as _dhan_import_exc:
+    dhan_execution_client = None
+    logging.getLogger(LOGGER_NAME).warning(
+        "Dhan execution layer unavailable (%s); Dhan live trading disabled.",
+        _dhan_import_exc,
+    )
+
 
 def _select_execution_client(broker_name: str):
     """Return client, exchange, and product for one explicit broker selection.
@@ -1074,8 +1090,11 @@ def _select_execution_client(broker_name: str):
     if broker == "FLATTRADE":
         product = _env_str("FLATTRADE_PRODUCT_TYPE", "INTRADAY").upper().strip() or "INTRADAY"
         return flattrade_execution_client, "NFO", product
+    if broker == "DHAN":
+        product = _env_str("DHAN_PRODUCT_TYPE", "INTRADAY").upper().strip() or "INTRADAY"
+        return dhan_execution_client, "NSE_FNO", product
     logging.getLogger(LOGGER_NAME).error(
-        "Unknown LIVE_BROKER=%r (expected KOTAK, SHOONYA, or FLATTRADE); "
+        "Unknown LIVE_BROKER=%r (expected KOTAK, SHOONYA, FLATTRADE, or DHAN); "
         "live trading DISABLED (paper only).",
         broker_name,
     )

--- a/algo.py
+++ b/algo.py
@@ -95,6 +95,7 @@ BACKTEST_SCRIPTS = {
 # these keys automatically; each value is the script that receives the remaining
 # CE/PE, strike, expiry, and --place-order arguments unchanged.
 BROKER_DIAGNOSTICS = {
+    "dhan": "Dependencies/Dhan API/diagnose_dhan_symbol.py",
     "flattrade": "Dependencies/Flattrade API/diagnose_flattrade_symbol.py",
     "kotak": "Dependencies/Kotak API/diagnose_kotak_symbol.py",
     "shoonya": "Dependencies/Shoonya API/diagnose_shoonya_symbol.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,8 @@ files = [
     "Dependencies/Shoonya API/diagnose_shoonya_symbol.py",
     "Dependencies/Flattrade API/flattrade_execution.py",
     "Dependencies/Flattrade API/diagnose_flattrade_symbol.py",
+    "Dependencies/Dhan API/dhan_execution.py",
+    "Dependencies/Dhan API/diagnose_dhan_symbol.py",
     "Signal Generators/ema_trend_strategy_logic.py",
     "Signal Generators/heikin_ashi_strategy_logic.py",
     "Signal Generators/renko_strategy_logic.py",

--- a/test_nifty_multi_strategy_master.py
+++ b/test_nifty_multi_strategy_master.py
@@ -6,6 +6,7 @@ import sys
 import tempfile
 import threading
 import unittest
+from contextlib import ExitStack
 from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -2056,6 +2057,70 @@ class TestEnvBool(unittest.TestCase):
             self.assertTrue(master_file._env_bool("X_FLAG", True))
         os.environ.pop("X_FLAG", None)
         self.assertFalse(master_file._env_bool("X_FLAG", False))
+
+
+class TestSelectExecutionClient(unittest.TestCase):
+    """`_select_execution_client` routes brokers and fails closed on a typo.
+
+    Its own docstring calls this out as the reason the decision lives in one
+    small function: a typo must never route real-money orders to another
+    broker, and an unrecognised name must disable live trading entirely.
+    """
+
+    def _select(self, broker, **clients):
+        """Run the selector with every broker client patched to a sentinel."""
+        defaults = {
+            "kotak_execution_client": "KOTAK-CLIENT",
+            "shoonya_execution_client": "SHOONYA-CLIENT",
+            "flattrade_execution_client": "FLATTRADE-CLIENT",
+            "dhan_execution_client": "DHAN-CLIENT",
+        }
+        defaults.update(clients)
+        with ExitStack() as stack:
+            for name, value in defaults.items():
+                stack.enter_context(patch.object(master_file, name, value))
+            return master_file._select_execution_client(broker)
+
+    def test_each_broker_routes_to_its_own_client_and_segment(self):
+        # The exchange-segment string is broker-specific and is passed straight
+        # through to the order call, so a wrong value would reject every order.
+        expected = {
+            "KOTAK": ("KOTAK-CLIENT", "nse_fo"),
+            "SHOONYA": ("SHOONYA-CLIENT", "NFO"),
+            "FLATTRADE": ("FLATTRADE-CLIENT", "NFO"),
+            "DHAN": ("DHAN-CLIENT", "NSE_FNO"),
+        }
+        for broker, (client, segment) in expected.items():
+            with self.subTest(broker=broker), patch.dict(os.environ, {}, clear=False):
+                got_client, got_segment, got_product = self._select(broker)
+                self.assertEqual(got_client, client)
+                self.assertEqual(got_segment, segment)
+                self.assertEqual(got_product, "INTRADAY")
+
+    def test_broker_name_is_case_and_whitespace_insensitive(self):
+        client, segment, _product = self._select("  dhan  ")
+        self.assertEqual(client, "DHAN-CLIENT")
+        self.assertEqual(segment, "NSE_FNO")
+
+    def test_product_type_comes_from_the_brokers_own_env_key(self):
+        with patch.dict(os.environ, {"DHAN_PRODUCT_TYPE": "normal"}):
+            _client, _segment, product = self._select("DHAN")
+        self.assertEqual(product, "NORMAL")
+
+    def test_unknown_broker_fails_closed(self):
+        for broker in ("ZERODHA", "", "dhann", None):
+            with self.subTest(broker=broker):
+                self.assertEqual(
+                    self._select(broker),
+                    (None, "", "INTRADAY"),
+                )
+
+    def test_missing_client_yields_none_so_startup_forces_paper(self):
+        # A broker whose SDK failed to import is None; the selector still
+        # returns it so `_configure_startup_live_trading` disables live mode.
+        client, segment, _product = self._select("DHAN", dhan_execution_client=None)
+        self.assertIsNone(client)
+        self.assertEqual(segment, "NSE_FNO")
 
 
 class TestTimezoneAssumption(unittest.TestCase):


### PR DESCRIPTION
Makes Dhan the fourth selectable live-order broker (`LIVE_BROKER=DHAN`), alongside Kotak, Shoonya and Flattrade. Dhan already served market data and auth; this reuses the same credentials for execution while keeping the two sessions separate.

**Stacked on #69 (MAT-110).** `broker_contract.py` does not exist in `main`, so this cannot stand alone.

## Two DhanHQ SDK hazards the adapter exists to contain

**1. The SDK turns every exception into a rejection-shaped envelope.**
`DhanHTTP._send_request` wraps its request in a bare `except Exception` and returns `{'status': 'failure', 'remarks': str(exc)}` — structurally identical to a genuine broker rejection. Under this repo's contract `REJECTED` means *provably zero fill, safe to fall back to paper*, so believing that envelope would re-enter on paper while real exposure sat at the broker.

`REJECTED` is therefore never derived from the placement envelope. The `remarks` **type** is the discriminator:

| `remarks` | origin | meaning | status |
|---|---|---|---|
| `dict` | non-2xx reply carrying `errorCode` | server answered and refused | candidate `REJECTED`, still corroborated |
| `str` | the SDK's own exception handler | may have reached the exchange | `UNKNOWN` → freeze |

`order_tag` is sent as Dhan's `correlationId`, so `get_order_by_correlationID` can recover an order whose response was lost entirely — a channel the other three adapters don't have.

**2. The SDK's native timeout is 60s, not 10.** `_login_locked` overrides it and verifies the HTTP layer exists, because `DhanContext.__init__` swallows its own exceptions and can return a half-built object.

## Design notes

- **State aliasing is adapter-local** (`EXPIRED`→`CANCELLED`, `PART_TRADED`→`PARTIAL`) so the shared contract and the other three adapters stay untouched. `TRANSIT`/`PENDING` stay unmapped so they remain transient and keep the fill loop polling.
- **Symbol vs securityId.** Dhan's order API takes a numeric `securityId`, not a symbol. `resolve_option_symbol` returns the human trading symbol (keeping logs and Telegram alerts readable) and maintains a symbol → id map that `place_market_order` consults; a lookup miss refuses rather than guessing, since a wrong id would trade a different contract.
- **Contracts come from the local `Dependencies/all_instrument <date>.csv`** the runner already refreshes nightly — it *is* Dhan's own scrip master, so the adapter and the strategies can never disagree about which contract a strike means. Missing file ⇒ `preload_scrip_master()` returns `False` ⇒ live disabled.

## Diagnostic pre-flight guards

Both came out of real failures during live testing:

- **Lot-multiple check.** `--qty 1` against a lot of 65 is unplaceable. Dhan reports this as a generic `DH-905` whose `error_message` reads *"Invalid IP"* — which sends you hunting a network fault that doesn't exist.
- **Margin pre-check.** Gates **entry only** and proceeds when inconclusive: blocking an exit on a failed pre-flight query could strand an open position.

Note `insufficientBalance` is `abs(totalMargin - availableBalance)` — **unsigned**, so it is positive whether you are short *or* have money to spare. Measured across four contracts straddling the balance in both directions, not assumed. Affordability compares the two balances directly; the four measurements are recorded in the code so nobody re-derives the wrong meaning.

## Token validity correction (second commit)

`dhan_token_setup.py` claimed a 12-month token and printed `"This token is valid for 12 months"`. Decoded from a real token's own `exp` claim: **24 hours**. That is the dangerous direction to be wrong in — it tells the operator no refresh is needed. A token dying mid-session makes orders fail, and since a rejected live **exit** leaves the position open, intraday positions can be left un-squareable through the API. The script now reads the expiry back out of the token and warns when it lands inside a weekday session.

Remaining "long-lived" references in the master file are correct — they describe `DHAN_API_KEY` / `DHAN_API_SECRET`, not the access token.

## Tests

- `test_dhan_*` conformance cases in `test_broker_contract.py`, including that a transport-failure envelope never yields `REJECTED`, and that the 10s deadline covers lock and rate-limiter wait.
- `Dependencies/Dhan API/test_dhan_execution.py` — scrip parsing, envelope classification, state aliasing, and both pre-flight guards (with a regression pinned to the real figures where a *surplus* was misread as a shortfall).
- `_select_execution_client` coverage in the master suite — the function's own docstring asked for it and nobody had written it.

## Verification

594 pytest, 325 unittest, ruff, mypy, compileall, bandit — all green on the rebased base.

Exercised live against the Dhan API **read-only**: symbol + securityId resolution for NIFTY and BankNIFTY reproduce the catalogue exactly, and the margin pre-check runs. **No order was placed** — the round-trip test remains operator-run behind `--place-order`, an explicit `--qty`, and a typed `YES`.

Also confirmed: Dhan enforces its static-IP whitelist on order-mutating endpoints only (place/cancel), while reads succeed from the same session in the same second — and the access token must be minted *after* the IP is registered. Both are now documented in `env.example`.
