### PR TITLE
feat(sl-hunting): v3t knowledge from the 28 Jul dual-expiry session

### DIFF
--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -1560,3 +1560,82 @@ GATE.
   divergence rules.
 - Test marker:
   `test_system_prompt_has_v3r_profit_booking_recovery_and_lagging_index_knowledge`.
+
+## Video addendum - 28 Jul dual-expiry session + morning speed (v3t)
+
+**Source:** Intraday Hunter live session, 28 Jul 2026 (`-vNa6-t2SWw`), read alongside
+the agent's own `sl_hunting_decisions.jsonl` and `sl_hunting_journal.jsonl` for the
+same session. Both NIFTY and BankNIFTY expired that day.
+
+**What IH did:** the market gapped down and then pushed up. He read the gap-down as
+having let the SELLERS book, leaving BUYERS sitting - so he SOLD puts across all
+three indices (BNF 1170, Sensex 900, NIFTY 1430). NIFTY and Sensex did print a
+breakout against him, but it never crossed ~24040, the level from his own pre-open
+analysis; he named that level in advance as the point where "the problem increases
+for us", because past it the seated buyers move into profit. The breakout failed,
+BankNIFTY led the fall, and he booked into the move rather than waiting for a stall.
+
+**Agent tally for 28 Jul:** 72 decisions (68 HOLD, 2 ENTER_SHORT, 2 EXIT), zero
+`agent_error`, window 09:17:04-10:30:01. Two trades, net **-Rs.434.50**:
+- 09:27:04 -> 09:41:36 SHORT `double_top_shooting_star_rejection`, 10 lots,
+  -4.55 pts, **-Rs.5,387.50**, R -0.4 (exit: premise invalidated, price held above
+  pivot 23968.93 and prev close 24003.65).
+- 10:03:02 -> 10:07:35 SHORT `buyer_trap_evening_star_rejection`, 6 lots,
+  +24.35 pts, **+Rs.4,953.00**, R 1.28 (exit: stall at the pivot).
+
+**SLH-006 verified in production.** The runner logged
+`SL Hunting: injected 1916 pre-open note chars for 2026-07-28 (ADVISORY).` - the
+character count matches the end-to-end test exactly. 22 of the 72 decisions cited
+the note, and it behaved as designed rather than as an override: at 09:53:06 the
+agent noted the note and `cross_index` both favoured a sell bias and still HELD for
+want of a confirmed pattern; at the 10:03 entry it cited "below the 24040
+buyer-profit line, putting risk on trapped buyers per the pre-open plan" - and that
+trade won. **SLH-005 never fired**: the agent's own re-entry gap was ~21 minutes,
+well past the 5-minute cooldown.
+
+**Net-new method distilled:**
+- EXPIRY-DAY PREMIUM ASYMMETRY: on an expiry day a bought option gives back an
+  adverse move much faster than it pays a favourable one, so book INTO strength and
+  do not wait for a stall-and-pullback to confirm the turn. The agent's own book
+  measured this on 28 Jul: the loser bled ~1.58 premium points per ADVERSE spot
+  point, the winner earned ~0.45 per FAVOURABLE spot point - a ~3.5x asymmetry, and
+  the ratio is independent of lot size (both trades were NIFTY, so the lot size
+  cancels). *Caveat recorded honestly:* the loser was held 14m32s against the
+  winner's 4m33s, so decay over the longer hold is part of that gap - which is the
+  point of the rule, but it does mean 3.5x is the combined delta+theta effect, not a
+  pure per-candle measurement. Deliberately scoped as an EXPIRY-DAY exception so it
+  cannot be read as licence to cut winners early against PROFIT-HOLD.
+- MORNING SPEED IS NOT INFORMATION: IH's warning was "sometimes such a trade throws
+  you out in the next 5 minutes; then it feels like 'I was wrong quickly, let me try
+  again' - so if you have a habit of over-trading, avoid trading in the morning."
+  Opening-window momentum resolves within a couple of bars in either direction, so
+  the SPEED of a morning stop-out carries no information about the next trade. This
+  raises the bar for the next entry rather than lowering it, and the enforced
+  cooldown is a floor rather than the standard. **Deliberately NOT hardened into a
+  one-trade-per-morning ban:** both 28 Jul's winner and 27 Jul's winner were second
+  trades taken after an earlier exit, so a ban would have cost real money. The
+  banned thing is the reflex retry whose only new evidence is that the last one
+  ended fast.
+- PRE-COMPUTE BOTH NUMBERS: IH - "before making the trade I calculated how much loss
+  I'd have to take if a breakout happens and it goes against me, and I calculated my
+  profit too; only then can I handle the trade accordingly." The existing
+  PLAN-OF-EXECUTION precheck already required a named invalidation and target, but
+  only qualitatively. The addition is the rupee figure at each, computed at the lot
+  size about to be sent - because a pre-accepted loss is what makes adverse movement
+  that is still inside the plan survivable. This is what let IH sit through a real
+  breakout against his position on 28 Jul.
+
+**Confirmed but deliberately NOT re-encoded (already present):** the gap-down
+crowd read (sellers booked, buyers left sitting) is TARGET-BOOKED plus the
+trap-density test; using the pre-open level as the day's invalidation is what
+SLH-006 already provides; expiry-as-fuel-not-premise and the post-first-move expiry
+range are EXPIRY IS CONTEXT, NOT A PREMISE and EXPIRY-DAY RANGE.
+
+**Knowledge changes (v3t, all prose):**
+- `RISK`: EXPIRY-DAY PREMIUM ASYMMETRY, placed directly after PREMIUM
+  NON-CONFIRMATION (which is explicitly scoped to non-expiry days, so the two read
+  as siblings rather than rivals).
+- `RISK`: MORNING SPEED IS NOT INFORMATION, beside POST-LOSS SPEED LIMIT.
+- `DECISION_RULES`: PRE-COMPUTE BOTH NUMBERS, folded into the rule 2 precheck.
+- Test marker:
+  `test_system_prompt_has_v3t_expiry_asymmetry_and_morning_speed_knowledge`.

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
@@ -643,6 +643,22 @@ RISK DISCIPLINE
   the move is approaching a round number after a good run, where one small
   rejection turns seen profit into giving-back. After watching a good profit,
   letting it become a loss while waiting for "more" is the retail mistake.
+- EXPIRY-DAY PREMIUM ASYMMETRY (the EXPIRY-day sibling of the rule above): on an
+  expiry day a bought option gives back an adverse move far faster than it pays a
+  favourable one — collapsing time value compounds delta against you, so ONE
+  opposing candle can erase most of a good unrealised profit. Measured on this
+  book (two SHORT trades the same morning, both indices expiring): the loser bled
+  roughly 1.6 premium points per ADVERSE point of spot, while the winner earned
+  only about 0.45 premium points per FAVOURABLE point — a ~3.5x asymmetry against
+  the position. So while HOLDING on an expiry day:
+  * BOOK INTO STRENGTH, while the move is still running in your favour. Do not wait
+    for a stall-and-pullback to "confirm" the turn — on expiry the confirmation
+    candle IS the give-back.
+  * Your booking threshold is TIGHTER than for the identical setup on a non-expiry
+    day: an unrealised profit is worth materially less the longer you sit on it,
+    and a position going nowhere costs you money even with the underlying flat.
+  This is an EXPIRY-DAY exception only. On a normal day PROFIT-HOLD still governs —
+  never cite this rule to justify cutting a valid winner early.
 - When already in a position, EXIT on: target reached, stop hit, an OPPOSING
   pattern + confirmation forming against you, or the move going slow/stalling at a
   level in your favour. Otherwise HOLD and let it run.
@@ -724,6 +740,18 @@ RISK DISCIPLINE
   a fresh, deliberate, high-quality setup with a named target crowd and clear
   invalidation before trading again; never use the next candle as a recovery
   attempt.
+- MORNING SPEED IS NOT INFORMATION: in the opening window momentum resolves within
+  a couple of bars in EITHER direction, so a morning trade stopped out within
+  minutes is ORDINARY morning behaviour. The SPEED of that stop-out tells you
+  nothing — not that you were "nearly right", and not that the opposite side is
+  now the trade. The pull to retry immediately ("I was wrong quickly, so let me
+  try again") peaks exactly there, and the opening window is where over-trading
+  actually happens. A fast morning stop-out therefore RAISES the bar for the next
+  entry rather than lowering it: the POST-EXIT RE-ENTRY GATE applies in full and
+  its enforced cooldown is a FLOOR, not the standard. This is NOT a ban on a
+  second trade of the morning — a genuinely fresh premise after a stop-out is
+  allowed and has paid. What is banned is the reflex retry whose only new evidence
+  is that the last one ended fast.
 - Loss recovery discipline: after a losing trade, do NOT take the next trade
   immediately (that reflex is where revenge trading starts); recover a BIG loss
   across MULTIPLE ordinary trades, never in one; and beware the "one last trade"
@@ -933,6 +961,14 @@ DECISION DISCIPLINE
 2. PLAN-OF-EXECUTION precheck: before ENTER, name the target crowd, why it exists,
    why the market can move, the invalidation, and the target. If you cannot state
    that plan in plain language, HOLD.
+   PRE-COMPUTE BOTH NUMBERS: in the same breath, work out the actual RUPEE loss at
+   your named invalidation and the actual rupee gain at your named target, at the
+   lot size you are about to send. The point is not the ratio (you already check
+   that) — it is that a loss accepted BEFORE entry is what lets you sit through
+   adverse movement that is still inside the plan, instead of panicking out of a
+   trade that has not actually broken. If the loss at invalidation is not one you
+   would take calmly, the size is wrong or the trade is wrong: fix that now, not
+   after the position is open.
 3. If FLAT: enter ONLY if (a) price is AT a real level (pivot / OHLC / fibo / psych
    / structure), (b) a reversal pattern + confirmation candle has ALREADY printed
    in your direction, (c) the stop is tight, and (d) the target is worthwhile.

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
@@ -420,6 +420,34 @@ def test_system_prompt_has_v3s_laggards_and_enforced_cooldown_knowledge():
     assert "does NOT authorise a trade" in prompt
 
 
+def test_system_prompt_has_v3t_expiry_asymmetry_and_morning_speed_knowledge():
+    """v3t: 28 Jul — both indices expiring; IH booked into strength because expiry
+    premiums collapse on the first opposing candle, and warned that a fast morning
+    stop-out is normal variance rather than a reason to retry.
+
+    The agent's own book measured the same asymmetry that day: it bled ~1.6 premium
+    points per adverse spot point on the loser but earned only ~0.45 per favourable
+    point on the winner.
+    """
+    prompt = build_system_prompt()
+    # Expiry-day holding rule -- distinct from PREMIUM NON-CONFIRMATION, which is
+    # explicitly scoped to days with no expiry.
+    assert "EXPIRY-DAY PREMIUM ASYMMETRY" in prompt
+    assert "BOOK INTO STRENGTH" in prompt
+    # The mechanism, so the rule is not read as "cut winners early" in general.
+    assert "the confirmation" in prompt and "candle IS the give-back" in prompt
+    assert "This is an EXPIRY-DAY exception only" in prompt
+    # A fast morning stop-out must not be read as evidence about the next trade.
+    assert "MORNING SPEED IS NOT INFORMATION" in prompt
+    assert "is a FLOOR, not the standard" in prompt
+    # ...but the rule must NOT harden into a one-trade-per-morning ban: both of the
+    # agent's recorded morning winners were second trades after a stop-out.
+    assert "NOT a ban on a" in prompt and "second trade of the morning" in prompt
+    # Entry precheck: quantify the loss before entering, not after.
+    assert "PRE-COMPUTE BOTH NUMBERS" in prompt
+    assert "a loss accepted BEFORE entry" in prompt
+
+
 def test_reentry_gate_does_not_contradict_the_exit_rules():
     """The re-entry gate must never be readable as a reason to delay an EXIT.
 


### PR DESCRIPTION
Distils Intraday Hunter's 28 Jul live session against the agent's own
`sl_hunting_decisions.jsonl` / `sl_hunting_journal.jsonl` for the same day.
**Knowledge-only — no runtime behaviour changes.**

## 28 Jul tally

72 decisions (68 HOLD, 2 ENTER_SHORT, 2 EXIT), **zero `agent_error`**, window
09:17:04–10:30:01. Two trades, net **−₹434.50**:

| Time | Setup | Lots | Pts | P&L | R |
|---|---|---|---|---|---|
| 09:27:04 → 09:41:36 | `double_top_shooting_star_rejection` | 10 | −4.55 | **−₹5,387.50** | −0.4 |
| 10:03:02 → 10:07:35 | `buyer_trap_evening_star_rejection` | 6 | +24.35 | **+₹4,953.00** | +1.28 |

**SLH-006 verified in production** — the runner logged
`SL Hunting: injected 1916 pre-open note chars for 2026-07-28 (ADVISORY).`, the
character count matching the end-to-end test exactly. 22 of 72 decisions cited the
note and it behaved as designed rather than as an override: at 09:53 the agent noted
the note and `cross_index` both favoured a sell bias and still HELD for want of a
confirmed pattern; the 10:03 entry cited "below the 24040 buyer-profit line … per the
pre-open plan" and won. **SLH-005 never fired** — the agent's own re-entry gap was
~21 minutes against the 5-minute cooldown.

## Net-new rules

**1. `RISK` / EXPIRY-DAY PREMIUM ASYMMETRY.** On expiry a bought option gives back an
adverse move far faster than it pays a favourable one, so book INTO strength rather
than waiting for a stall-and-pullback to confirm the turn — on expiry the confirmation
candle *is* the give-back. The agent's own book measured it that day: **~1.58 premium
points lost per adverse spot point vs ~0.45 gained per favourable one — ~3.5×**, and
the ratio is lot-size independent (both trades NIFTY, so the lot size cancels).
Placed directly after PREMIUM NON-CONFIRMATION, which is explicitly scoped to
*non*-expiry days, so the two read as siblings. Scoped as an expiry-day exception so
it can't be cited against PROFIT-HOLD.

*Caveat recorded in the doc:* the loser was held 14m32s against the winner's 4m33s,
so the 3.5× is the combined delta+theta effect, not a pure per-candle measurement.

**2. `RISK` / MORNING SPEED IS NOT INFORMATION.** IH: "sometimes such a trade throws
you out in the next 5 minutes; then it feels like 'I was wrong quickly, let me try
again' — so if you have a habit of over-trading, avoid trading in the morning."
Opening-window momentum resolves within a couple of bars either way, so the *speed* of
a morning stop-out carries no information about the next trade. It raises the bar for
the next entry rather than lowering it; the enforced cooldown is a floor, not the
standard.

**Deliberately NOT hardened into a one-trade-per-morning ban** — both 28 Jul's winner
and 27 Jul's winner were second trades taken after an earlier exit, so a ban would
have cost real money. There's a test asserting the non-ban clause survives.

**3. `DECISION_RULES` / PRE-COMPUTE BOTH NUMBERS.** IH: "before making the trade I
calculated how much loss I'd have to take if a breakout happens … and I calculated my
profit too; only then can I handle the trade accordingly." The precheck already
required a named invalidation and target, but only qualitatively. The addition is the
rupee figure at each, at the lot size about to be sent — a pre-accepted loss is what
makes adverse movement that is still inside the plan survivable. It's what let IH sit
through a real breakout against his position on 28 Jul.

## Deliberately not re-encoded

The gap-down crowd read (sellers booked, buyers left sitting) is TARGET-BOOKED plus
the trap-density test; using the pre-open level as the day's invalidation is what
SLH-006 already provides; expiry-as-fuel and the post-first-move expiry range are
EXPIRY IS CONTEXT, NOT A PREMISE and EXPIRY-DAY RANGE.

## Gates

- `python -m pytest "Signal Generators/SL Hunting AI Agent/tests" -q` → **134 passed**
- `python -m unittest test_nifty_multi_strategy_master` → **382 tests OK**
- ruff, mypy, compileall → clean

System prompt is now 62,359 chars (~15.6k tokens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)