### PR TITLE
Treat Kotak's exact No Data reply as an empty book, not a failed query

### DIFF
--- a/Dependencies/Kotak API/kotak_execution.py
+++ b/Dependencies/Kotak API/kotak_execution.py
@@ -222,6 +222,49 @@ def _response_rows(response: Any) -> list[Any] | None:
     return None
 
 
+# Kotak's empty-book reply, captured live on 2026-07-23 from BOTH the order and
+# position books before the day's first order:
+#
+#   {'stCode': 5203, 'errMsg': 'No Data', 'desc': 'data not found',
+#    'stat': 'Not_Ok'}
+#
+# It arrives with stat=Not_Ok, so the generic error-envelope check treats it as a
+# failed query -- which is why a brand-new trading day (both books legitimately
+# empty) blocked live trading at startup until the first order existed.
+_KOTAK_NO_DATA_CODE = 5203
+
+
+def _is_kotak_no_data_envelope(value: Any) -> bool:
+    """Recognize ONLY Kotak's exact, determinate empty-book response.
+
+    Every field is matched exactly, and the message comparison is equality
+    rather than a substring test.  That strictness is the whole point: this
+    repo already learned with Shoonya that a session failure can *contain* the
+    words "no data" (``"No data because session expired"``), and accepting that
+    as an empty book would report a flat account and enable live trading
+    against exposure nobody can see.
+
+    A genuine session problem also looks different earlier in the call: the SDK
+    gates ``order_report``/``positions`` on ``edit_token``/``edit_sid`` and
+    returns ``{"Error Message": "Complete the 2fa process..."}`` when they are
+    missing, so reaching a structured ``stCode`` reply at all means the
+    authenticated request was made and the server answered on its merits.
+    """
+
+    if not isinstance(value, dict):
+        return False
+    if _exact_int(value.get("stCode")) != _KOTAK_NO_DATA_CODE:
+        return False
+    state = str(value.get("stat") or "").strip().lower().replace("_", "")
+    if state not in {"notok", "rejected"}:
+        return False
+    message = " ".join(
+        str(value.get("errMsg") or value.get("emsg") or "").strip().lower().split()
+    )
+    description = " ".join(str(value.get("desc") or "").strip().lower().split())
+    return message == "no data" and description == "data not found"
+
+
 def _kotak_net_quantity(row: dict[str, Any]) -> int | None:
     """Return one position row's net size, or ``None`` when it cannot be read.
 
@@ -1164,6 +1207,11 @@ class KotakExecutionClient:
                 f"Kotak open-order query failed: {exc}",
                 broker_state="SESSION_POISONED" if self.session_poisoned else "UNKNOWN",
             )
+        # Checked BEFORE the generic parser: the empty-book reply carries
+        # stat=Not_Ok, which _response_rows would otherwise read as a failure.
+        if _is_kotak_no_data_envelope(response):
+            log.info("Kotak order book is empty (broker reported no data).")
+            return BrokerQueryResult.success([])
         rows = _response_rows(response)
         if rows is None:
             return _indeterminate_book(
@@ -1237,6 +1285,10 @@ class KotakExecutionClient:
                 f"Kotak open-position query failed: {exc}",
                 broker_state="SESSION_POISONED" if self.session_poisoned else "UNKNOWN",
             )
+        # Checked BEFORE the generic parser: see list_open_orders above.
+        if _is_kotak_no_data_envelope(response):
+            log.info("Kotak position book is empty (broker reported no data).")
+            return BrokerQueryResult.success([])
         rows = _response_rows(response)
         if rows is None:
             return _indeterminate_book(

--- a/Dependencies/env.example
+++ b/Dependencies/env.example
@@ -1255,17 +1255,27 @@ SL_HUNTING_LOTS=1
 SL_HUNTING_RISK_BUDGET=2500
 SL_HUNTING_MAX_LOTS=5
 # BankNIFTY mirror (Intraday Hunter style): every NIFTY entry also buys the SAME
-# lot count on the BankNIFTY ATM option of the CURRENT BankNIFTY monthly expiry
-# (BNF has no weekly series; see the rollover knob below), entered/exited as ONE
+# lot count on the BankNIFTY option of the NEAREST BankNIFTY monthly expiry
+# (BNF has no weekly series; see the near-expiry knobs below), entered/exited as ONE
 # basket with the NIFTY leg and following the same paper/live gates. NOTE: this
 # roughly DOUBLES the basket's rupee risk beyond SL_HUNTING_RISK_BUDGET (the
 # daily max-loss kill-switch still applies). Set false to trade NIFTY-only.
 SL_HUNTING_BNF_MIRROR=true
-# Mirror expiry rollover (BNF-001): the mirror trades the CURRENT BNF monthly
-# expiry normally, and rolls to the NEXT month once fewer than this many days
-# remain to the current one (avoids holding an about-to-expire contract while
-# never parking an intraday leg in the illiquid second month out).
+# Mirror near-expiry switch (BNF-001 + BNF-002): the mirror ALWAYS trades the
+# NEAREST BNF monthly expiry and NEVER rolls to the next month -- Kotak rejects
+# MIS (intraday) orders on next-month contracts, so the live mirror leg kept
+# failing to fire (operator finding, 2026-07-23). Expiry week is handled on the
+# STRIKE axis instead: once fewer than this many days remain to that nearest
+# expiry, the mirror buys a deep IN-THE-MONEY strike (mostly intrinsic value,
+# so it tracks BankNIFTY) rather than a near-expiry ATM contract (almost pure
+# decaying time premium).
+# NOTE the key name: "_ROLLOVER_DAYS" no longer rolls anything -- it is purely
+# the days-to-expiry threshold for the ATM -> ITM switch. Name kept so existing
+# .env files keep working.
 SL_HUNTING_BNF_MIRROR_ROLLOVER_DAYS=7
+# How deep in the money that expiry-week strike sits, in strike steps
+# (BankNIFTY steps are 100 points, so 4 = 400 points ITM).
+SL_HUNTING_BNF_MIRROR_NEAR_EXPIRY_ITM_STEPS=4
 # Daily kill-switch -- SEPARATE from the per-trade RISK_BUDGET above. The strategy
 # halts for the rest of the day once its cumulative P&L (realized + open) hits
 # -(STARTING_CAPITAL * DAILY_MAX_LOSS_PCT). 600000 * 0.0125 = Rs.7,500/day, i.e.

--- a/Dependencies/test_broker_contract.py
+++ b/Dependencies/test_broker_contract.py
@@ -2080,6 +2080,132 @@ def test_kotak_indeterminate_book_queries_are_logged(
     ), f"no warning logged; records={[r.message for r in caplog.records]}"
 
 
+# Captured live on 2026-07-23 from BOTH Kotak books, before the day's first
+# order. It carries stat=Not_Ok, so the generic error-envelope check treated it
+# as a failed query and blocked live trading every morning until an order
+# existed.
+_KOTAK_EMPTY_BOOK_ENVELOPE = {
+    "stCode": 5203,
+    "errMsg": "No Data",
+    "desc": "data not found",
+    "stat": "Not_Ok",
+}
+
+
+def test_kotak_empty_books_are_determinate_not_indeterminate(
+    kotak_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """A brand-new trading day has empty books; that is proof of flat, not doubt."""
+
+    class EmptyBookKotak(_FakeKotakSdk):
+        def order_report(self):
+            return dict(_KOTAK_EMPTY_BOOK_ENVELOPE)
+
+        def positions(self):
+            return dict(_KOTAK_EMPTY_BOOK_ENVELOPE)
+
+    client = _ready_kotak_client(kotak_module, monkeypatch, EmptyBookKotak())
+
+    orders = client.list_open_orders()
+    positions = client.list_open_positions()
+
+    assert orders.is_indeterminate is False, orders.reason
+    assert orders.items == ()
+    assert positions.is_indeterminate is False, positions.reason
+    assert positions.items == ()
+
+
+@pytest.mark.parametrize(
+    "envelope",
+    [
+        # THE trap: a session failure whose text CONTAINS "no data". Matching by
+        # substring would report a flat account and enable live trading against
+        # exposure nobody can see.
+        {
+            "stCode": 5203,
+            "errMsg": "No data because session expired",
+            "desc": "data not found",
+            "stat": "Not_Ok",
+        },
+        {
+            "stCode": 5203,
+            "errMsg": "No Data",
+            "desc": "session expired",
+            "stat": "Not_Ok",
+        },
+        # Right words, different code.
+        {"stCode": 5001, "errMsg": "No Data", "desc": "data not found", "stat": "Not_Ok"},
+        # Code alone is not enough.
+        {"stCode": 5203, "errMsg": "Unauthorized", "desc": "data not found", "stat": "Not_Ok"},
+        {"stCode": 5203, "stat": "Not_Ok"},
+        # A plain error envelope must keep failing closed.
+        {"stat": "Not_Ok", "emsg": "session expired", "data": []},
+    ],
+)
+def test_kotak_only_the_exact_no_data_envelope_proves_an_empty_book(
+    kotak_module: ModuleType,
+    monkeypatch,
+    envelope: dict,
+) -> None:
+    class AmbiguousKotak(_FakeKotakSdk):
+        def order_report(self):
+            return dict(envelope)
+
+        def positions(self):
+            return dict(envelope)
+
+    client = _ready_kotak_client(kotak_module, monkeypatch, AmbiguousKotak())
+
+    assert client.list_open_orders().is_indeterminate is True
+    assert client.list_open_positions().is_indeterminate is True
+
+
+def test_kotak_empty_books_let_the_startup_audit_prove_flat(
+    kotak_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """End to end: the real startup decision must allow live on a flat account."""
+
+    from Dependencies.startup_exposure import audit_startup_exposure
+
+    class EmptyBookKotak(_FakeKotakSdk):
+        def order_report(self):
+            return dict(_KOTAK_EMPTY_BOOK_ENVELOPE)
+
+        def positions(self):
+            return dict(_KOTAK_EMPTY_BOOK_ENVELOPE)
+
+    client = _ready_kotak_client(kotak_module, monkeypatch, EmptyBookKotak())
+
+    audit = audit_startup_exposure(client)
+
+    assert audit.safe_to_enable_live is True, audit.reasons
+    assert audit.evidence == ("open_orders=0", "relevant_positions=0")
+
+
+def test_kotak_no_data_does_not_leak_into_order_status(
+    kotak_module: ModuleType,
+    monkeypatch,
+) -> None:
+    """For ONE order, "no data" means not visible yet -- still indeterminate.
+
+    The empty-book rule is scoped to the two book queries on purpose: an order
+    we just placed and cannot find is exactly the ambiguity that must never be
+    reported as a clean zero-fill.
+    """
+
+    class NoHistoryKotak(_FakeKotakSdk):
+        def order_history(self, order_id):
+            return dict(_KOTAK_EMPTY_BOOK_ENVELOPE)
+
+    client = _ready_kotak_client(kotak_module, monkeypatch, NoHistoryKotak())
+
+    result = client.get_order_status("KT-1", 75)
+
+    assert result.status.name == "UNKNOWN"
+
+
 def test_kotak_error_envelopes_cannot_masquerade_as_empty_books(
     kotak_module: ModuleType,
     monkeypatch,

--- a/Nifty Multi Strategy Front Test - Master File.py
+++ b/Nifty Multi Strategy Front Test - Master File.py
@@ -95,11 +95,17 @@ expiry rule it uses:
 observation legs use the current-week expiry.)
 
 One deliberate exception (BNF-001): the SL Hunting BankNIFTY MIRROR leg uses
-OptionsContractResolver.get_monthly_rollover_expiry() -- the CURRENT BankNIFTY
-monthly expiry, rolling to the next month once fewer than
-SL_HUNTING_BNF_MIRROR_ROLLOVER_DAYS days remain. BankNIFTY lists only monthly
+OptionsContractResolver.get_nearest_monthly_expiry() -- the NEAREST BankNIFTY
+monthly expiry, which it NEVER rolls forward. BankNIFTY lists only monthly
 series, so "next-next" would park an intraday mirror in the illiquid second
 month out.
+
+BNF-002 (2026-07-23): the mirror also never rolls to the NEXT month in expiry
+week, because Kotak rejects MIS (intraday) orders on next-month contracts and
+the live mirror leg kept failing to fire. Expiry week is handled on the STRIKE
+axis instead -- inside SL_HUNTING_BNF_MIRROR_ROLLOVER_DAYS the mirror buys a
+deep ITM strike (get_itm_option) whose value is mostly intrinsic, rather than a
+near-expiry ATM contract that is almost pure decaying time premium.
 
 Both methods live on the same resolver so the choice is one line at
 the call site. That keeps the rule visible in the code and easy to
@@ -2823,31 +2829,29 @@ class OptionsContractResolver:
             raise ValueError(f"No future {self.underlying} expiry found in instrument master.")
         return expiries[0]
 
-    def get_monthly_rollover_expiry(self, min_days_to_expiry: int) -> date:
+    def get_nearest_monthly_expiry(self) -> date:
         """
-        Return the FIRST expiry on or after today, rolling to the SECOND when
-        fewer than `min_days_to_expiry` days remain to the first.
+        Return the FIRST (nearest) expiry on or after today. It NEVER rolls to
+        a later month.
 
         Used by the SL Hunting BankNIFTY mirror leg (BNF-001). BankNIFTY lists
         only MONTHLY series, so the ATM family's "next-next" rule would park an
-        intraday mirror in the SECOND month out -- low gamma, wide spreads. The
-        operator's rule instead: trade the CURRENT monthly normally, and only
-        roll to the next month once the current contract is inside its final
-        week (threshold via SL_HUNTING_BNF_MIRROR_ROLLOVER_DAYS, default 7).
+        intraday mirror in the SECOND month out -- low gamma, wide spreads.
 
-        Boundary semantics: exactly `min_days_to_expiry` days away is NOT
-        "fewer than", so the current expiry is kept. With a single listed
-        expiry there is nothing to roll to, so it is returned even inside the
-        window -- the mirror is fail-soft and trading the only listed contract
-        beats silently skipping the leg.
+        Why never roll (BNF-002, operator finding 2026-07-23): an earlier rule
+        rolled to the NEXT month inside the current contract's final week. In
+        live trading Kotak REJECTED those orders outright -- it does not accept
+        MIS (intraday) orders on a next-month expiry -- so the mirror leg failed
+        to fire again and again. The near-expiry problem the roll was meant to
+        solve (an ATM contract decaying fast in its last days) is now handled by
+        moving the STRIKE deep in-the-money instead of moving the EXPIRY out;
+        see `get_itm_option` and the mirror's call site.
         """
         options = self._load_option_chain()
         today = datetime.now().date()
         expiries = sorted({exp for exp in options["expiry"].tolist() if exp is not None and exp >= today})
         if not expiries:
             raise ValueError(f"No future {self.underlying} expiry found in instrument master.")
-        if len(expiries) >= 2 and (expiries[0] - today).days < int(min_days_to_expiry):
-            return expiries[1]
         return expiries[0]
 
     # ------------------------------------------------------------------
@@ -2920,6 +2924,98 @@ class OptionsContractResolver:
             "freeze_qty": _to_int_safe(row["freeze_qty"], 0),
             "spot_reference": float(spot),
             "atm_strike_rounded": float(atm_strike),
+        }
+
+    def get_itm_option(
+        self,
+        spot_price: float,
+        direction: str,
+        itm_steps: int,
+        expiry_date: date | None = None,
+    ) -> dict:
+        """
+        Resolve an IN-THE-MONEY option row, `itm_steps` strikes inside the money.
+
+        Used by the SL Hunting BankNIFTY mirror in its expiry week (BNF-002).
+        A deep-ITM contract carries mostly INTRINSIC value, so it tracks the
+        underlying far more closely than a near-expiry ATM contract, whose
+        remaining premium is almost pure time value and bleeds fastest exactly
+        in those final days. Moving the strike is how the mirror survives expiry
+        week now that moving the EXPIRY (rolling to next month) is forbidden --
+        Kotak rejects MIS orders on next-month contracts.
+
+        Direction / ITM side (same mapping as `get_atm_option`, and the same
+        sign convention CPR Algo 3 uses for its ITM legs):
+        - "LONG"  -> CE, in the money BELOW spot: target = ATM - steps * step
+        - "SHORT" -> PE, in the money ABOVE spot: target = ATM + steps * step
+        `itm_steps=0` degenerates to the ATM strike for that right.
+
+        `step` is this resolver's own `self.strike_step` (100 for BankNIFTY,
+        50 for NIFTY) -- NOT the global NIFTY constant, so the BankNIFTY grid
+        is respected.
+
+        Expiry: defaults to `get_target_expiry()`; the mirror passes the nearest
+        monthly explicitly, keeping the expiry choice visible at the call site
+        like every other expiry rule in this file.
+
+        Strike pick: exact target if listed, else the closest available strike
+        (smallest absolute difference, lower strike breaking ties) -- identical
+        to `get_atm_option`.
+        """
+        direction_upper = str(direction).strip().upper()
+        if direction_upper == "LONG":
+            right = "CE"
+        elif direction_upper == "SHORT":
+            right = "PE"
+        else:
+            raise ValueError(f"Unsupported direction for ITM resolution: {direction!r}")
+
+        spot = _safe_float(spot_price, 0.0)
+        if spot <= 0:
+            raise ValueError(f"Invalid spot price for ITM resolution: {spot_price!r}")
+
+        steps = int(itm_steps)
+        if steps < 0:
+            raise ValueError(f"itm_steps must be >= 0, got {itm_steps!r}")
+
+        options = self._load_option_chain()
+        target_expiry = expiry_date if expiry_date is not None else self.get_target_expiry()
+
+        atm_strike = round(spot / self.strike_step) * self.strike_step
+        if right == "CE":
+            target_strike = atm_strike - steps * self.strike_step
+        else:
+            target_strike = atm_strike + steps * self.strike_step
+
+        subset = options[(options["expiry"] == target_expiry) & (options["option_type"] == right)].copy()
+        if subset.empty:
+            raise ValueError(
+                f"No {right} rows found for {self.underlying} expiry {target_expiry}."
+            )
+
+        subset["strike_diff"] = (subset["strike"] - target_strike).abs()
+        subset = subset.sort_values(["strike_diff", "strike"])
+        row = subset.iloc[0]
+
+        today = datetime.now().date()
+        resolved_expiry = row["expiry"]
+        days_to_expiry = (resolved_expiry - today).days if resolved_expiry is not None else None
+
+        return {
+            "security_id": int(row["security_id"]),
+            "exchange_segment": OPTION_EXCHANGE_SEGMENT,
+            "trading_symbol": str(row["trading_symbol"]).strip(),
+            "custom_symbol": str(row["custom_symbol"]).strip(),
+            "strike": float(row["strike"]),
+            "option_type": right,
+            "expiry_date": resolved_expiry,
+            "days_to_expiry": days_to_expiry,
+            "lot_size": _to_int_safe(row["lot_size"], 0),
+            "freeze_qty": _to_int_safe(row["freeze_qty"], 0),
+            "spot_reference": float(spot),
+            "atm_strike_rounded": float(atm_strike),
+            "itm_steps": steps,
+            "target_strike": float(target_strike),
         }
 
     def get_otm_option(
@@ -11907,11 +12003,26 @@ if SL_HUNTING_AVAILABLE:
     # the daily max-loss kill-switch still caps the day). Fail-soft: any mirror
     # problem only skips the mirror, never the NIFTY leg.
     SL_HUNTING_BNF_MIRROR = _env_bool("SL_HUNTING_BNF_MIRROR", True)
-    # Mirror expiry rule (BNF-001): BankNIFTY lists only MONTHLY series, so the
-    # ATM family's "next-next" rule would put an intraday mirror in the SECOND
-    # month out. Instead the mirror trades the CURRENT monthly expiry, rolling
-    # to the NEXT one once fewer than this many days remain to the current.
+    # Mirror expiry rule (BNF-001 + BNF-002): BankNIFTY lists only MONTHLY
+    # series, so the ATM family's "next-next" rule would put an intraday mirror
+    # in the SECOND month out. The mirror therefore ALWAYS trades the NEAREST
+    # monthly expiry and NEVER rolls to the next month -- Kotak rejects MIS
+    # (intraday) orders on next-month contracts, which silently killed the live
+    # mirror leg over and over (operator finding, 2026-07-23).
+    #
+    # Expiry week is instead handled on the STRIKE axis: once fewer than
+    # ..._ROLLOVER_DAYS remain to that nearest expiry, the mirror buys a
+    # ..._NEAR_EXPIRY_ITM_STEPS-deep IN-THE-MONEY strike instead of the ATM one.
+    # A deep-ITM contract is mostly intrinsic value, so it tracks BankNIFTY
+    # closely instead of bleeding the near-expiry ATM time premium.
+    #
+    # NOTE the retained key name: "_ROLLOVER_DAYS" no longer rolls anything, it
+    # is purely the days-to-expiry threshold at which the mirror switches to ITM
+    # strikes. The name is kept so existing .env files keep working.
     SL_HUNTING_BNF_MIRROR_ROLLOVER_DAYS = _env_int("SL_HUNTING_BNF_MIRROR_ROLLOVER_DAYS", 7)
+    SL_HUNTING_BNF_MIRROR_NEAR_EXPIRY_ITM_STEPS = _env_int(
+        "SL_HUNTING_BNF_MIRROR_NEAR_EXPIRY_ITM_STEPS", 4
+    )
     # Trade journal (v3): record each trade's entry context + exit outcome to a
     # gitignored JSONL the reflection coach reads. Best-effort; never blocks trading.
     SL_HUNTING_JOURNAL_ENABLED = _env_bool("SL_HUNTING_JOURNAL_ENABLED", True)
@@ -12100,9 +12211,15 @@ if SL_HUNTING_AVAILABLE:
             return ok
 
         def _open_bnf_mirror(self, direction: str) -> None:
-            """Buy the BankNIFTY ATM CE/PE at the same lot COUNT as the
-            just-opened NIFTY leg, on the CURRENT BankNIFTY monthly expiry
-            (rolled to the next month inside its final week -- BNF-001)."""
+            """Buy the BankNIFTY CE/PE at the same lot COUNT as the just-opened
+            NIFTY leg, ALWAYS on the NEAREST BankNIFTY monthly expiry.
+
+            Strike rule (BNF-002): normally ATM, but once fewer than
+            SL_HUNTING_BNF_MIRROR_ROLLOVER_DAYS remain to that expiry the leg
+            switches to a deep IN-THE-MONEY strike. The mirror never rolls to
+            the next month, because Kotak rejects MIS orders on next-month
+            contracts and the live leg simply never fired.
+            """
             if self._mirror_pos.active or self._bnf_resolver is None:
                 return
             nifty_lot_size = max(int(self.pos.option_lot_size), 1)
@@ -12113,11 +12230,29 @@ if SL_HUNTING_AVAILABLE:
                 self.log.warning("BNF mirror skipped: no BankNIFTY close seen yet this session.")
                 return
             # Explicit expiry at the call site, like every other expiry rule in
-            # this file: current monthly, rolling inside the last-week window.
-            mirror_expiry = self._bnf_resolver.get_monthly_rollover_expiry(
-                SL_HUNTING_BNF_MIRROR_ROLLOVER_DAYS
-            )
-            contract = self._bnf_resolver.get_atm_option(bnf_spot, direction, expiry_date=mirror_expiry)
+            # this file: the nearest monthly, never rolled forward.
+            mirror_expiry = self._bnf_resolver.get_nearest_monthly_expiry()
+            days_to_expiry = (mirror_expiry - datetime.now().date()).days
+            near_expiry = days_to_expiry < SL_HUNTING_BNF_MIRROR_ROLLOVER_DAYS
+            if near_expiry:
+                # Expiry week: buy intrinsic value instead of decaying premium.
+                contract = self._bnf_resolver.get_itm_option(
+                    bnf_spot,
+                    direction,
+                    SL_HUNTING_BNF_MIRROR_NEAR_EXPIRY_ITM_STEPS,
+                    expiry_date=mirror_expiry,
+                )
+                self.log.info(
+                    "BNF mirror in expiry week (%s day(s) to %s): using %s-step ITM strike "
+                    "instead of ATM (never rolls to next month -- Kotak rejects MIS there).",
+                    days_to_expiry,
+                    mirror_expiry.isoformat(),
+                    SL_HUNTING_BNF_MIRROR_NEAR_EXPIRY_ITM_STEPS,
+                )
+            else:
+                contract = self._bnf_resolver.get_atm_option(
+                    bnf_spot, direction, expiry_date=mirror_expiry
+                )
             sec_id = int(contract["security_id"])
             segment = str(contract["exchange_segment"])
             symbol = str(contract["trading_symbol"])

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -1261,3 +1261,97 @@ v3m losing-side flip ban).
   self-check on a strongly one-way day.
 - Test markers: `test_system_prompt_has_v3p_runaway_trend_knowledge`,
   `test_runaway_trend_section_is_composed_into_the_prompt`.
+
+## Video addendum - 23 Jul re-entry gate + expiry pinning (v3q)
+
+> Source: `9Tzi96RY7Jc` (23 Jul 2026, "Live Bank Nifty Option Trading"). Full Hindi
+> auto-transcript (fresh-tab recipe, first try).
+> Tallied against BOTH artefacts for 2026-07-23.
+
+**The tally — the agent's most active day, and a losing one:**
+
+| Source | Result |
+|---|---|
+| decisions | 69 decisions: 60 HOLD, **5 entries** (3 SHORT / 2 LONG), 4 EXIT |
+| journal | **5 completed trades, net -Rs.7,054.75** |
+| `agent_error` | 3 rows, all "usage-limited" (10:27-10:29, end of session) |
+| IH | **WIN** — ONE put trade, booked on the BankNIFTY breakdown |
+
+| # | Entry | Direction / setup | Result |
+|---|---|---|---|
+| 1 | 09:32 | SHORT `gap_down_bounce_fail_bearish_engulfing` | **+Rs.7,281** (1.58R) |
+| 2 | 09:41 | SHORT `trendline_4th_touch_fib78_rejection` | **-Rs.6,921** (stop) |
+| 3 | 10:02 | LONG `gap_down_seller_hunt_trendline_reclaim` | **+Rs.6,408** (0.73R) |
+| 4 | 10:11 | LONG `gapdown_averaging_trap_reclaim` | **-Rs.1,296** |
+| 5 | 10:21 | SHORT `double_top_rejection_prev_low_resistance` | **-Rs.12,526** (AI_STOP) |
+
+**The pattern is unmistakable: the FIRST trade of each thesis WON; every RE-ENTRY
+LOST.** Winners +Rs.13,688; the three re-entries -Rs.20,743. Without them the day is
++Rs.13,688 instead of -Rs.7,055.
+
+Timing makes it worse: trade 2 opened **2.5 minutes** after booking trade 1 (same
+direction); trade 4 opened **2.5 minutes** after booking trade 3 (same direction);
+trade 5 opened **~4 minutes** after exiting the losing trade 4, reversing INTO the
+move that had just hurt it — and became the day's biggest loss.
+
+**These were already banned.** Trades 2 and 4 are textbook MOVE-EXHAUSTION ("do NOT
+re-enter the SAME direction on a later, smaller pattern chasing the tail of the move
+you just took"); trade 5 is the v3m losing-side NO INSTANT FLIP ban verbatim. So the
+gap is NOT missing knowledge — it is that **both rules are judgement calls, and the
+agent satisfied them rhetorically every time** by naming a genuinely different-sounding
+setup on the same price structure: "4th touch of the descending trendline + 78% fib",
+"averaging trap reclaim", "double top rejection". Each reads as a fresh premise; each
+was the same move wearing a new label. MOVE-EXHAUSTION even says a fresh trade "needs
+a NEW named crowd trapped by NEW price action" — and the agent believed it had one.
+
+Session summary (IH): a good gap-down after a weak prior day, so he planned to go WITH
+the selling. He predicted the shape — "it will come up once, then fall; finding that
+turning point is the only work today" — entered PUTs into the bounce rather than at
+the extreme, and read BOTH crowds as unavailable (yesterday's sellers already paid;
+today's would-be sellers never got their breakdown, so they did not hold). He then
+waited for ONE breakdown and booked it. Two of his asides drive this addendum: that
+Sensex, **the expiring index, would be least likely to break down**, so the trigger
+would come from BankNIFTY or NIFTY; and that no chain reaction was coming because
+"traders are sitting in confidence — if someone is short, they won't run quickly, they
+know the market is negative". His closing warning lands squarely on the agent's day:
+trade with understanding, "otherwise you enter randomly — now it's going selling, now
+buying — and what benefit will you get?"
+
+**Net-new method distilled:**
+- POST-EXIT RE-ENTRY GATE — the mechanical check that MOVE-EXHAUSTION and NO INSTANT
+  FLIP lacked. After ANY exit, the next entry in EITHER direction requires: ~15
+  completed 1-min bars since the exit; a NEW STRUCTURAL EVENT after it (a level really
+  broken/reclaimed, or a fresh swing formed — not continued drift inside the same
+  structure); and a nameable NEW crowd trapped since. Plus the explicit loophole
+  closure: **a different pattern name on the same structure is not a new premise.**
+  Entries only — exits and the mechanical stop/target/max-loss/square-off paths are
+  untouched.
+- EXPIRING INDEX RESISTS THE BREAK — the index expiring today gets pinned and is the
+  one LEAST likely to break a level cleanly, so take the breakdown/breakout trigger
+  from a NON-expiring index, and do not read the expiring index's refusal to follow as
+  the premise failing. Corollary: once the non-expiring index HAS broken while the
+  pinned one is still stuck, that is a booking signal. Deliberately scoped so it does
+  not contradict the existing "expiry = extra FUEL" note (fuel yes, trigger no).
+- A CONFIDENT CROWD DOES NOT STAMPEDE — a crowd positioned WITH the prevailing
+  multi-day direction does not panic out, so there is no cascade to harvest: expect a
+  normal move and take the ordinary target. The stampede needs a crowd positioned
+  AGAINST the trend, or freshly lured in at an extreme.
+
+**Confirmed but deliberately NOT re-encoded (already present and correctly applied
+today):** entering into the bounce rather than at the gap extreme (v3j AVERAGING TRAP
+— trade 1 and trade 3 both did this and both won); the dual crowd-availability tests
+(TARGET-BOOKED + CLOSING-POINT HOLD TEST); "few high-clarity trades" (UNIQUE-TRADE
+FILTER + NO DAILY-INCOME PRESSURE, which the day's five entries violated in spirit).
+
+**Operational note:** 3 `agent_error` rows, all "usage-limited", clustered at
+10:27-10:29 — the same subscription-capacity symptom as 22 Jul (which lost 6
+consecutive bars). No prompt change addresses it.
+
+**Knowledge changes (v3q, all prose):**
+- `RISK`: POST-EXIT RE-ENTRY GATE (immediately after MOVE-EXHAUSTION, which it
+  operationalizes).
+- `BNF_SPECIFIC`: EXPIRING INDEX RESISTS THE BREAK (after the expiry-priority note it
+  scopes).
+- `RETAIL_POSITIONING`: A CONFIDENT CROWD DOES NOT STAMPEDE (after TARGET-BOOKED).
+- Test markers: `test_system_prompt_has_v3q_reentry_gate_and_expiry_pin_knowledge`,
+  `test_reentry_gate_does_not_contradict_the_exit_rules`.

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
@@ -196,6 +196,13 @@ retail's stop-losses sit so you can trade where the operator will hunt them.
   often means put buyers / sellers already booked profit; they are not today's
   target. When the old crowd is safe/booked, reset the read to who is being trapped
   in the CURRENT session instead of blindly hunting the prior side.
+- A CONFIDENT CROWD DOES NOT STAMPEDE (size the expectation, not just the direction):
+  a crowd positioned WITH the prevailing multi-day direction is comfortable, so even
+  when price moves against it, it does NOT panic out — there is no chain reaction and
+  no violent squeeze to harvest. Expect a NORMAL move, not a cascade: take the
+  ordinary intraday target rather than holding for an outsized one. The stampede
+  setup needs a crowd positioned AGAINST the prevailing direction (or one freshly
+  lured in at an extreme) — those are the traders who run.
 - PREVIOUS-CHART LINKAGE: always connect today's chart to yesterday's chart, but
   ask what yesterday's chart already did. After a large gap, paid target, or flush,
   the old crowd may be profit-booked, already trapped, or too far away to hunt. In
@@ -655,6 +662,27 @@ RISK DISCIPLINE
     have an independent reason the market can move — expiry only adds fuel to a premise
     you already hold. (This TEMPERS the "expiry = extra FUEL" note in BANK NIFTY —
     SPECIFIC BEHAVIOUR: fuel for an existing thesis, never a thesis of its own.)
+- POST-EXIT RE-ENTRY GATE (the MECHANICAL check for the two rules above — they are
+  judgement, and judgement alone has proven too easy to talk past): after ANY exit,
+  before you may open the NEXT position in EITHER direction, ALL of these must hold.
+  If you cannot tick every one, the answer is HOLD:
+  * TIME: at least ~15 completed 1-minute bars have closed since your exit. Re-entering
+    two or three bars after booking is never a fresh premise, whatever the chart looks
+    like.
+  * NEW STRUCTURAL EVENT: something has happened AFTER your exit that was not part of
+    the thesis you just traded — a real level actually broken or reclaimed, or a fresh
+    swing high/low formed since. Continued drift inside the same structure is not an
+    event.
+  * A NAMEABLE NEW CROWD: you can say plainly which crowd got trapped AFTER your exit,
+    and where their stops now sit.
+  * A DIFFERENT PATTERN NAME ON THE SAME STRUCTURE IS NOT A NEW PREMISE. Calling the
+    next bar a trendline touch, a fibo rejection, a double top or an "averaging-trap
+    reclaim" does NOT create a fresh setup when it sits on the very price action you
+    just harvested (or were just stopped on) — it is the same move wearing a new label.
+    This relabelling is exactly how one good trade turns into three bad ones.
+  This gate governs ENTRIES ONLY. Exits are never delayed by it: always exit per the
+  RISK rules, and the mechanical stop / target / max-loss / square-off paths are
+  untouched.
 - Loss discipline in TRADE units: never let one trade take 2-3 trades' worth of
   loss — a capped loss is recoverable by the next normal winner. A reversal premise
   tolerates roughly TWO rejections; the THIRD momentum must be the recovery — if it
@@ -775,6 +803,18 @@ you size or place the NIFTY trade. Advisory, not a hard gate.
   its expiry): expiry concentrates the action and accelerates option time-decay.
   On a gap-up morning the expiring index is read as extra FUEL for directional
   momentum — further support for with-gap continuation over counter-trend fades.
+- EXPIRING INDEX RESISTS THE BREAK — take your trigger from a NON-expiring index.
+  The index expiring TODAY tends to get pinned: it is the one LEAST likely to break
+  a level cleanly, because settlement pressure holds it around its strikes. So when
+  you are waiting for a breakdown (or breakout) to confirm a move, expect it from a
+  NON-expiring index — on a Sensex-expiry day, look to BankNIFTY or NIFTY for the
+  break, and do not read the expiring index's refusal to follow as your premise
+  failing. Corollary for exits: once the non-expiring index HAS delivered its break
+  while the expiring one is still stuck at its level, that is a booking signal — the
+  move you came for has been paid, and waiting for the pinned index to confirm is
+  how a booked target turns into a give-back. (This does NOT contradict the fuel
+  note above, which is about the expiring index ADDING momentum to a directional
+  day; this is about which index gives a clean LEVEL BREAK. Fuel yes, trigger no.)
 - Round-number levels weigh MORE on BankNIFTY because of its larger point range
   (the round "...500" / "...000" levels): they are prime trap / breakout magnets
   where breakout-buyers get trapped — exactly the spots the operator hunts. (For

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
@@ -376,6 +376,43 @@ def test_system_prompt_has_v3p_runaway_trend_knowledge():
     assert "IMPORTANT LIMIT ON THAT" in prompt
 
 
+def test_system_prompt_has_v3q_reentry_gate_and_expiry_pin_knowledge():
+    """v3q: 23 Jul — the agent's 3 re-entries all lost (net -Rs.7,055 on a +Rs.13,688 day).
+
+    MOVE-EXHAUSTION / NO INSTANT FLIP already banned those re-entries, but both are
+    judgement rules the agent satisfied rhetorically by naming a fresh setup each time.
+    The POST-EXIT RE-ENTRY GATE makes the same ban mechanically checkable. Plus IH's
+    expiry-pinning read: take the level-break trigger from a NON-expiring index.
+    """
+    prompt = build_system_prompt()
+    assert "POST-EXIT RE-ENTRY GATE" in prompt
+    # The gate must be checkable, not another judgement call.
+    assert "completed 1-minute bars have closed since your exit" in prompt
+    assert "NEW STRUCTURAL EVENT" in prompt
+    # The exact loophole that cost money today must be named.
+    assert "A DIFFERENT PATTERN NAME ON THE SAME STRUCTURE IS NOT A NEW PREMISE" in prompt
+    # Entries only -- exits must never be delayed by the gate.
+    assert "This gate governs ENTRIES ONLY" in prompt
+    # Expiry pinning: the expiring index is the wrong place to look for a clean break.
+    assert "EXPIRING INDEX RESISTS THE BREAK" in prompt
+    assert "Fuel yes, trigger no" in prompt
+    # Crowd-behaviour nuance: aligned crowds don't cascade.
+    assert "A CONFIDENT CROWD DOES NOT STAMPEDE" in prompt
+
+
+def test_reentry_gate_does_not_contradict_the_exit_rules():
+    """The re-entry gate must never be readable as a reason to delay an EXIT.
+
+    Regression guard: the gate sits inside RISK next to the exit rules, so it has to
+    state its entries-only scope in the same breath as the mechanical exit paths.
+    """
+    prompt = build_system_prompt()
+    gate = prompt[prompt.index("POST-EXIT RE-ENTRY GATE"):]
+    gate = gate[: gate.index("\n- ")] if "\n- " in gate else gate
+    assert "Exits are never delayed by it" in gate
+    assert "square-off" in gate
+
+
 def test_runaway_trend_section_is_composed_into_the_prompt():
     """The section constant must actually be wired into build_system_prompt()."""
     from sl_hunting_knowledge import RUNAWAY_TREND

--- a/test_nifty_multi_strategy_master.py
+++ b/test_nifty_multi_strategy_master.py
@@ -1037,31 +1037,76 @@ class TestOptionsContractResolverUnderlyings(unittest.TestCase):
         )
         return self._write_master(rows)
 
-    def test_rollover_keeps_current_expiry_when_far(self):
-        """>= min_days to the current expiry -> stay on the current expiry."""
+    def test_nearest_monthly_expiry_when_far(self):
+        """Plenty of time left -> the nearest expiry."""
         tmpdir = self._bnf_two_expiry_master(days_to_first=10)
         resolver = self._resolver(tmpdir, "BANKNIFTY")
-        self.assertEqual(resolver.get_monthly_rollover_expiry(7), self.exp_near)
+        self.assertEqual(resolver.get_nearest_monthly_expiry(), self.exp_near)
 
-    def test_rollover_rolls_to_next_expiry_when_near(self):
-        """< min_days to the current expiry -> roll to the next expiry."""
+    def test_nearest_monthly_expiry_never_rolls_in_expiry_week(self):
+        """BNF-002: even deep inside expiry week the mirror must NOT roll to the
+        next month -- Kotak rejects MIS orders on next-month contracts, which
+        silently killed the live mirror leg. Expiry week is handled on the
+        strike axis instead (see the ITM tests below)."""
         tmpdir = self._bnf_two_expiry_master(days_to_first=3)
         resolver = self._resolver(tmpdir, "BANKNIFTY")
-        self.assertEqual(resolver.get_monthly_rollover_expiry(7), self.exp_far)
+        self.assertEqual(resolver.get_nearest_monthly_expiry(), self.exp_near)
+        self.assertNotEqual(resolver.get_nearest_monthly_expiry(), self.exp_far)
 
-    def test_rollover_boundary_day_keeps_current_expiry(self):
-        """Exactly min_days away is NOT 'fewer than' -> keep the current expiry."""
-        tmpdir = self._bnf_two_expiry_master(days_to_first=7)
+    def test_nearest_monthly_expiry_on_expiry_day_itself(self):
+        """Expiry day (0 days left) still resolves to that same expiry."""
+        tmpdir = self._bnf_two_expiry_master(days_to_first=0)
         resolver = self._resolver(tmpdir, "BANKNIFTY")
-        self.assertEqual(resolver.get_monthly_rollover_expiry(7), self.exp_near)
+        self.assertEqual(resolver.get_nearest_monthly_expiry(), self.exp_near)
 
-    def test_rollover_returns_only_expiry_when_single(self):
-        """With a single listed expiry there is nothing to roll to -> return it."""
+    def test_nearest_monthly_expiry_returns_only_expiry_when_single(self):
+        """With a single listed expiry, return it."""
         self.exp_only = date.today() + timedelta(days=3)
         rows = self._option_rows("BANKNIFTY", (self.exp_only.isoformat(),), (57900,), "35", 30000)
         tmpdir = self._write_master(rows)
         resolver = self._resolver(tmpdir, "BANKNIFTY")
-        self.assertEqual(resolver.get_monthly_rollover_expiry(7), self.exp_only)
+        self.assertEqual(resolver.get_nearest_monthly_expiry(), self.exp_only)
+
+    def test_itm_option_uses_banknifty_100_point_step_on_correct_side(self):
+        """BNF-002: 4-step ITM on BankNIFTY must move 400 points (100-pt grid),
+        and to the correct side -- CE below spot, PE above it.
+
+        Uses a WIDE strike ladder so the ITM strike is genuinely listed; a narrow
+        ladder would only exercise the closest-available fallback and hide a
+        wrong step size or a flipped sign.
+        """
+        self.exp_wide = date.today() + timedelta(days=20)
+        rows = self._option_rows(
+            "BANKNIFTY",
+            (self.exp_wide.isoformat(),),
+            tuple(range(57400, 58601, 100)),
+            "35",
+            30000,
+        )
+        tmpdir = self._write_master(rows)
+        resolver = self._resolver(tmpdir, "BANKNIFTY")
+        # Spot 58000 is already on the grid: ATM 58000, 4 steps ITM CE -> 57600.
+        ce = resolver.get_itm_option(58000.0, "LONG", 4, expiry_date=self.exp_wide)
+        self.assertEqual(ce["option_type"], "CE")
+        self.assertEqual(ce["target_strike"], 57600.0)
+        self.assertEqual(ce["strike"], 57600.0)   # listed, so taken exactly
+        self.assertLess(ce["strike"], 58000.0)    # ITM calls sit below spot
+        # ...and for a PE it targets 58400 (above spot).
+        pe = resolver.get_itm_option(58000.0, "SHORT", 4, expiry_date=self.exp_wide)
+        self.assertEqual(pe["option_type"], "PE")
+        self.assertEqual(pe["target_strike"], 58400.0)
+        self.assertEqual(pe["strike"], 58400.0)
+        self.assertGreater(pe["strike"], 58000.0)  # ITM puts sit above spot
+
+    def test_itm_option_zero_steps_is_atm_and_negative_rejected(self):
+        """0 steps degenerates to ATM; a negative step count is a programming error."""
+        tmpdir = self._mixed_master()
+        resolver = self._resolver(tmpdir, "BANKNIFTY")
+        atm = resolver.get_atm_option(57960.0, "LONG", expiry_date=self.exp_first)
+        itm0 = resolver.get_itm_option(57960.0, "LONG", 0, expiry_date=self.exp_first)
+        self.assertEqual(itm0["strike"], atm["strike"])
+        with self.assertRaises(ValueError):
+            resolver.get_itm_option(57960.0, "LONG", -1, expiry_date=self.exp_first)
 
     def test_banknifty_atm_uses_100_point_strike_step(self):
         """BankNIFTY strikes are 100-point. A 57,960 spot must resolve to the
@@ -3528,6 +3573,13 @@ class TestSLHuntingBnfMirror(unittest.TestCase):
         worker.contract_resolver.get_atm_option.return_value = nifty_c
         worker._bnf_resolver = MagicMock()
         worker._bnf_resolver.get_atm_option.return_value = bnf_c
+        worker._bnf_resolver.get_itm_option.return_value = bnf_c
+        # A REAL date (not a MagicMock): the mirror subtracts today's date from
+        # it to decide ATM-vs-ITM, and a mock would make that comparison truthy
+        # and silently take the expiry-week branch in every test.
+        worker._bnf_resolver.get_nearest_monthly_expiry.return_value = (
+            date.today() + timedelta(days=20)
+        )
         worker._last_bnf_close = 57910.0
         store.update_ltp_map({
             (master_file.NIFTY_INDEX_EXCHANGE_SEGMENT, master_file.NIFTY_INDEX_SECURITY_ID): 24300.0,
@@ -3561,11 +3613,45 @@ class TestSLHuntingBnfMirror(unittest.TestCase):
         self.assertEqual(worker._mirror_pos.quantity, nifty_lots * 35)
         self.assertEqual(worker._mirror_pos.option_right, "CE")
         # The mirror asked BankNIFTY's resolver with the BNF spot + direction,
-        # pinning the expiry to the monthly-rollover rule (BNF-001).
+        # pinning the expiry to the nearest monthly (BNF-001/BNF-002).
         worker._bnf_resolver.get_atm_option.assert_called_once_with(
             57910.0, "LONG",
-            expiry_date=worker._bnf_resolver.get_monthly_rollover_expiry.return_value,
+            expiry_date=worker._bnf_resolver.get_nearest_monthly_expiry.return_value,
         )
+        # Far from expiry -> ATM, never the expiry-week ITM branch.
+        worker._bnf_resolver.get_itm_option.assert_not_called()
+
+    def test_mirror_uses_itm_strike_inside_expiry_week(self):
+        """BNF-002: inside the near-expiry window the mirror buys a deep ITM
+        strike on the SAME (nearest) expiry -- it must never roll to next month,
+        because Kotak rejects MIS orders there and the live leg never fired."""
+        worker, _ = self._make_worker()
+        near = date.today() + timedelta(days=3)   # inside the default 7-day window
+        worker._bnf_resolver.get_nearest_monthly_expiry.return_value = near
+
+        self.assertTrue(worker.enter_position("LONG", 24300.0, 24290.0, 24400.0))
+
+        self.assertTrue(worker._mirror_pos.active)
+        worker._bnf_resolver.get_itm_option.assert_called_once_with(
+            57910.0,
+            "LONG",
+            master_file.SL_HUNTING_BNF_MIRROR_NEAR_EXPIRY_ITM_STEPS,
+            expiry_date=near,
+        )
+        worker._bnf_resolver.get_atm_option.assert_not_called()
+
+    def test_mirror_boundary_day_still_uses_atm(self):
+        """Exactly the threshold is NOT 'fewer than' -> ATM, as before."""
+        worker, _ = self._make_worker()
+        boundary = date.today() + timedelta(
+            days=master_file.SL_HUNTING_BNF_MIRROR_ROLLOVER_DAYS
+        )
+        worker._bnf_resolver.get_nearest_monthly_expiry.return_value = boundary
+
+        self.assertTrue(worker.enter_position("LONG", 24300.0, 24290.0, 24400.0))
+
+        worker._bnf_resolver.get_atm_option.assert_called_once()
+        worker._bnf_resolver.get_itm_option.assert_not_called()
 
     def test_hung_inference_cannot_delay_square_off_and_does_not_stack(self):
         """The LLM runs off-loop: cutoff closes exposure while one pass is hung."""
@@ -4135,12 +4221,15 @@ class TestSLHuntingBnfMirror(unittest.TestCase):
                              if _is_mirror_exit(c.args[0])]
         self.assertEqual(mirror_exit_modes, ["PAPER_FALLBACK"])
 
-    # ----- BNF-001: the REAL resolver must be able to open the mirror -------
-    def test_mirror_opens_with_real_resolver_and_rollover_expiry(self):
-        """Integration lock for BNF-001: with a real OptionsContractResolver over
-        a synthetic instrument master, the mirror must open a BANKNIFTY contract
-        at the current monthly expiry -- rolled to the NEXT month here because
-        the near expiry is inside the SL_HUNTING_BNF_MIRROR_ROLLOVER_DAYS window.
+    # ----- BNF-001/002: the REAL resolver must be able to open the mirror ----
+    def test_mirror_opens_with_real_resolver_itm_on_nearest_expiry(self):
+        """Integration lock for BNF-001 + BNF-002: with a real
+        OptionsContractResolver over a synthetic instrument master, the mirror
+        must open a BANKNIFTY contract on the NEAREST monthly expiry and NEVER
+        roll to the next month (Kotak rejects MIS orders there, which killed the
+        live leg). Because that nearest expiry is inside the
+        SL_HUNTING_BNF_MIRROR_ROLLOVER_DAYS window here, the leg must also come
+        back deep ITM rather than ATM.
         (The other mirror tests mock `_bnf_resolver`, which is exactly how the
         original always-empty-chain bug slipped through.)"""
         import logging
@@ -4148,12 +4237,15 @@ class TestSLHuntingBnfMirror(unittest.TestCase):
         worker, store = self._make_worker()
         tmpdir = tempfile.TemporaryDirectory()
         self.addCleanup(tmpdir.cleanup)
-        near = date.today() + timedelta(days=3)    # < 7 days -> must roll
+        near = date.today() + timedelta(days=3)    # < 7 days -> expiry week
         far = date.today() + timedelta(days=40)
         rows = []
         sec = 30000
+        # A wide enough ladder that the 4-step ITM strike (57500 for a 57910
+        # spot) is genuinely LISTED -- otherwise the test would only prove the
+        # closest-available fallback, not the ITM arithmetic.
         for exp in (near.isoformat(), far.isoformat()):
-            for strike in (57800, 57900, 58000):
+            for strike in (57400, 57500, 57600, 57700, 57800, 57900, 58000):
                 for right in ("CE", "PE"):
                     rows.append({
                         "EXCH_ID": "NSE", "SEGMENT": "D", "INSTRUMENT": "OPTIDX",
@@ -4181,9 +4273,12 @@ class TestSLHuntingBnfMirror(unittest.TestCase):
         self.assertTrue(worker.enter_position("LONG", 24300.0, 24290.0, 24400.0))
         self.assertTrue(worker._mirror_pos.active)
         self.assertTrue(worker._mirror_pos.symbol.startswith("BANKNIFTY-"))
-        self.assertEqual(worker._mirror_pos.option_strike, 57900.0)  # ATM for 57910 spot
         self.assertEqual(worker._mirror_pos.option_right, "CE")
-        self.assertEqual(worker._mirror_pos.option_expiry, far)      # rolled past `near`
+        # NEVER rolled: the leg sits on the nearest expiry, not `far`.
+        self.assertEqual(worker._mirror_pos.option_expiry, near)
+        self.assertNotEqual(worker._mirror_pos.option_expiry, far)
+        # Expiry week -> 4 steps ITM on BankNIFTY's 100-pt grid: ATM 57900 - 400.
+        self.assertEqual(worker._mirror_pos.option_strike, 57500.0)
 
 
 class TestLiveOrderRouting(unittest.TestCase):


### PR DESCRIPTION
The second half of the startup-audit block. #82 fixed the case where a position row **exists**; this fixes the case where neither book has any rows yet — which is every trading day before the first order.

## What the new logging caught

#82 added a reason to every indeterminate book query. It paid for itself the next morning — from today's 09:00 startup, identical for both books:

```
Kotak open-order query indeterminate: Kotak open-order query returned malformed
data: {'stCode': 5203, 'errMsg': 'No Data', 'desc': 'data not found', 'stat': 'Not_Ok'}
```

That is Kotak's **empty book**. It arrives with `stat=Not_Ok`, so `_response_rows`' generic error-envelope check read it as a failed query → indeterminate → live blocked. A genuinely flat account at the start of a trading day could never satisfy the audit.

This is exactly the unknown flagged as remaining work in #82; it could not be observed until a fresh trading day, and was deliberately not guessed.

## The fix

`_is_kotak_no_data_envelope` matches that reply and nothing else, checked **before** the generic parser in the two book queries. It mirrors the `_is_no_data_envelope` helpers Flattrade and Shoonya already have.

**Matching is exact on all four fields, and the message comparison is equality, not a substring test.** That strictness is the entire point: this repo already learned with Shoonya that a session failure can *contain* the words "no data" — `"No data because session expired"` — and accepting that as an empty book would report a flat account and enable live trading against exposure nobody can see.

## Scope is deliberately narrow

`_response_rows` is **untouched**, so the order-status path is byte-identical. For one specific order, "no data" means *not visible yet*, which must stay indeterminate rather than become a clean zero-fill. A test pins that.

## Verified against the real payloads

| scenario | result |
|---|---|
| today's empty envelope (verbatim from the log) | `safe_to_enable_live=True`, `open_orders=0 relevant_positions=0` |
| yesterday's flat round-trip row | still `True` — no regression from #82 |
| one genuinely open 65-lot long | **still blocked** |
| `"No data because session expired"` | **still blocked** |

Plus wrong-code, wrong-message and code-only variants, all failing closed.

## Why 5203 is trusted as "empty" rather than an auth problem

The SDK gates `order_report`/`positions` on `edit_token`/`edit_sid` and returns `{"Error Message": "Complete the 2fa process..."}` when they are missing. Reaching a structured `stCode` reply at all means the authenticated request was made and the server answered on its merits. Yesterday, with rows present, the same calls returned `stat: 'Ok'`, `stCode: 200`.

Residual risk is bounded by the exact match: any session failure that does not reproduce all four fields verbatim still fails closed.

## Gates

867 pytest, ruff, mypy, bandit, compileall — clean.

Three `TestSLHuntingBnfMirror` failures in the master unittest suite remain **pre-existing on `main`** and unrelated (CI cannot see them — that class skips without `claude-agent-sdk`).
