### PR TITLE
feat(sl-hunting): v3u knowledge from the 29 Jul big-gap follow day

### DIFF
--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -1639,3 +1639,77 @@ range are EXPIRY IS CONTEXT, NOT A PREMISE and EXPIRY-DAY RANGE.
 - `DECISION_RULES`: PRE-COMPUTE BOTH NUMBERS, folded into the rule 2 precheck.
 - Test marker:
   `test_system_prompt_has_v3t_expiry_asymmetry_and_morning_speed_knowledge`.
+## Video addendum - 29 Jul big-gap follow day + the friction floor (v3u)
+
+**Source:** Intraday Hunter live session, 29 Jul 2026 (`e9qDdFfOVyk`, 5:52), read
+alongside the agent's own decisions/journal for the same session.
+
+**What IH did:** NIFTY and Sensex gapped up hard with a slight rejection after. He
+bought CALLs - the same side his own pre-open note had called - but was explicit that
+he was FOLLOWING the market rather than hunting anyone: "neither buyers nor sellers
+are seated, so we follow what is already running." Three things he said matter:
+- "If this gap-up had been a bit SMALLER there would have been no difficulty in
+  buying. We will buy here too, but the worry is that no rejection comes... the
+  gap-up is a bit too much, and because of this the market becomes risky."
+- "Directly, buyers' and sellers' SLs are not available here" - no stop cluster near
+  price, therefore no fuel.
+- "We will make a NORMAL profit and leave"; and at the exit, "we had reached close to
+  an AVERAGE target... this is a sideways market, it will not give us much momentum.
+  Today there is no momentum."
+
+**Agent tally for 29 Jul:** 65 decisions (60 HOLD, 3 ENTER_LONG, 2 EXIT), zero
+`agent_error`. Three trades, all LONG, net **+Rs.3,695.25**:
+- 09:22:02 -> 09:25:37 `opening_drive_gapup_continuation`, 2 lots, -7.45 pts,
+  **-Rs.1,339.00**, R -0.15, held 215s.
+- 09:32:01 -> 09:40:59 `gap_up_fibo50_continuation`, 6 lots, +37.30 pts,
+  **+Rs.10,335.00**, R 2.04, held 538s, exit `AI_TARGET`.
+- 10:02:00 -> 10:03:45 `fibo_50_inside_bar_reclaim`, 7 lots, +4.65 pts,
+  **-Rs.5,300.75**, R 0.31, held 105s.
+
+The agent independently reached IH's side of the market, and 17 of the 65 decisions
+cited the pre-open note. The winner was the one trade that actually ran (37 points
+over nine minutes); the two losers were both short holds.
+
+**The measurement that drove this version.** The third trade moved 4.65 points IN ITS
+FAVOUR and still lost Rs.5,300.75 - about 10 premium points per unit against a
+favourable move, over 105 seconds. This is not a modelled cost: the runner applies no
+slippage or spread modelling at all, so that is an observed option-LTP move. The most
+likely mechanism is gap premium bleeding out of the option faster than delta paid for
+the spot move, which is exactly the effect IH described as "after the rejection, when
+momentum started, we are not seeing much profit". *Recorded honestly:* the mechanism
+is inferred; only the numbers are measured. Worth an operator eye on whether the
+option LTP feed is jumpy on thin strikes, since that would change the reading.
+
+**Net-new method distilled:**
+- GAP SIZE IS A RISK DIAL, NOT A CONFIDENCE DIAL: a bigger gap makes the with-gap
+  continuation WORSE, because price has jumped past the stop clusters that fuel a
+  move - slow momentum, and lots of room for a rejection to run back through you.
+  Trade an oversized gap as a smaller, normal-target trade or not at all. Explicitly
+  scoped against the existing GAP-SIZE ASYMMETRY, which compares gaps ACROSS indices;
+  this one is about the absolute size of the gap being traded.
+- NO NEARBY STOPS -> NORMAL TARGET, DECIDED AT ENTRY: when following the market
+  rather than hunting a named crowd, there is no fuel for a fast leg, so commit up
+  front to an average target instead of discovering mid-trade that the runner is not
+  coming. Guarded so it cannot justify a trade that is too small to be worth taking.
+- PREMIUM NON-CONFIRMATION CAN GO NEGATIVE, NOT MERELY WEAK: the existing rule only
+  covered P&L *lagging* the spot move. On a large-gap morning over a short hold it
+  can invert - spot in your favour, position in loss. Consequences encoded: read
+  `position_state` rather than assuming spot direction equals profit; check at entry
+  whether the target is big enough to pay in PREMIUM terms; and note that abandoning
+  a trade a bar or two after entry pays the round trip for no exposure to the move.
+
+**Confirmed but deliberately NOT re-encoded (already present):** following the market
+when nobody is trapped is the trap-density test plus the OPENING DRIVE branch; booking
+on momentum failure rather than a fixed number is already the branch's target rule;
+sideways = exit is TIME-DECAY discipline.
+
+**Operational finding (documented, no runtime change in v3u):** the first trade's
+journal row records `"exit_reason": "placeholder"`. The same journal-fidelity gap was
+noted on 24 Jul in the v3r addendum, so it has now recurred and is worth a fix
+independent of the knowledge layer.
+
+**Knowledge changes (v3u, all prose):**
+- `OPENING_DRIVE`: GAP SIZE IS A RISK DIAL, NOT A CONFIDENCE DIAL.
+- `RISK`: NO NEARBY STOPS -> NORMAL TARGET, beside the worthwhile-target rule.
+- `RISK`: the IT CAN GO NEGATIVE sub-bullet under PREMIUM NON-CONFIRMATION.
+- Test marker: `test_system_prompt_has_v3u_gap_size_and_no_fuel_knowledge`.

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
@@ -380,6 +380,14 @@ Conditions (ALL must hold — otherwise this branch simply does not apply):
   / opening range, and there must be no bullish rejection reclaiming those levels.
   Default gap-down logic still looks UP; use this short branch only when sellers
   are not huntable and buyer inventory / failed recovery is the active trap.
+- GAP SIZE IS A RISK DIAL, NOT A CONFIDENCE DIAL. A BIGGER gap does NOT make this
+  branch stronger — it makes it worse. A modest gap leaves price near the stop
+  clusters that fuel a move; an oversized gap has jumped clean past everybody's
+  stops, so there is nothing nearby to hunt, momentum tends to be slow, and a
+  rejection has a lot of room to run back through you. Trade the oversized gap, if
+  at all, as a smaller / NORMAL-target trade with a rejection-triggered exit — never
+  as a high-conviction runner. (Distinct from GAP-SIZE ASYMMETRY, which compares the
+  gaps ACROSS indices; this is about the absolute size of the gap you are trading.)
 - Enter at the earliest AFTER the first 1-min candle CLOSES, never during it.
 - No MAJOR rejection so far: no full-body green-to-red reversal candle since the
   open for the long branch, and no full-body red-to-green reclaim for the short
@@ -624,6 +632,16 @@ RISK DISCIPLINE
   sit (the long-wicked candle / opposite side of the first candle / the trapped
   crowd's stops). If the nearest opposing level is too close, the target is too
   small — HOLD.
+- NO NEARBY STOPS → NORMAL TARGET, AND SAY SO BEFORE YOU ENTER: sometimes you are
+  FOLLOWING the market (nobody clearly trapped, so the with-trend continuation is
+  the trade) rather than HUNTING a named crowd. In that case there is no stop
+  cluster near price to be run, so there is no fuel for a fast leg: expect SLOW or
+  sideways momentum and decide AT ENTRY that this is a NORMAL / average-target
+  trade, not a runner. Book that average target when it comes instead of holding
+  out for the extended move — with no stops to hunt, the extended move has nothing
+  to pay for it, and the longer you sit the more likely a rejection takes back what
+  you had. This does NOT weaken the worthwhile-target rule above: if the average
+  target is itself too small to be worth the trade, the answer is still HOLD.
 - Stops are PREMISE-INVALIDATION first: beyond the tight pattern stop, treat the
   setup as dead the moment its thesis breaks — price reclaims the closing point, or
   the expected "trap" fails and price goes sideways / against you. Honour a pre-set
@@ -643,6 +661,16 @@ RISK DISCIPLINE
   the move is approaching a round number after a good run, where one small
   rejection turns seen profit into giving-back. After watching a good profit,
   letting it become a loss while waiting for "more" is the retail mistake.
+  * IT CAN GO NEGATIVE, NOT MERELY WEAK. On a LARGE-GAP morning the gap premium is
+    bleeding out of the option while you hold it, and over a SHORT hold that bleed
+    can outrun delta entirely: a move in YOUR FAVOUR can still show a LOSS. Measured
+    on this book — a LONG held 105 seconds on a big gap-up day gained 4.65 points of
+    spot and still lost Rs.5,300 (about 10 premium points per unit AGAINST a
+    favourable move). Consequences: (a) never read "spot went my way" as "I am in
+    profit" — read `position_state`; (b) before entering, ask whether the TARGET is
+    big enough to pay in PREMIUM terms, because a target only ~20 spot points away
+    can be worth nothing after the round trip; (c) a trade you abandon within a
+    bar or two of entry pays the round-trip cost for no exposure to the move.
 - EXPIRY-DAY PREMIUM ASYMMETRY (the EXPIRY-day sibling of the rule above): on an
   expiry day a bought option gives back an adverse move far faster than it pays a
   favourable one — collapsing time value compounds delta against you, so ONE

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
@@ -448,6 +448,31 @@ def test_system_prompt_has_v3t_expiry_asymmetry_and_morning_speed_knowledge():
     assert "a loss accepted BEFORE entry" in prompt
 
 
+def test_system_prompt_has_v3u_gap_size_and_no_fuel_knowledge():
+    """v3u: 29 Jul — a large gap-up with nobody trapped.
+
+    IH bought WITH the gap but said plainly that the oversized gap made it riskier,
+    that buyers'/sellers' stops were not available nearby, and that he would take a
+    normal profit rather than a runner. The agent's own book supplied the sharp
+    edge: a LONG held 105 seconds gained 4.65 spot points and still lost Rs.5,300.
+    """
+    prompt = build_system_prompt()
+    # A bigger gap is a worse trade, not a better one.
+    assert "GAP SIZE IS A RISK DIAL, NOT A CONFIDENCE DIAL" in prompt
+    # Must not be confused with the existing cross-index gap rule.
+    assert "GAP-SIZE ASYMMETRY, which compares the" in prompt
+    # Following the market (no trapped crowd) means a normal target, decided up front.
+    assert "NO NEARBY STOPS" in prompt
+    assert "NORMAL / average-target" in prompt
+    # ...but it must not become a licence to take trades that are too small.
+    assert "the answer is still HOLD" in prompt
+    # Premium can go NEGATIVE on a favourable spot move, not merely lag.
+    assert "IT CAN GO NEGATIVE, NOT MERELY WEAK" in prompt
+    assert "never read" in prompt and "as \"I am in" in prompt
+    # The round-trip cost of abandoning a trade immediately.
+    assert "pays the round-trip cost for no exposure" in prompt
+
+
 def test_reentry_gate_does_not_contradict_the_exit_rules():
     """The re-entry gate must never be readable as a reason to delay an EXIT.
 


### PR DESCRIPTION
Distils Intraday Hunter's 29 Jul live session ([`e9qDdFfOVyk`](https://www.youtube.com/watch?v=e9qDdFfOVyk))
against the agent's own decisions/journal for the same day. **Knowledge-only — no runtime changes.**

## 29 Jul tally

65 decisions (60 HOLD, 3 ENTER_LONG, 2 EXIT), **zero `agent_error`**. Three trades, all LONG,
net **+₹3,695.25**:

| Time | Setup | Lots | Pts | P&L | R | Held |
|---|---|---|---|---|---|---|
| 09:22:02 → 09:25:37 | `opening_drive_gapup_continuation` | 2 | −7.45 | −₹1,339.00 | −0.15 | 215s |
| 09:32:01 → 09:40:59 | `gap_up_fibo50_continuation` | 6 | +37.30 | **+₹10,335.00** | +2.04 | 538s |
| 10:02:00 → 10:03:45 | `fibo_50_inside_bar_reclaim` | 7 | +4.65 | **−₹5,300.75** | +0.31 | 105s |

The agent independently reached IH's side of the market, and **17 of 65 decisions cited the
pre-open note**. The winner was the one trade that actually ran; both losers were short holds.

## The measurement that drove this version

**Trade 3 moved 4.65 points in its favour and still lost ₹5,300.75** — about 10 premium points
per unit *against* a favourable move, over 105 seconds.

This is not a modelled cost. I checked: the runner applies **no slippage or spread modelling at
all**, so that is an observed option-LTP move. The likely mechanism is gap premium bleeding out
faster than delta paid for the spot move — which is exactly what IH described as *"after the
rejection, when momentum started, we are not seeing much profit."*

**Recorded honestly in the doc:** the mechanism is inferred; only the numbers are measured. Worth
your eye on whether the option LTP feed is jumpy on thin strikes, because that would change the
reading.

## Net-new rules

**1. `OPENING_DRIVE` / GAP SIZE IS A RISK DIAL, NOT A CONFIDENCE DIAL.** IH: *"if this gap-up had
been a bit smaller there would have been no difficulty in buying… the gap-up is a bit too much,
and because of this the market becomes risky."* A bigger gap has jumped clean past the stop
clusters that fuel a move, so momentum is slow and a rejection has room to run back through you.
Scoped explicitly against the existing GAP-SIZE ASYMMETRY, which compares gaps *across* indices —
this one is about the absolute size of the gap being traded.

**2. `RISK` / NO NEARBY STOPS → NORMAL TARGET, DECIDED AT ENTRY.** IH: *"directly, buyers' and
sellers' SLs are not available here"* and *"we will make a normal profit and leave."* When
following the market rather than hunting a named crowd there is no fuel for a fast leg, so commit
to an average target up front instead of discovering mid-trade that the runner isn't coming.
Guarded so it can't justify a trade too small to be worth taking.

**3. `RISK` / PREMIUM NON-CONFIRMATION CAN GO NEGATIVE, NOT MERELY WEAK.** The existing rule only
covered P&L *lagging*. Today it inverted. Encoded consequences: read `position_state` rather than
assuming spot direction equals profit; check at entry whether the target is big enough to pay in
*premium* terms; and note that abandoning a trade a bar or two after entry pays the round trip for
no exposure to the move.

## Deliberately not re-encoded

Following the market when nobody is trapped is the trap-density test plus the OPENING DRIVE
branch; booking on momentum failure rather than a fixed number is already that branch's target
rule; sideways = exit is TIME-DECAY discipline.

## Operational finding (no runtime change here)

Trade 1's journal row records `"exit_reason": "placeholder"`. The **same journal-fidelity gap was
noted on 24 Jul** in the v3r addendum, so it has now recurred and deserves a fix independent of
the knowledge layer.

## Gates

- `python -m pytest "Signal Generators/SL Hunting AI Agent/tests" -q` → **135 passed**
- `python -m unittest test_nifty_multi_strategy_master` → **382 tests OK**
- ruff, mypy, compileall → clean

System prompt is now 64,646 chars (~16.2k tokens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)