### PR TITLE
Fix Kotak startup audit blocking live on a flat account (no netQty field)

### DIFF
--- a/Dependencies/Kotak API/kotak_execution.py
+++ b/Dependencies/Kotak API/kotak_execution.py
@@ -222,6 +222,68 @@ def _response_rows(response: Any) -> list[Any] | None:
     return None
 
 
+def _kotak_net_quantity(row: dict[str, Any]) -> int | None:
+    """Return one position row's net size, or ``None`` when it cannot be read.
+
+    Kotak's position book carries NO net-quantity field.  It reports the four
+    component quantities and leaves the arithmetic to the caller::
+
+        net = (cfBuyQty + flBuyQty) - (cfSellQty + flSellQty)
+
+    ``cf*`` are carry-forward (overnight) legs and ``fl*`` are the day's filled
+    legs.  A BUY 65 / SELL 65 round trip therefore appears as ``flBuyQty 65``
+    and ``flSellQty 65`` -- net zero, i.e. flat.
+
+    Reading a missing ``netQty`` as "unparseable" is what made the startup audit
+    fail on 2026-07-22: a genuinely flat account was reported as indeterminate
+    and live trading stayed blocked.
+
+    ``None`` is returned only when the row truly cannot be trusted, because the
+    caller turns a number into a flatness claim -- and a wrong "flat" is what
+    would let live trading start against real exposure.  So a quantity that is
+    PRESENT but unparseable fails closed rather than defaulting to zero.
+    """
+
+    # Prefer an explicit net if a future master revision ever supplies one.
+    for key in ("netQty", "netqty"):
+        if key in row:
+            return _exact_int(row.get(key))
+
+    components: dict[str, int] = {}
+    for key in ("cfBuyQty", "flBuyQty", "cfSellQty", "flSellQty"):
+        if key not in row:
+            continue
+        value = _exact_int(row.get(key))
+        if value is None:
+            return None  # Present but unreadable: never guess at exposure.
+        components[key] = value
+    if not components:
+        return None  # No quantity information at all.
+
+    bought = components.get("cfBuyQty", 0) + components.get("flBuyQty", 0)
+    sold = components.get("cfSellQty", 0) + components.get("flSellQty", 0)
+    return bought - sold
+
+
+def _indeterminate_book(
+    kind: str,
+    reason: str,
+    *,
+    broker_state: str = "UNKNOWN",
+) -> BrokerQueryResult[Any]:
+    """Log why a reconciliation query failed, then return the typed result.
+
+    ``audit_startup_exposure`` deliberately keeps broker-provided text out of
+    its operator alert, so without this the startup log says only
+    "indeterminate" and the actual cause has to be reproduced by hand against a
+    live session.  The adapter's own logger is already scrubbed by the shared
+    redaction filter, so it is the right place to record the detail.
+    """
+
+    log.warning("Kotak %s query indeterminate: %s", kind, reason)
+    return BrokerQueryResult.indeterminate(reason, broker_state=broker_state)
+
+
 class KotakExecutionClient:
     """
     One shared "phone line" to Kotak that every live strategy uses.
@@ -1093,24 +1155,27 @@ class KotakExecutionClient:
         with self._lock:
             client = self.client
         if client is None:
-            return BrokerQueryResult.indeterminate("Kotak client not initialised.")
+            return _indeterminate_book("open-order", "Kotak client not initialised.")
         try:
             response = self._sdk_call("order_report", client.order_report)
         except Exception as exc:
-            return BrokerQueryResult.indeterminate(
+            return _indeterminate_book(
+                "open-order",
                 f"Kotak open-order query failed: {exc}",
                 broker_state="SESSION_POISONED" if self.session_poisoned else "UNKNOWN",
             )
         rows = _response_rows(response)
         if rows is None:
-            return BrokerQueryResult.indeterminate(
-                f"Kotak open-order query returned malformed data: {response!r}"
+            return _indeterminate_book(
+                "open-order",
+                f"Kotak open-order query returned malformed data: {response!r}",
             )
         orders: list[OpenOrder] = []
         for row in rows:
             if not isinstance(row, dict):
-                return BrokerQueryResult.indeterminate(
-                    "Kotak open-order query contained a malformed row."
+                return _indeterminate_book(
+                    "open-order",
+                    "Kotak open-order query contained a malformed row.",
                 )
             raw_state = str(row.get("ordSt") or "").strip().upper()
             snapshot = normalize_order_result(
@@ -1129,8 +1194,9 @@ class KotakExecutionClient:
                 or "malformed" in snapshot.reason.lower()
                 or snapshot.requested_quantity <= 0
             ):
-                return BrokerQueryResult.indeterminate(
-                    "Kotak open-order query contained incomplete order data."
+                return _indeterminate_book(
+                    "open-order",
+                    "Kotak open-order query contained incomplete order data.",
                 )
             if raw_state in {
                 "COMPLETE", "COMPLETED", "FILLED", "TRADED", "EXECUTED",
@@ -1162,33 +1228,36 @@ class KotakExecutionClient:
         with self._lock:
             client = self.client
         if client is None:
-            return BrokerQueryResult.indeterminate("Kotak client not initialised.")
+            return _indeterminate_book("open-position", "Kotak client not initialised.")
         try:
             response = self._sdk_call("positions", client.positions)
         except Exception as exc:
-            return BrokerQueryResult.indeterminate(
+            return _indeterminate_book(
+                "open-position",
                 f"Kotak open-position query failed: {exc}",
                 broker_state="SESSION_POISONED" if self.session_poisoned else "UNKNOWN",
             )
         rows = _response_rows(response)
         if rows is None:
-            return BrokerQueryResult.indeterminate(
-                f"Kotak open-position query returned malformed data: {response!r}"
+            return _indeterminate_book(
+                "open-position",
+                f"Kotak open-position query returned malformed data: {response!r}",
             )
         positions: list[OpenPosition] = []
         for row in rows:
             if not isinstance(row, dict):
-                return BrokerQueryResult.indeterminate(
-                    "Kotak open-position query contained a malformed row."
+                return _indeterminate_book(
+                    "open-position",
+                    "Kotak open-position query contained a malformed row.",
                 )
-            raw_quantity = row.get("netQty") if "netQty" in row else row.get("netqty")
-            quantity = _exact_int(raw_quantity)
+            quantity = _kotak_net_quantity(row)
             symbol = str(
                 row.get("trdSym") or row.get("tradingSymbol") or row.get("pTrdSymbol") or ""
             ).strip()
             if quantity is None or not symbol:
-                return BrokerQueryResult.indeterminate(
-                    "Kotak open-position query contained incomplete position data."
+                return _indeterminate_book(
+                    "open-position",
+                    "Kotak open-position query contained incomplete position data.",
                 )
             if quantity == 0:
                 continue

--- a/Dependencies/test_broker_contract.py
+++ b/Dependencies/test_broker_contract.py
@@ -1909,6 +1909,177 @@ def test_kotak_malformed_history_row_normalizes_unknown(
     assert "malformed" in result.reason.lower()
 
 
+# One real row captured from Kotak's live position book, immediately after a
+# BUY 65 / SELL 65 round trip on NIFTY26JUL24500CE. The point of keeping it
+# verbatim: it carries NO netQty/netqty key at all. Kotak reports the four
+# component quantities and expects the caller to compute the net, so an adapter
+# reading row["netQty"] sees None and calls a flat account "indeterminate" --
+# which blocked live trading at startup on 2026-07-22.
+_KOTAK_FLAT_ROUND_TRIP_POSITION = {
+    "actId": "YHRT0",
+    "brdLtQty": 65,
+    "cfBuyQty": "0",
+    "cfSellQty": "0",
+    "flBuyQty": "65",
+    "flSellQty": "65",
+    "buyAmt": "1972.75",
+    "sellAmt": "1982.50",
+    "exSeg": "nse_fo",
+    "prod": "MIS",
+    "trdSym": "NIFTY26JUL24500CE",
+    "optTp": "CE",
+    "sym": "NIFTY",
+    "lotSz": "65",
+}
+
+
+def _kotak_position(**overrides):
+    """Return the captured live row with specific quantities overridden."""
+
+    row = dict(_KOTAK_FLAT_ROUND_TRIP_POSITION)
+    row.update(overrides)
+    return row
+
+
+def test_kotak_completed_round_trip_position_reads_as_flat(
+    kotak_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """A bought-then-sold position is flat, not an unreadable row.
+
+    Kotak's book has no net-quantity field, so the net must be computed as
+    (cfBuy + flBuy) - (cfSell + flSell). Reading a missing netQty as "cannot
+    parse" made every startup audit fail once any position row existed.
+    """
+
+    client = _ready_kotak_client(
+        kotak_module,
+        monkeypatch,
+        _FakeKotakSdk(positions=[_kotak_position()]),
+    )
+
+    result = client.list_open_positions()
+
+    assert result.is_indeterminate is False, result.reason
+    # Flat legs are dropped, so a closed round trip leaves nothing open.
+    assert result.items == ()
+
+
+@pytest.mark.parametrize(
+    ("overrides", "expected_quantity"),
+    [
+        # Open long: bought today, nothing sold back.
+        ({"flBuyQty": "65", "flSellQty": "0"}, 65),
+        # Open short.
+        ({"flBuyQty": "0", "flSellQty": "65"}, -65),
+        # Carry-forward legs must count toward the net too.
+        ({"cfBuyQty": "130", "flBuyQty": "0", "flSellQty": "65"}, 65),
+        # Partially closed: 130 bought, 65 sold back.
+        ({"flBuyQty": "130", "flSellQty": "65"}, 65),
+    ],
+)
+def test_kotak_net_position_is_computed_from_its_components(
+    kotak_module: ModuleType,
+    monkeypatch,
+    overrides: dict,
+    expected_quantity: int,
+) -> None:
+    client = _ready_kotak_client(
+        kotak_module,
+        monkeypatch,
+        _FakeKotakSdk(positions=[_kotak_position(**overrides)]),
+    )
+
+    result = client.list_open_positions()
+
+    assert result.is_indeterminate is False, result.reason
+    assert len(result.items) == 1
+    assert result.items[0].quantity == expected_quantity
+    assert result.items[0].symbol == "NIFTY26JUL24500CE"
+
+
+def test_kotak_explicit_net_quantity_still_wins_when_present(
+    kotak_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """If a future master revision supplies netQty, trust it over the parts."""
+
+    client = _ready_kotak_client(
+        kotak_module,
+        monkeypatch,
+        _FakeKotakSdk(positions=[_kotak_position(netQty="-65")]),
+    )
+
+    result = client.list_open_positions()
+
+    assert result.is_indeterminate is False, result.reason
+    assert result.items[0].quantity == -65
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        # No quantity information of any kind.
+        {"cfBuyQty": None, "cfSellQty": None, "flBuyQty": None, "flSellQty": None},
+        # Present but unparseable: never silently treat this as zero.
+        {"flBuyQty": "abc"},
+        {"flSellQty": "6.5"},
+        {"netQty": "not-a-number"},
+    ],
+)
+def test_kotak_unreadable_position_quantity_fails_closed(
+    kotak_module: ModuleType,
+    monkeypatch,
+    overrides: dict,
+) -> None:
+    """An unreadable row must never be reported as flat.
+
+    "Flat" is what lets live trading start, so a quantity we cannot parse has
+    to stay indeterminate rather than default to zero.
+    """
+
+    row = _kotak_position()
+    for key, value in overrides.items():
+        if value is None:
+            row.pop(key, None)
+        else:
+            row[key] = value
+    client = _ready_kotak_client(
+        kotak_module,
+        monkeypatch,
+        _FakeKotakSdk(positions=[row]),
+    )
+
+    assert client.list_open_positions().is_indeterminate is True
+
+
+def test_kotak_indeterminate_book_queries_are_logged(
+    kotak_module: ModuleType,
+    monkeypatch,
+    caplog,
+) -> None:
+    """The reason must reach the log, not just the returned object.
+
+    ``audit_startup_exposure`` deliberately strips broker text from its alert,
+    so an unlogged reason is invisible: the 2026-07-22 startup block reported
+    only "indeterminate" and the cause had to be reproduced by hand.
+    """
+
+    client = _ready_kotak_client(
+        kotak_module,
+        monkeypatch,
+        _FakeKotakSdk(positions=[{"trdSym": "NIFTY26JUL24500CE"}]),
+    )
+
+    with caplog.at_level(logging.WARNING):
+        result = client.list_open_positions()
+
+    assert result.is_indeterminate is True
+    assert any(
+        "indeterminate" in record.message.lower() for record in caplog.records
+    ), f"no warning logged; records={[r.message for r in caplog.records]}"
+
+
 def test_kotak_error_envelopes_cannot_masquerade_as_empty_books(
     kotak_module: ModuleType,
     monkeypatch,


### PR DESCRIPTION
Live trading was blocked at startup all morning on 2026-07-22 — three consecutive runs (08:05, 09:00, 09:15):

```
STARTUP LIVE BLOCKED by broker exposure audit | Open-order query was
indeterminate. Open-position query was indeterminate. |
open_orders=indeterminate relevant_positions=indeterminate
```

Order placement itself was fine throughout: a real BUY 65 / SELL 65 round trip on `NIFTY26JUL24500CE` filled and flattened during the same session.

## Root cause

**Kotak's position book carries no net-quantity field.** A row captured live from the account, immediately after that round trip:

```
cfBuyQty '0'   flBuyQty '65'   cfSellQty '0'   flSellQty '65'
```

No `netQty`, no `netqty` — anywhere. Kotak reports the four component quantities and leaves the arithmetic to the caller:

```
net = (cfBuy + flBuy) - (cfSell + flSell) = (0 + 65) - (0 + 65) = 0   → flat
```

The adapter did `row.get("netQty")` → `None` → `_exact_int(None)` → `None` → *"incomplete position data"* → indeterminate. A **provably flat account could never satisfy the audit**, so live trading could not start once any position row existed.

`_kotak_net_quantity` now computes the net from those components, still preferring an explicit `netQty` if a future master revision supplies one.

### It fails closed, deliberately

A quantity that is **present but unparseable** returns `None` rather than defaulting to zero. The caller turns that number into a flatness claim, and a wrong "flat" is exactly what would let live trading start against real exposure. Four fail-closed cases are covered by tests.

## Verified against the real payloads

Replaying the exact captured responses through `audit_startup_exposure`:

| scenario | before | after |
|---|---|---|
| flat round-trip row (real data) | `safe_to_enable_live=False` | **`True`**, evidence `open_orders=0 relevant_positions=0` |
| control: one open 65-lot long | blocked | **still blocked**, `relevant_positions=1` |

The gate is fixed, not weakened.

## Second change: the reason was invisible

`audit_startup_exposure` deliberately keeps broker-provided text out of its operator alert (`_pluralized_count` builds a fixed vocabulary), and the adapter never logged the reason either. `_read_typed_book` collapses **seven distinct conditions** — raise, wrong type, non-bool flag, non-tuple items, non-str reason, indeterminate, foreign item — into a single word.

So a live-money startup block reported only "indeterminate", and the actual cause had to be reproduced by hand against a live session with a TOTP.

Every indeterminate book query now routes through `_indeterminate_book`, which logs the reason (through the shared redaction filter, so it is safe to share) before returning the typed result.

## Known remaining issue — deliberately not fixed here

With an **empty** order book — the state at 09:15, before any order existed — the order query was *also* indeterminate, and became determinate only once the book had rows. Kotak evidently returns something other than `{"stat":"Ok","data":[]}` for an empty book.

That shape cannot be observed until a fresh trading day, and guessing it is unsafe in one specific direction: mistaking a genuine error for "empty" would report flat and enable live trading against unknown exposure. The new logging captures the raw response, so the next empty-book run identifies it exactly and the follow-up is a one-liner.

## Tests

The position row is copied verbatim from the live account. Coverage: flat round trip, open long, open short, carry-forward legs, partial close, explicit `netQty` precedence, four fail-closed cases, and a regression test asserting the reason reaches the log.

## Gates

856 pytest, ruff, mypy, bandit, compileall — all clean.

Three `TestSLHuntingBnfMirror` failures in the master unittest suite are **pre-existing on `main`** (reproduced with this change stashed) and unrelated to this fix. CI does not see them because that class skips when `claude-agent-sdk` is absent. Worth a separate issue.
