### PR TITLE
fix(sl-hunting): SLH-007 make the order tool's reason a real record

### DIFF
--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -1639,3 +1639,77 @@ range are EXPIRY IS CONTEXT, NOT A PREMISE and EXPIRY-DAY RANGE.
 - `DECISION_RULES`: PRE-COMPUTE BOTH NUMBERS, folded into the rule 2 precheck.
 - Test marker:
   `test_system_prompt_has_v3t_expiry_asymmetry_and_morning_speed_knowledge`.
+## Video addendum - 29 Jul big-gap follow day + the friction floor (v3u)
+
+**Source:** Intraday Hunter live session, 29 Jul 2026 (`e9qDdFfOVyk`, 5:52), read
+alongside the agent's own decisions/journal for the same session.
+
+**What IH did:** NIFTY and Sensex gapped up hard with a slight rejection after. He
+bought CALLs - the same side his own pre-open note had called - but was explicit that
+he was FOLLOWING the market rather than hunting anyone: "neither buyers nor sellers
+are seated, so we follow what is already running." Three things he said matter:
+- "If this gap-up had been a bit SMALLER there would have been no difficulty in
+  buying. We will buy here too, but the worry is that no rejection comes... the
+  gap-up is a bit too much, and because of this the market becomes risky."
+- "Directly, buyers' and sellers' SLs are not available here" - no stop cluster near
+  price, therefore no fuel.
+- "We will make a NORMAL profit and leave"; and at the exit, "we had reached close to
+  an AVERAGE target... this is a sideways market, it will not give us much momentum.
+  Today there is no momentum."
+
+**Agent tally for 29 Jul:** 65 decisions (60 HOLD, 3 ENTER_LONG, 2 EXIT), zero
+`agent_error`. Three trades, all LONG, net **+Rs.3,695.25**:
+- 09:22:02 -> 09:25:37 `opening_drive_gapup_continuation`, 2 lots, -7.45 pts,
+  **-Rs.1,339.00**, R -0.15, held 215s.
+- 09:32:01 -> 09:40:59 `gap_up_fibo50_continuation`, 6 lots, +37.30 pts,
+  **+Rs.10,335.00**, R 2.04, held 538s, exit `AI_TARGET`.
+- 10:02:00 -> 10:03:45 `fibo_50_inside_bar_reclaim`, 7 lots, +4.65 pts,
+  **-Rs.5,300.75**, R 0.31, held 105s.
+
+The agent independently reached IH's side of the market, and 17 of the 65 decisions
+cited the pre-open note. The winner was the one trade that actually ran (37 points
+over nine minutes); the two losers were both short holds.
+
+**The measurement that drove this version.** The third trade moved 4.65 points IN ITS
+FAVOUR and still lost Rs.5,300.75 - about 10 premium points per unit against a
+favourable move, over 105 seconds. This is not a modelled cost: the runner applies no
+slippage or spread modelling at all, so that is an observed option-LTP move. The most
+likely mechanism is gap premium bleeding out of the option faster than delta paid for
+the spot move, which is exactly the effect IH described as "after the rejection, when
+momentum started, we are not seeing much profit". *Recorded honestly:* the mechanism
+is inferred; only the numbers are measured. Worth an operator eye on whether the
+option LTP feed is jumpy on thin strikes, since that would change the reading.
+
+**Net-new method distilled:**
+- GAP SIZE IS A RISK DIAL, NOT A CONFIDENCE DIAL: a bigger gap makes the with-gap
+  continuation WORSE, because price has jumped past the stop clusters that fuel a
+  move - slow momentum, and lots of room for a rejection to run back through you.
+  Trade an oversized gap as a smaller, normal-target trade or not at all. Explicitly
+  scoped against the existing GAP-SIZE ASYMMETRY, which compares gaps ACROSS indices;
+  this one is about the absolute size of the gap being traded.
+- NO NEARBY STOPS -> NORMAL TARGET, DECIDED AT ENTRY: when following the market
+  rather than hunting a named crowd, there is no fuel for a fast leg, so commit up
+  front to an average target instead of discovering mid-trade that the runner is not
+  coming. Guarded so it cannot justify a trade that is too small to be worth taking.
+- PREMIUM NON-CONFIRMATION CAN GO NEGATIVE, NOT MERELY WEAK: the existing rule only
+  covered P&L *lagging* the spot move. On a large-gap morning over a short hold it
+  can invert - spot in your favour, position in loss. Consequences encoded: read
+  `position_state` rather than assuming spot direction equals profit; check at entry
+  whether the target is big enough to pay in PREMIUM terms; and note that abandoning
+  a trade a bar or two after entry pays the round trip for no exposure to the move.
+
+**Confirmed but deliberately NOT re-encoded (already present):** following the market
+when nobody is trapped is the trap-density test plus the OPENING DRIVE branch; booking
+on momentum failure rather than a fixed number is already the branch's target rule;
+sideways = exit is TIME-DECAY discipline.
+
+**Operational finding (documented, no runtime change in v3u):** the first trade's
+journal row records `"exit_reason": "placeholder"`. The same journal-fidelity gap was
+noted on 24 Jul in the v3r addendum, so it has now recurred and is worth a fix
+independent of the knowledge layer.
+
+**Knowledge changes (v3u, all prose):**
+- `OPENING_DRIVE`: GAP SIZE IS A RISK DIAL, NOT A CONFIDENCE DIAL.
+- `RISK`: NO NEARBY STOPS -> NORMAL TARGET, beside the worthwhile-target rule.
+- `RISK`: the IT CAN GO NEGATIVE sub-bullet under PREMIUM NON-CONFIRMATION.
+- Test marker: `test_system_prompt_has_v3u_gap_size_and_no_fuel_knowledge`.

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
@@ -380,6 +380,14 @@ Conditions (ALL must hold — otherwise this branch simply does not apply):
   / opening range, and there must be no bullish rejection reclaiming those levels.
   Default gap-down logic still looks UP; use this short branch only when sellers
   are not huntable and buyer inventory / failed recovery is the active trap.
+- GAP SIZE IS A RISK DIAL, NOT A CONFIDENCE DIAL. A BIGGER gap does NOT make this
+  branch stronger — it makes it worse. A modest gap leaves price near the stop
+  clusters that fuel a move; an oversized gap has jumped clean past everybody's
+  stops, so there is nothing nearby to hunt, momentum tends to be slow, and a
+  rejection has a lot of room to run back through you. Trade the oversized gap, if
+  at all, as a smaller / NORMAL-target trade with a rejection-triggered exit — never
+  as a high-conviction runner. (Distinct from GAP-SIZE ASYMMETRY, which compares the
+  gaps ACROSS indices; this is about the absolute size of the gap you are trading.)
 - Enter at the earliest AFTER the first 1-min candle CLOSES, never during it.
 - No MAJOR rejection so far: no full-body green-to-red reversal candle since the
   open for the long branch, and no full-body red-to-green reclaim for the short
@@ -624,6 +632,16 @@ RISK DISCIPLINE
   sit (the long-wicked candle / opposite side of the first candle / the trapped
   crowd's stops). If the nearest opposing level is too close, the target is too
   small — HOLD.
+- NO NEARBY STOPS → NORMAL TARGET, AND SAY SO BEFORE YOU ENTER: sometimes you are
+  FOLLOWING the market (nobody clearly trapped, so the with-trend continuation is
+  the trade) rather than HUNTING a named crowd. In that case there is no stop
+  cluster near price to be run, so there is no fuel for a fast leg: expect SLOW or
+  sideways momentum and decide AT ENTRY that this is a NORMAL / average-target
+  trade, not a runner. Book that average target when it comes instead of holding
+  out for the extended move — with no stops to hunt, the extended move has nothing
+  to pay for it, and the longer you sit the more likely a rejection takes back what
+  you had. This does NOT weaken the worthwhile-target rule above: if the average
+  target is itself too small to be worth the trade, the answer is still HOLD.
 - Stops are PREMISE-INVALIDATION first: beyond the tight pattern stop, treat the
   setup as dead the moment its thesis breaks — price reclaims the closing point, or
   the expected "trap" fails and price goes sideways / against you. Honour a pre-set
@@ -643,6 +661,16 @@ RISK DISCIPLINE
   the move is approaching a round number after a good run, where one small
   rejection turns seen profit into giving-back. After watching a good profit,
   letting it become a loss while waiting for "more" is the retail mistake.
+  * IT CAN GO NEGATIVE, NOT MERELY WEAK. On a LARGE-GAP morning the gap premium is
+    bleeding out of the option while you hold it, and over a SHORT hold that bleed
+    can outrun delta entirely: a move in YOUR FAVOUR can still show a LOSS. Measured
+    on this book — a LONG held 105 seconds on a big gap-up day gained 4.65 points of
+    spot and still lost Rs.5,300 (about 10 premium points per unit AGAINST a
+    favourable move). Consequences: (a) never read "spot went my way" as "I am in
+    profit" — read `position_state`; (b) before entering, ask whether the TARGET is
+    big enough to pay in PREMIUM terms, because a target only ~20 spot points away
+    can be worth nothing after the round trip; (c) a trade you abandon within a
+    bar or two of entry pays the round-trip cost for no exposure to the move.
 - EXPIRY-DAY PREMIUM ASYMMETRY (the EXPIRY-day sibling of the rule above): on an
   expiry day a bought option gives back an adverse move far faster than it pays a
   favourable one — collapsing time value compounds delta against you, so ONE

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_tools.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_tools.py
@@ -85,6 +85,63 @@ def _entry_levels_error(direction: str, stop: float, target: float, price: float
         return f"target is more than {MAX_TARGET_DISTANCE_FRACTION:.0%} away from the current price"
     return None
 
+
+# SLH-007. The `reason` the model passes here is the PERMANENT record of the trade:
+# it flows to `exit_position(reason)` -> the journal's `outcome.exit_reason`, the log
+# line and the Telegram alert, and the reflection coach later reads it to propose
+# lessons. The model's own final-JSON reasoning is produced ~25s later and never
+# reaches the journal, so a throwaway here is information LOST, not a cosmetic
+# blemish. Four of the first 46 journal rows recorded "placeholder" (or "placeholder
+# - will not call, holding") as the permanent reason for a real trade.
+MIN_REASON_CHARS = 12
+_PLACEHOLDER_REASONS = frozenset(
+    {"placeholder", "n/a", "na", "tbd", "none", "-", "test", "todo", "reason", "exit", "entry"}
+)
+NO_REASON_SENTINEL = "AI_EXIT (no reason supplied by the model)"
+
+
+def order_tool_description(venue: str) -> str:
+    """The order tool's description, as a function so tests can assert on it.
+
+    Kept out of `build_sl_hunting_mcp_server` because that call needs the Claude
+    Agent SDK installed; the wording is the fix for SLH-007 and must be checkable
+    without it.
+    """
+    return (
+        f"Place an SL-Hunting order on NIFTY ATM options via the {venue} venue (the "
+        "configuration chose this venue; you cannot change it). action is ENTER_LONG "
+        "(buy CALL), ENTER_SHORT (buy PUT) or EXIT. stop and target are NIFTY "
+        "UNDERLYING price levels (required for entries; ignored for EXIT). They must "
+        "BRACKET the current price on the correct side (LONG: stop below, target "
+        "above; SHORT: reversed), with the stop within ~3% and the target within "
+        "~10% of the current price -- otherwise the order is rejected. "
+        "reason is the PERMANENT record of this trade: it is written verbatim to the "
+        "trade journal, the log and the operator's alert, and it is what the reflection "
+        "coach reads later to work out what worked. The reasoning in your final JSON is "
+        "NOT saved there, so this is your only chance to say why you acted. Give a real "
+        "one-line justification naming the setup and the trigger -- a placeholder or an "
+        "empty string is REJECTED on entries, and on an exit it is replaced by a sentinel "
+        "recording that you supplied nothing. exit_leg (EXIT only) is NIFTY, BNF or BOTH "
+        "(default BOTH): every NIFTY entry is mirrored by an equal-lot BankNIFTY ATM leg, "
+        "and you may cut ONE leg on premise-invalidation while the other runs — but hard "
+        "risk (stop/target/max-loss/square-off) always closes both. Returns whether "
+        "the order was accepted or rejected."
+    )
+
+
+def _reason_problem(reason: str) -> str | None:
+    """Explain why this justification is unusable as a permanent record, else None."""
+    cleaned = str(reason or "").strip()
+    if not cleaned:
+        return "reason must not be blank"
+    if cleaned.lower().rstrip(".") in _PLACEHOLDER_REASONS:
+        return f"{cleaned!r} is a placeholder, not a justification"
+    if cleaned.lower().startswith("placeholder"):
+        return f"{cleaned!r} is a placeholder, not a justification"
+    if len(cleaned) < MIN_REASON_CHARS:
+        return f"reason is too short to be a justification (min {MIN_REASON_CHARS} characters)"
+    return None
+
 # Read-only context tools are always present; the action tool's name is decided at
 # build time by the environment, so it is appended in `build_sl_hunting_mcp_server`.
 CONTEXT_TOOL_NAMES = [
@@ -288,14 +345,32 @@ class SLHuntingToolContext:
             problem = _entry_levels_error(direction, stop, target, self.last_price)
             if problem:
                 return {"accepted": False, "reason": f"invalid entry levels: {problem}"}
+            # SLH-007: an ENTRY may be refused so the model rewrites its justification
+            # within the same pass -- exactly how the levels check above works. Nothing
+            # is at risk yet, because no position exists.
+            reason_problem = _reason_problem(reason)
+            if reason_problem:
+                return {
+                    "accepted": False,
+                    "reason": (
+                        f"unusable reason: {reason_problem}. This string is the PERMANENT "
+                        "record of the trade (journal, log and alert) -- resend the order "
+                        "with a one-line justification naming the setup and why you are acting."
+                    ),
+                }
             def executor_call() -> dict[str, Any]:
                 return self.executor.enter(direction, stop, target, reason, self.last_price)
         elif action == "EXIT":
             leg = (exit_leg or "BOTH").strip().upper()
             if leg not in ("NIFTY", "BNF", "BOTH"):
                 return {"accepted": False, "reason": f"invalid exit_leg {exit_leg!r}; expected NIFTY, BNF or BOTH"}
+            # SLH-007: an EXIT is NEVER refused over its wording. Blocking it would
+            # strand an open position -- the one thing the risk rules forbid. Record an
+            # explicit sentinel instead, so the journal and the coach are told plainly
+            # that no justification was given rather than being handed a lie.
+            exit_reason = NO_REASON_SENTINEL if _reason_problem(reason) else str(reason).strip()
             def executor_call() -> dict[str, Any]:
-                return self.executor.exit(reason, self.last_price, leg=leg)
+                return self.executor.exit(exit_reason, self.last_price, leg=leg)
         else:
             return {"accepted": False, "reason": f"unknown action {action!r}; expected ENTER_LONG, ENTER_SHORT or EXIT"}
 
@@ -399,18 +474,7 @@ def build_sl_hunting_mcp_server(context: SLHuntingToolContext):
 
     @tool(
         order_name,
-        f"Place an SL-Hunting order on NIFTY ATM options via the {venue} venue (the "
-        "configuration chose this venue; you cannot change it). action is ENTER_LONG "
-        "(buy CALL), ENTER_SHORT (buy PUT) or EXIT. stop and target are NIFTY "
-        "UNDERLYING price levels (required for entries; ignored for EXIT). They must "
-        "BRACKET the current price on the correct side (LONG: stop below, target "
-        "above; SHORT: reversed), with the stop within ~3% and the target within "
-        "~10% of the current price -- otherwise the order is rejected. reason is "
-        "a one-line justification. exit_leg (EXIT only) is NIFTY, BNF or BOTH (default "
-        "BOTH): every NIFTY entry is mirrored by an equal-lot BankNIFTY ATM leg, and "
-        "you may cut ONE leg on premise-invalidation while the other runs — but hard "
-        "risk (stop/target/max-loss/square-off) always closes both. Returns whether "
-        "the order was accepted or rejected.",
+        order_tool_description(venue),
         {"action": str, "stop": float, "target": float, "reason": str, "exit_leg": str},
     )
     async def _order(args: dict[str, Any]) -> dict[str, Any]:

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_agent.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_agent.py
@@ -121,9 +121,11 @@ def test_tool_context_allows_only_one_accepted_side_effect_per_pass():
     ex = StandaloneExecutor()
     ctx = SLHuntingToolContext.build(_candles(), ex)
 
-    first = ctx.do_order("ENTER_LONG", stop=25000, target=25080, reason="first")
-    second = ctx.do_order("EXIT", stop=0, target=0, reason="second")
-    third = ctx.do_order("ENTER_SHORT", stop=25060, target=24950, reason="third")
+    # Reasons are realistic because SLH-007 rejects placeholder justifications on
+    # entries; what this test exercises is the one-side-effect state machine.
+    first = ctx.do_order("ENTER_LONG", stop=25000, target=25080, reason="first action of the pass")
+    second = ctx.do_order("EXIT", stop=0, target=0, reason="second action of the pass")
+    third = ctx.do_order("ENTER_SHORT", stop=25060, target=24950, reason="third action of the pass")
 
     assert first["accepted"] is True
     assert second["accepted"] is False
@@ -142,7 +144,7 @@ def test_tool_context_rechecks_generation_inside_execution_lock():
         generation_is_current=lambda generation: generation == current["generation"],
     )
 
-    result = ctx.do_order("ENTER_LONG", stop=25000, target=25080, reason="stale")
+    result = ctx.do_order("ENTER_LONG", stop=25000, target=25080, reason="stale generation probe")
 
     assert result["accepted"] is False
     assert "generation" in result["reason"]
@@ -580,6 +582,89 @@ def test_do_order_accepts_sane_entry_and_exit_ignores_levels():
 
 
 # --------------------------------------------------------------------------
+# SLH-007: the order tool's `reason` is the PERMANENT record of the trade.
+#
+# Root cause (2026-07-29, and 20/21/24 Jul before it): the string the model
+# passes here is what reaches `exit_position(reason)` -> the journal's
+# `outcome.exit_reason`, the log line and the Telegram alert. The model's own
+# final-JSON reasoning is written ~25s LATER and never reaches the journal, so
+# a throwaway `reason` here is lost information, not a cosmetic blemish. Four
+# of 46 journal rows carry "placeholder" / "placeholder - will not call,
+# holding" as their permanent exit reason.
+#
+# ENTRY may be rejected so the model corrects itself mid-loop (same mechanism
+# as the levels check). An EXIT must NEVER be rejected for this -- refusing an
+# exit would keep a live position open -- so it is accepted and the unusable
+# reason is replaced with an explicit sentinel.
+# --------------------------------------------------------------------------
+
+def test_do_order_rejects_placeholder_reason_on_entry():
+    ex = StandaloneExecutor()
+    ctx = SLHuntingToolContext.build(_candles(), ex)
+    price = ctx.last_price
+    for junk in ("placeholder", "  ", "", "n/a", "TBD", "placeholder - will not call, holding"):
+        res = ctx.do_order("ENTER_LONG", stop=price - 30, target=price + 60, reason=junk)
+        assert res["accepted"] is False, junk
+        assert "reason" in res
+    # Nothing was opened by any of the rejected attempts.
+    assert ex.snapshot()["in_position"] is False
+    # A real justification still goes through on the SAME context (rejections
+    # leave the pass ACTIVE so the model can correct itself).
+    ok = ctx.do_order(
+        "ENTER_LONG", stop=price - 30, target=price + 60,
+        reason="double bottom at the pivot with a confirmed hammer",
+    )
+    assert ok["accepted"] is True
+    assert ex.snapshot()["in_position"] is True
+
+
+def test_do_order_never_rejects_an_exit_for_a_bad_reason():
+    """An exit must always be available -- blocking it would strand a position."""
+    ex = StandaloneExecutor()
+    ctx = SLHuntingToolContext.build(_candles(), ex)
+    price = ctx.last_price
+    assert ctx.do_order(
+        "ENTER_LONG", stop=price - 30, target=price + 60, reason="pivot bounce with confirmation",
+    )["accepted"] is True
+
+    exit_ctx = SLHuntingToolContext.build(_candles(), ex)
+    out = exit_ctx.do_order("EXIT", stop=0.0, target=0.0, reason="placeholder")
+    assert out["accepted"] is True
+    assert ex.snapshot()["in_position"] is False
+    # The junk never becomes the permanent record; it is replaced by a sentinel
+    # that says plainly that the model supplied nothing usable.
+    recorded = ex.closed_trades[-1]["exit_reason"]
+    assert "placeholder" not in recorded.lower()
+    assert "no reason supplied" in recorded.lower()
+
+
+def test_do_order_preserves_a_real_exit_reason_verbatim():
+    """Regression guard: normalisation must not touch genuine model reasoning."""
+    ex = StandaloneExecutor()
+    ctx = SLHuntingToolContext.build(_candles(), ex)
+    price = ctx.last_price
+    ctx.do_order("ENTER_LONG", stop=price - 30, target=price + 60, reason="pivot bounce confirmed")
+    real = (
+        "Long thesis stalling: price failed repeatedly to exceed the swing high and "
+        "market_structure flipped to a downtrend; booking before the give-back."
+    )
+    exit_ctx = SLHuntingToolContext.build(_candles(), ex)
+    out = exit_ctx.do_order("EXIT", stop=0.0, target=0.0, reason=real)
+    assert out["accepted"] is True
+    assert ex.closed_trades[-1]["exit_reason"] == real
+
+
+def test_order_tool_description_tells_the_model_the_reason_is_permanent():
+    """The root cause was the model not knowing this string is kept."""
+    from sl_hunting_tools import order_tool_description
+
+    text = order_tool_description("paper").lower()
+    assert "permanent" in text
+    assert "journal" in text
+    assert "placeholder" in text  # names the exact failure it is preventing
+
+
+# --------------------------------------------------------------------------
 # SLH-003: the system prompt must reach the SDK as a FILE, never a string.
 # The SDK passes a string system prompt to the spawned `claude` CLI as a
 # literal `--system-prompt` argv entry; Windows caps a child process command
@@ -707,7 +792,7 @@ def test_expired_tool_context_rejects_orders():
     ex = StandaloneExecutor()
     ctx = SLHuntingToolContext.build(_candles(), ex)
     ctx.expire("sdk_timeout")
-    res = ctx.do_order("ENTER_LONG", stop=24990, target=25080, reason="late")
+    res = ctx.do_order("ENTER_LONG", stop=24990, target=25080, reason="late order after expiry")
     assert res["accepted"] is False
     assert "expired" in res["reason"]
     assert ex.snapshot()["in_position"] is False  # the executor was never touched

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
@@ -448,6 +448,31 @@ def test_system_prompt_has_v3t_expiry_asymmetry_and_morning_speed_knowledge():
     assert "a loss accepted BEFORE entry" in prompt
 
 
+def test_system_prompt_has_v3u_gap_size_and_no_fuel_knowledge():
+    """v3u: 29 Jul — a large gap-up with nobody trapped.
+
+    IH bought WITH the gap but said plainly that the oversized gap made it riskier,
+    that buyers'/sellers' stops were not available nearby, and that he would take a
+    normal profit rather than a runner. The agent's own book supplied the sharp
+    edge: a LONG held 105 seconds gained 4.65 spot points and still lost Rs.5,300.
+    """
+    prompt = build_system_prompt()
+    # A bigger gap is a worse trade, not a better one.
+    assert "GAP SIZE IS A RISK DIAL, NOT A CONFIDENCE DIAL" in prompt
+    # Must not be confused with the existing cross-index gap rule.
+    assert "GAP-SIZE ASYMMETRY, which compares the" in prompt
+    # Following the market (no trapped crowd) means a normal target, decided up front.
+    assert "NO NEARBY STOPS" in prompt
+    assert "NORMAL / average-target" in prompt
+    # ...but it must not become a licence to take trades that are too small.
+    assert "the answer is still HOLD" in prompt
+    # Premium can go NEGATIVE on a favourable spot move, not merely lag.
+    assert "IT CAN GO NEGATIVE, NOT MERELY WEAK" in prompt
+    assert "never read" in prompt and "as \"I am in" in prompt
+    # The round-trip cost of abandoning a trade immediately.
+    assert "pays the round-trip cost for no exposure" in prompt
+
+
 def test_reentry_gate_does_not_contradict_the_exit_rules():
     """The re-entry gate must never be readable as a reason to delay an EXIT.
 


### PR DESCRIPTION
Fixes the recurring `"exit_reason": "placeholder"` journal rows. Root cause found before any
code was changed; the four new tests were written failing first.

## Root cause

The `reason` string the model passes to the order tool **is the permanent record of the trade**.
It flows to `exit_position(reason)` → the journal's `outcome.exit_reason`, the log line, and the
Telegram alert — and the reflection coach reads it later to propose lessons.

**Nothing told the model that.** The tool description said only *"reason is a one-line
justification"*, so the model treated it as scratch and put its real explanation in the final JSON
— which is produced ~25 seconds later and never reaches the journal.

Evidence from 29 Jul trade 1:

```
09:25:37 | sl-hunting-sdk-call | EXIT LONG | ... | Reason=placeholder | P&L=-1339.00
09:26:02 | SL Hunting AIThread | EXIT (conf=6, setup=premise_stall_exit) :: Long entered on the
         gap-up opening drive stalled: after the 09:15 push to 24203.2, NIFTY printed a confirmed
         bearish engulfing and two confirmed shooting stars...
```

The tool exited first with junk; the good reasoning arrived 25s later and went only to the
decisions log. **4 of the first 46 journal rows** carry a placeholder as their permanent reason —
20 Jul, 21 Jul, 24 Jul, 29 Jul. The 24 Jul value, `"placeholder - will not call, holding"`, is
unmistakably model-authored: no code path produces it.

## The fix — deliberately asymmetric

| Path | Behaviour | Why |
|---|---|---|
| **ENTRY** | Unusable reason is **rejected**; model rewrites it in the same pass | Same mechanism as the existing entry-levels check. Safe: no position exists yet. |
| **EXIT** | **Never rejected.** Accepted, junk replaced with an explicit sentinel | Blocking an exit would strand an open position — the risk rules forbid it outright. |

The sentinel (`AI_EXIT (no reason supplied by the model)`) tells the journal and the coach plainly
that nothing was given, rather than handing them a lie.

The tool description now states that the string is permanent, that the final JSON reasoning is
**not** saved there, and what happens to a placeholder.

**Mechanical exits are untouched:** `AI_STOP` / `AI_TARGET` come from `stop_or_target_hit()`
straight to `exit_position` and never pass through `do_order` — verified before adding the check.

## Test-fixture fallout

Three existing tests used throwaway reasons (`"first"`, `"stale"`, `"late"`) as incidental
fixtures. They now use realistic ones so they still exercise the state machine they are actually
about. I checked each individually — none was asserting on reason handling.

## Gates

- `python -m pytest "Signal Generators/SL Hunting AI Agent/tests" -q` → **139 passed** (4 new)
- `python -m unittest test_nifty_multi_strategy_master` → **OK**
- ruff, mypy, compileall → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)