### PR TITLE
Tune Dependabot for policy-pinned deps; take the safe weekly bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,35 @@ updates:
       python-runtime:
         patterns:
           - "*"
+    # Packages Dependabot must NOT propose, because its grouped bump would be
+    # un-mergeable by policy (each reason below is enforced by CI, so an
+    # auto-bump only produces a red PR -- exactly what happened in PR #76):
+    ignore:
+      # Kotak's official v2.0.1 tag hard-depends on websocket-client==1.8.0,
+      # and pyotp rides in the same isolated broker environment. Bump these
+      # only together with a new validated Kotak SDK tag.
+      - dependency-name: "websocket-client"
+      - dependency-name: "pyotp"
+      # MAT-106 pins the exact TA-Lib build as the deterministic indicator
+      # backend for every strategy. A version change can shift warm-up and
+      # smoothing semantics, so it is bumped deliberately, with revalidation,
+      # never automatically.
+      - dependency-name: "ta-lib"
+      # The numeric core under pandas + TA-Lib. Patches are welcome; minor and
+      # major bumps can change floating-point behaviour across the indicator
+      # pipeline, so they follow the same deliberate path as TA-Lib.
+      - dependency-name: "numpy"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+      # Typing majors routinely break the mypy gate wholesale; take them as
+      # dedicated upgrades, not weekly noise.
+      - dependency-name: "mypy"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "pandas-stubs"
+        update-types:
+          - "version-update:semver-major"
 
   - package-ecosystem: github-actions
     directory: "/"

--- a/.github/workflows/quality-and-security.yml
+++ b/.github/workflows/quality-and-security.yml
@@ -113,7 +113,7 @@ jobs:
         # impossible combined dependency graph.
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest==9.0.3 -r requirements-brokers.txt
+          python -m pip install pytest==9.1.1 -r requirements-brokers.txt
           python -m pip check
 
       - name: Run broker contract and adapter suites

--- a/Dependencies/test_repository_policy.py
+++ b/Dependencies/test_repository_policy.py
@@ -29,13 +29,13 @@ def test_optional_dependency_sets_are_exact_and_kotak_uses_official_tag():
     ai = _requirement_lines("requirements-ai.txt")
     brokers = _requirement_lines("requirements-brokers.txt")
 
-    assert "requests==2.33.0" in core
+    assert "requests==2.34.2" in core
     assert "python-dotenv==1.2.2" in core
     # The full quality job imports the vendored Shoonya client while measuring
     # broker-adapter coverage, so its import-time WebSocket dependency belongs
     # in the core test/runtime environment as well as the isolated broker set.
     assert "websocket-client==1.8.0" in core
-    assert "claude-agent-sdk==0.2.115" in ai
+    assert "claude-agent-sdk==0.2.123" in ai
     assert "pydantic==2.13.4" in ai
     assert all("==" in line for line in ai)
     assert "pyotp==2.9.0" in brokers

--- a/requirements-ai.txt
+++ b/requirements-ai.txt
@@ -3,8 +3,8 @@
 # These versions are the Python 3.12/3.13 set validated by the MAT safety stack.
 # The first three packages are the Claude Agent SDK's direct runtime dependencies;
 # pinning them prevents a fresh install from silently changing the agent transport.
-claude-agent-sdk==0.2.115
-anyio==4.14.1
+claude-agent-sdk==0.2.123
+anyio==4.14.2
 mcp==1.28.1
 sniffio==1.3.1
 pydantic==2.13.4

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,15 +1,17 @@
 # Development / CI quality-gate tools (runtime deps live in requirements.txt).
 # Versions mirror the Streamlit Scanner App's verified set where shared.
-pytest==9.0.3
-ruff==0.15.1
+pytest==9.1.1
+ruff==0.15.22
 mypy==1.19.1
 bandit==1.9.4
 pre-commit==4.6.0
-coverage==7.14.1
+coverage==7.15.2
 pytest-cov==7.1.0
 pip-audit==2.10.1
 # Type stubs for typed third-party usage in the mypy scope. pandas-stubs is
 # pinned so local and CI mypy see the exact same pandas typing (an out-of-band
 # stubs install once made local mypy fail while CI stayed green).
-types-requests==2.33.0.20260518
+# mypy and pandas-stubs majors are deliberately NOT auto-bumped (see
+# .github/dependabot.yml); take them as dedicated typing upgrades.
+types-requests==2.33.0.20260712
 pandas-stubs==2.3.3.260113

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,8 +13,9 @@ python-dotenv==1.2.2
 gspread==6.2.1
 pytz==2026.2
 # The broker, symbol-master and Telegram HTTP paths all use requests. Keep this
-# at the first release that clears the repository audit after PYSEC-2026-2275.
-requests==2.33.0
+# at the newest release that clears the repository audit (2.33.0 was the first
+# past PYSEC-2026-2275; 2.34.2 is the current audited pin).
+requests==2.34.2
 # The vendored Shoonya client imports websocket at module load. Keep this
 # harmless, conflict-free import dependency in the core set so diagnostics and
 # the broker coverage suite work even before optional live credentials exist.


### PR DESCRIPTION
## Summary

Replaces Dependabot's un-mergeable grouped PR #76 with (a) ignore rules so Dependabot stops proposing bumps CI can never accept automatically, and (b) a deliberate adoption of this week's safe subset with the policy-test pins moved in lockstep — the workflow the MAT-110 gates were designed to enforce.

### Why #76 failed (all three failures were the gates working as intended)

1. **Broker-dependency jobs**: `neo-api-client` (Kotak's official v2.0.1 tag) hard-depends on `websocket-client==1.8.0`; the grouped bump to 1.9.0 made pip resolution impossible.
2. **`test_talib_is_an_exact_mandatory_runtime_dependency`**: TA-Lib 0.6.8 is MAT-106's deterministic indicator backend; 0.7.1 would silently swap indicator semantics for every strategy.
3. **`test_optional_dependency_sets_are_exact_and_kotak_uses_official_tag`**: the audited exact pins changed without review.

### Dependabot tuning (`.github/dependabot.yml`)

New `ignore` rules, each with its reason in the file: `websocket-client` + `pyotp` (locked to the Kotak v2.0.1 tag), `ta-lib` (determinism pin — deliberate bumps only), `numpy` minors/majors (numeric core; patches still flow), `mypy`/`pandas-stubs` majors (dedicated typing upgrades). Future weekly PRs should now contain only proposals that can actually go green.

### Safe subset taken (with policy pins updated in lockstep)

| Package | From → To | Notes |
|---|---|---|
| requests | 2.33.0 → 2.34.2 | current audited pin; comment updated |
| claude-agent-sdk | 0.2.115 → 0.2.123 | CI runs the full SL Hunting suites against it |
| anyio | 4.14.1 → 4.14.2 | SDK transport patch |
| pytest | 9.0.3 → 9.1.1 | also updated in the broker CI job's install line |
| ruff | 0.15.1 → 0.15.22 | |
| coverage | 7.14.1 → 7.15.2 | |
| types-requests | →2.33.0.20260712 | |

**Deliberately not taken**: TA-Lib 0.7.1, websocket-client 1.9.0, pyotp 2.10.0, numpy 2.5.1, mypy 2.3.0, pandas-stubs 3.x (now ignore-ruled or reserved for dedicated upgrades).

### Verification

- `Dependencies/test_repository_policy.py` + `Signal Generators/test_deterministic_strategy_safety.py` — 21 passed against the new pins
- Master unittest suite — 325 tests OK
- CI on this PR installs the NEW pins and runs every gate (including pip-audit and the SL Hunting suites on claude-agent-sdk 0.2.123) — that is the authoritative validation

### Operator note

The live box keeps running the old versions until you `pip install -r requirements.txt -r requirements-dev.txt -r requirements-ai.txt` — do that outside market hours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
