### PR TITLE
SL Hunting v3s: laggards-must-join booking + post-exit re-entry cooldown enforced in code (SLH-005)

### DIFF
--- a/Dependencies/env.example
+++ b/Dependencies/env.example
@@ -1276,6 +1276,16 @@ SL_HUNTING_BNF_MIRROR_ROLLOVER_DAYS=7
 # How deep in the money that expiry-week strike sits, in strike steps
 # (BankNIFTY steps are 100 points, so 4 = 400 points ITM).
 SL_HUNTING_BNF_MIRROR_NEAR_EXPIRY_ITM_STEPS=4
+# Post-exit re-entry cooldown in MINUTES (SLH-005). After ANY close, the agent's
+# order tool refuses a new entry for this long. The prompt already carries a
+# judgement-based re-entry gate, but the live journal showed the agent talking
+# past it twice (23 + 27 Jul 2026) by relabelling the same price structure as a
+# fresh setup -- so the time arm is enforced in code. Replaying both journals, a
+# 5-minute floor blocks exactly the losing snap-backs, while 15 minutes would
+# ALSO have blocked 27 Jul's biggest winner. EXITS are never delayed by this, and
+# the mechanical stop / target / max-loss / square-off paths are untouched.
+# Set 0 to disable.
+SL_HUNTING_POST_EXIT_COOLDOWN_MINUTES=5
 # Daily kill-switch -- SEPARATE from the per-trade RISK_BUDGET above. The strategy
 # halts for the rest of the day once its cumulative P&L (realized + open) hits
 # -(STARTING_CAPITAL * DAILY_MAX_LOSS_PCT). 600000 * 0.0125 = Rs.7,500/day, i.e.

--- a/Nifty Multi Strategy Front Test - Master File.py
+++ b/Nifty Multi Strategy Front Test - Master File.py
@@ -12023,6 +12023,21 @@ if SL_HUNTING_AVAILABLE:
     SL_HUNTING_BNF_MIRROR_NEAR_EXPIRY_ITM_STEPS = _env_int(
         "SL_HUNTING_BNF_MIRROR_NEAR_EXPIRY_ITM_STEPS", 4
     )
+    # Post-exit re-entry cooldown (SLH-005). After ANY close, the agent's order
+    # tool REFUSES a new entry for this many minutes. The prompt already carries
+    # a judgement-based POST-EXIT RE-ENTRY GATE, but the live journal showed the
+    # agent talking past it twice (23 and 27 Jul 2026) by relabelling the same
+    # price structure as a fresh setup -- so the time arm is enforced in code,
+    # where it cannot be reasoned away.
+    #
+    # Why 5 and not the prompt's older "~15 bars": replaying both journals, a
+    # 5-minute floor blocks exactly the losing snap-backs while a 15-minute one
+    # would ALSO have blocked 27 Jul's +Rs.18,858 winner (entered 12.4 min after
+    # the prior exit). 5 also matches POST_EXIT_COOLDOWN_MINUTES, the same guard
+    # the hedged-puts worker has always used. Set 0 to disable.
+    SL_HUNTING_POST_EXIT_COOLDOWN_MINUTES = _env_int(
+        "SL_HUNTING_POST_EXIT_COOLDOWN_MINUTES", 5
+    )
     # Trade journal (v3): record each trade's entry context + exit outcome to a
     # gitignored JSONL the reflection coach reads. Best-effort; never blocks trading.
     SL_HUNTING_JOURNAL_ENABLED = _env_bool("SL_HUNTING_JOURNAL_ENABLED", True)
@@ -12145,6 +12160,10 @@ if SL_HUNTING_AVAILABLE:
             # exit path (SL/target, max-loss, square-off, EXIT BOTH) leaves it False, so
             # the mirror stays tied for hard risk exactly as before.
             self._suppress_mirror_close = False
+            # Wall-clock of this worker's most recent close, used by the
+            # post-exit re-entry cooldown (SLH-005). None until the first exit,
+            # so the day's FIRST entry is never delayed.
+            self._last_exit_at: datetime | None = None
             # Latest BankNIFTY close seen this session (refreshed each decision
             # bar from the same fetch that feeds cross-confirmation); used to
             # pick the mirror's ATM strike.
@@ -12627,6 +12646,11 @@ if SL_HUNTING_AVAILABLE:
             mirror stays open AND the journal close is DEFERRED so option_pnl still
             captures both legs -- finalized when the mirror closes."""
             super().after_exit(closed_position, reason)
+            # SLH-005: arm the post-exit re-entry cooldown. Deliberately set for
+            # EVERY close (agent EXIT, stop/target, max-loss, square-off): the
+            # failure this guards against is re-entering straight after ANY exit,
+            # and a stop-out is the case where that reflex is most costly.
+            self._last_exit_at = datetime.now()
             if not self._suppress_mirror_close:
                 try:
                     self._close_bnf_mirror(reason)
@@ -12647,6 +12671,27 @@ if SL_HUNTING_AVAILABLE:
                 self._pending_journal_exit = static
                 return
             self._finalize_journal(static)
+
+        def post_exit_cooldown_remaining_seconds(self) -> float:
+            """Seconds still to run on the post-exit re-entry cooldown (SLH-005).
+
+            0.0 means a new entry is allowed. Read by the agent's entry path
+            (`MasterWorkerExecutor.enter`) so a fresh ENTER inside the window is
+            REJECTED with a reason the model can see, rather than relying on the
+            prompt's judgement-based POST-EXIT RE-ENTRY GATE -- which the live
+            journal showed being talked past on 23 and 27 Jul 2026 by relabelling
+            the same price structure as a new setup.
+
+            Set `SL_HUNTING_POST_EXIT_COOLDOWN_MINUTES=0` to disable entirely.
+            EXITS are never affected: this is consulted on the entry path only.
+            """
+            if SL_HUNTING_POST_EXIT_COOLDOWN_MINUTES <= 0:
+                return 0.0
+            if self._last_exit_at is None:
+                return 0.0
+            elapsed = (datetime.now() - self._last_exit_at).total_seconds()
+            remaining = SL_HUNTING_POST_EXIT_COOLDOWN_MINUTES * 60.0 - elapsed
+            return remaining if remaining > 0 else 0.0
 
         def minimum_strategy_rows(self) -> int:
             # Enough derived bars for swings / fibo / structure, with a margin.

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -1356,6 +1356,118 @@ consecutive bars). No prompt change addresses it.
 - Test markers: `test_system_prompt_has_v3q_reentry_gate_and_expiry_pin_knowledge`,
   `test_reentry_gate_does_not_contradict_the_exit_rules`.
 
+## Video addendum - 27 Jul laggards-must-join + the gate moves into code (v3s)
+
+> Source: `PezwEQ300lo` (27 Jul 2026, "Live Bank Nifty Option Trading"). Full Hindi
+> auto-transcript (fresh-tab recipe). No weekend lecture this cycle — the channel
+> went 24 Jul prediction straight to 27 Jul.
+> Tallied against BOTH artefacts for 2026-07-27.
+
+**The tally — a WINNING day whose shape still exposes the same defect:**
+
+| Source | Result |
+|---|---|
+| decisions | 73 (63 HOLD, **5 entries**, 5 EXIT) + 2 `agent_error` ("usage-limited", 09:17) |
+| journal | **5 trades, net +Rs.9,012.25** |
+| IH | **WIN** — one short basket into the gap-up, booked early without his breakdown |
+
+| # | Entry | Direction / setup | Result |
+|---|---|---|---|
+| 1 | 09:20 | SHORT `huge_gap_mindset_trap_fade` | **-Rs.2,703** (held 55 seconds) |
+| 2 | 09:23 | LONG `gapup_flush_hammer_reclaim` | -Rs.1,666 |
+| 3 | 10:02 | LONG `psych_support_hammer_reversal` | -Rs.1,679 |
+| 4 | 10:18 | SHORT `double_top_bearish_engulfing` | **+Rs.18,858** |
+| 5 | 10:22 | SHORT `trendline_continuation_fibo_rejection` | **-Rs.3,797** |
+
+Session summary (IH): a clear gap-up (big on Sensex). He SOLD immediately across all
+three. Premise: the prior session sold continuously then closed off a recovery, and
+**the two-day weekend made those short-holders book and leave** — so no seller SLs are
+seated, and the gap-up must therefore build a BUYER trap. He conceded his entry looked
+early ("the entry seems to have gone wrong, but we won't be wrong on DIRECTION") and
+held within a loss limit. BankNIFTY then fell hard — but Sensex and NIFTY refused to
+break down. He waited for that breakdown, never got it, and **booked anyway** once
+BankNIFTY started printing very small candles: "if Sensex and NIFTY had broken down the
+target could have DOUBLED, but they keep holding and retracing, so the risk has grown."
+His closing read is the sharp part: with the shared move dead the session can only
+resolve two ways, and "if it starts going up, good seller SLs will be available" — i.e.
+his own short would become the harvestable inventory.
+
+**Agent vs IH — same thesis, opposite conviction.** Trade 1 IS IH's trade: the agent
+named the huge-gap mindset trap and shorted the gap-up at 09:20. It then **abandoned it
+after 55 seconds** at -26.2 points, with an exit reason asserting the "SL-hunt leg ...
+captured" while the position was in fact at a loss. It spent the next hour fighting its
+own read with two LONGs (both losers) before returning to the identical short thesis at
+10:18 — which produced the day's entire profit. Direction agreement was never the
+problem; conviction and re-entry discipline were.
+
+**The defect this addendum exists for.** Trade 5 opened **89 seconds** after trade 4
+closed, in the SAME direction, and gave back Rs.3,797 of an Rs.18,858 winner. Its
+reasoning never mentions the POST-EXIT RE-ENTRY GATE at all — it simply named a new
+setup ("the 4th touch on a descending trendline"), which is precisely the relabelling
+loophole v3q was written to close. The gate has been in the prompt since 23 Jul, so
+this is the SECOND consecutive session in which a prose rule failed to bind.
+
+Replaying both journals against candidate cooldowns (approximate — blocking one entry
+shifts the clock for the next):
+
+| Cooldown | 23 Jul kept | 27 Jul kept |
+|---|---|---|
+| none (actual) | -Rs.7,055 | +Rs.9,012 |
+| 2 min | -Rs.7,055 | +Rs.12,810 |
+| **5 min** | **+Rs.1,163** | **+Rs.14,476** |
+| 10 min | +Rs.1,163 | +Rs.14,476 |
+| 15 min | +Rs.13,689 | **-Rs.8,179** |
+
+5 and 10 minutes are identical on this sample; **15 minutes is actively harmful** — it
+would have blocked 27 Jul's Rs.18,858 winner (entered 12.4 min after the prior exit).
+That is direct evidence AGAINST v3q's own "~15 completed bars" prose, which is
+corrected here.
+
+**Net-new method distilled:**
+- LAGGARDS NEVER JOINED → BOOK WHAT YOU HAVE: the HOLDING-side counterpart to
+  SOLO-LEADER VETO (entry-only). When the leader delivers your direction but the other
+  two indices never break their own levels, the triple-index move that justified your
+  TARGET is not forming — take what the leader gave instead of waiting for the
+  breakdown that would "double" it. Booking trigger: the leader starts stalling into
+  small candles while the laggards are still unbroken. Urgency: with the shared move
+  dead the session resolves binary, and if it resolves against you the crowd holding
+  your direction — now including YOU — is the freshly seated inventory the operator
+  hunts next. Distinct from the leader FAILING to lead (v3l): there the leader quit;
+  here the leader worked and the followers refused.
+
+**Behaviour change (operator-approved): the re-entry gate's TIME arm is now enforced in
+CODE (SLH-005), not prose.** `MasterWorkerExecutor.enter` consults the worker's
+`post_exit_cooldown_remaining_seconds()` and REJECTS the entry with the remaining
+seconds in the reason, so the model sees a refusal instead of self-policing. State
+lives on `SLHuntingAIWorker` (`_last_exit_at`, armed in `after_exit` for EVERY close —
+a stop-out is when the reflex is most costly). Knob
+`SL_HUNTING_POST_EXIT_COOLDOWN_MINUTES` (default 5, `0` disables). This reuses the
+pattern `SupertrendBullishWorker` has always used (`POST_EXIT_COOLDOWN_MINUTES`, also
+5). ENTRIES ONLY: exits, stop/target, max-loss and square-off are untouched, and the
+guard fails OPEN (a raising hook never becomes a trading outage).
+
+**Confirmed but deliberately NOT re-encoded (already present, and correctly applied):**
+the weekend/holiday flattening of the prior crowd (WEEKEND / HOLIDAY CARRY-RISK — it
+was IH's whole premise today); the huge-gap mindset trap (the agent named it verbatim);
+booking on a stall rather than the perfect target; and holding within a loss limit.
+Deliberately NOT encoded: IH's "entry early but direction right, so hold through the
+drawdown". Encoding hold-through-drawdown into a live agent is how a capped loss becomes
+an uncapped one, and v3j already fixes the same problem from the safe side — do not
+enter at the gap extreme, wait for the bounce.
+
+**Knowledge changes (v3s, prose + code):**
+- `BNF_SPECIFIC`: LAGGARDS NEVER JOINED → BOOK WHAT YOU HAVE (before the v3r
+  LAGGING-INDEX ENTRY LOCATOR it complements).
+- `RISK`: the POST-EXIT RE-ENTRY GATE's TIME arm now states it is ENFORCED IN CODE, and
+  its "~15 bars" figure is corrected (clearing the clock does not by itself authorise a
+  trade).
+- Code: `SL_HUNTING_POST_EXIT_COOLDOWN_MINUTES`, `SLHuntingAIWorker._last_exit_at` +
+  `post_exit_cooldown_remaining_seconds()`, and the rejection in
+  `MasterWorkerExecutor.enter`.
+- Test markers: `test_system_prompt_has_v3s_laggards_and_enforced_cooldown_knowledge`,
+  plus executor tests (reject / allow / never-blocks-exit / fail-open / duck-typed) and
+  worker tests (first entry free, arms on exit incl. stop-out, expires, disable).
+
 ## Video addendum - 24 Jul profit-booking recovery + lagging-index entry (v3r)
 
 > Sources (full Hindi auto-transcripts from the YouTube transcript panel):

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_executor.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_executor.py
@@ -334,6 +334,26 @@ class MasterWorkerExecutor:
                 "accepted": False,
                 "reason": "BankNIFTY mirror leg still open; EXIT it (exit_leg=BNF) before a new entry",
             }
+        # SLH-005: hard post-exit cooldown. The prompt's POST-EXIT RE-ENTRY GATE is
+        # judgement and was talked past twice in live trading by relabelling the same
+        # structure as a new setup, so the TIME arm is enforced here where the model
+        # cannot reason around it. Duck-typed: runners whose worker predates this
+        # (or the standalone paper runner) simply have no cooldown.
+        remaining_fn = getattr(self._w, "post_exit_cooldown_remaining_seconds", None)
+        if callable(remaining_fn):
+            try:
+                remaining = float(remaining_fn())
+            except Exception:  # noqa: BLE001 - a broken guard must never block trading outright
+                remaining = 0.0
+            if remaining > 0:
+                return {
+                    "accepted": False,
+                    "reason": (
+                        f"post-exit cooldown: {remaining:.0f}s still to run since the last close. "
+                        "Re-entering straight after an exit is the relabelling trap (the same price "
+                        "structure under a new setup name). Wait for genuinely new price action."
+                    ),
+                }
         ok = bool(self._w.enter_position(
             direction,
             float(price),

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
@@ -682,9 +682,12 @@ RISK DISCIPLINE
   judgement, and judgement alone has proven too easy to talk past): after ANY exit,
   before you may open the NEXT position in EITHER direction, ALL of these must hold.
   If you cannot tick every one, the answer is HOLD:
-  * TIME: at least ~15 completed 1-minute bars have closed since your exit. Re-entering
-    two or three bars after booking is never a fresh premise, whatever the chart looks
-    like.
+  * TIME (ENFORCED IN CODE — the order tool REJECTS an entry inside this window, so
+    do not spend a decision proposing one): a hard cooldown runs from your last close.
+    Re-entering two or three bars after booking is never a fresh premise, whatever the
+    chart looks like. Past the cooldown the clock alone does NOT authorise a trade —
+    the structural conditions below still have to hold, and a re-entry roughly 10-15
+    bars out still deserves real scepticism.
   * NEW STRUCTURAL EVENT: something has happened AFTER your exit that was not part of
     the thesis you just traded — a real level actually broken or reclaimed, or a fresh
     swing high/low formed since. Continued drift inside the same structure is not an
@@ -847,6 +850,23 @@ you size or place the NIFTY trade. Advisory, not a hard gate.
   honest read (the divergence-fails rule, two holders against one breaker). Do not
   rush an entry merely because the leader moved first; wait for at least one other
   index to reclaim its closing point.
+- LAGGARDS NEVER JOINED → BOOK WHAT YOU HAVE (the HOLDING-side counterpart of
+  SOLO-LEADER VETO, which only governs ENTRY). While already in a position, if the
+  leader (usually BankNIFTY) is delivering your direction but the other TWO indices
+  never break their own levels — they hold, retrace, or just sit — then the
+  triple-index move that justified your TARGET is not forming. Do not sit waiting for
+  the breakdown/breakout that would "double" the target: take the profit the leader
+  has already given.
+  * The tell that the wait is over: the LEADER starts printing small, stalling
+    candles while the laggards are still unbroken. That combination — leader spent,
+    laggards absent — is the booking signal.
+  * WHY it is urgent and not merely disappointing: with the shared move dead, the
+    session resolves in one of two ways, and if it resolves AGAINST you, the crowd
+    holding your direction (which now includes YOU) becomes the freshly seated
+    inventory the operator hunts next. Book before your own position turns into the
+    liquidity for someone else's trade.
+  * This is distinct from the leader FAILING to lead (above): here the leader worked
+    and the followers refused. Both end the same way — book and stand aside.
 - LAGGING-INDEX ENTRY LOCATOR: when the day direction is ALREADY established from
   retail positioning and the triple-index read, but NIFTY / Sensex are moving too
   quickly to offer a controlled entry, use the lagging index (often BankNIFTY) to

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_agent.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_agent.py
@@ -423,6 +423,59 @@ def test_master_worker_executor_delegates():
     assert ex.snapshot()["in_position"] is False
 
 
+class _CooldownWorker(_FakeWorker):
+    """Worker exposing the SLH-005 cooldown the real master worker provides."""
+
+    def __init__(self, remaining):
+        super().__init__()
+        self.remaining = remaining
+
+    def post_exit_cooldown_remaining_seconds(self):
+        return self.remaining
+
+
+def test_entry_rejected_while_post_exit_cooldown_runs():
+    """SLH-005: the prompt's re-entry gate is judgement and was talked past twice in
+    live trading (23 + 27 Jul 2026) by relabelling the same structure as a new setup.
+    The order tool must refuse the entry outright, with a reason the model can read."""
+    ex = MasterWorkerExecutor(_CooldownWorker(212.0))
+    r = ex.enter("SHORT", stop=24000, target=23900, reason="4th trendline touch", price=23950)
+    assert r["accepted"] is False
+    assert "cooldown" in r["reason"].lower()
+    assert "212" in r["reason"]          # tells the agent how long is left
+    assert ex._w.entries == []           # nothing reached the worker
+
+
+def test_entry_allowed_once_cooldown_has_elapsed():
+    ex = MasterWorkerExecutor(_CooldownWorker(0.0))
+    assert ex.enter("SHORT", stop=24000, target=23900, reason="ok", price=23950)["accepted"] is True
+
+
+def test_cooldown_never_blocks_an_exit():
+    """Entries only. A cooldown must never trap an open position."""
+    w = _CooldownWorker(999.0)
+    ex = MasterWorkerExecutor(w)
+    w.pos.active = True
+    assert ex.exit("premise dead", price=23950)["accepted"] is True
+
+
+def test_broken_cooldown_hook_cannot_block_trading():
+    """Fail-open: a raising guard must not become an outage that stops all entries."""
+
+    class _Boom(_FakeWorker):
+        def post_exit_cooldown_remaining_seconds(self):
+            raise RuntimeError("clock unavailable")
+
+    ex = MasterWorkerExecutor(_Boom())
+    assert ex.enter("LONG", stop=1, target=2, reason="x", price=25000)["accepted"] is True
+
+
+def test_worker_without_cooldown_hook_still_enters():
+    """Duck-typed: the standalone runner / older workers have no cooldown at all."""
+    ex = MasterWorkerExecutor(_FakeWorker())
+    assert ex.enter("LONG", stop=1, target=2, reason="x", price=25000)["accepted"] is True
+
+
 # --------------------------------------------------------------------------
 # SLH-002: agent-provided ENTRY stop/target must be sane at the order tool.
 # The mechanical per-poll exit uses these UNDERLYING levels verbatim, so a

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
@@ -386,8 +386,10 @@ def test_system_prompt_has_v3q_reentry_gate_and_expiry_pin_knowledge():
     """
     prompt = build_system_prompt()
     assert "POST-EXIT RE-ENTRY GATE" in prompt
-    # The gate must be checkable, not another judgement call.
-    assert "completed 1-minute bars have closed since your exit" in prompt
+    # The gate must be checkable, not another judgement call. v3s moved the TIME arm
+    # out of prose and into the order tool, so the wording here changed with it --
+    # what must survive is that a time floor exists and runs from the last close.
+    assert "a hard cooldown runs from your last close" in prompt
     assert "NEW STRUCTURAL EVENT" in prompt
     # The exact loophole that cost money today must be named.
     assert "A DIFFERENT PATTERN NAME ON THE SAME STRUCTURE IS NOT A NEW PREMISE" in prompt
@@ -398,6 +400,24 @@ def test_system_prompt_has_v3q_reentry_gate_and_expiry_pin_knowledge():
     assert "Fuel yes, trigger no" in prompt
     # Crowd-behaviour nuance: aligned crowds don't cascade.
     assert "A CONFIDENT CROWD DOES NOT STAMPEDE" in prompt
+
+
+def test_system_prompt_has_v3s_laggards_and_enforced_cooldown_knowledge():
+    """v3s: 27 Jul — IH booked without his breakdown because BankNIFTY delivered
+    alone while Sensex/NIFTY never broke; and the re-entry gate's TIME arm moved
+    into code after the prompt version was talked past twice."""
+    prompt = build_system_prompt()
+    assert "LAGGARDS NEVER JOINED" in prompt
+    # The booking trigger: leader spent while the followers are still unbroken.
+    # (Wrap-independent fragments only -- the phrase spans a line break.)
+    assert "leader spent" in prompt and "laggards absent" in prompt
+    assert "is the booking signal" in prompt
+    # The urgency: your own position becomes the next hunted inventory.
+    assert "liquidity for someone else's trade" in prompt
+    # The agent must know the time arm is now refused by the tool, not self-policed.
+    assert "ENFORCED IN CODE" in prompt
+    # ...and that clearing the clock is not by itself permission to trade.
+    assert "does NOT authorise a trade" in prompt
 
 
 def test_reentry_gate_does_not_contradict_the_exit_rules():

--- a/test_nifty_multi_strategy_master.py
+++ b/test_nifty_multi_strategy_master.py
@@ -3640,6 +3640,47 @@ class TestSLHuntingBnfMirror(unittest.TestCase):
         )
         worker._bnf_resolver.get_atm_option.assert_not_called()
 
+    # ----- SLH-005: post-exit re-entry cooldown --------------------------
+    def test_cooldown_is_zero_before_any_exit(self):
+        """The day's FIRST entry must never be delayed."""
+        worker, _ = self._make_worker()
+        self.assertIsNone(worker._last_exit_at)
+        self.assertEqual(worker.post_exit_cooldown_remaining_seconds(), 0.0)
+
+    def test_cooldown_arms_on_exit_and_expires(self):
+        """Any close arms the window; it drains to 0 once the minutes elapse."""
+        worker, _ = self._make_worker()
+        self.assertTrue(worker.enter_position("LONG", 24300.0, 24290.0, 24400.0))
+        worker.exit_position("AI_TARGET")
+
+        self.assertIsNotNone(worker._last_exit_at)
+        remaining = worker.post_exit_cooldown_remaining_seconds()
+        self.assertGreater(remaining, 0.0)
+        self.assertLessEqual(
+            remaining, master_file.SL_HUNTING_POST_EXIT_COOLDOWN_MINUTES * 60.0
+        )
+
+        # Pretend the cooldown elapsed: it must stop blocking, not go negative.
+        worker._last_exit_at = datetime.now() - timedelta(
+            minutes=master_file.SL_HUNTING_POST_EXIT_COOLDOWN_MINUTES + 1
+        )
+        self.assertEqual(worker.post_exit_cooldown_remaining_seconds(), 0.0)
+
+    def test_cooldown_arms_on_a_stop_out_too(self):
+        """A stop-out is exactly when the re-entry reflex is most expensive, so the
+        window must arm for mechanical exits as well as the agent's own EXIT."""
+        worker, _ = self._make_worker()
+        self.assertTrue(worker.enter_position("LONG", 24300.0, 24290.0, 24400.0))
+        worker.exit_position("AI_STOP")
+        self.assertGreater(worker.post_exit_cooldown_remaining_seconds(), 0.0)
+
+    def test_cooldown_can_be_disabled(self):
+        """0 disables the guard outright (operator escape hatch)."""
+        worker, _ = self._make_worker()
+        worker._last_exit_at = datetime.now()
+        with patch.object(master_file, "SL_HUNTING_POST_EXIT_COOLDOWN_MINUTES", 0):
+            self.assertEqual(worker.post_exit_cooldown_remaining_seconds(), 0.0)
+
     def test_mirror_boundary_day_still_uses_atm(self):
         """Exactly the threshold is NOT 'fewer than' -> ATM, as before."""
         worker, _ = self._make_worker()


### PR DESCRIPTION
Distils Intraday Hunter's **27 Jul** session (`PezwEQ300lo`) against **both** agent artefacts — and acts on a defect the journal has now shown **twice**.

## Tally for 27 Jul — a winning day whose shape still exposes the defect

| Source | Result |
|---|---|
| decisions | 73 (63 HOLD, **5 entries**, 5 EXIT) + 2 `agent_error` ("usage-limited") |
| journal | **5 trades, net +₹9,012.25** |
| IH | **WIN** — one short basket into the gap-up, booked early |

| # | Entry | Direction / setup | Result |
|---|---|---|---|
| 1 | 09:20 | SHORT `huge_gap_mindset_trap_fade` | **−₹2,703** (held 55 seconds) |
| 2 | 09:23 | LONG `gapup_flush_hammer_reclaim` | −₹1,666 |
| 3 | 10:02 | LONG `psych_support_hammer_reversal` | −₹1,679 |
| 4 | 10:18 | SHORT `double_top_bearish_engulfing` | **+₹18,858** |
| 5 | 10:22 | SHORT `trendline_continuation_fibo_rejection` | **−₹3,797** |

**Trade 1 *is* IH's trade.** The agent named the huge-gap mindset trap and shorted the gap-up — then abandoned it after **55 seconds** at −26.2 points, with an exit reason claiming the SL-hunt leg was *"captured"* while the position was actually at a loss. It spent the next hour fighting its own read with two longs, then returned to the identical short at 10:18 for the day's entire profit. Direction agreement was never the problem.

## The defect

Trade 5 opened **89 seconds** after trade 4 closed, same direction, and gave back ₹3,797 of an ₹18,858 winner. Its reasoning **never mentions the POST-EXIT RE-ENTRY GATE** — it just named a new setup (*"4th touch on a descending trendline"*), the exact relabelling loophole v3q was written to close. The gate has been in the prompt since 23 Jul, so this is the **second consecutive session** in which a prose rule failed to bind.

Replaying both journals against candidate cooldowns (*approximate* — blocking one entry shifts the clock for the next):

| Cooldown | 23 Jul kept | 27 Jul kept |
|---|---|---|
| none (actual) | −₹7,055 | +₹9,012 |
| 2 min | −₹7,055 | +₹12,810 |
| **5 min** | **+₹1,163** | **+₹14,476** |
| 10 min | +₹1,163 | +₹14,476 |
| 15 min | +₹13,689 | **−₹8,179** |

5 and 10 are identical on this sample; **15 minutes is actively harmful** — it would have blocked 27 Jul's ₹18,858 winner (entered 12.4 min after the prior exit). That's direct evidence against v3q's own *"~15 completed bars"* prose, **corrected here**. 5 also matches `POST_EXIT_COOLDOWN_MINUTES`, the guard `SupertrendBullishWorker` has always used.

## Code (SLH-005) — operator-approved

The gate's **TIME arm** now lives where it cannot be reasoned around:

- `SL_HUNTING_POST_EXIT_COOLDOWN_MINUTES` (default **5**, `0` disables) — in `env.example` **and** the gitignored local `.env`.
- `SLHuntingAIWorker._last_exit_at`, armed in `after_exit` for **every** close (a stop-out is when the re-entry reflex is most costly), plus `post_exit_cooldown_remaining_seconds()`.
- `MasterWorkerExecutor.enter` rejects inside the window and returns the remaining seconds in the reason, so the model sees a **refusal** instead of self-policing.

⚠️ **Safety scope:** entries only. Exits, stop/target, max-loss and square-off are untouched. The hook is duck-typed (standalone runner unaffected) and **fails open** — a raising guard can never become a trading outage. All four properties have tests.

## Knowledge

- **`LAGGARDS NEVER JOINED → BOOK WHAT YOU HAVE`** (`BNF_SPECIFIC`) — the holding-side counterpart to `SOLO-LEADER VETO` (entry-only). IH's actual exit today: BankNIFTY fell hard while Sensex/NIFTY refused to break, so he booked without the breakdown that "could have doubled" the target. Trigger: leader stalling into small candles while laggards are still unbroken. Urgency: with the shared move dead the session resolves binary, and if it resolves against you, the crowd holding your direction — *now including you* — is the next hunted inventory. Distinct from the leader *failing* to lead (v3l): there the leader quit; here it worked and the followers refused.
- **`RISK`** — the gate's TIME arm now states it is enforced in code, and clearing the clock explicitly does **not** by itself authorise a trade.

**Deliberately NOT encoded:** IH's *"entry early but direction right, so hold the drawdown"*. Encoding hold-through-drawdown into a live agent is how a capped loss becomes an uncapped one — and v3j already fixes the same problem from the safe side (don't enter at the gap extreme; wait for the bounce).

## Verification

- **115** agent tests · **377** master tests · ruff clean · mypy clean (40 files) · compileall clean · `check-env` 0 missing / 0 undocumented
- **End-to-end check with the REAL worker + REAL executor** (the unit tests use a fake worker on one side and call the helper directly on the other, so neither proved the halves meet): entry **rejected** inside the window, **exit still accepted** during it, guard **releases** after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
