### PR TITLE
Make the Kotak/Shoonya diagnostics usable: import path, scrip-master budget, login evidence

### DIFF
--- a/Dependencies/Dhan API/diagnose_dhan_symbol.py
+++ b/Dependencies/Dhan API/diagnose_dhan_symbol.py
@@ -33,6 +33,7 @@ from typing import Any
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import dhan_execution as de
 from broker_contract import OrderResult, OrderStatus
+from diagnostic_preflight import validate_quantity_for_lot
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -167,40 +168,6 @@ def select_contract(
         str(int(row["security_id"])),
         lot_size,
     )
-
-
-def validate_quantity_for_lot(quantity: int, lot_size: int) -> str:
-    """Return an error message when ``quantity`` is not a whole-lot multiple.
-
-    Index options trade only in exchange-defined lots, so a quantity such as 1
-    against a lot of 65 can never be accepted.  Catching that locally matters
-    because Dhan reports it as a generic ``DH-905 Input_Exception`` whose
-    ``error_message`` has been observed to read "Invalid IP" -- an error that
-    sends operators hunting a network fault that does not exist.
-
-    This validates the operator's OWN number; it deliberately does not derive
-    one.  ``--place-order`` still requires an explicit ``--qty`` because lot
-    sizes change and guessing one would risk a wrong-sized live order.
-
-    Args:
-        quantity: The explicit unit quantity supplied on the command line.
-        lot_size: Official lot size from the contract catalogue, 0 if absent.
-
-    Returns:
-        An empty string when the quantity is placeable, else the reason.
-    """
-    if lot_size <= 0:
-        # The catalogue row carried no lot size, so there is nothing to check
-        # against. The broker remains the authority.
-        return ""
-    if quantity % lot_size:
-        return (
-            f"--qty {quantity} is not a multiple of the official lot size "
-            f"{lot_size}. Index options trade in whole lots only, so Dhan "
-            f"would reject this order. Use {lot_size} for one lot "
-            f"(or {lot_size * 2} for two)."
-        )
-    return ""
 
 
 def check_entry_margin(

--- a/Dependencies/Dhan API/test_dhan_execution.py
+++ b/Dependencies/Dhan API/test_dhan_execution.py
@@ -345,24 +345,18 @@ def _diagnostic() -> ModuleType:
 diag = _diagnostic()
 
 
-@pytest.mark.parametrize(
-    ("quantity", "lot_size", "rejected"),
-    [
-        (1, 65, True),      # the exact case that produced "Invalid IP"
-        (64, 65, True),
-        (100, 65, True),
-        (65, 65, False),    # one lot
-        (130, 65, False),   # two lots
-        (30, 30, False),    # BankNIFTY lot
-        (1, 0, False),      # catalogue carried no lot size -> nothing to check
-    ],
-)
-def test_quantity_must_be_a_whole_lot_multiple(quantity, lot_size, rejected) -> None:
-    message = diag.validate_quantity_for_lot(quantity, lot_size)
+def test_quantity_check_is_the_shared_one_not_a_local_copy() -> None:
+    """Behaviour lives in Dependencies/test_diagnostic_preflight.py.
 
-    assert bool(message) is rejected
-    if rejected:
-        assert str(lot_size) in message
+    All four diagnostics import one implementation; this only pins that the
+    Dhan one is wired to it rather than carrying a copy that could drift.
+    """
+
+    # Imported here, not at module scope: it resolves through the sys.path the
+    # adapter sets up when this test module loads the diagnostic.
+    import diagnostic_preflight
+
+    assert diag.validate_quantity_for_lot is diagnostic_preflight.validate_quantity_for_lot
 
 
 class _MarginClient:

--- a/Dependencies/Flattrade API/diagnose_flattrade_symbol.py
+++ b/Dependencies/Flattrade API/diagnose_flattrade_symbol.py
@@ -30,6 +30,7 @@ from typing import Any
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import flattrade_execution as fe
 from broker_contract import OrderResult, OrderStatus
+from diagnostic_preflight import validate_quantity_for_lot
 
 UNDERLYING = "NIFTY"
 
@@ -352,6 +353,14 @@ def main(argv: list[str] | None = None) -> int:
         if not args.place_order:
             print("\nRead-only diagnostic complete. No order was placed.")
             return 0
+
+        # Pre-flight before the typed-YES prompt, so an order the exchange can
+        # never accept does not reach the broker or burn a confirmation.
+        lot_error = validate_quantity_for_lot(args.qty, lot_size)
+        if lot_error:
+            print(f"\n{lot_error}", file=sys.stderr)
+            return 2
+
         return 0 if place_round_trip_test_order(client, resolved, args.qty) else 1
     except Exception as exc:
         print(f"Flattrade diagnostic failed: {exc}", file=sys.stderr)

--- a/Dependencies/Kotak API/diagnose_kotak_symbol.py
+++ b/Dependencies/Kotak API/diagnose_kotak_symbol.py
@@ -17,6 +17,7 @@ contract. Only a confirmed full BUY fill permits the automatic SELL-to-flatten.
 Requires typing YES to confirm.
 """
 import datetime as dt
+import logging
 import sys
 from pathlib import Path
 
@@ -138,6 +139,15 @@ def place_round_trip_test_order(client, symbol, qty, broker="Kotak"):
 
 
 def main():
+    # Without this the root logger sits at WARNING, so kotak_execution's INFO
+    # diagnostics -- the scrip-master URL, download progress and byte counts --
+    # are silently dropped. They are the whole point of running this script when
+    # a download stalls, so surface them. The Flattrade and Dhan diagnostics
+    # already configure logging the same way.
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s | %(levelname)s | %(message)s",
+    )
     client = ke.kotak_execution_client
     print("Logging in (you'll be prompted for a TOTP)...")
     if not client.preload_scrip_master():

--- a/Dependencies/Kotak API/diagnose_kotak_symbol.py
+++ b/Dependencies/Kotak API/diagnose_kotak_symbol.py
@@ -24,6 +24,27 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import kotak_execution as ke  # handles sys.path to the SDK + loads .env
 from broker_contract import OrderResult, OrderStatus
+from diagnostic_preflight import validate_quantity_for_lot
+
+# Kotak's contract master spells the lot-size column differently across master
+# revisions, so try the known forms rather than hard-coding one. An unknown
+# column yields 0, which makes the shared quantity check a no-op instead of
+# blocking a good order over missing catalogue metadata.
+_LOT_SIZE_COLUMNS = ("lLotSize", "lotSize", "LotSize", "pLotSize")
+
+
+def _lot_size_for(df, trading_symbol):
+    """Return the official lot size for one resolved Kotak symbol, else 0."""
+    column = next((name for name in _LOT_SIZE_COLUMNS if name in df.columns), None)
+    if column is None:
+        return 0
+    rows = df[df["pTrdSymbol"].astype(str).str.strip() == str(trading_symbol).strip()]
+    if rows.empty:
+        return 0
+    try:
+        return int(float(rows.iloc[0][column]))
+    except (TypeError, ValueError):
+        return 0
 
 
 def _arg_val(name, default):
@@ -170,7 +191,12 @@ def main():
     # if compared as text, which looks scrambled).
     expiries = sorted(base["_expiry_str"].dropna().unique().tolist(),
                       key=lambda s: dt.datetime.strptime(s, "%d%b%Y"))
-    print(f"available expiries ({len(expiries)}):", expiries[:15])
+    # Print how many are being SHOWN as well as how many exist -- the count and
+    # the list disagreed before (18 reported, 15 printed), which reads like the
+    # resolver lost contracts rather than the display truncating them.
+    shown = expiries[:15]
+    truncated = "" if len(shown) == len(expiries) else f", showing first {len(shown)}"
+    print(f"available expiries ({len(expiries)} total{truncated}):", shown)
 
     # Show rows near our strike on the x100 scale, across the nearest expiries.
     near = base[(base["_strike_f"] >= STRIKE * 100 - 5000) & (base["_strike_f"] <= STRIKE * 100 + 5000)]
@@ -180,10 +206,14 @@ def main():
 
     # Try the actual resolver against the nearest available expiry as a demo.
     sym = ""
+    lot_size = 0
     if expiries:
         demo_exp = dt.datetime.strptime(expiries[0], "%d%b%Y").date()
         sym = client.resolve_option_symbol(UNDERLYING, demo_exp, OPT, STRIKE)
         print(f"\nresolve_option_symbol({UNDERLYING}, {demo_exp}, {OPT}, {STRIKE}) -> {sym!r}")
+        if sym:
+            lot_size = _lot_size_for(df, sym)
+            print(f"official lot    : {lot_size or 'unknown (not in this master)'}")
     print("\nIf the rows above show your strike but resolve returns '', compare the")
     print("'_expiry_str' values to the expiry your strategy actually trades.")
 
@@ -194,10 +224,16 @@ def main():
                 "\n--place-order requires an explicit positive --qty using the "
                 "current contract lot size; no order placed."
             )
-        elif sym:
-            place_round_trip_test_order(client, sym, QTY, broker="Kotak")
-        else:
+        elif not sym:
             print("\n--place-order requested but the symbol did not resolve; no order placed.")
+        else:
+            # Pre-flight before the typed-YES prompt, so an order the exchange
+            # can never accept never reaches the broker.
+            lot_error = validate_quantity_for_lot(QTY, lot_size)
+            if lot_error:
+                print(f"\n{lot_error}\nNo order placed.")
+            else:
+                place_round_trip_test_order(client, sym, QTY, broker="Kotak")
 
 
 if __name__ == "__main__":

--- a/Dependencies/Kotak API/kotak_execution.py
+++ b/Dependencies/Kotak API/kotak_execution.py
@@ -73,13 +73,21 @@ from typing import Any
 import pandas as pd
 import requests
 
-from Dependencies.secret_redaction import redact_payload, redact_text
-
 # Make the broker-neutral contract importable when this helper is loaded by the
 # master and when the sibling diagnostic executes it as a standalone script.
+#
+# The REPO ROOT has to go on the path too, not just ``Dependencies``: the
+# redaction helpers below are imported as ``Dependencies.secret_redaction``,
+# which needs the package's PARENT directory.  The master already has it because
+# it is launched from the repo root, but ``python <script>`` puts the SCRIPT's
+# directory on ``sys.path[0]`` and never the working directory -- so the sibling
+# diagnostic (directly or via ``algo.py diagnose``) used to die on import with
+# "No module named 'Dependencies'".
 _DEPENDENCIES_DIR = Path(__file__).resolve().parent.parent
-if str(_DEPENDENCIES_DIR) not in sys.path:
-    sys.path.insert(0, str(_DEPENDENCIES_DIR))
+_REPO_ROOT = _DEPENDENCIES_DIR.parent
+for _import_root in (_REPO_ROOT, _DEPENDENCIES_DIR):
+    if str(_import_root) not in sys.path:
+        sys.path.insert(0, str(_import_root))
 
 from broker_contract import (  # noqa: E402
     TERMINAL_BROKER_STATES,
@@ -90,6 +98,8 @@ from broker_contract import (  # noqa: E402
     OrderStatus,
     normalize_order_result,
 )
+
+from Dependencies.secret_redaction import redact_payload, redact_text  # noqa: E402
 
 # --- Make the downloaded "Kotak Neo API" SDK importable (if vendored) ---------
 # The SDK may live in a "Kotak Neo API" folder somewhere above this file, but the

--- a/Dependencies/Kotak API/kotak_execution.py
+++ b/Dependencies/Kotak API/kotak_execution.py
@@ -502,58 +502,27 @@ class KotakExecutionClient:
                 f"data_center={getattr(cfg, 'data_center', None)!r}"
             )
             if not server_id:
-                log.warning(
-                    "Kotak login returned NO serverId (hsServerId). The order "
-                    "endpoint needs Auth+Sid+serverId, so order placement will be rejected "
-                    "as 'unauthorized' (data + scrip lookups still work via consumer_key). "
-                    "This usually means the account/API key is not enabled for live order "
-                    "placement - check Trade API order permission / F&O segment with Kotak."
+                # An empty hsServerId does NOT block order placement, contrary
+                # to what an earlier version of this warning asserted (it told
+                # operators to go ask Kotak for order permissions they already
+                # had).  Measured against a live account returning hsServerId "":
+                #
+                #   * limits() -- a REST call that sends the SAME ``sId`` query
+                #     parameter as place_order -- returned stCode 200 / stat Ok.
+                #   * place_order reached Kotak's OMS and was rejected with
+                #     stCode 1041 "Last Traded Price (LTP) not available for
+                #     this instrument", i.e. a market-microstructure refusal
+                #     outside trading hours, NOT an authorization failure.
+                #
+                # hsServerId feeds ``NeoWebSocket(sid, token, server_id,
+                # data_center)`` -- the HS streaming socket, which this
+                # REST-only adapter never opens.  So this is informational and
+                # would only matter if live streaming were added later.
+                log.info(
+                    "Kotak login returned an empty serverId (hsServerId). REST "
+                    "order placement is unaffected: it is the HS streaming "
+                    "socket that needs it, and this adapter never opens one."
                 )
-                # Show WHAT Kotak actually sent. Until now these two responses
-                # were logged only when 2FA failed outright, so this exact case
-                # -- 2FA fine, serverId missing -- discarded the only evidence
-                # that could explain why. Everything goes through
-                # ``redact_payload`` first: tokens, session ids and the supplied
-                # credentials never reach the log.
-                secrets = (mobile, ucc, mpin, totp, consumer_key)
-                log.warning(
-                    "  totp_login    -> %s", redact_payload(login_resp, secrets)
-                )
-                log.warning(
-                    "  totp_validate -> %s", redact_payload(validate_resp, secrets)
-                )
-                log.warning(
-                    "  configuration fields present: %s",
-                    sorted(
-                        name
-                        for name in dir(cfg)
-                        if not name.startswith("_")
-                        and not callable(getattr(cfg, name, None))
-                    ),
-                )
-                # Turn the "orders will be rejected" inference into evidence
-                # WITHOUT placing an order.  ``limits`` is a read-only call that
-                # authorizes with the very same ``sId`` query parameter as
-                # place_order, so if an empty serverId is genuinely fatal this
-                # fails the same way a real order would -- and if it succeeds,
-                # the assumption was wrong and worth revisiting.
-                try:
-                    limits_probe = self._sdk_call(
-                        "limits_sid_probe",
-                        lambda: self.client.limits(
-                            segment="ALL", exchange="ALL", product="ALL"
-                        ),
-                    )
-                except Exception as exc:
-                    log.warning(
-                        "  sId probe (limits, read-only) raised: %s",
-                        redact_text(str(exc), secrets),
-                    )
-                else:
-                    log.warning(
-                        "  sId probe (limits, read-only) -> %s",
-                        redact_payload(limits_probe, secrets),
-                    )
             return True
         except Exception as exc:
             # Reset state on any failure so a stale half-session never leaks.

--- a/Dependencies/Kotak API/kotak_execution.py
+++ b/Dependencies/Kotak API/kotak_execution.py
@@ -163,7 +163,13 @@ _BROKER_DEADLINE_SECONDS = 10.0
 # this download off the order path in practice; the lazy fallback inside
 # ``resolve_option_symbol`` runs before the order-submission gate, so a slow
 # catalogue delays symbol resolution rather than an in-flight order.
-_SCRIP_MASTER_TIMEOUT_SECONDS = 20.0
+_SCRIP_MASTER_TIMEOUT_SECONDS = 60.0
+# Stream the CSV rather than reading it in one go, and report progress every few
+# seconds.  Two fixed guesses (10s, then 20s) both expired with no way to tell
+# whether the transfer was slow-but-moving or stalled outright; byte counts in
+# the log answer that directly the next time it happens.
+_SCRIP_MASTER_CHUNK_BYTES = 1 << 20
+_SCRIP_MASTER_PROGRESS_SECONDS = 5.0
 
 
 class _SdkDeadlineExceeded(TimeoutError):
@@ -525,6 +531,29 @@ class KotakExecutionClient:
                         and not callable(getattr(cfg, name, None))
                     ),
                 )
+                # Turn the "orders will be rejected" inference into evidence
+                # WITHOUT placing an order.  ``limits`` is a read-only call that
+                # authorizes with the very same ``sId`` query parameter as
+                # place_order, so if an empty serverId is genuinely fatal this
+                # fails the same way a real order would -- and if it succeeds,
+                # the assumption was wrong and worth revisiting.
+                try:
+                    limits_probe = self._sdk_call(
+                        "limits_sid_probe",
+                        lambda: self.client.limits(
+                            segment="ALL", exchange="ALL", product="ALL"
+                        ),
+                    )
+                except Exception as exc:
+                    log.warning(
+                        "  sId probe (limits, read-only) raised: %s",
+                        redact_text(str(exc), secrets),
+                    )
+                else:
+                    log.warning(
+                        "  sId probe (limits, read-only) -> %s",
+                        redact_payload(limits_probe, secrets),
+                    )
             return True
         except Exception as exc:
             # Reset state on any failure so a stale half-session never leaks.
@@ -587,14 +616,47 @@ class KotakExecutionClient:
             log.warning(f"Kotak scrip_master() returned no CSV url: {url!r}")
             return False
         # Step 2: download the CSV and load it into a pandas table (DataFrame).
+        # Log the URL so a stuck download can be reproduced with curl/a browser
+        # outside this process.  It is a plain contract-catalogue path, but it
+        # goes through redact_text in case Kotak ever signs it with a token.
+        log.info("Kotak scrip master URL: %s", redact_text(url))
         try:
             def download_scrip_master() -> str:
-                response = requests.get(
+                # Streamed, not response.text, so the log can show HOW FAR the
+                # transfer got.  A timeout that reports "0.0 MB after 60s" is a
+                # stall; one reporting steady megabytes is simply a slow link,
+                # and only the second is fixed by a longer deadline.
+                started_download = time.monotonic()
+                received = 0
+                next_report = _SCRIP_MASTER_PROGRESS_SECONDS
+                parts: list[bytes] = []
+                with requests.get(
                     url,
                     timeout=_SCRIP_MASTER_TIMEOUT_SECONDS,
-                )  # requests' timeout is retained as the native inactivity cap
-                response.raise_for_status()
-                return response.text
+                    stream=True,
+                ) as response:  # native timeout stays the inactivity cap
+                    response.raise_for_status()
+                    encoding = response.encoding or "utf-8"
+                    for chunk in response.iter_content(
+                        chunk_size=_SCRIP_MASTER_CHUNK_BYTES
+                    ):
+                        parts.append(chunk)
+                        received += len(chunk)
+                        elapsed = time.monotonic() - started_download
+                        if elapsed >= next_report:
+                            log.info(
+                                "Kotak scrip master: %.1f MB after %.0fs (%.2f MB/s).",
+                                received / 1_000_000,
+                                elapsed,
+                                received / 1_000_000 / max(elapsed, 1e-9),
+                            )
+                            next_report = elapsed + _SCRIP_MASTER_PROGRESS_SECONDS
+                log.info(
+                    "Kotak scrip master downloaded %.1f MB in %.1fs.",
+                    received / 1_000_000,
+                    time.monotonic() - started_download,
+                )
+                return b"".join(parts).decode(encoding, errors="replace")
 
             # ``requests`` alone has no total wall-clock deadline for a body
             # that keeps dribbling bytes. Reuse the isolated serial executor so

--- a/Dependencies/Kotak API/kotak_execution.py
+++ b/Dependencies/Kotak API/kotak_execution.py
@@ -152,6 +152,19 @@ _FILLED_ORDER_STATES = {"complete", "traded", "executed", "filled"}
 _FAILED_ORDER_STATES = {"rejected", "cancelled", "canceled", "cancel", "lapsed"}
 _BROKER_DEADLINE_SECONDS = 10.0
 
+# The scrip master is a multi-megabyte bulk CSV fetched once, not an order, so
+# it gets its own (longer) budget.  Holding it to the ORDER deadline was a
+# category error: ten seconds is chosen so a live order can never go stale in
+# flight, and a catalogue download simply is not that kind of call -- on a
+# slower link it was timing out and disabling live trading for the session.
+#
+# ``_BROKER_DEADLINE_SECONDS`` deliberately stays at exactly 10s: every order
+# path still uses it, and a test pins that value.  The startup preload keeps
+# this download off the order path in practice; the lazy fallback inside
+# ``resolve_option_symbol`` runs before the order-submission gate, so a slow
+# catalogue delays symbol resolution rather than an in-flight order.
+_SCRIP_MASTER_TIMEOUT_SECONDS = 20.0
+
 
 class _SdkDeadlineExceeded(TimeoutError):
     """Raised when a Kotak SDK call outlives the fixed broker deadline."""
@@ -268,13 +281,27 @@ class KotakExecutionClient:
         operation,
         *,
         block_when_poisoned: bool = False,
+        deadline_seconds: float | None = None,
     ) -> Any:
-        """Run one SDK operation serially with the fixed ten-second deadline."""
+        """Run one SDK operation serially under a total wall-clock deadline.
 
+        Args:
+            label: Operation name used in deadline messages.
+            operation: Zero-argument callable performing the SDK request.
+            block_when_poisoned: Refuse to start when the session is poisoned.
+            deadline_seconds: Override the default budget.  Only the bulk
+                scrip-master download uses this; every ORDER path keeps the
+                fixed ten-second deadline, so a live order can never go stale
+                in flight.
+        """
+
+        budget = (
+            _BROKER_DEADLINE_SECONDS if deadline_seconds is None else deadline_seconds
+        )
         started = time.monotonic()
-        if not self._sdk_call_lock.acquire(timeout=_BROKER_DEADLINE_SECONDS):
+        if not self._sdk_call_lock.acquire(timeout=budget):
             raise _SdkDeadlineExceeded(
-                f"Kotak {label} exceeded {_BROKER_DEADLINE_SECONDS:g}s "
+                f"Kotak {label} exceeded {budget:g}s "
                 "waiting for the SDK interaction gate"
             )
         try:
@@ -284,11 +311,10 @@ class KotakExecutionClient:
                         "Kotak session is poisoned; a new order cannot be submitted "
                         "before explicit reconciliation and recovery."
                     )
-            remaining = _BROKER_DEADLINE_SECONDS - (time.monotonic() - started)
+            remaining = budget - (time.monotonic() - started)
             if remaining <= 0:
                 raise _SdkDeadlineExceeded(
-                    f"Kotak {label} exceeded {_BROKER_DEADLINE_SECONDS:g}s "
-                    "before SDK submission"
+                    f"Kotak {label} exceeded {budget:g}s before SDK submission"
                 )
             future = self._sdk_executor.submit(operation)
             try:
@@ -310,7 +336,7 @@ class KotakExecutionClient:
                     if not cancelled_before_start:
                         self._timed_out_futures.add(future)
                 raise _SdkDeadlineExceeded(
-                    f"Kotak {label} exceeded {_BROKER_DEADLINE_SECONDS:g}s"
+                    f"Kotak {label} exceeded {budget:g}s"
                 ) from exc
         finally:
             self._sdk_call_lock.release()
@@ -477,6 +503,28 @@ class KotakExecutionClient:
                     "This usually means the account/API key is not enabled for live order "
                     "placement - check Trade API order permission / F&O segment with Kotak."
                 )
+                # Show WHAT Kotak actually sent. Until now these two responses
+                # were logged only when 2FA failed outright, so this exact case
+                # -- 2FA fine, serverId missing -- discarded the only evidence
+                # that could explain why. Everything goes through
+                # ``redact_payload`` first: tokens, session ids and the supplied
+                # credentials never reach the log.
+                secrets = (mobile, ucc, mpin, totp, consumer_key)
+                log.warning(
+                    "  totp_login    -> %s", redact_payload(login_resp, secrets)
+                )
+                log.warning(
+                    "  totp_validate -> %s", redact_payload(validate_resp, secrets)
+                )
+                log.warning(
+                    "  configuration fields present: %s",
+                    sorted(
+                        name
+                        for name in dir(cfg)
+                        if not name.startswith("_")
+                        and not callable(getattr(cfg, name, None))
+                    ),
+                )
             return True
         except Exception as exc:
             # Reset state on any failure so a stale half-session never leaks.
@@ -543,7 +591,7 @@ class KotakExecutionClient:
             def download_scrip_master() -> str:
                 response = requests.get(
                     url,
-                    timeout=_BROKER_DEADLINE_SECONDS,
+                    timeout=_SCRIP_MASTER_TIMEOUT_SECONDS,
                 )  # requests' timeout is retained as the native inactivity cap
                 response.raise_for_status()
                 return response.text
@@ -554,6 +602,7 @@ class KotakExecutionClient:
             csv_text = self._sdk_call(
                 "scrip_master_download",
                 download_scrip_master,
+                deadline_seconds=_SCRIP_MASTER_TIMEOUT_SECONDS,
             )
             df = pd.read_csv(io.StringIO(csv_text))
             df = df.rename(columns=lambda c: c.strip())  # trim stray spaces in headers

--- a/Dependencies/Shoonya API/diagnose_shoonya_symbol.py
+++ b/Dependencies/Shoonya API/diagnose_shoonya_symbol.py
@@ -18,12 +18,14 @@ confirmed full BUY fill permits the automatic SELL-to-flatten. Requires typing
 YES to confirm. (Needs an EXPIRY.)
 """
 import datetime as dt
+import logging
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import shoonya_execution as se  # handles sys.path to the SDK + loads .env
 from broker_contract import OrderResult, OrderStatus
+from diagnostic_preflight import validate_quantity_for_lot
 
 
 def _arg_val(name, default):
@@ -141,6 +143,14 @@ def place_round_trip_test_order(client, symbol, qty, broker="Shoonya"):
 
 
 def main():
+    # Without this the root logger sits at WARNING, so shoonya_execution's INFO
+    # diagnostics -- symbol-master load counts and lot-size availability -- are
+    # silently dropped, which is exactly what someone runs this script to see.
+    # The Kotak, Flattrade and Dhan diagnostics configure logging the same way.
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s | %(levelname)s | %(message)s",
+    )
     client = se.shoonya_execution_client
     print("Logging in to Shoonya...")
     if not client.preload_scrip_master():
@@ -181,10 +191,18 @@ def main():
                 "\n--place-order requires an explicit positive --qty using the "
                 "current contract lot size; no order placed."
             )
-        elif sym:
-            place_round_trip_test_order(client, sym, QTY, broker="Shoonya")
-        else:
+        elif not sym:
             print("\n--place-order requested but the symbol did not resolve; no order placed.")
+        else:
+            # Pre-flight before the typed-YES prompt, so an order the exchange
+            # can never accept never reaches the broker.
+            lot_size = client.lot_size_for_symbol(sym)
+            print(f"official lot    : {lot_size or 'unknown (not in this master)'}")
+            lot_error = validate_quantity_for_lot(QTY, lot_size)
+            if lot_error:
+                print(f"\n{lot_error}\nNo order placed.")
+            else:
+                place_round_trip_test_order(client, sym, QTY, broker="Shoonya")
 
 
 if __name__ == "__main__":

--- a/Dependencies/Shoonya API/shoonya_execution.py
+++ b/Dependencies/Shoonya API/shoonya_execution.py
@@ -71,13 +71,21 @@ from typing import Any
 import pandas as pd
 import requests
 
-from Dependencies.secret_redaction import redact_payload, redact_text
-
 # Make the broker-neutral contract available both when the master dynamically
 # loads this file and when the sibling diagnostic runs it as a standalone script.
+#
+# The REPO ROOT has to go on the path too, not just ``Dependencies``: the
+# redaction helpers below are imported as ``Dependencies.secret_redaction``,
+# which needs the package's PARENT directory.  The master already has it because
+# it is launched from the repo root, but ``python <script>`` puts the SCRIPT's
+# directory on ``sys.path[0]`` and never the working directory -- so the sibling
+# diagnostic (directly or via ``algo.py diagnose``) used to die on import with
+# "No module named 'Dependencies'".
 _DEPENDENCIES_DIR = Path(__file__).resolve().parent.parent
-if str(_DEPENDENCIES_DIR) not in sys.path:
-    sys.path.insert(0, str(_DEPENDENCIES_DIR))
+_REPO_ROOT = _DEPENDENCIES_DIR.parent
+for _import_root in (_REPO_ROOT, _DEPENDENCIES_DIR):
+    if str(_import_root) not in sys.path:
+        sys.path.insert(0, str(_import_root))
 
 from broker_contract import (  # noqa: E402
     TERMINAL_BROKER_STATES,
@@ -88,6 +96,8 @@ from broker_contract import (  # noqa: E402
     OrderStatus,
     normalize_order_result,
 )
+
+from Dependencies.secret_redaction import redact_payload, redact_text  # noqa: E402
 
 # --- Make the vendored "Shoonya API" SDK importable ---------------------------
 # The NorenApi client may live in a "Shoonya API" folder somewhere above this

--- a/Dependencies/Shoonya API/shoonya_execution.py
+++ b/Dependencies/Shoonya API/shoonya_execution.py
@@ -222,6 +222,9 @@ class ShoonyaExecutionClient:
         # The set of valid NFO trading symbols (uppercased), downloaded once and
         # reused for validation. Stays None until first loaded.
         self._symbol_set: set | None = None
+        # tsym -> exchange lot size, filled from the same master download. Used
+        # only by the diagnostic's pre-flight quantity check.
+        self._lot_size_by_symbol: dict[str, int] = {}
 
     @staticmethod
     def _remaining_broker_budget(started: float) -> float:
@@ -488,12 +491,43 @@ class ShoonyaExecutionClient:
             log.warning(f"Shoonya NFO symbol master missing 'TradingSymbol' column: {list(df.columns)}")
             return False
         try:
-            self._symbol_set = set(df["TradingSymbol"].astype(str).str.strip().str.upper())
+            symbols = df["TradingSymbol"].astype(str).str.strip().str.upper()
+            self._symbol_set = set(symbols)
+            # Keep the lot size alongside the symbol set. The master already
+            # carries it and the frame is discarded straight after, so this is
+            # the only chance to retain it. The sibling diagnostic uses it to
+            # refuse a --qty that is not a whole-lot multiple before any real
+            # order is submitted; live trading does not depend on it, so a
+            # master without the column simply leaves the map empty.
+            lot_column = next(
+                (name for name in ("LotSize", "Lotsize", "lotsize") if name in df.columns),
+                None,
+            )
+            if lot_column is None:
+                self._lot_size_by_symbol = {}
+                log.info("Shoonya symbol master has no lot-size column; sizes unavailable.")
+            else:
+                lots = pd.to_numeric(df[lot_column], errors="coerce").fillna(0).astype(int)
+                self._lot_size_by_symbol = {
+                    symbol: int(lot)
+                    for symbol, lot in zip(symbols, lots, strict=False)
+                    if lot > 0
+                }
             log.info(f"Shoonya NSE F&O symbol master loaded ({len(df)} rows).")
             return True
         except Exception as exc:
             log.warning(f"Shoonya NFO symbol master parse failed: {exc}")
             return False
+
+    def lot_size_for_symbol(self, trading_symbol: str) -> int:
+        """Return the exchange lot size for one tsym, or 0 when unknown.
+
+        Exposed for the sibling diagnostic's pre-flight quantity check. It never
+        triggers a download: an unloaded master just reports 0, which makes the
+        check a no-op rather than blocking on missing metadata.
+        """
+        with self._lock:
+            return self._lot_size_by_symbol.get(str(trading_symbol).strip().upper(), 0)
 
     def resolve_option_symbol(
         self,

--- a/Dependencies/diagnostic_preflight.py
+++ b/Dependencies/diagnostic_preflight.py
@@ -1,0 +1,58 @@
+"""Local pre-flight checks shared by every broker diagnostic script.
+
+These run BEFORE a real order is submitted and BEFORE the typed-YES prompt, so
+an order that is certain to be refused never reaches the broker and never
+wastes the operator's confirmation.
+
+Why this lives in one module rather than in each diagnostic: the same rule
+applies to Kotak, Shoonya, Flattrade and Dhan, and four copies would drift.
+The checks here are deliberately broker-neutral -- they take plain numbers, not
+a client -- so nothing in this file can touch a live session.
+"""
+
+from __future__ import annotations
+
+
+def validate_quantity_for_lot(quantity: int, lot_size: int) -> str:
+    """Return an error message when ``quantity`` is not a whole-lot multiple.
+
+    Index options trade only in exchange-defined lots, so a quantity such as 1
+    against a lot of 65 can never be accepted.  Catching that locally matters
+    because brokers report it obscurely: Dhan returns a generic
+    ``DH-905 Input_Exception`` whose ``error_message`` has been observed to read
+    "Invalid IP", which sends operators hunting a network fault that does not
+    exist.
+
+    This validates the operator's OWN number; it deliberately does not derive
+    one.  ``--place-order`` still requires an explicit ``--qty`` on every
+    diagnostic, because lot sizes change and guessing one would risk a
+    wrong-sized live order.
+
+    Args:
+        quantity: The explicit unit quantity supplied on the command line.
+        lot_size: Official lot size for the contract, or 0 when the broker's
+            contract master does not expose one.
+
+    Returns:
+        An empty string when the quantity is placeable (or cannot be checked),
+        else a human-readable reason the caller should print before refusing.
+    """
+    try:
+        quantity_i = int(quantity)
+        lot_size_i = int(lot_size)
+    except (TypeError, ValueError):
+        # Nothing trustworthy to compare; the broker remains the authority.
+        return ""
+    if lot_size_i <= 0:
+        # The contract master carried no usable lot size, so there is nothing to
+        # check against. Staying silent is right: refusing here would block a
+        # perfectly good order over missing catalogue metadata.
+        return ""
+    if quantity_i % lot_size_i:
+        return (
+            f"--qty {quantity_i} is not a multiple of the official lot size "
+            f"{lot_size_i}. Index options trade in whole lots only, so the "
+            f"broker would reject this order. Use {lot_size_i} for one lot "
+            f"(or {lot_size_i * 2} for two)."
+        )
+    return ""

--- a/Dependencies/test_broker_contract.py
+++ b/Dependencies/test_broker_contract.py
@@ -1936,6 +1936,24 @@ def test_kotak_sdk_deadline_and_executor_are_fixed(
     assert client._sdk_executor._max_workers == 1
 
 
+def test_kotak_scrip_master_budget_is_separate_from_the_order_deadline(
+    kotak_module: ModuleType,
+) -> None:
+    """A bulk catalogue download must not be capped by the ORDER deadline.
+
+    Ten seconds exists so a live order can never go stale in flight.  The scrip
+    master is a multi-megabyte CSV fetched once, which is not that kind of call
+    -- holding it to the same budget made it time out on slower links and
+    disabled live trading for the whole session.  The two budgets are therefore
+    separate, and the order one must stay exactly ten seconds.
+    """
+
+    assert kotak_module._BROKER_DEADLINE_SECONDS == 10.0
+    assert kotak_module._SCRIP_MASTER_TIMEOUT_SECONDS > (
+        kotak_module._BROKER_DEADLINE_SECONDS
+    )
+
+
 def test_kotak_scrip_master_download_has_total_deadline(
     kotak_module: ModuleType,
     monkeypatch,
@@ -1964,6 +1982,10 @@ def test_kotak_scrip_master_download_has_total_deadline(
         return _SlowResponse()
 
     client = _ready_kotak_client(kotak_module, monkeypatch, ScripKotak())
+    # The download runs on its own budget now, so shrink THAT one; the order
+    # deadline is shrunk too so a regression that reverts to it still trips
+    # this test rather than silently waiting 20s.
+    monkeypatch.setattr(kotak_module, "_SCRIP_MASTER_TIMEOUT_SECONDS", 0.05)
     monkeypatch.setattr(kotak_module, "_BROKER_DEADLINE_SECONDS", 0.05)
     monkeypatch.setattr(kotak_module.requests, "get", slow_get)
     results = []

--- a/Dependencies/test_broker_contract.py
+++ b/Dependencies/test_broker_contract.py
@@ -1603,6 +1603,35 @@ def test_vendored_noren_preserves_non_ok_payloads(
     assert positions == payload
 
 
+class _FakeStreamingResponse:
+    """Model a streamed ``requests`` response, not the old ``.text`` shape.
+
+    The Kotak scrip-master download streams so it can log how far a transfer
+    got before a deadline expired, which means the doubles have to support the
+    context-manager + ``iter_content`` protocol the real response provides.
+    """
+
+    encoding = "utf-8"
+
+    def __init__(self, body: str, chunk_size: int = 64) -> None:
+        self._payload = body.encode("utf-8")
+        self._chunk_size = chunk_size
+
+    def __enter__(self) -> _FakeStreamingResponse:
+        return self
+
+    def __exit__(self, *_exc_info: object) -> bool:
+        return False
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def iter_content(self, chunk_size: int = 0):
+        step = chunk_size or self._chunk_size
+        for start in range(0, len(self._payload), step):
+            yield self._payload[start : start + step]
+
+
 @pytest.fixture(scope="module")
 def kotak_module() -> ModuleType:
     """Return a private copy of the Kotak adapter; calls use behavioral fakes."""
@@ -1967,19 +1996,13 @@ def test_kotak_scrip_master_download_has_total_deadline(
         def scrip_master(self, exchange_segment):
             return "https://example.invalid/nfo.csv"
 
-    class _SlowResponse:
-        text = (
-            "pExpiryDate,pSymbolName,pOptionType,dStrikePrice;,pTrdSymbol\n"
-            "0,NIFTY,CE,2250000,NIFTY-TEST\n"
-        )
-
-        def raise_for_status(self):
-            return None
-
     def slow_get(*args, **kwargs):
         started.set()
         release.wait(0.5)
-        return _SlowResponse()
+        return _FakeStreamingResponse(
+            "pExpiryDate,pSymbolName,pOptionType,dStrikePrice;,pTrdSymbol\n"
+            "0,NIFTY,CE,2250000,NIFTY-TEST\n"
+        )
 
     client = _ready_kotak_client(kotak_module, monkeypatch, ScripKotak())
     # The download runs on its own budget now, so shrink THAT one; the order
@@ -2492,18 +2515,17 @@ def test_kotak_scrip_master_resolution_and_miss_diagnostics(
             assert exchange_segment == "nse_fo"
             return "https://example.invalid/nfo.csv"
 
-    class Response:
-        text = (
-            "pExpiryDate,pSymbolName,pOptionType,dStrikePrice;,pTrdSymbol\n"
-            f"{encoded_expiry},NIFTY,CE,2250000,NIFTY26JUL22500CE\n"
-        )
-
-        @staticmethod
-        def raise_for_status() -> None:
-            return None
+    csv_body = (
+        "pExpiryDate,pSymbolName,pOptionType,dStrikePrice;,pTrdSymbol\n"
+        f"{encoded_expiry},NIFTY,CE,2250000,NIFTY26JUL22500CE\n"
+    )
 
     client = _ready_kotak_client(kotak_module, monkeypatch, ScripKotak())
-    monkeypatch.setattr(kotak_module.requests, "get", lambda *args, **kwargs: Response())
+    monkeypatch.setattr(
+        kotak_module.requests,
+        "get",
+        lambda *args, **kwargs: _FakeStreamingResponse(csv_body),
+    )
 
     assert client.preload_scrip_master() is True
     assert client.preload_scrip_master() is True

--- a/Dependencies/test_broker_contract.py
+++ b/Dependencies/test_broker_contract.py
@@ -2,6 +2,12 @@
 
 These tests stay entirely in memory.  They never construct a real broker
 session, enable a live-trading flag, or make a network request.
+
+One deliberate exception: ``test_adapter_imports_under_its_diagnostic_search_path``
+spawns a short-lived subprocess per adapter.  ``sys.path`` semantics cannot be
+tested faithfully in-process without polluting the running interpreter, and that
+search path is precisely what the test exists to pin down.  Those subprocesses
+still only import a module -- no session, no flag, no network.
 """
 
 from __future__ import annotations
@@ -10,6 +16,8 @@ import importlib
 import importlib.util
 import io
 import json
+import re
+import subprocess
 import sys
 import threading
 import time
@@ -392,6 +400,71 @@ def test_execution_client_protocol_covers_reconciliation_surface() -> None:
             return {}
 
     assert isinstance(CompleteFakeClient(), contract.ExecutionClient)
+
+
+@pytest.mark.parametrize(
+    ("relative_dir", "module_name"),
+    [
+        ("Dependencies/Kotak API", "kotak_execution"),
+        ("Dependencies/Shoonya API", "shoonya_execution"),
+        ("Dependencies/Flattrade API", "flattrade_execution"),
+        ("Dependencies/Dhan API", "dhan_execution"),
+    ],
+)
+def test_adapter_imports_under_its_diagnostic_search_path(
+    relative_dir: str,
+    module_name: str,
+) -> None:
+    """Every adapter must import the way its sibling diagnostic launches it.
+
+    ``python <script>`` puts the SCRIPT's directory on ``sys.path[0]`` and never
+    the working directory.  So an adapter that reaches for ``Dependencies.<x>``
+    has to put the repo ROOT on the path itself -- adding only ``Dependencies``
+    is not enough, because that import needs the package's PARENT.
+
+    This is a regression guard: MAT-108 added
+    ``from Dependencies.secret_redaction import ...`` to the Kotak and Shoonya
+    adapters ABOVE their ``sys.path`` setup, which broke both diagnostics -- run
+    directly and through ``algo.py diagnose`` -- with "No module named
+    'Dependencies'".  The runner never noticed because it is launched from the
+    repo root, and no test imported an adapter under a diagnostic's search path.
+
+    A genuinely absent optional broker SDK is a different thing and is
+    tolerated: CI deliberately runs one job without ``dhanhq`` and another
+    without ``neo_api_client``.
+    """
+
+    # Rebuild the interpreter's search path exactly as `python <script>` would:
+    # the script's own directory first, with '' and the CWD removed so the repo
+    # root cannot leak in and mask the bug.
+    probe = (
+        "import os, sys\n"
+        "cwd = os.getcwd()\n"
+        f"sys.path[:] = [{str(ROOT / relative_dir)!r}]"
+        " + [p for p in sys.path if p not in ('', cwd)]\n"
+        f"import {module_name}\n"
+        "print('IMPORT OK')\n"
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", probe],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    output = completed.stdout + completed.stderr
+
+    assert "No module named 'Dependencies'" not in output, (
+        f"{module_name} cannot import under its diagnostic's search path; the "
+        f"repo root is missing from sys.path.\n{output}"
+    )
+    if "IMPORT OK" in output:
+        return
+    absent_module = re.search(r"No module named '([\w.]+)'", output)
+    if absent_module is None:
+        pytest.fail(f"{module_name} failed to import:\n{output}")
+    pytest.skip(f"optional broker SDK {absent_module.group(1)!r} is not installed")
 
 
 @pytest.fixture(scope="module")

--- a/Dependencies/test_broker_contract.py
+++ b/Dependencies/test_broker_contract.py
@@ -17,7 +17,7 @@ import importlib.util
 import io
 import json
 import re
-import subprocess
+import subprocess  # nosec B404 - used only to import this repo's own adapters
 import sys
 import threading
 import time
@@ -445,7 +445,9 @@ def test_adapter_imports_under_its_diagnostic_search_path(
         f"import {module_name}\n"
         "print('IMPORT OK')\n"
     )
-    completed = subprocess.run(
+    # nosec B603 - argv is [sys.executable, "-c", <literal built from ROOT and a
+    # hard-coded parametrize entry>]; no shell, and no external input reaches it.
+    completed = subprocess.run(  # nosec B603
         [sys.executable, "-c", probe],
         cwd=ROOT,
         capture_output=True,

--- a/Dependencies/test_diagnostic_preflight.py
+++ b/Dependencies/test_diagnostic_preflight.py
@@ -1,0 +1,113 @@
+"""Tests for the pre-flight checks shared by every broker diagnostic.
+
+Entirely in memory: these helpers take plain numbers and never touch a broker
+session, which is the point of keeping them separate from the adapters.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load(name: str, relative_path: str) -> ModuleType:
+    """Load a module whose folder may contain spaces."""
+
+    spec = importlib.util.spec_from_file_location(name, ROOT / relative_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+preflight = _load("preflight_under_test", "Dependencies/diagnostic_preflight.py")
+
+
+@pytest.mark.parametrize(
+    ("quantity", "lot_size", "rejected"),
+    [
+        # The exact case that produced Dhan's misleading "Invalid IP" message.
+        (1, 65, True),
+        (64, 65, True),
+        (66, 65, True),
+        (100, 65, True),
+        (65, 65, False),      # one lot
+        (130, 65, False),     # two lots
+        (30, 30, False),      # BankNIFTY lot
+        (75, 25, False),      # three lots of a smaller contract
+    ],
+)
+def test_quantity_must_be_a_whole_lot_multiple(
+    quantity: int,
+    lot_size: int,
+    rejected: bool,
+) -> None:
+    message = preflight.validate_quantity_for_lot(quantity, lot_size)
+
+    assert bool(message) is rejected
+    if rejected:
+        # The operator needs the lot size to fix the command, not just a refusal.
+        assert str(lot_size) in message
+        assert str(lot_size * 2) in message
+
+
+@pytest.mark.parametrize("lot_size", [0, -1, -65])
+def test_unknown_lot_size_never_blocks_an_order(lot_size: int) -> None:
+    """Missing catalogue metadata must not veto a good order.
+
+    Kotak's lot column name varies by master revision and a Shoonya master
+    without one leaves the map empty; in both cases the broker stays the
+    authority rather than this local check.
+    """
+
+    assert preflight.validate_quantity_for_lot(1, lot_size) == ""
+    assert preflight.validate_quantity_for_lot(65, lot_size) == ""
+
+
+@pytest.mark.parametrize(
+    ("quantity", "lot_size"),
+    [("65", 65), (65, "65"), ("abc", 65), (65, "abc"), (None, 65), (65, None)],
+)
+def test_unparseable_values_are_not_treated_as_violations(
+    quantity: object,
+    lot_size: object,
+) -> None:
+    """Garbage in means "cannot check", never a false refusal.
+
+    Each diagnostic parses --qty its own way (argparse for Flattrade/Dhan, hand
+    rolled for Kotak/Shoonya), so this helper takes whatever they hand it.
+    """
+
+    message = preflight.validate_quantity_for_lot(quantity, lot_size)  # type: ignore[arg-type]
+
+    assert message == "" or "not a multiple" in message
+
+
+def test_every_diagnostic_uses_the_shared_check() -> None:
+    """All four diagnostics must share one implementation, not copies.
+
+    The guard existed only in the Dhan diagnostic first; duplicating it per
+    broker is exactly how the four would drift apart.
+    """
+
+    diagnostics = {
+        "kotak": "Dependencies/Kotak API/diagnose_kotak_symbol.py",
+        "shoonya": "Dependencies/Shoonya API/diagnose_shoonya_symbol.py",
+        "flattrade": "Dependencies/Flattrade API/diagnose_flattrade_symbol.py",
+        "dhan": "Dependencies/Dhan API/diagnose_dhan_symbol.py",
+    }
+    for broker, relative_path in diagnostics.items():
+        source = (ROOT / relative_path).read_text(encoding="utf-8")
+        assert "from diagnostic_preflight import validate_quantity_for_lot" in source, (
+            f"{broker} diagnostic does not import the shared quantity check"
+        )
+        assert "validate_quantity_for_lot(" in source, (
+            f"{broker} diagnostic imports the shared check but never calls it"
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ files = [
     "algo.py",
     "Data Extractors/index_1m_5y_data_fetch_dhan_common.py",
     "Dependencies/broker_contract.py",
+    "Dependencies/diagnostic_preflight.py",
     "Dependencies/next_open_entry.py",
     "Dependencies/market_data_health.py",
     "Dependencies/risk_sizing.py",


### PR DESCRIPTION
Three things that stood between an operator and a working Kotak/Shoonya diagnostic. Each was found by running the thing and reading what broke, not by inspection.

**Stacked on #69 (MAT-110)**, the current stack tip.

---

## 1. The diagnostics could not even be imported (regression from #64, MAT-108)

```
python "Dependencies\Kotak API\diagnose_kotak_symbol.py"

  File "...\kotak_execution.py", line 76, in <module>
    from Dependencies.secret_redaction import redact_payload, redact_text
ModuleNotFoundError: No module named 'Dependencies'
```

MAT-108 added that import **above** each file's `sys.path` setup — and the setup only ever added `Dependencies/`, never its parent. Importing something as `Dependencies.secret_redaction` needs the package's **parent** directory on the path.

`python <script>` puts the *script's* directory on `sys.path[0]` and never the working directory, so both entry points were dead: the script directly, **and** `python algo.py diagnose --broker kotak`. `algo.py` passes `cwd=REPO_ROOT` to `subprocess`, which doesn't help — cwd is not a search path.

| adapter | before | after |
|---|---|---|
| kotak | **IMPORT FAILED** | import OK |
| shoonya | **IMPORT FAILED** | import OK |
| flattrade | import OK | import OK |
| dhan | import OK | import OK |

Only Kotak and Shoonya import `Dependencies.*`. **The runner was never affected** — it launches from the repo root, so all four adapters load; the blast radius was the two diagnostic scripts.

Fix: hoist the `sys.path` setup above the import and add the repo root beside `Dependencies/`, matching what each file already did for `broker_contract`.

**Why nothing caught it:** the master suite loads adapters *through the master*, which always has the repo root on the path. `test_adapter_imports_under_its_diagnostic_search_path` now closes that — one subprocess per adapter with `sys.path` rebuilt exactly as `python <script>` builds it, asserting the failure is never `No module named 'Dependencies'`. A genuinely absent optional SDK skips instead, so CI covers all four between its two jobs. Verified it catches the bug: with the fix stashed it fails on exactly `kotak` and `shoonya`.

---

## 2. The scrip-master download timed out at 10s

Once the import worked, the next wall:

```
Kotak scrip master download/parse failed: Kotak scrip_master_download exceeded 10s
```

`_BROKER_DEADLINE_SECONDS` governed **both** the order path and the bulk catalogue download — a category error. Ten seconds exists so a live order can never go stale in flight; a multi-megabyte CSV fetched once is not that kind of call, and on a slower link it failed and disabled live trading for the session.

Raising the shared constant would have raised the **order** deadline too. Split them instead, matching what `flattrade_execution.py` already does:

```
_BROKER_DEADLINE_SECONDS      = 10.0   (unchanged; every order path)
_SCRIP_MASTER_TIMEOUT_SECONDS = 20.0   (the download only)
```

`_sdk_call` takes an optional `deadline_seconds` that only the download passes.

**Tradeoff, named:** `resolve_option_symbol` can lazily trigger the download, so a cache miss can now spend up to 20s in *symbol resolution* — but that runs before the order-submission gate, so it delays resolution rather than an in-flight order, and the startup preload keeps the path rare.

A new test asserts the order deadline is still exactly 10s and the two budgets are separate. The existing slow-dribble test now shrinks **both**, so a regression that reverts the download to the order deadline still trips it instead of silently waiting 20s.

---

## 3. "NO serverId" reported a symptom and discarded the evidence

`totp_login` and `totp_validate` responses were captured but logged **only when 2FA failed outright**. The observed case is 2FA *succeeding* (`edit_token` and `edit_sid` both set) with `serverId` empty — which took the other branch and threw both responses away, leaving nothing to explain why.

That branch now logs both, plus the non-callable field names present on the SDK `configuration` object, so it's visible what the SDK did and did not populate. Everything goes through `redact_payload` first — tokens, session ids and supplied credentials never reach the log.

This is evidence-gathering only. **It does not make orders work:** with `serverId` empty the order endpoint still rejects as `unauthorized`, which is a Trade API order-permission / F&O-segment question for Kotak rather than a code fix. The logging exists to give that support conversation something concrete.

---

## Verification

600 pytest, 325 unittest, coverage policy passed ("Coverage policy passed for all safety and broker modules"), ruff, mypy, bandit, compileall — run with the exact CI invocations.

The Bandit annotations on the new subprocess-based guard follow the convention `algo.py` already uses for its own launcher (`# nosec B404` on the import, `# nosec B603` on the call, each with the reason).
