### PR TITLE
Groundwork: exchange freeze-limit order splitting (NOT wired - no behaviour change)

### DIFF
--- a/Dependencies/order_splitting.py
+++ b/Dependencies/order_splitting.py
@@ -1,0 +1,107 @@
+"""Split an oversized options order into exchange-legal chunks.
+
+NSE caps how much of a contract may be sent in ONE order -- the "freeze
+quantity".  An order at or above it is rejected by the exchange, and in this
+runner a rejected live ENTRY with zero fill is deliberately treated as a paper
+fallback, so an oversized order would quietly trade on paper while the operator
+believed it was live.  This module turns one oversized quantity into a sequence
+of quantities the exchange will accept.
+
+Worked example (the real NIFTY numbers from the instrument master):
+
+    lot size        65 units per lot
+    freeze quantity 1756  -> the largest LEGAL order is 1755 units
+    largest chunk   floor(1755 / 65) = 27 lots = 1755 units
+
+    A 30-lot order is 1950 units, over the limit.  ``split_order_quantity``
+    returns ``(1755, 195)`` -- 27 lots then 3 lots, both legal, together
+    exactly the 30 lots the strategy asked for.
+
+Two properties the callers rely on:
+
+* every chunk is a whole number of lots (the exchange rejects part-lots), and
+* ``sum(chunks) == total_units`` exactly -- splitting never silently drops or
+  invents quantity.
+
+BankNIFTY has its own numbers (lot 30, freeze 601 -> 20 lots per chunk), which
+is why the freeze quantity is passed in per contract rather than hard-coded:
+the SL Hunting mirror splits against BankNIFTY's limit, not NIFTY's.
+
+This module is deliberately pure -- no broker, no I/O, no logging -- so the
+arithmetic can be tested exhaustively on its own.
+"""
+
+from __future__ import annotations
+
+
+def _positive_int(value: object, name: str) -> int:
+    """Return ``value`` as a positive int or raise a named ``ValueError``.
+
+    Booleans are rejected explicitly: ``True`` is an ``int`` in Python and
+    would otherwise sail through as the quantity ``1``.
+    """
+    if isinstance(value, bool):
+        raise ValueError(f"{name} must be a positive integer, not a bool")
+    if not isinstance(value, int):
+        raise ValueError(f"{name} must be a positive integer, got {type(value).__name__}")
+    if value <= 0:
+        raise ValueError(f"{name} must be a positive integer, got {value}")
+    return value
+
+
+def max_legal_chunk_units(freeze_qty: int, lot_size: int) -> int:
+    """Return the largest whole-lot quantity that stays under the freeze limit.
+
+    ``freeze_qty`` is the exchange's THRESHOLD as published in the instrument
+    master (NIFTY 1756), so the largest legal order is one unit below it.  That
+    is then rounded DOWN to a whole number of lots.
+
+    Raises ``ValueError`` when the limit cannot fit even a single lot, because
+    that contract simply cannot be traded by this runner and silently sending
+    nothing would be worse than a loud failure.
+    """
+    freeze = _positive_int(freeze_qty, "freeze_qty")
+    lot = _positive_int(lot_size, "lot_size")
+    chunk_lots = (freeze - 1) // lot
+    if chunk_lots <= 0:
+        raise ValueError(
+            f"freeze_qty {freeze} cannot fit even one lot of {lot} units"
+        )
+    return chunk_lots * lot
+
+
+def split_order_quantity(
+    total_units: int,
+    freeze_qty: int,
+    lot_size: int,
+) -> tuple[int, ...]:
+    """Split ``total_units`` into chunks the exchange will accept.
+
+    Returns a tuple of quantities in UNITS (not lots), largest-first, that sum
+    to exactly ``total_units``.  A quantity already inside the limit comes back
+    as a single-element tuple, so callers can always treat the result as "the
+    orders to send" without special-casing the common path.
+
+    ``total_units`` is expected to be a whole number of lots (every caller
+    computes it as ``lots * lot_size``).  A non-multiple is not rejected --
+    it is split with the odd remainder in the final chunk -- because refusing
+    to place an order the strategy already sized would be a worse failure than
+    forwarding an unusual quantity the broker can still validate.
+
+    Raises ``ValueError`` on genuinely unusable inputs (non-positive or
+    non-integer quantities, or a freeze limit too small for one lot).  Callers
+    treat that as a refuse-to-trade condition rather than guessing a size.
+    """
+    total = _positive_int(total_units, "total_units")
+    chunk_units = max_legal_chunk_units(freeze_qty, lot_size)
+
+    if total <= chunk_units:
+        return (total,)
+
+    chunks: list[int] = []
+    remaining = total
+    while remaining > chunk_units:
+        chunks.append(chunk_units)
+        remaining -= chunk_units
+    chunks.append(remaining)
+    return tuple(chunks)

--- a/Dependencies/test_order_splitting.py
+++ b/Dependencies/test_order_splitting.py
@@ -1,0 +1,106 @@
+"""Exhaustive arithmetic tests for exchange-legal order splitting.
+
+The two invariants every caller depends on -- chunks are whole lots, and they
+sum to exactly the requested quantity -- are checked here against the REAL
+instrument numbers so a lot-size or freeze-quantity revision shows up as a test
+failure rather than a rejected live order.
+"""
+
+from __future__ import annotations
+
+import pytest
+from order_splitting import max_legal_chunk_units, split_order_quantity
+
+# Straight from `Dependencies/all_instrument <date>.csv` (2026-07-22).
+NIFTY_LOT, NIFTY_FREEZE = 65, 1756
+BANKNIFTY_LOT, BANKNIFTY_FREEZE = 30, 601
+
+
+class TestMaxLegalChunk:
+    def test_real_instrument_limits(self):
+        # 1755 legal units / 65 = 27 lots exactly.
+        assert max_legal_chunk_units(NIFTY_FREEZE, NIFTY_LOT) == 27 * NIFTY_LOT == 1755
+        # 600 legal units / 30 = 20 lots exactly.
+        assert max_legal_chunk_units(BANKNIFTY_FREEZE, BANKNIFTY_LOT) == 20 * BANKNIFTY_LOT == 600
+
+    def test_freeze_is_a_threshold_not_an_allowance(self):
+        """The published number is the quantity that TRIPS the freeze, so the
+        largest legal order is one unit below it."""
+        # 200 units, lot 100 -> 199 legal -> only 1 whole lot fits.
+        assert max_legal_chunk_units(200, 100) == 100
+        # 201 units, lot 100 -> 200 legal -> 2 lots fit.
+        assert max_legal_chunk_units(201, 100) == 200
+
+    def test_limit_too_small_for_one_lot_is_an_error(self):
+        with pytest.raises(ValueError, match="cannot fit even one lot"):
+            max_legal_chunk_units(65, 65)  # 64 legal units < one 65-unit lot
+
+
+class TestSplitting:
+    def test_quantity_already_legal_returns_one_chunk_unchanged(self):
+        """The common path: today's behaviour must be untouched."""
+        for lots in (1, 5, 27):
+            units = lots * NIFTY_LOT
+            assert split_order_quantity(units, NIFTY_FREEZE, NIFTY_LOT) == (units,)
+
+    def test_thirty_lot_nifty_order_splits_27_then_3(self):
+        """The multiplier-6 case that motivated this module."""
+        chunks = split_order_quantity(30 * NIFTY_LOT, NIFTY_FREEZE, NIFTY_LOT)
+        assert chunks == (27 * NIFTY_LOT, 3 * NIFTY_LOT) == (1755, 195)
+
+    def test_banknifty_mirror_splits_against_its_own_limit(self):
+        """Multiplier 5 breaches BankNIFTY one step before NIFTY does."""
+        chunks = split_order_quantity(25 * BANKNIFTY_LOT, BANKNIFTY_FREEZE, BANKNIFTY_LOT)
+        assert chunks == (20 * BANKNIFTY_LOT, 5 * BANKNIFTY_LOT) == (600, 150)
+
+    def test_exact_multiple_of_the_chunk_size_has_no_remainder(self):
+        chunks = split_order_quantity(54 * NIFTY_LOT, NIFTY_FREEZE, NIFTY_LOT)
+        assert chunks == (1755, 1755)
+
+    def test_large_order_splits_into_many_chunks(self):
+        """The 25x ceiling on a 5-lot cap: 125 lots.  No chunk limit applies."""
+        chunks = split_order_quantity(125 * NIFTY_LOT, NIFTY_FREEZE, NIFTY_LOT)
+        assert len(chunks) == 5
+        assert chunks[:4] == (1755,) * 4
+        assert chunks[4] == 125 * NIFTY_LOT - 4 * 1755
+
+    @pytest.mark.parametrize("lots", range(1, 130))
+    def test_invariants_hold_for_every_lot_count(self, lots):
+        """Chunks are whole lots, each is legal, and they sum exactly."""
+        units = lots * NIFTY_LOT
+        chunks = split_order_quantity(units, NIFTY_FREEZE, NIFTY_LOT)
+
+        assert sum(chunks) == units, "splitting must never drop or invent quantity"
+        assert all(chunk % NIFTY_LOT == 0 for chunk in chunks), "part-lots are rejected by NSE"
+        assert all(0 < chunk < NIFTY_FREEZE for chunk in chunks), "every chunk must be legal"
+
+    def test_non_multiple_keeps_the_remainder_rather_than_refusing(self):
+        """Callers always pass lots x lot_size, but an odd quantity is still
+        forwarded intact -- dropping it would be the worse failure."""
+        chunks = split_order_quantity(1800, NIFTY_FREEZE, NIFTY_LOT)
+        assert sum(chunks) == 1800
+        assert chunks == (1755, 45)
+
+
+class TestInvalidInputs:
+    @pytest.mark.parametrize("bad", [0, -1, -65])
+    def test_non_positive_quantity_is_rejected(self, bad):
+        with pytest.raises(ValueError, match="total_units"):
+            split_order_quantity(bad, NIFTY_FREEZE, NIFTY_LOT)
+
+    @pytest.mark.parametrize("bad", [None, "65", 65.0, [65]])
+    def test_non_integer_quantity_is_rejected(self, bad):
+        with pytest.raises(ValueError, match="total_units"):
+            split_order_quantity(bad, NIFTY_FREEZE, NIFTY_LOT)  # type: ignore[arg-type]
+
+    def test_bool_is_not_accepted_as_a_quantity(self):
+        """True is an int in Python and would otherwise become quantity 1."""
+        with pytest.raises(ValueError, match="not a bool"):
+            split_order_quantity(True, NIFTY_FREEZE, NIFTY_LOT)  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("bad", [0, -1, None, 65.0, True])
+    def test_invalid_freeze_or_lot_size_is_rejected(self, bad):
+        with pytest.raises(ValueError):
+            split_order_quantity(650, bad, NIFTY_LOT)  # type: ignore[arg-type]
+        with pytest.raises(ValueError):
+            split_order_quantity(650, NIFTY_FREEZE, bad)  # type: ignore[arg-type]

--- a/Nifty Multi Strategy Front Test - Master File.py
+++ b/Nifty Multi Strategy Front Test - Master File.py
@@ -2659,6 +2659,11 @@ class OptionsContractResolver:
         cs_col = _first_existing_col(df, ["DISPLAY_NAME"])
         exp_col = _first_existing_col(df, ["SM_EXPIRY_DATE"])
         lot_col = _first_existing_col(df, ["LOT_SIZE"])
+        # NSE's per-order freeze quantity for THIS contract. Optional in the
+        # same way LOT_SIZE is: an older CSV snapshot without the column leaves
+        # it blank, and the order path falls back to ORDER_FREEZE_QTY_FALLBACK
+        # rather than treating "unknown" as "unlimited".
+        freeze_col = _first_existing_col(df, ["SM_FREEZE_QTY"])
         sec_col = _first_existing_col(df, ["SECURITY_ID"])
         strike_col = _first_existing_col(df, ["STRIKE_PRICE"])
         opt_type_col = _first_existing_col(df, ["OPTION_TYPE"])
@@ -2682,6 +2687,7 @@ class OptionsContractResolver:
                 "option_type": df[opt_type_col].fillna("").astype(str).str.upper().str.strip(),
                 "expiry_raw": df[exp_col].fillna("").astype(str).str.strip(),
                 "lot_raw": (df[lot_col].fillna("").astype(str).str.strip() if lot_col else ""),
+                "freeze_raw": (df[freeze_col].fillna("").astype(str).str.strip() if freeze_col else ""),
                 "sm_symbol": (df[sm_col].fillna("").astype(str).str.upper().str.strip() if sm_col else ""),
             }
         )
@@ -2689,6 +2695,7 @@ class OptionsContractResolver:
         work["strike"] = pd.to_numeric(work["strike_raw"], errors="coerce")
         work["security_id"] = pd.to_numeric(work["security_id_raw"], errors="coerce")
         work["lot_size"] = pd.to_numeric(work["lot_raw"], errors="coerce")
+        work["freeze_qty"] = pd.to_numeric(work["freeze_raw"], errors="coerce")
 
         # Keep only NSE index-option rows for our underlying that expire today
         # or later. The extra string filters reject BANKNIFTY/FINNIFTY/etc.
@@ -2730,6 +2737,7 @@ class OptionsContractResolver:
                 "option_type",
                 "expiry",
                 "lot_size",
+                "freeze_qty",
             ],
         ].copy()
 
@@ -2886,6 +2894,7 @@ class OptionsContractResolver:
             "expiry_date": expiry_date,
             "days_to_expiry": days_to_expiry,
             "lot_size": _to_int_safe(row["lot_size"], 0),
+            "freeze_qty": _to_int_safe(row["freeze_qty"], 0),
             "spot_reference": float(spot),
             "atm_strike_rounded": float(atm_strike),
         }
@@ -2965,6 +2974,7 @@ class OptionsContractResolver:
             "expiry_date": expiry_date,
             "days_to_expiry": days_to_expiry,
             "lot_size": _to_int_safe(row["lot_size"], 0),
+            "freeze_qty": _to_int_safe(row["freeze_qty"], 0),
             "spot_reference": float(spot),
             "atm_strike_rounded": float(atm_strike),
             "target_strike": float(target_strike),
@@ -3041,6 +3051,7 @@ class OptionsContractResolver:
             "option_type": "PE",
             "expiry_date": best_row["expiry"],
             "lot_size": _to_int_safe(best_row["lot_size"], 0),
+            "freeze_qty": _to_int_safe(best_row["freeze_qty"], 0),
             "entry_ltp": float(best_ltp),
         }
 
@@ -3108,6 +3119,7 @@ class OptionsContractResolver:
             "option_type": "CE",
             "expiry_date": best_row["expiry"],
             "lot_size": _to_int_safe(best_row["lot_size"], 0),
+            "freeze_qty": _to_int_safe(best_row["freeze_qty"], 0),
             "entry_ltp": float(best_ltp),
         }
 
@@ -3185,6 +3197,7 @@ class OptionsContractResolver:
             "option_type": right_upper,
             "expiry_date": best["expiry"],
             "lot_size": _to_int_safe(best["lot_size"], 0),
+            "freeze_qty": _to_int_safe(best["freeze_qty"], 0),
         }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ files = [
     "Dependencies/check_env_config.py",
     "Dependencies/diagnostic_preflight.py",
     "Dependencies/next_open_entry.py",
+    "Dependencies/order_splitting.py",
     "Dependencies/market_data_health.py",
     "Dependencies/tick_bar_builder.py",
     "Dependencies/risk_sizing.py",

--- a/scripts/check_coverage_thresholds.py
+++ b/scripts/check_coverage_thresholds.py
@@ -30,6 +30,9 @@ SAFETY_THRESHOLDS = {
     "Dependencies/tick_bar_builder.py": 90.0,
     "Dependencies/next_open_entry.py": 90.0,
     "Dependencies/risk_sizing.py": 90.0,
+    # Exchange freeze-limit arithmetic: an off-by-one here means a live order
+    # the exchange rejects, which this runner would treat as a paper fallback.
+    "Dependencies/order_splitting.py": 90.0,
     # MAT-108's redaction layer is data-safety code: a regression here leaks
     # credentials into logs, so it carries the same 90% budget.
     "Dependencies/secret_redaction.py": 90.0,


### PR DESCRIPTION
> ## ⚠️ Groundwork only — this changes NO behaviour
>
> Nothing reads `freeze_qty` yet and no order path is touched. Merging this does **not**
> protect you from oversized orders. It lands the tested arithmetic and the data plumbing
> so the actual guard can be built later (targeted ~Dec 2026 / Jan 2027) without
> re-deriving any of it.

## The problem this is groundwork for

NSE caps how much of a contract may go in **one** order. Confirmed from the committed
instrument master (`all_instrument 2026-07-22.csv`):

| | LOT_SIZE | SM_FREEZE_QTY | Max lots per order |
|---|---|---|---|
| NIFTY options | 65 | 1756 | **27** (1,755 units) |
| BANKNIFTY options | 30 | 601 | **20** (600 units) |

Both are `(max_lots × lot_size) + 1`, so the published number is the quantity that *trips*
the freeze; the largest legal order is one unit below it.

With `<PREFIX>_SIZE_MULTIPLIER` (#80), a risk-budget strategy at the default 5-lot cap
reaches 30 lots = 1,950 units at **multiplier 6**, and the SL Hunting BankNIFTY mirror
breaches one step earlier at **multiplier 5** (25 lots × 30 = 750 units).

The cap only binds when the stop is tighter than ~7.7 NIFTY points
(`d ≤ 2500 ÷ (5 × 65)`) — and note the multiplier **cancels out** of that condition, so
the threshold is identical at every multiplier.

**Why it matters more than a rejected order:** per [master:4885], a rejected live *entry*
with zero fill returns `PAPER_FALLBACK`. An over-freeze order would therefore silently
trade paper while the operator believed it was live, and land in the Sheet under a PAPER
label.

## What's in here

- **`Dependencies/order_splitting.py`** — a pure, broker-free helper turning one oversized
  quantity into exchange-legal whole-lot chunks. Two invariants every future caller relies
  on: chunks sum to *exactly* the request, and each is whole lots strictly below the freeze
  threshold.
- **`Dependencies/test_order_splitting.py`** — 151 tests, including a parametrised sweep
  asserting both invariants for **every lot count from 1 to 129**, and the real NIFTY and
  BankNIFTY numbers so a future lot-size or freeze revision fails a test rather than a live
  order.
- **Resolver plumbing** — each contract's own `SM_FREEZE_QTY` carried into all five contract
  dicts, read with the same optional pattern as `LOT_SIZE`, so an older CSV snapshot
  degrades to "unknown" instead of breaking startup.
- `order_splitting.py` added to the 90% safety coverage budget and the mypy file list.

## Why the wiring is deferred

Implementation hit a real blocker, recorded here so it isn't re-derived:

1. **`ExecutionLedger.start_attempt` rejects chunked quantities.**
   [execution_ledger.py:491] enforces
   `if requested_quantity != safe_quantity: raise ValueError(...)`, commented *"makes it
   impossible to bypass the quantity maths by accident."* Repeatedly calling
   `_place_real_leg` therefore does **not** chunk — each call re-requests the whole
   remainder, and a smaller request raises, which the worker converts into a freeze.
2. **The chunk loop cannot sit above `_place_real_leg`.** `enter_position` only attaches a
   tracked leg when `live_leg.entry_complete` ([master:6109]), and
   `_entry_outcome_allows_position` gates on the same — so a half-filled split returning to
   the caller reads as a failed entry.

Wiring therefore means relaxing a deliberate invariant inside a 90%-branch-coverage safety
module. That deserves its own PR and its own review, not a bundle with the multiplier work.

**To resume:** add a `max_attempt_quantity` keyword to `start_attempt` so the rule becomes
`requested == min(safe_quantity, cap)` — preserving the invariant's spirit, since the caller
still cannot pick an arbitrary number but must pass the contract's freeze cap and arrive at
the same value — then put the chunk loop *inside* `_place_real_leg`. The ledger's
delta-based fill accounting already supports multi-attempt legs.

## Operator trigger

The ceiling is unguarded until the wiring lands. At `LOTS=1` with one strategy live that is
far away, but the trigger to remember is: **before setting any `SIZE_MULTIPLIER` to 5 or
above**, since BankNIFTY breaches at 5 and NIFTY at 6.

## Verification

Full gate suite green: master **363 OK**, health **21 OK**, pytest **845 passed**, coverage
policy passed with `order_splitting.py` at **100% branch coverage**, plus Ruff, mypy
(40 files), compileall, Bandit and pre-commit. `pip-audit` not required — no pins change.

Behaviour is unchanged by construction: nothing consumes `freeze_qty`.

## Relationship to #80

Built on top of #80 (now merged), so this targets `main` directly and the diff is a single
commit. The code is genuinely independent of the multiplier — that feature is the
motivation for needing large orders, not a code dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
