### PR TITLE
Final review: Dhan coverage budget, redaction parity + docs pass

### DIFF
--- a/Dependencies/Dhan API/dhan_execution.py
+++ b/Dependencies/Dhan API/dhan_execution.py
@@ -96,9 +96,18 @@ from dhanhq import DhanContext, dhanhq
 # The broker helpers live in folders with spaces and are also executable as
 # standalone diagnostics.  Add their shared ``Dependencies`` parent explicitly
 # so the broker-neutral contract imports the same way in both entry points.
+#
+# The REPO ROOT goes on the path too, not just ``Dependencies``: the redaction
+# helper below is imported as ``Dependencies.secret_redaction``, which needs
+# the package's PARENT directory.  The master already has it because it is
+# launched from the repo root, but ``python <script>`` puts the SCRIPT's
+# directory on ``sys.path[0]`` and never the working directory (same fix the
+# Kotak/Shoonya helpers carry).
 _DEPENDENCIES_DIR = Path(__file__).resolve().parent.parent
-if str(_DEPENDENCIES_DIR) not in sys.path:
-    sys.path.insert(0, str(_DEPENDENCIES_DIR))
+_REPO_ROOT = _DEPENDENCIES_DIR.parent
+for _import_root in (_REPO_ROOT, _DEPENDENCIES_DIR):
+    if str(_import_root) not in sys.path:
+        sys.path.insert(0, str(_import_root))
 
 from broker_contract import (  # noqa: E402
     TERMINAL_BROKER_STATES,
@@ -109,6 +118,8 @@ from broker_contract import (  # noqa: E402
     OrderStatus,
     normalize_order_result,
 )
+
+from Dependencies.secret_redaction import redact_text  # noqa: E402
 
 try:
     from dotenv import load_dotenv
@@ -581,7 +592,12 @@ class DhanExecutionClient:
         except Exception as exc:
             self.client = None
             self._context = None
-            log.error("Dhan session construction failed: %s", exc)
+            # MAT-108: SDK construction errors can echo their arguments, and one
+            # of those arguments IS the access token -- never log the raw text.
+            log.error(
+                "Dhan session construction failed: %s",
+                redact_text(exc, (access_token,)),
+            )
             return False
 
         if not self._validate_session_locked():
@@ -597,7 +613,9 @@ class DhanExecutionClient:
         try:
             envelope = self._call_api("fund limits", lambda client: client.get_fund_limits())
         except Exception as exc:
-            log.error("Dhan session validation failed: %s", exc)
+            # MAT-108: exception/response text from an auth-adjacent call is
+            # exactly where a credential could surface -- redact before logging.
+            log.error("Dhan session validation failed: %s", redact_text(exc))
             return False
         outcome, _data, reason = _classify_envelope(envelope)
         if outcome != "ok":
@@ -605,7 +623,7 @@ class DhanExecutionClient:
                 "Dhan session validation rejected (%s): %s. "
                 "Re-run 'python algo.py setup-token' if the token has expired.",
                 outcome,
-                reason,
+                redact_text(reason),
             )
             return False
         return True

--- a/Dependencies/Flattrade API/flattrade_execution.py
+++ b/Dependencies/Flattrade API/flattrade_execution.py
@@ -463,6 +463,10 @@ class FlattradeExecutionClient:
             log.error("Flattrade login aborted: no request_code supplied.")
             return False
 
+        # Flattrade's documented recipe: the API secret is never sent raw.
+        # Instead sha256(api_key + request_code + api_secret) proves we hold
+        # the secret while binding this exchange to THIS request code -- a
+        # replayed digest is useless once the code expires.
         digest = hashlib.sha256(
             f"{api_key}{request_code}{raw_secret}".encode()
         ).hexdigest()
@@ -533,7 +537,15 @@ class FlattradeExecutionClient:
         return True
 
     def _validate_session_locked(self) -> bool:
-        """Validate the current token and remember Flattrade's account id."""
+        """Validate the current token and remember Flattrade's account id.
+
+        ``UserDetails`` is the cheapest authenticated read, so it doubles as
+        the token check.  Two extra facts are harvested while we are here:
+        the ``exarr`` exchange list (an account without NFO enabled could log
+        in fine and then have every option order rejected -- fail that at
+        startup instead) and ``actid`` (the account id later order payloads
+        must carry, which is not always identical to the login client id).
+        """
         try:
             payload = self._post_api("UserDetails", {"uid": self._client_id})
         except Exception as exc:
@@ -546,6 +558,8 @@ class FlattradeExecutionClient:
         enabled_exchanges = {
             str(value).upper() for value in (payload.get("exarr") or [])
         }
+        # An EMPTY exarr is tolerated (some responses omit it); only a present
+        # list that excludes NFO is proof the account cannot trade options.
         if enabled_exchanges and "NFO" not in enabled_exchanges:
             log.error("Flattrade account does not report NFO access; live trading disabled.")
             return False

--- a/Dependencies/dhan_token_setup.py
+++ b/Dependencies/dhan_token_setup.py
@@ -281,6 +281,17 @@ def _describe_token_expiry(access_token: str) -> str:
     leaves a position open, intraday positions can be left un-squareable
     through the API.
 
+    A weekday expiry lands in one of three situations, each with its own
+    message (a weekend expiry needs none -- no session is at risk that day):
+
+    - BETWEEN 09:15 and 15:30 -> the real danger: the token dies mid-session,
+      so the loud DURING-market-hours warning fires.
+    - BEFORE 09:15            -> nothing can fail mid-session, but that day's
+      session is not covered at all; a calmer note says to re-mint before
+      trading that day.
+    - AFTER 15:30             -> the whole session of the expiry day is
+      covered; say so, so the operator knows this is the GOOD outcome.
+
     Returns:
         A human-readable line for the operator; never raises, because a
         cosmetic decode problem must not fail an otherwise good setup run.
@@ -298,13 +309,31 @@ def _describe_token_expiry(access_token: str) -> str:
 
     hours_left = (expires_at - datetime.now().astimezone()).total_seconds() / 3600
     line = f"Token expires {expires_at:%Y-%m-%d %H:%M:%S} (about {hours_left:.0f}h from now)."
-    # 09:15-15:30 IST is the NSE equity-derivatives session.
+    if expires_at.weekday() >= 5:
+        # Weekend expiry: no session is at risk that day, and main() already
+        # prints the generic "re-run whenever it expires" advice.
+        return line
+    # 09:15-15:30 IST is the NSE equity-derivatives session. See the
+    # docstring for the three weekday situations distinguished below.
+    session_open = expires_at.replace(hour=9, minute=15, second=0, microsecond=0)
     session_close = expires_at.replace(hour=15, minute=30, second=0, microsecond=0)
-    if expires_at < session_close and expires_at.weekday() < 5:
+    if session_open <= expires_at < session_close:
         line += (
             "\n  WARNING: that is DURING market hours. If it expires while positions"
             "\n  are open you may be unable to square off through the API. Re-run this"
             "\n  script outside market hours so the window covers a whole session."
+        )
+    elif expires_at < session_open:
+        line += (
+            "\n  NOTE: that is BEFORE that day's 09:15 open, so the token does NOT"
+            "\n  cover that day's trading session at all. Nothing can fail"
+            "\n  mid-session, but re-run this script before trading that day"
+            "\n  (outside market hours)."
+        )
+    else:
+        line += (
+            "\n  Good: that is after the 15:30 close, so the token covers that"
+            "\n  day's whole trading session."
         )
     return line
 

--- a/Dependencies/execution_ledger.py
+++ b/Dependencies/execution_ledger.py
@@ -467,9 +467,14 @@ class ExecutionLedger:
             raise ValueError("requested_quantity must be a positive integer")
         with self._lock:
             leg = self._legs[str(exposure_id)]
+            # One attempt at a time per leg: while the previous order may still
+            # fill, submitting more quantity could overshoot the target.
             if leg.latest_attempt is not None and not leg.latest_attempt.terminal:
                 raise RuntimeError("the previous order attempt is not terminal")
             if intent is OrderIntent.OPEN:
+                # A leg is one-directional: once closing has begun, "reopening"
+                # would blur which fills belong to the entry and which to the
+                # exit.  A fresh signal gets a fresh correlation instead.
                 if leg.closing_started:
                     raise RuntimeError(
                         "cannot open a live leg after closing has started; "
@@ -480,6 +485,9 @@ class ExecutionLedger:
             else:
                 safe_quantity = self._snapshot_leg(leg).safe_close_retry_quantity
                 phase = "X"
+            # The caller must ask for EXACTLY the quantity the ledger deems
+            # safe (see the safe-retry properties). Rejecting any other number
+            # makes it impossible to bypass the quantity maths by accident.
             if requested_quantity != safe_quantity:
                 raise ValueError(f"requested_quantity must equal safe retry quantity {safe_quantity}")
             sequence = leg.attempt_count + 1
@@ -493,6 +501,8 @@ class ExecutionLedger:
             leg.attempt_count = sequence
             if intent is OrderIntent.CLOSE:
                 leg.closing_started = True
+            # From this instant until a terminal result arrives, the leg's
+            # true exposure is unknown -- the order is (about to be) in flight.
             leg.exposure_indeterminate = True
             leg.latest_attempt = _MutableOrderAttempt(
                 intent=intent,
@@ -523,15 +533,26 @@ class ExecutionLedger:
             attempt = leg.latest_attempt
             if attempt is None:
                 raise RuntimeError("cannot apply a result before start_attempt")
+            # Identity checks: a status probe launched for attempt #1 can
+            # return AFTER a retry already started attempt #2.  The handle's
+            # sequence/tag pin the evidence to the attempt it describes, so a
+            # late reply can never be mistaken for news about the newer order.
             if attempt.sequence != handle.sequence or attempt.order_tag != handle.order_tag:
                 raise RuntimeError("stale order-attempt handle cannot mutate the current attempt")
             if result.requested_quantity != attempt.requested_quantity:
                 raise ValueError("broker result requested quantity changed within an attempt")
             if attempt.order_id and result.order_id and result.order_id != attempt.order_id:
                 raise ValueError("broker result order id changed within an attempt")
+            # Brokers report fills CUMULATIVELY per order; a count that shrank
+            # means one of the two snapshots is wrong, and guessing which
+            # would corrupt the quantity books.
             if result.filled_quantity < attempt.filled_quantity:
                 raise ValueError("broker cumulative filled quantity moved backwards")
             broker_state = str(result.broker_state).upper().strip()
+            # PARTIAL alone is not final -- the order may still be filling.
+            # It becomes terminal only alongside a terminal broker label
+            # (e.g. partially filled, then cancelled): the same rule the
+            # adapters' fill-confirmation loops poll by.
             terminal = result.status in {OrderStatus.FILLED, OrderStatus.REJECTED} or (
                 result.status is OrderStatus.PARTIAL
                 and broker_state in _TERMINAL_BROKER_STATES
@@ -546,17 +567,24 @@ class ExecutionLedger:
                 # snapshot already applied to this attempt, so it cannot reopen
                 # uncertainty or undo an entry/flat decision.
                 return self._snapshot_leg(leg)
+            # The DELTA is what this snapshot newly proves: cumulative report
+            # minus what this attempt had already been credited.  Applying
+            # deltas (never totals) is what makes a repeated or re-ordered
+            # status report unable to double-count a fill.
             fill_delta = result.filled_quantity - attempt.filled_quantity
             new_entry_filled = leg.filled_quantity
             new_entry_remaining = leg.remaining_quantity
             new_live_quantity = leg.confirmed_live_quantity
             if attempt.intent is OrderIntent.OPEN:
+                # Entry fills grow both the entry tally and the live position.
                 if leg.filled_quantity + fill_delta > leg.spec.target_quantity:
                     raise ValueError("open fills exceed the leg target quantity")
                 new_entry_filled += fill_delta
                 new_entry_remaining = leg.spec.target_quantity - new_entry_filled
                 new_live_quantity += fill_delta
             else:
+                # Close fills only shrink the live position; the entry tally
+                # keeps recording how much was ever opened.
                 if fill_delta > leg.confirmed_live_quantity:
                     raise ValueError("close fills exceed confirmed live quantity")
                 new_live_quantity -= fill_delta

--- a/Dependencies/market_data_health.py
+++ b/Dependencies/market_data_health.py
@@ -168,7 +168,12 @@ def newest_completed_minute_timestamp(
     *,
     now: datetime | None = None,
 ) -> datetime | None:
-    """Return the newest candle whose one-minute interval has completed."""
+    """Return the newest candle whose one-minute interval has completed.
+
+    Candles are stamped with their START minute, so the row stamped with the
+    CURRENT minute is still forming and is deliberately excluded -- freshness
+    is judged only on candles the market has finished printing.
+    """
 
     if frame is None or frame.empty or "timestamp" not in frame.columns:
         return None
@@ -184,7 +189,23 @@ def newest_completed_minute_timestamp(
 
 @dataclass(frozen=True)
 class MarketDataHealthSnapshot:
-    """Immutable worker-facing view of the current feed safety state."""
+    """Immutable worker-facing view of the current feed safety state.
+
+    - ``monitoring``            : False outside a live producer session; every
+                                  gate then passes so offline tools/backtests
+                                  are unaffected.
+    - ``entry_allowed``         : True only when the feed is currently healthy
+                                  AND has been healthy for the required streak
+                                  of producer refreshes (recovery hysteresis).
+    - ``liquidation_required``  : True once the feed has been continuously
+                                  unhealthy past the liquidation deadline --
+                                  live workers must start flattening.
+    - ``healthy_streak``        : consecutive healthy producer refreshes.
+    - ``unhealthy_seconds``     : how long the current unhealthy episode has
+                                  lasted (0 while healthy).
+    - ``reasons``               : operator-readable explanations, empty when
+                                  healthy.
+    """
 
     monitoring: bool
     entry_allowed: bool
@@ -195,7 +216,29 @@ class MarketDataHealthSnapshot:
 
 
 class MarketDataHealth:
-    """Track freshness, recovery hysteresis, and the liquidation deadline."""
+    """Track freshness, recovery hysteresis, and the liquidation deadline.
+
+    Beginner's map of the timing rules (all configurable via ``__init__``):
+
+    - An LTP older than **10s** or a newest completed 1-minute bar older than
+      **90s** marks the whole feed unhealthy.  90s (not 60s) for the bar
+      because a candle stamped 09:20 only COMPLETES at 09:21, and the producer
+      then needs a poll cycle to fetch it -- 90s is "one full candle plus
+      slack", while 60s would false-alarm every minute boundary.
+    - Unhealthy for **30s** continuously -> ``liquidation_required``: a blip
+      should not dump positions, but half a minute without prices means live
+      stops/targets are flying blind, so tracked exposure must come off.
+    - Recovery needs **3 consecutive healthy refreshes** before entries
+      resume.  A single good poll right after an outage is often the first
+      gasp of a flapping connection; the streak requirement stops the gate
+      from oscillating open/closed ("hysteresis").
+
+    Two entry points feed the same state: the producer calls
+    ``record_refresh`` once per fetch cycle (the only place the healthy streak
+    can ADVANCE), while workers call ``snapshot`` on their own schedule (which
+    re-evaluates ages so a silently WEDGED producer still goes stale on time
+    -- see the ``snapshot`` docstring).
+    """
 
     def __init__(
         self,
@@ -263,20 +306,36 @@ class MarketDataHealth:
             }
             reasons = self._reasons_locked(now_ist)
             if reasons:
+                # Any problem resets the recovery streak to zero and pins the
+                # START of the unhealthy episode (kept, not overwritten, so the
+                # 30s liquidation clock measures the WHOLE outage).
                 self._healthy_streak = 0
                 if self._unhealthy_since is None:
                     self._unhealthy_since = now_ist
             else:
+                # Only a producer refresh may advance the streak: three healthy
+                # WORKER polls in the same second prove nothing new about the
+                # feed, three healthy PRODUCER cycles do.
                 self._healthy_streak += 1
                 self._unhealthy_since = None
             return self._snapshot_locked(now_ist, reasons)
 
     def snapshot(self, *, now: datetime | None = None) -> MarketDataHealthSnapshot:
-        """Evaluate current ages so a silent producer becomes stale on time."""
+        """Evaluate current ages so a silent producer becomes stale on time.
+
+        This deliberately re-runs the age checks against ``now`` instead of
+        replaying the producer's last verdict: if the fetcher thread wedges and
+        never calls ``record_refresh`` again, its final (healthy) result would
+        otherwise stay "fresh" forever.  Recomputing here means the stored
+        timestamps age naturally and the gates fail closed on schedule even
+        when the producer has gone completely quiet.
+        """
 
         now_ist = _as_aware_ist(now or datetime.now(IST))
         with self._lock:
             if not self._monitoring:
+                # No live producer session: every gate passes so backtests and
+                # offline diagnostics are unaffected by freshness rules.
                 return MarketDataHealthSnapshot(
                     monitoring=False,
                     entry_allowed=True,
@@ -287,6 +346,9 @@ class MarketDataHealth:
                 )
             reasons = self._reasons_locked(now_ist)
             if reasons:
+                # Same episode bookkeeping as record_refresh -- but note the
+                # healthy branch does NOT advance the streak here: only the
+                # producer's own refreshes count as recovery evidence.
                 self._healthy_streak = 0
                 if self._unhealthy_since is None:
                     self._unhealthy_since = now_ist
@@ -295,6 +357,7 @@ class MarketDataHealth:
             return self._snapshot_locked(now_ist, reasons)
 
     def _reasons_locked(self, now: datetime) -> tuple[str, ...]:
+        """Collect every current problem; an empty tuple means healthy."""
         reasons: list[str] = []
         if not self._refresh_ok:
             reasons.append("latest OHLC refresh failed")
@@ -302,6 +365,9 @@ class MarketDataHealth:
             reasons.append("newest completed one-minute bar is unavailable")
         else:
             bar_age = (now - self._newest_completed_bar).total_seconds()
+            # A slightly future timestamp is normal clock skew; more than 5s
+            # ahead means the feed's clock (or an epoch-unit bug) cannot be
+            # trusted, which is just as unsafe as stale data.
             if bar_age < -5.0:
                 reasons.append("newest completed one-minute bar is in the future")
             elif bar_age > self._bar_max_age:
@@ -324,6 +390,7 @@ class MarketDataHealth:
         now: datetime,
         reasons: tuple[str, ...],
     ) -> MarketDataHealthSnapshot:
+        """Freeze the two gate decisions into one immutable, coherent view."""
         unhealthy_seconds = (
             max(0.0, (now - self._unhealthy_since).total_seconds())
             if self._unhealthy_since is not None
@@ -332,6 +399,10 @@ class MarketDataHealth:
         healthy = not reasons
         return MarketDataHealthSnapshot(
             monitoring=self._monitoring,
+            # Entries need BOTH currently-healthy and a full recovery streak;
+            # liquidation needs BOTH currently-unhealthy and a full 30s episode.
+            # The asymmetry is deliberate: reopening entries is the risky
+            # direction, so it carries the extra hysteresis requirement.
             entry_allowed=healthy and self._healthy_streak >= self._recovery_refreshes,
             liquidation_required=bool(
                 reasons and unhealthy_seconds >= self._liquidation_after

--- a/Dependencies/next_open_entry.py
+++ b/Dependencies/next_open_entry.py
@@ -100,6 +100,10 @@ class PendingNextOpenEntry:
         assert setup_stop is not None
         assert setup_target is not None
 
+        # Geometry check: a LONG only makes sense with the stop BELOW the
+        # entry and the target ABOVE it (mirrored for SHORT).  Anything else
+        # means the signal engine handed over levels that would fill as an
+        # instant stop-out or an instant "win" -- refuse them at the source.
         if normalized_direction == "LONG":
             valid_geometry = setup_stop < setup_entry < setup_target
             stop_distance = setup_entry - setup_stop
@@ -111,6 +115,10 @@ class PendingNextOpenEntry:
         if not valid_geometry:
             raise ValueError("setup entry/stop/target geometry is invalid")
 
+        # Candles are stamped by their START minute: the signal candle stamped
+        # 09:20 completes at 09:25, so its "next open" is the bar STAMPED
+        # 09:25 -- one full timeframe after the signal stamp.  The intent then
+        # expires one further bar later (see the module docstring).
         bar = timedelta(minutes=timeframe_minutes)
         expected_open_at = signal_at + bar
         return cls(
@@ -147,12 +155,20 @@ class PendingNextOpenEntry:
 
         if not isinstance(observed_at, datetime):
             return None
+        # EXACT slot equality, not >=: a later bar means the intended entry
+        # moment was missed (a feed gap or a slow poll), and executing on a
+        # substitute bar would be a different trade from the one the setup
+        # described.  The caller keeps the intent queued until it expires.
         if observed_at != self.expected_open_at:
             return None
         entry = _finite_price(observed_entry)
         if entry is None:
             return None
 
+        # Shift the ORIGINAL stop/target distances onto the actually observed
+        # open, then re-check geometry: a large opening gap can push the
+        # rebased stop to zero/negative territory, which the finite-positive
+        # check below turns into a refusal rather than a nonsense order.
         if self.direction == "LONG":
             stop = entry - self.stop_distance
             target = entry + self.target_distance

--- a/Dependencies/risk_sizing.py
+++ b/Dependencies/risk_sizing.py
@@ -5,6 +5,24 @@ lot.  Both behaviours can exceed the configured budget.  ``SizingDecision``
 is the single authority used by the master runner and the standalone SL
 Hunting executor: invalid inputs and one-lot-over-budget setups are explicit
 rejections, while accepted trades use ``floor`` with a configurable lot cap.
+
+Beginner's walkthrough of why floor-and-reject, with a worked example
+(budget Rs.2500, NIFTY lot 75, entry 24300, stop 24290 -> 10-point risk):
+
+- one lot risks 10 * 75 = Rs.750, so floor(2500 / 750) = **3 lots**
+  (Rs.2250 worst case, inside the budget).
+- the old ``ceil`` gave 4 lots = Rs.3000 worst case -- 20% OVER the budget
+  the operator configured, on every single trade with an awkward stop.
+- with a 40-point stop, one lot risks Rs.3000 > budget.  The old "minimum
+  one lot" still traded it; this module REJECTS it, because a budget that
+  silently stretches for wide stops is not a budget at all.  A skipped
+  setup costs an opportunity; an oversized one costs real money.
+
+The rupee-risk proxy is deliberately simple: ``|entry - stop| * lot_size``
+measures the UNDERLYING's move as if the option gained/lost point-for-point
+(delta ~= 1).  Real ATM option deltas are nearer 0.5, so this proxy usually
+OVERSTATES the risk -- conservative in exactly the direction a hard limit
+should be.
 """
 
 from __future__ import annotations
@@ -28,7 +46,13 @@ def _finite_number(value: Any) -> float | None:
 
 @dataclass(frozen=True, slots=True)
 class SizingDecision:
-    """Immutable explanation of an accepted or rejected position size."""
+    """Immutable explanation of an accepted or rejected position size.
+
+    Every field the sizing maths used is carried on the decision itself, so a
+    log line or Telegram alert can show WHY a trade was sized (or skipped)
+    without re-deriving anything.  ``accepted=False`` always comes with
+    ``lots=0``/``quantity=0`` -- callers never need to double-check.
+    """
 
     accepted: bool
     lots: int
@@ -106,6 +130,11 @@ class SizingDecision:
         The spot-distance proxy is conservative and intentionally unchanged:
         ``one_lot_risk = abs(entry - stop) * lot_size``.  What changes is the
         hard-limit policy—there is no fallback lot and no rounding upward.
+
+        The validation ladder below runs most-fundamental-first (budget, then
+        lot size, then cap, then prices, then stop distance) so the rejection
+        ``reason`` always names the FIRST thing the operator must fix, and
+        each rejection carries whatever figures were already validated.
         """
 
         normalized_budget = _finite_number(budget)

--- a/Dependencies/startup_exposure.py
+++ b/Dependencies/startup_exposure.py
@@ -56,7 +56,16 @@ def _read_typed_book[BookItem: (OpenOrder, OpenPosition)](
     query: Callable[[], object],
     item_type: type[BookItem],
 ) -> tuple[BookItem, ...] | None:
-    """Return a validated book, or ``None`` for any ambiguous outcome."""
+    """Return a validated book, or ``None`` for any ambiguous outcome.
+
+    ``None`` never means "empty" here -- an empty-but-successful book is the
+    empty tuple.  ``None`` means "could not be proven", which the caller
+    treats exactly like exposure.  The type checks below look paranoid on
+    purpose: this function is the last line between an adapter bug (or a
+    monkeypatched test double drifting from the contract) and the decision to
+    let real orders start, so any shape that is not literally the contract's
+    is refused rather than coerced.
+    """
 
     try:
         result = query()
@@ -65,6 +74,8 @@ def _read_typed_book[BookItem: (OpenOrder, OpenPosition)](
 
     if not isinstance(result, BrokerQueryResult):
         return None
+    # ``type(...) is not bool`` rather than truthiness: a mock returning a
+    # truthy non-bool (e.g. a MagicMock) must not read as "determinate".
     if type(result.is_indeterminate) is not bool:  # bool is intentional here.
         return None
     if not isinstance(result.items, tuple):
@@ -73,6 +84,8 @@ def _read_typed_book[BookItem: (OpenOrder, OpenPosition)](
         return None
     if result.is_indeterminate:
         return None
+    # Every element must be the exact typed item -- one foreign object means
+    # the whole snapshot cannot be trusted.
     if any(not isinstance(item, item_type) for item in result.items):
         return None
     return result.items

--- a/Dependencies/test_broker_contract.py
+++ b/Dependencies/test_broker_contract.py
@@ -16,6 +16,7 @@ import importlib
 import importlib.util
 import io
 import json
+import logging
 import re
 import subprocess  # nosec B404 - used only to import this repo's own adapters
 import sys
@@ -3487,6 +3488,98 @@ def test_dhan_login_fails_closed_without_credentials(
     client = dhan_module.DhanExecutionClient()
 
     assert client.ensure_logged_in() is False
+
+
+def test_dhan_login_failure_never_logs_the_access_token(
+    dhan_module: ModuleType,
+    monkeypatch,
+    caplog,
+) -> None:
+    """MAT-108 parity: a token-bearing construction error must be redacted.
+
+    The exception message here deliberately does NOT look like a
+    ``token=value`` assignment, so only the known-secret replacement can
+    scrub it -- proving the adapter passes the real token to ``redact_text``
+    rather than relying on the pattern pass getting lucky.
+    """
+
+    canary = "CANARY-DHAN-ACCESS-TOKEN"
+
+    class _LeakyContext:
+        def __init__(self, client_id, access_token) -> None:
+            raise RuntimeError(f"handshake rejected for {access_token} by gateway")
+
+    monkeypatch.setenv("DHAN_CLIENT_CODE", "1000000001")
+    monkeypatch.setenv("DHAN_ACCESS_TOKEN", canary)
+    monkeypatch.setattr(dhan_module, "DhanContext", _LeakyContext)
+
+    client = dhan_module.DhanExecutionClient()
+    with caplog.at_level(logging.ERROR):
+        assert client.ensure_logged_in() is False
+
+    assert canary not in caplog.text
+    assert "<redacted>" in caplog.text
+
+
+def test_dhan_logout_clears_local_session_state(
+    dhan_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """Logout is local-only: close the pool and erase every session cache."""
+
+    class _Session:
+        def __init__(self) -> None:
+            self.closed = 0
+
+        def close(self) -> None:
+            self.closed += 1
+
+    class _Http:
+        def __init__(self) -> None:
+            self.session = _Session()
+
+    class _Context:
+        def __init__(self) -> None:
+            self.http = _Http()
+
+        def get_dhan_http(self):
+            return self.http
+
+    client = _ready_dhan_client(dhan_module, monkeypatch, _FakeDhanSdk([]))
+    context = _Context()
+    client._context = context
+    client._symbol_cache[("NIFTY",)] = DHAN_SYMBOL
+
+    result = client.logout()
+
+    assert result["status"] == "success"
+    assert context.http.session.closed == 1
+    assert client.is_logged_in is False
+    assert client.client is None
+    assert client._context is None
+    assert client._symbol_cache == {}
+    assert client._security_id_by_symbol == {}
+    assert client._scrip_df is None
+
+
+def test_dhan_logout_survives_a_failing_session_close(
+    dhan_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """A pool that will not close still ends with a cleared local session."""
+
+    class _BrokenContext:
+        def get_dhan_http(self):
+            raise RuntimeError("connection pool already torn down")
+
+    client = _ready_dhan_client(dhan_module, monkeypatch, _FakeDhanSdk([]))
+    client._context = _BrokenContext()
+
+    result = client.logout()
+
+    assert result["status"] == "success"
+    assert client.client is None
+    assert client.is_logged_in is False
 
 
 def test_dhan_total_deadline_includes_lock_wait(

--- a/Dependencies/test_dhan_token_setup.py
+++ b/Dependencies/test_dhan_token_setup.py
@@ -1,0 +1,69 @@
+"""Tests for the token-expiry advisory in the Dhan OAuth setup script.
+
+The three weekday messages steer a live operator's next action, so each case
+is locked in: mid-session expiry warns loudly, pre-open expiry gets the calmer
+"session not covered" note, and post-close expiry is reported as the good
+outcome.  Timestamps are built from the LOCAL clock (the same clock the helper
+renders with), which keeps the tests deterministic on an IST box and on a UTC
+CI runner alike.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from datetime import datetime, timedelta
+
+from Dependencies.dhan_token_setup import _describe_token_expiry
+
+
+def _token_with_exp(expires_at: datetime) -> str:
+    """Build a JWT-shaped token whose middle segment carries ``exp``."""
+    payload = (
+        base64.urlsafe_b64encode(
+            json.dumps({"exp": int(expires_at.timestamp())}).encode("utf-8")
+        )
+        .decode("ascii")
+        .rstrip("=")
+    )
+    return f"header.{payload}.signature"
+
+
+def _upcoming_weekday_at(hour: int, minute: int, *, weekday: int = 0) -> datetime:
+    """Return the NEXT occurrence of ``weekday`` (0=Monday) at HH:MM local time."""
+    now = datetime.now().astimezone()
+    days_ahead = (weekday - now.weekday()) % 7 or 7
+    return (now + timedelta(days=days_ahead)).replace(
+        hour=hour, minute=minute, second=0, microsecond=0
+    )
+
+
+def test_mid_session_weekday_expiry_warns_during_market_hours():
+    expiry = _upcoming_weekday_at(11, 0)
+    text = _describe_token_expiry(_token_with_exp(expiry))
+    assert "DURING market hours" in text
+
+
+def test_pre_open_weekday_expiry_notes_uncovered_session_not_market_hours():
+    expiry = _upcoming_weekday_at(8, 0)
+    text = _describe_token_expiry(_token_with_exp(expiry))
+    assert "DURING market hours" not in text
+    assert "BEFORE that day's 09:15 open" in text
+
+
+def test_post_close_weekday_expiry_reports_the_session_as_covered():
+    expiry = _upcoming_weekday_at(17, 0)
+    text = _describe_token_expiry(_token_with_exp(expiry))
+    assert "DURING market hours" not in text
+    assert "covers that" in text
+
+
+def test_weekend_expiry_carries_no_session_message():
+    expiry = _upcoming_weekday_at(11, 0, weekday=6)  # next Sunday, mid-day
+    text = _describe_token_expiry(_token_with_exp(expiry))
+    assert text.startswith("Token expires ")
+    assert "\n" not in text
+
+
+def test_non_jwt_token_degrades_to_an_unknown_validity_note():
+    assert "unknown" in _describe_token_expiry("not-a-jwt")

--- a/Dependencies/test_secret_redaction.py
+++ b/Dependencies/test_secret_redaction.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 import io
 import logging
 
-from Dependencies.secret_redaction import REDACTED, RedactingFilter, redact_payload, redact_text
+from Dependencies.secret_redaction import (
+    REDACTED,
+    RedactingFilter,
+    install_redaction_filter,
+    redact_payload,
+    redact_text,
+)
 
 
 def test_recursive_redaction_covers_broker_and_identity_fields():
@@ -47,3 +53,38 @@ def test_debug_and_exception_records_never_emit_canary_secrets():
     output = stream.getvalue()
     assert secret not in output
     assert REDACTED in output
+
+
+def test_redaction_reaches_secrets_inside_tuples_and_sets():
+    """Broker payloads can nest sequences; every container type is walked."""
+    payload = (
+        "password=CANARY-TUPLE",
+        {"CANARY-SET-SECRET", "harmless"},
+        ["token=CANARY-LIST"],
+    )
+    safe = redact_payload(payload, ("CANARY-SET-SECRET",))
+    rendered = repr(safe)
+    assert "CANARY" not in rendered
+    assert isinstance(safe, tuple)
+    assert isinstance(safe[1], set)
+
+
+def test_install_redaction_filter_covers_logger_and_existing_handlers():
+    """One install call must guard both the logger and its current handlers."""
+    secret = "CANARY-INSTALL-SECRET"
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    logger = logging.getLogger("mat110.install.canary")
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+
+    install_redaction_filter(logger, [secret])
+    logger.debug("session token is %s somewhere in this line", secret)
+
+    output = stream.getvalue()
+    assert secret not in output
+    assert REDACTED in output
+    # The guard sits on the handler too, so records that reach the handler
+    # directly (propagated from child loggers) are also scrubbed.
+    assert any(isinstance(f, RedactingFilter) for f in handler.filters)

--- a/Dependencies/trading_lifecycle.py
+++ b/Dependencies/trading_lifecycle.py
@@ -147,6 +147,10 @@ class TradingLifecycle:
                 self._state = LifecycleState.FLAT
                 self._next_retry_at = None
             elif self._next_retry_at is None:
+                # Capped backoff: attempt 1 retries after 1s, attempt 2 after
+                # 2s, attempt 3 AND EVERY LATER attempt after 5s.  The cap is
+                # deliberate -- unlike a network backoff this loop is trying to
+                # CLOSE live exposure, so it must never back off into minutes.
                 delay_index = min(
                     self._flatten_attempts - 1,
                     len(_RETRY_DELAYS_SECONDS) - 1,

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_coach.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_coach.py
@@ -258,6 +258,13 @@ def summarize_journal(rows: list[dict[str, Any]], limit: int = 60) -> str:
     )
 
     # Build newest-first against the total character budget, then restore chronology.
+    #
+    # How the loop works: each iteration PREPENDS one older trade to the
+    # candidate list and renders the whole block.  If that render busts the
+    # character budget, the loop stops and keeps ``included`` -- the largest
+    # set that fit.  Walking newest-first means the trades sacrificed to the
+    # budget are always the OLDEST ones, and because each accepted candidate
+    # was prepended, ``included`` is already back in chronological order.
     included: list[dict[str, Any]] = []
     for trade in reversed(recent):
         candidate = [trade.model_dump(mode="json"), *included]
@@ -286,7 +293,14 @@ def summarize_journal(rows: list[dict[str, Any]], limit: int = 60) -> str:
 
 
 def _build_read_only_options(model: str, system_prompt: str, max_turns: int) -> dict[str, Any]:
-    """Build the coach SDK options with every tool surface explicitly disabled."""
+    """Build the coach SDK options with every tool surface explicitly disabled.
+
+    Both ``tools`` and ``allowed_tools`` are empty ON PURPOSE (belt and
+    braces): the journal text the coach reads is untrusted, so even a
+    perfectly injected "run this tool" instruction has no tool to run.
+    ``setting_sources`` is empty so no local settings file can quietly
+    re-enable one.
+    """
     return {
         "model": model,
         "system_prompt": system_prompt,

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_lessons.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_lessons.py
@@ -215,7 +215,21 @@ def _now() -> str:
 
 
 def lesson_content_digest(record: StoredLesson | dict[str, Any]) -> str:
-    """Return the canonical digest that binds operator approval to lesson content."""
+    """Return the canonical digest that binds operator approval to lesson content.
+
+    What the digest is FOR: the operator approves a lesson by reading its exact
+    text.  If the stored file were later edited (by a bug, a merge, or a
+    prompt-injection-shaped payload), the approved id would silently point at
+    words the operator never reviewed -- and those words are injected into the
+    live agent's prompt.  ``StoredLesson`` therefore recomputes this digest on
+    every load and rejects any approved record whose content no longer matches.
+
+    Only the reviewed CONTENT participates (id, scope, lesson, rationale,
+    evidence, confidence).  Timestamps and status are deliberately excluded so
+    a harmless metadata touch cannot invalidate a genuine approval.  The
+    canonical JSON form (sorted keys, fixed separators) makes the digest
+    stable regardless of dict ordering or formatting.
+    """
     source = record.model_dump(mode="json") if isinstance(record, StoredLesson) else record
     evidence = source.get("evidence") or {}
     content = {
@@ -296,6 +310,8 @@ def save_lessons(path: str, lessons: list[dict[str, Any]]) -> None:
     see either the previous complete store or the new complete store, never a partially
     written JSON document after a crash.
     """
+    # Validate BEFORE opening any file: a malformed record must fail loudly
+    # here rather than half-replace the store.
     validated = [
         StoredLesson.model_validate(record).model_dump(mode="json", exclude_none=True)
         for record in lessons
@@ -303,6 +319,9 @@ def save_lessons(path: str, lessons: list[dict[str, Any]]) -> None:
     parent = os.path.dirname(path)
     if parent:
         os.makedirs(parent, exist_ok=True)
+    # The temp file must live in the SAME directory as the target: os.replace
+    # is atomic only within one filesystem, and a cross-device rename would
+    # degrade to the copy-then-delete window this function exists to remove.
     directory = parent or "."
     descriptor, temporary_path = tempfile.mkstemp(
         prefix=f".{os.path.basename(path)}.", suffix=".tmp", dir=directory, text=True
@@ -311,10 +330,15 @@ def save_lessons(path: str, lessons: list[dict[str, Any]]) -> None:
         with os.fdopen(descriptor, "w", encoding="utf-8") as file_handle:
             json.dump(validated, file_handle, indent=2, ensure_ascii=False)
             file_handle.write("\n")
+            # flush() pushes Python's buffer to the OS; fsync() pushes the OS
+            # buffer to disk. Only after BOTH is the temp file guaranteed
+            # complete on disk, making the replace below crash-safe.
             file_handle.flush()
             os.fsync(file_handle.fileno())
         os.replace(temporary_path, path)
     finally:
+        # On success the temp path no longer exists (it BECAME the store); on
+        # any failure this removes the orphaned partial file.
         if os.path.exists(temporary_path):
             os.unlink(temporary_path)
 
@@ -328,14 +352,23 @@ def consolidate(lessons: list[dict[str, Any]], max_lessons: int = MAX_LIVE_LESSO
     """De-duplicate by id (keep the better-evidenced copy), rank by sample size then
     recency, and cap at `max_lessons` — so the store stays bounded and non-contradictory."""
     by_id: dict[str, dict[str, Any]] = {}
+    # Strict validation first: consolidation is a write-path chokepoint (both
+    # add_proposed and promote funnel through it), so a malformed record dies
+    # here instead of ever reaching the saved store.
     validated, _rejected = _validated_records(lessons)
     for lesson in validated:
         lid = lesson.get("id")
         if not lid:
             continue
+        # Same slug = same lesson text seen across coach runs.  Keep the copy
+        # backed by MORE trades: growing evidence should win, and a rerun on a
+        # shrunken journal must not downgrade a well-supported lesson.
         prev = by_id.get(lid)
         if prev is None or _sample(lesson) > _sample(prev):
             by_id[lid] = lesson
+    # Rank best-evidenced first (recency breaks ties), then cap: with a
+    # bounded list, a new well-supported lesson naturally evicts the weakest
+    # one, keeping the prompt block a stable size forever.
     ranked = sorted(
         by_id.values(),
         key=lambda rec: (_sample(rec), str(rec.get("updated_at", ""))),

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_tools.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_tools.py
@@ -99,7 +99,23 @@ CONTEXT_TOOL_NAMES = [
 
 
 class ToolContextState(StrEnum):
-    """Lifecycle of the one side-effect capability granted to an agent pass."""
+    """Lifecycle of the one side-effect capability granted to an agent pass.
+
+    The transitions, in plain English:
+
+    - ``ACTIVE``    : the pass may still place its one order.  Rejected
+                      validation attempts return here so the model can
+                      correct its levels within the same pass.
+    - ``EXECUTING`` : an order is inside the executor right now -- a second
+                      call arriving mid-flight is refused, never queued.
+    - ``CONSUMED``  : an ACCEPTED side effect happened.  Terminal: one pass
+                      gets at most one accepted ENTER or EXIT, ever.
+    - ``EXPIRED``   : the decision window closed (deadline, stale generation,
+                      mechanical exit, or the pass simply finished) before an
+                      accepted action.  Terminal: a late tool call from an
+                      abandoned SDK loop finds a dead capability, not a
+                      market order.
+    """
 
     ACTIVE = "ACTIVE"
     EXECUTING = "EXECUTING"
@@ -283,6 +299,13 @@ class SLHuntingToolContext:
         else:
             return {"accepted": False, "reason": f"unknown action {action!r}; expected ENTER_LONG, ENTER_SHORT or EXIT"}
 
+        # The final gate.  The freshness checks (state, generation, deadline)
+        # run INSIDE the same lock that serializes the executor call, because
+        # checking first and locking second would leave a gap: the mechanical
+        # risk loop could invalidate this pass between the check and the
+        # order.  Inside the lock, what was checked is what executes.  This is
+        # also the lock the worker's stop/target/square-off paths hold while
+        # THEY act, so an agent order and a mechanical exit can never race.
         with self._execution_lock:
             refusal = self._refusal_inside_lock()
             if refusal is not None:
@@ -291,6 +314,8 @@ class SLHuntingToolContext:
             try:
                 result = executor_call()
             except BaseException:
+                # An executor that blew up mid-order leaves unknown exposure;
+                # this pass must not get a second try at it.
                 self.expired_reason = "executor raised"
                 self.state = ToolContextState.EXPIRED
                 raise

--- a/scripts/check_coverage_thresholds.py
+++ b/scripts/check_coverage_thresholds.py
@@ -20,12 +20,20 @@ SAFETY_THRESHOLDS = {
     "Dependencies/market_data_health.py": 90.0,
     "Dependencies/next_open_entry.py": 90.0,
     "Dependencies/risk_sizing.py": 90.0,
+    # MAT-108's redaction layer is data-safety code: a regression here leaks
+    # credentials into logs, so it carries the same 90% budget.
+    "Dependencies/secret_redaction.py": 90.0,
 }
 
+# EVERY live execution adapter belongs in this dict. A broker added without a
+# row here silently escapes the "80% per broker adapter" policy that
+# CLAUDE.md/AGENTS.md promise (exactly what happened when the Dhan adapter
+# first landed), so treat this list as part of adding a broker.
 BROKER_THRESHOLDS = {
     "Dependencies/Kotak API/kotak_execution.py": 80.0,
     "Dependencies/Shoonya API/shoonya_execution.py": 80.0,
     "Dependencies/Flattrade API/flattrade_execution.py": 80.0,
+    "Dependencies/Dhan API/dhan_execution.py": 80.0,
 }
 
 

--- a/scripts/check_coverage_thresholds.py
+++ b/scripts/check_coverage_thresholds.py
@@ -3,6 +3,13 @@
 Coverage.py's ``percent_covered`` combines statements and measured branch exits.
 The CI run enables branch measurement globally, then this script applies stricter
 budgets to the live-money safety core and each broker adapter.
+
+Why this script exists at all: Coverage.py has exactly ONE global
+``fail_under`` setting (pyproject pins it to the repository's 54.7% baseline),
+so the stricter 90%/80% per-module budgets have to be enforced from the JSON
+report by hand.  The split is deliberate -- the global floor stops overall
+erosion, while these budgets stop a specific safety module from quietly losing
+its tests.
 """
 
 from __future__ import annotations
@@ -62,13 +69,21 @@ def evaluate_coverage(
         path = _portable_path(raw_path)
         details = files.get(path)
         if details is None:
+            # A renamed/deleted module must FAIL the gate, not silently drop
+            # out of it -- otherwise moving a file would retire its budget.
             failures.append(f"{path}: missing from coverage report")
             continue
         summary = details.get("summary") or {}
         if int(summary.get("num_branches", 0)) <= 0:
+            # Percent alone can look fine while branch measurement was never
+            # switched on (a broken [tool.coverage.run] branch=true would
+            # silently weaken every budget). Zero measured branches in modules
+            # this size is only ever a measurement failure.
             failures.append(f"{path}: branch data was not measured")
             continue
         measured = float(summary.get("percent_covered", 0.0))
+        # The epsilon keeps an exactly-on-budget module passing despite float
+        # representation (e.g. a true 80.0 stored as 79.999...).
         if measured + 1e-9 < float(threshold):
             failures.append(
                 f"{path}: {measured:.2f}% is below the {float(threshold):.1f}% budget"


### PR DESCRIPTION
## Final review of the MAT stack (MAT-101…MAT-110) — verdict: Approve

Full re-review of the stack at its current head, including MAT-110 (#69) with its Dhan execution client (#70) and diagnostics fixes (#72), plus structured code-review and security-review passes over the entire main→stack diff (~30k lines). This PR carries the two small fixes those passes surfaced and the final beginner-friendly documentation pass.

### Review summary

- **Stack integrity**: the 07-18 restack was verified clean (delta = main's v3m/v3n + Profit Shooter 5m only); all four fixes from PR #66 survived; the full stack merges cleanly onto current main (v3n included).
- **PR #67** (health gates live-only): clean, operator-decided, tested in both directions.
- **Dhan adapter**: follows every established safety pattern (10s deadline executor, session poisoning, order gate, transient-state fill polling, `TERMINAL_BROKER_STATES`) and adds correlation-ID recovery the other brokers lack. The `_classify_envelope` handling of the SDK's rejection-shaped transport failures is exactly right. Conformance tests cover every MAT-101 acceptance scenario.
- **MAT-110 infra**: pip-audit + pip check + Dependabot, branch coverage (54.7% floor in pyproject + per-module policy script), isolated broker-deps CI job, exact requirement sets. CI now installs `requirements-ai.txt`, closing the gap that previously let stale SL-Hunting tests hide.
- **Security lenses**: no dangerous patterns in the delta; all token-adjacent logging routes through `secret_redaction` (with the one exception fixed below); no injection/SSRF surfaces; Dhan lock discipline mirrors the proven adapter shape.

### Fixes in this PR

1. **Dhan adapter added to the 80% broker coverage budget** (`scripts/check_coverage_thresholds.py`). It was the only adapter missing from `BROKER_THRESHOLDS` — and it measured **79.42%**, i.e. it would have failed the gate it escaped. `secret_redaction` (83.58%, no budget) is now under the 90% safety budget too. New tests close both gaps: Dhan `logout()` (the whole body was unmeasured) incl. the failing-pool branch, tuple/set redaction, and `install_redaction_filter`.
2. **Dhan login/validation error logs now redacted** (MAT-108 parity). `_login_locked` logged the raw SDK construction exception — whose arguments include the access token — and `_validate_session_locked` logged the raw envelope reason. Both now route through `redact_text` (token passed as a known secret), with a canary test whose leaked-token message deliberately does *not* match the pattern pass, proving the known-secret path works.
3. **Token-expiry advisory made three-way** (`dhan_token_setup.py`). The old warning said "that is DURING market hours" for ANY weekday expiry before 15:30 — including a pre-open expiry, where the wording is wrong. Now: 09:15–15:30 keeps the loud warning; before 09:15 gets a calmer "that day's session is not covered, re-mint before trading" note; after 15:30 is reported as the good outcome. New timezone-portable tests lock in all three messages plus the weekend and non-JWT paths.
4. **Final docs pass** (comments/docstrings only, **verified by docstring-stripped AST comparison of all 11 touched files — identical**): the freshness state machine in `market_data_health`, floor-sizing rationale in `risk_sizing`, digest binding + atomic saves in `sl_hunting_lessons`, delta accounting in `execution_ledger`, the tool-context state machine in `sl_hunting_tools`, the coach's budget/escape loop, `startup_exposure`'s paranoid checks, Flattrade's token-exchange recipe, the lifecycle backoff cap, and the coverage policy script.

### Verification

- `python -m unittest test_nifty_multi_strategy_master` — 325 tests, OK (claude-agent-sdk + TA-Lib installed, nothing skips)
- CI-equivalent coverage pipeline — 617 pytest cases; overall 67.0% (floor 54.7%); **coverage policy passed for all safety and broker modules** including the two new budgets
- ruff, mypy (37 files), compileall, CI-equivalent Bandit — all clean

### Accepted observations (no change)

- Kotak's lazy scrip-master fallback (60s budget) can block a concurrent order's SDK gate in the rare failed-preload-then-concurrent-first-orders case; startup preload keeps it off the hot path (per #72's reasoning).

## Ship checklist

1. **Merge order** (bottom-up, delete each head branch; GitHub retargets the children automatically): merge **this PR into #69's branch first**, then #54 → #56 → #59 → #60 → #61 → #62 → #63 → #64 → #65 → #69.
2. **Before the next live session**:
   - `pip install TA-Lib==0.6.8` on the live box (hard dependency once #62 merges).
   - **Add `<Strategy> [LIVE]` and `<Strategy> [MIXED]` rows to the P&L Google Sheet** for any strategy that may trade live — the new telemetry writes live/mixed results to those dedicated rows and only *warns* if they don't exist.
   - If `LIVE_BROKER=DHAN`: mint the access token **outside market hours every trading day** (web-issued tokens are 24h; the setup script now prints the real expiry).
3. **Run one full paper session** with all strategies enabled before re-enabling any live flag (the backlog's own delivery gate); watch for stale-data, reconciliation, sizing, or shutdown alerts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
