### PR TITLE
Add v3r July 24 SL Hunting match lessons

### DIFF
--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -1355,3 +1355,91 @@ consecutive bars). No prompt change addresses it.
 - `RETAIL_POSITIONING`: A CONFIDENT CROWD DOES NOT STAMPEDE (after TARGET-BOOKED).
 - Test markers: `test_system_prompt_has_v3q_reentry_gate_and_expiry_pin_knowledge`,
   `test_reentry_gate_does_not_contradict_the_exit_rules`.
+
+## Video addendum - 24 Jul profit-booking recovery + lagging-index entry (v3r)
+
+> Sources (full Hindi auto-transcripts from the YouTube transcript panel):
+> - `c6fC2LRkocE` (24 Jul 2026, "Live Bank Nifty Option Trading", 11:25) -
+>   primary live-session evidence.
+> - `ekVgnszh7tU` (23 Jul 2026, "Prediction For 24 JULY 2026", 2:17) -
+>   supporting premarket plan for the 24 Jul session.
+>
+> Cross-checked against BOTH agent artefacts for 2026-07-24:
+> `Backtest Outputs/sl_hunting_decisions.jsonl` and
+> `Backtest Outputs/sl_hunting_journal.jsonl`.
+
+The premarket thesis was sell-side under every opening type. The preceding market
+had already sold hard and given some retracement, so established sellers were in
+profit and were not the crowd to hunt. A gap-down was the cleanest continuation
+case; flat carried some support-trap risk, while a gap-up would first need to build
+its own negative-side trap.
+
+The live market gapped down and recovered. NIFTY and Sensex rose too quickly to show
+a controlled short entry, so IH watched the lagging BankNIFTY for the recovery to
+stall. When it did, he opened one PUT basket: BankNIFTY 56200 PUT (1,170 quantity),
+Sensex PUT (900), and NIFTY PUT (1,365). The failure case was explicit: if the
+recovery kept running, retraced, and then produced another strong upward impulse,
+the short direction was wrong. Instead, the recovery stalled and selling resumed.
+He booked the profitable basket after the sharp drop began attracting obvious new
+sellers and the intraday reward had paid the planned risk.
+
+**The tally for 2026-07-24:**
+
+| Source | Result |
+|---|---|
+| decisions | **72 decisions**: 64 HOLD, 4 entries, 4 EXIT |
+| decision errors | **1 `agent_error`** at 10:26 ("Previous agent call still running") |
+| journal | **4 completed trades**, net **+Rs.19,136.75** |
+| IH | **WIN** - one PUT basket after the gap-down recovery stalled |
+
+| # | Entry | Direction / setup | Result |
+|---|---|---|---|
+| 1 | 09:20 | LONG `gap_down_flush_hammer_reversal` | **-Rs.726.25** |
+| 2 | 09:27 | SHORT `gap_down_recovery_fail_bearish_engulfing` | **+Rs.11,951.25** |
+| 3 | 09:39 | SHORT `gap_down_recovery_fail_bearish_engulfing` | **+Rs.3,633.00** |
+| 4 | 10:01 | SHORT `gap_down_failed_recovery_short` | **+Rs.4,278.75** |
+
+The 09:27 short matched IH's direction and recovery-failure premise. The agent's
+preceding 09:20 long treated the first hammer recovery as a seller hunt, which was
+the method mismatch: paid multi-day sellers plus an expected profit-booking bounce
+did not establish a new long premise. The two later shorts repeated the same
+already-captured move. Short trades made **+Rs.19,863.00** in total, but their profit
+does not turn the repeated entries into new method evidence.
+
+**Net-new method distilled:**
+- PROFIT-BOOKING RECOVERY TEST: after an established multi-day selloff has paid the
+  seller crowd and the next session gaps down, the first green recovery can be
+  seller profit-booking rather than a seller-hunt reversal. A hammer / first bounce
+  is not enough for a long. Keep the continuation short conditional until the
+  recovery either stalls below the closing point / round number / opening range, or
+  invalidates it with a reclaim, held pullback, and second strong upward impulse.
+- LAGGING-INDEX ENTRY LOCATOR: when positioning and the triple-index read have
+  already fixed the day direction but the faster indices provide no clean entry,
+  use the lagging index's stall / rejection to locate timing. It is an entry cue,
+  not a standalone directional premise, and remains subordinate to MASKED BNF LAG,
+  GAP-SIZE ASYMMETRY, and SOLO-LEADER VETO.
+
+**Confirmed but deliberately NOT re-encoded (already present):** TARGET-BOOKED
+crowd filtering; the strict GAP-DOWN CONTINUATION SHORT; fast-spike profit booking;
+the fast-one-way / slow-other-way trap; MOVE-EXHAUSTION; and the POST-EXIT RE-ENTRY
+GATE.
+
+**Historical operational findings (documented, no runtime change in v3r):**
+- The first short's journal row says `placeholder - will not call, holding`, while
+  its 09:38 decision records that an erroneous order-tool invocation closed both
+  legs early. This is journal fidelity, not a new SL-hunting method.
+- Every entry after an exit occurred inside the existing ~15 completed-bar re-entry
+  gate: 09:27 after the long exit, 09:39 after the first short exit, and 10:01 after
+  the second short exit. The 09:38 decision even named the gate, but the next
+  independent per-bar call received only the current FLAT state and recent candles,
+  not the previous exit time / structure. Another prose rule cannot supply missing
+  cross-call state; runtime enforcement is a separate follow-up.
+- The single 10:26 `agent_error` was a still-running prior call. No prompt change
+  addresses inference concurrency in this knowledge-only version.
+
+**Knowledge changes (v3r, all prose):**
+- `RETAIL_POSITIONING`: PROFIT-BOOKING RECOVERY TEST, beside TARGET-BOOKED.
+- `BNF_SPECIFIC`: LAGGING-INDEX ENTRY LOCATOR, scoped against the existing lag and
+  divergence rules.
+- Test marker:
+  `test_system_prompt_has_v3r_profit_booking_recovery_and_lagging_index_knowledge`.

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
@@ -196,6 +196,22 @@ retail's stop-losses sit so you can trade where the operator will hunt them.
   often means put buyers / sellers already booked profit; they are not today's
   target. When the old crowd is safe/booked, reset the read to who is being trapped
   in the CURRENT session instead of blindly hunting the prior side.
+- PROFIT-BOOKING RECOVERY TEST (scopes TARGET-BOOKED on an established selloff):
+  after a real multi-day selloff has already paid the seller crowd and the next
+  session gaps down, the first green recovery may simply let those profitable
+  sellers book and keep obvious fresh shorts from entering. It is not proof that a
+  new seller crowd is seated and huntable; the first bounce alone is not a LONG
+  premise, even when it prints a hammer. Keep the continuation-short plan
+  CONDITIONAL until the recovery declares itself:
+  * Recovery stalls / rejects below the closing point, round number, or opening
+    range -> the profit-booking leg is spent; use the normal confirmed-rejection
+    rules (or every condition of GAP-DOWN CONTINUATION SHORT) to enter with selling.
+  * Recovery reclaims that level, holds a pullback, and then produces a SECOND
+    strong upward impulse -> the continuation-short premise is invalid; do not
+    rationalise the first plan against a genuine two-leg bullish recovery.
+  This test applies only when PREVIOUS-CHART LINKAGE and TARGET-BOOKED show that the
+  established seller crowd was already paid. Otherwise the normal gap-down
+  seller-hunt and current-session trap rules still govern.
 - A CONFIDENT CROWD DOES NOT STAMPEDE (size the expectation, not just the direction):
   a crowd positioned WITH the prevailing multi-day direction is comfortable, so even
   when price moves against it, it does NOT panic out — there is no chain reaction and
@@ -831,6 +847,15 @@ you size or place the NIFTY trade. Advisory, not a hard gate.
   honest read (the divergence-fails rule, two holders against one breaker). Do not
   rush an entry merely because the leader moved first; wait for at least one other
   index to reclaim its closing point.
+- LAGGING-INDEX ENTRY LOCATOR: when the day direction is ALREADY established from
+  retail positioning and the triple-index read, but NIFTY / Sensex are moving too
+  quickly to offer a controlled entry, use the lagging index (often BankNIFTY) to
+  LOCATE the timing. Wait for that laggard to stall, print small candles / rejection,
+  and confirm in the planned direction; its failure to join the fast move is the
+  entry-timing cue only, never a standalone directional premise. This does not
+  overrule MASKED BNF LAG, GAP-SIZE ASYMMETRY, or SOLO-LEADER VETO: if the other two
+  indices sustain and hold the move, or the laggard joins instead of rejecting, the
+  contrary entry is absent. BankNIFTY remains advisory; execution stays NIFTY-only.
 - THIRD-INDEX LAG: when TWO indices have broken a shared round number / closing
   price, the THIRD frequently does NOT follow — it lags or reacts in the opposite
   direction. Do not assume a two-index break commits the third; its refusal is

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
@@ -413,6 +413,24 @@ def test_reentry_gate_does_not_contradict_the_exit_rules():
     assert "square-off" in gate
 
 
+def test_system_prompt_has_v3r_profit_booking_recovery_and_lagging_index_knowledge():
+    """v3r: 24 Jul - classify the recovery first, then time entry from the laggard.
+
+    A first bounce after a paid multi-day selloff is not automatically a seller-hunt
+    long. Once the short day-direction premise is established, a lagging index may
+    locate the entry, but it may not invent the direction.
+    """
+    prompt = build_system_prompt()
+    assert "PROFIT-BOOKING RECOVERY TEST" in prompt
+    assert "first bounce alone" in prompt and "not a LONG" in prompt
+    assert "LAGGING-INDEX ENTRY LOCATOR" in prompt
+    assert "entry-timing cue only" in prompt
+    # v3r scopes the existing rules; it does not replace or weaken them.
+    assert "TARGET-BOOKED crowd test" in prompt
+    assert "GAP-DOWN CONTINUATION SHORT" in prompt
+    assert "MASKED BNF LAG" in prompt
+
+
 def test_runaway_trend_section_is_composed_into_the_prompt():
     """The section constant must actually be wired into build_system_prompt()."""
     from sl_hunting_knowledge import RUNAWAY_TREND


### PR DESCRIPTION
## Summary

- add `PROFIT-BOOKING RECOVERY TEST` so the first bounce after a paid multi-day selloff is not automatically treated as a seller-hunt long
- add `LAGGING-INDEX ENTRY LOCATOR` so an already-established day direction can use the lagging index's stall for timing without letting lag invent direction
- document the July 24 Intraday Hunter live-session and premarket transcripts, the exact agent-vs-IH trade tally, and the deferred cross-call re-entry context limitation
- keep the change prompt-only: no runtime, broker, order, schema, environment, or sizing behavior changes

## Evidence

The July 24 live transcript shows one profitable PUT basket after the gap-down recovery stalled. The agent recorded 72 decisions and four completed trades: one contrary long for -Rs.726.25 and three shorts for +Rs.19,863.00, net +Rs.19,136.75. The 09:27 short matched the Intraday Hunter premise; the later shorts repeated the same move.

## Validation

- `python -m pytest "Signal Generators/SL Hunting AI Agent/tests" -q` -> 109 passed, 1 upstream deprecation warning
- `python -m compileall -q "Signal Generators/SL Hunting AI Agent"`
- `git diff --check`

Co-authored with Codex (`Co-authored-by: Codex <codex@openai.com>`).