### PR TITLE
chore(sl-hunting): pre-open note for 2026-07-29

### DIFF
--- a/Signal Generators/SL Hunting AI Agent/premarket_note.json
+++ b/Signal Generators/SL Hunting AI Agent/premarket_note.json
@@ -1,29 +1,30 @@
 {
-  "for_date": "2026-07-28",
-  "source": "Intraday Hunter, 'Prediction For 28 JULY 2026' (video L8t0iLNhq2o)",
-  "context": "27 Jul gapped up then gave the whole move back; only small breakdowns, with repeated recovery attempts, so buyers and sellers are seated around the SAME price level and neither side clearly held overnight.",
+  "for_date": "2026-07-29",
+  "source": "Intraday Hunter, 'Prediction For 29 JULY 2026' (video 3yhXRT6Sc5Y)",
+  "context": "27 Jul's gap-up was rejected and 28 Jul was rejected again, yet NIFTY and Sensex still closed holding above their own closing points - so BankNIFTY shows selling without real momentum and neither side is clearly trapped.",
   "plan": [
-    "Who actually held overnight is decided by the OPENING, not by yesterday's chart.",
-    "GAP-UP open: any seated buyers are already in profit and cannot be targeted, so the risk sits on the SELLERS - look for BUY-side setups and go with the market.",
-    "FLAT to GAP-DOWN open: the risk sits on the BUYERS (NIFTY and Sensex were trending up, BankNIFTY closed above 57000) - look for SELL-side setups targeting those buyers.",
-    "NIFTY reference: an open above roughly 24040 puts buyers in profit, which flips the plan to the buy side.",
-    "Both NIFTY (weekly) and BankNIFTY have expiry on 28 Jul - expect expiry-day range behaviour and treat expiry as context, not as a premise."
+    "Neither side is clearly positioned and the confusion is deliberate; few traders are carrying a trade into today, so there is no obvious trapped crowd to hunt.",
+    "When nothing is readable, do what the market is ALREADY doing - it has spent two to three days trying to cover and hold itself up.",
+    "GAP-UP or GAP-DOWN open: the plan is the same either way - look for BUY-side setups and go with the market.",
+    "FLAT open: the same buy-side plan can apply, but ONLY if momentum is genuinely good; flat is the riskier case.",
+    "The named risk is a SIDEWAYS range building here - if the market stalls and ranges instead of moving, the problem gets big.",
+    "All three indices read alike: little momentum, price staying and working in the same area it has been in."
   ],
   "levels": [
     {
       "index": "NIFTY",
-      "resistance": [24110, 24200],
-      "support": [23940, 23860]
+      "resistance": [24038, 24116],
+      "support": [23857, 23734]
     },
     {
       "index": "BANKNIFTY",
-      "resistance": [57500, 57832],
-      "support": [56750]
+      "resistance": [56930, 57126],
+      "support": [56430, 56076]
     },
     {
       "index": "SENSEX",
-      "resistance": [77200, 77364],
-      "support": [76650]
+      "resistance": [76966, 77201],
+      "support": [76441, 76102]
     }
   ]
 }


### PR DESCRIPTION
Replaces the now-stale 28 Jul note with Intraday Hunter's **"Prediction For 29 JULY 2026"**
([video `3yhXRT6Sc5Y`](https://www.youtube.com/watch?v=3yhXRT6Sc5Y), published 28 Jul 21:25 IST).

## The read

Different shape from 28 Jul. That note was conditional — gap-up → buy, flat/gap-down → sell.
**This one is buy-side in every open scenario.** Two rejected gap-ups in a row (27 and 28 Jul)
still left NIFTY and Sensex holding above their own closing points, so nobody is clearly trapped
and there is no crowd to hunt. His conclusion: follow what the market has already been doing —
two-to-three days of trying to cover and hold itself up. The named risk is a **sideways range**,
and he flags a flat open as the riskier case.

## Levels — audio transcribed, then verified against the charts

The auto-caption dropped a digit on two levels (`"2410"` and `"7640"`), so rather than guess I
stepped the video to each chart and read the drawn lines off the price axis:

| Index | Resistance | Support |
|---|---|---|
| NIFTY | 24038.25, 24116.35 | 23857.05, 23734.45 |
| BANKNIFTY | 56930.05, 57126.30 | 56429.60, 56076.35 |
| SENSEX | 76965.99, 77200.63 | 76441.10, 76101.80 |

That resolved `"2410"` → **24116.35** and `"7640"` → **76441.10**. Stored rounded to whole points
so they render exactly through the block's `%g` formatting (which would otherwise truncate
7-significant-digit values).

A third NIFTY line at **24200.65** is drawn on his chart, but he explicitly said *"two
resistances"* — so it is deliberately **not** included.

## Verification

- Note validates against `PremarketNote`.
- Renders **2031 chars** for `2026-07-29`, and **0 chars** for any other date (stale-note gate).
- `python -m pytest "Signal Generators/SL Hunting AI Agent/tests" -q` → **134 passed**.

## Note for the session

29 Jul is the day *after* a dual expiry, so v3t's EXPIRY-DAY PREMIUM ASYMMETRY rule will not
fire — by design. Tomorrow is the first session exercising v3t's other two rules on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)