### PR TITLE
SL Hunting v3n: recruitment history + one-breakdown-not-two (19 Jul closed-chart lecture)

### DIFF
--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -1026,3 +1026,68 @@ nothing was loosened.
 - `RETAIL_POSITIONING`: GIFT-GAP AFTER A NOBODY'S-CROWD DAY.
 - `RISK`: NO INSTANT FLIP extended with the losing-side panic-flip ban.
 - Test marker: `test_system_prompt_has_v3m_gift_gap_and_loss_flip_knowledge`.
+
+## Video addendum - 19 Jul closed-chart lecture (v3n)
+
+> Source: `OVs8-y2HTl8` (19 Jul 2026, "The Secret of the Closed Chart | Every Trader
+> Must Know", 22:22). Full Hindi auto-transcript captured from the transcript panel.
+>
+> NO agent-vs-IH journal comparison for this addendum: 19 Jul was a Sunday, markets
+> shut, so there are no 2026-07-19 journal rows and no trade to compare. The last
+> trading day (Fri 17 Jul) is covered by v3m.
+
+What this video is: not a trade session but a **week-in-review teaching session**. IH
+walks the CLOSED chart of each day of 13-17 Jul and explains how the next day's
+conditional plan was built from it — **including a self-diagnosis of the 17 Jul losing
+trade**. It therefore exposes the reasoning BEHIND the conditional gap plans distilled
+piecemeal since v3d, and it patches a gap that cost him real money.
+
+**Net-new method distilled:**
+- RECRUITMENT HISTORY, NOT CHART SHAPE: he shows two consecutive days whose charts are
+  near-identical ("even point-wise both are almost the same") and asks why the plans
+  were OPPOSITE. The discriminator is what the prior move RECRUITED — a chart that was
+  negative and then reversed up recruits NO buyers (the move ran against the mood and
+  turned too suddenly for them to join), whereas an already-positive chart that goes
+  positive AGAIN does seat buyers ("traders slowly start taking risk"). The law: a
+  FIRST, reversal-type move recruits nobody; the SECOND consecutive same-direction day
+  seats the crowd. This turns the existing PREVIOUS-CHART LINKAGE instruction into an
+  actual test, and is the general principle underneath v3j's two-day AVERAGING TRAP
+  trigger (its gap-down-specific case).
+- ONE BREAKDOWN, NOT TWO — the rule whose absence cost him 17 Jul. Diagnosing that
+  loss: "when the market breaks down one level, normally the market does NOT break the
+  second level". After the 500-level breakdown, sellers had joined progressively and
+  were SEATED, so the correct plan was the seller-seated template (gap-up -> buy,
+  gap-down -> buy, flat -> sell); he instead read buyers as available, planned
+  flat -> sell, and lost. Stated corollary: even if the breakdown did NOT seat
+  sellers, it AT MINIMUM evicted the buyers — so after a level breakdown, buyers are
+  never the target. That asymmetry alone rules out the buyer-hunt when the seated side
+  is uncertain.
+- BREAK-WITHOUT-MOMENTUM — **a correction to v3l**. He shows a 58,000 breakout that
+  then produced no momentum for ~2 hours and concludes "even if someone bought, they
+  would not have held; we don't need to target the buyers". As originally written, the
+  v3l CLOSING-POINT HOLD TEST said break-AND-held-beyond => crowd seated, which would
+  misread exactly this case. The "held beyond" arm now additionally requires that the
+  break produced real MOMENTUM; a break that idles beyond the level for hours seats
+  nobody and falls into the no-inventory arm instead.
+
+**Confirmed but deliberately NOT re-encoded (already present):** crowd-opposite
+psychology ("if the crowd is buying, the one who makes money sells"); the
+gap-up/gap-down/flat conditional framework (v3d/v3k/v3l/v3m); a big gap-down changing
+the whole structure; counter-trend risk-takers booking their momentum and leaving
+rather than holding (already TARGET-BOOKED); and the loss discipline ("accept the
+mistake, take the loss, don't sit insisting the market must fall") from v3m.
+
+Also NOT encoded, deliberately: the lecture's meta-thesis that learning happens on the
+CLOSED chart and that tomorrow's plan is built from it overnight. True for a human
+studying after hours, but the agent decides per completed 1-minute bar and performs no
+overnight study — it is not actionable for it. (The reflection coach in
+`sl_hunting_coach.py` is the closest analogue and already operates off-loop.)
+
+**Knowledge changes (v3n, all prose):**
+- `RETAIL_POSITIONING`: RECRUITMENT HISTORY, NOT CHART SHAPE (after PREVIOUS-CHART
+  LINKAGE, which it sharpens).
+- `RETAIL_POSITIONING`: ONE BREAKDOWN, NOT TWO (beside the other inventory-existence
+  tests).
+- `RETAIL_POSITIONING`: momentum requirement added to the CLOSING-POINT HOLD TEST's
+  "BROKE it and held beyond" arm (self-correction to v3l).
+- Test marker: `test_system_prompt_has_v3n_closed_chart_knowledge`.

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
@@ -160,6 +160,11 @@ retail's stop-losses sit so you can trade where the operator will hunt them.
   * BROKE it and held beyond → that crowd is SEATED overnight with live SLs. They are
     huntable: expect a rejection and a move back THROUGH their stops (the textbook
     hunt — after a down-break that held, look UP).
+    BUT the break must have produced actual MOMENTUM to seat anyone. A level that was
+    broken and then went NOWHERE — price idling beyond it for a couple of hours with
+    no follow-through — seats NOBODY: whoever took that break either never committed
+    size or left while it stalled. "Broken and held" without momentum is the
+    no-inventory case below, not this one.
   * Did NOT break it (price rejected but stalled at/above the closing point, often
     hovering there a long time) → whoever traded that move BOOKED the momentum and
     LEFT; they did not carry the position overnight. There is NO inventory to hunt,
@@ -168,6 +173,20 @@ retail's stop-losses sit so you can trade where the operator will hunt them.
     trade, not the hunt up).
   The level does the work here: an unbroken closing point means the crowd never got
   the confirmation it needed to hold, so its SLs never came into being.
+- ONE BREAKDOWN, NOT TWO (a structural read on where the crowd ended up): once price
+  has broken ONE significant level, it does NOT normally break the NEXT level straight
+  after — the second break is the low-probability path. Two inferences follow, and the
+  weaker one is still usable:
+  * The breakdown itself RECRUITS the other side: as price broke down and kept
+    grinding lower with retracements, sellers joined progressively, so they are likely
+    SEATED with live SLs → treat them as the huntable crowd (gap-up or gap-down →
+    buy-side setups; flat → go with the selling).
+  * Even if you are unsure they seated, a breakdown has DEFINITELY evicted the buyers —
+    they were stopped out or scared off. So after a level breakdown, buyers are never
+    the target. When in doubt about who is seated, this asymmetry alone rules out the
+    buyer-hunt.
+  Read it with TRAP-DENSITY (which sizes the move) rather than against it: this says
+  WHO ended up positioned and where the next break is unlikely, not how far price ran.
 - TARGET-BOOKED crowd test: before hunting yesterday's crowd, ask whether the prior
   move already paid them and let them exit. Breakdown + retracement + continuation
   often means put buyers / sellers already booked profit; they are not today's
@@ -178,6 +197,23 @@ retail's stop-losses sit so you can trade where the operator will hunt them.
   the old crowd may be profit-booked, already trapped, or too far away to hunt. In
   that case, follow the NEW chart: identify who is being recruited now, where their
   fresh SLs sit, and whether the current move is building a fresh trap.
+- RECRUITMENT HISTORY, NOT CHART SHAPE (this is the TEST that PREVIOUS-CHART LINKAGE
+  asks for): two days can print an almost IDENTICAL chart — same gap direction, near
+  identical points — and still demand OPPOSITE plans, because what matters is not the
+  shape but whether the prior move actually RECRUITED a crowd:
+  * Prior chart was NEGATIVE and then REVERSED up → buyers could NOT participate in
+    that move (it ran against the prevailing mood and turned too suddenly for them to
+    join) → there is NO buyer inventory → flat / gap-down is a BUY setup.
+  * Prior chart was ALREADY POSITIVE and went positive AGAIN (a second consecutive
+    with-trend day) → now traders gain confidence and start taking risk on the long
+    side → buyer inventory EXISTS → flat / gap-down is a SELL setup (target those
+    buyers); on a gap-up they are already in profit and cannot be targeted, so go WITH
+    the market instead.
+  The general law: a FIRST, reversal-type move recruits nobody — it is the SECOND
+  consecutive same-direction day that seats the crowd. So never carry yesterday's plan
+  forward just because today's chart "looks the same"; re-derive who was recruited.
+  (This is the principle underneath the two-day AVERAGING TRAP trigger above, which is
+  its gap-down-specific case.)
 - WEEKEND / HOLIDAY CARRY-RISK: before a Friday close, weekend, or multi-day market
   holiday, large retail inventory may be absent or reduced because traders avoid
   overnight/news risk. Do not hunt a crowd that likely exited or never entered; use

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
@@ -307,3 +307,26 @@ def test_system_prompt_has_v3m_gift_gap_and_loss_flip_knowledge():
     # (assert wrap-independent fragments, not exact line breaks).
     assert "LOSING side" in prompt and "whipsaw" in prompt
     assert "POST-LOSS SPEED LIMIT" in prompt
+
+
+def test_system_prompt_has_v3n_closed_chart_knowledge():
+    """v3n: 19 Jul closed-chart lecture (IH's week review + self-diagnosed loss).
+
+    - RECRUITMENT HISTORY: two near-identical charts demand OPPOSITE plans, because a
+      first reversal-type move recruits nobody while the SECOND consecutive
+      same-direction day seats the crowd.
+    - ONE BREAKDOWN, NOT TWO: the rule whose absence cost IH the 17 Jul trade — after
+      one level break the next rarely breaks; sellers are likely seated and buyers are
+      definitely evicted.
+    - The CLOSING-POINT HOLD TEST's "held beyond" arm now requires real MOMENTUM: a
+      break that idles for hours seats nobody (a correction to v3l).
+    """
+    prompt = build_system_prompt()
+    assert "RECRUITMENT HISTORY, NOT CHART SHAPE" in prompt
+    assert "ONE BREAKDOWN, NOT TWO" in prompt
+    # The recruitment law, wrap-independent.
+    assert "SECOND" in prompt and "consecutive same-direction day" in prompt
+    # The asymmetric fallback: a breakdown always evicts the buyers.
+    assert "buyers are never" in prompt
+    # The v3l correction: break-and-held only seats a crowd if momentum followed.
+    assert "produced actual MOMENTUM" in prompt


### PR DESCRIPTION
Distils Intraday Hunter's **19 Jul** video — [`OVs8-y2HTl8`](https://www.youtube.com/watch?v=OVs8-y2HTl8), *"The Secret of the Closed Chart | Every Trader Must Know"* (22:22, full Hindi ASR transcript captured). Knowledge-only prose.

**No agent-vs-IH journal comparison in this one:** 19 Jul was a Sunday, markets shut, so there are no `2026-07-19` journal rows and no trade to compare. Friday 17 Jul is covered by v3m.

## What the video is

Not a trade session — a **week-in-review teaching session**. IH walks the *closed* chart of each day of 13–17 Jul and explains how the next day's conditional plan was built from it, **including a self-diagnosis of Friday's losing trade**. That makes it unusually high-yield: it exposes the reasoning *behind* the conditional gap plans distilled piecemeal since v3d, and it patches a gap that cost him money.

## Net-new encoded (3 items)

1. **`RECRUITMENT HISTORY, NOT CHART SHAPE`** — the headline finding. He shows two consecutive days whose charts are near-identical — *"even point-wise both are almost the same"* — and asks why the plans were **opposite**. The discriminator is what the prior move **recruited**:
   - Chart was **negative then reversed up** → buyers could *not* participate (it ran against the mood and turned too suddenly to join) ⇒ **no buyer inventory** ⇒ flat/gap-down = **BUY**.
   - Chart was **already positive and went positive again** → traders *"slowly start taking risk"* ⇒ **buyers seated** ⇒ flat/gap-down = **SELL** (target them); gap-up = go with the market, since they're already in profit.

   The law: **a first, reversal-type move recruits nobody; the SECOND consecutive same-direction day seats the crowd.** This turns the existing `PREVIOUS-CHART LINKAGE` from an instruction into an actual test, and is the general principle underneath v3j's two-day `AVERAGING TRAP` trigger (its gap-down-specific case).

2. **`ONE BREAKDOWN, NOT TWO`** — the rule whose absence cost him Friday. Diagnosing that loss: *"when the market breaks down one level, normally the market does NOT break the second level."* After the 500-level breakdown, sellers had joined progressively and were **seated**, so the correct plan was the seller-seated template (gap-up→buy, gap-down→buy, flat→sell); he read buyers as available, planned flat→sell, and lost. His stated corollary is the useful fallback: even if the breakdown did *not* seat sellers, it **at minimum evicted the buyers** — so after a level breakdown, buyers are never the target. Framed to complement `TRAP-DENSITY` (which sizes the move), not contradict it. Grepped first: `"second level" / "next level" / "two levels"` had **zero** matches in the prompt.

3. **Momentum requirement on `CLOSING-POINT HOLD TEST` — a self-correction to v3l.** He shows a 58,000 breakout that then produced **no momentum for ~2 hours** and concludes *"even if someone bought, they would not have held."* As I originally wrote it in v3l, break-**and-held-beyond** ⇒ crowd seated — which would misread exactly this case. The "held beyond" arm now also requires the break to have produced **real momentum**; a break that idles beyond the level for hours seats nobody and falls into the no-inventory arm instead.

**Confirmed but NOT re-encoded:** crowd-opposite psychology; the gap-up/gap-down/flat conditional framework (v3d/v3k/v3l/v3m); big gap-down changing the whole structure; counter-trend risk-takers booking their momentum and leaving (already `TARGET-BOOKED`); loss discipline (v3m).

**Deliberately skipped:** the lecture's meta-thesis that *learning happens on the closed chart* overnight. True for a human studying after hours, but the agent decides per completed 1-minute bar and does no overnight study — not actionable for it. (`sl_hunting_coach.py` is the closest analogue and already runs off-loop.)

## Verification

- `python -m pytest "Signal Generators/SL Hunting AI Agent/tests" -q` → **88 passed** (new `test_system_prompt_has_v3n_closed_chart_knowledge` plus every prior v2–v3m marker). The **v3l marker was re-run specifically** — it asserts the literal `"BROKE it and held beyond"` string I edited, confirming the rewrite *narrows* rather than breaks it.
- `python -m unittest test_nifty_multi_strategy_master` → **217 tests, OK**
- `python -m ruff check .` → clean · `python -m mypy` → clean (29 files)

No schema/executor/order-path changes; no env knobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
