### PR TITLE
fix(sl-hunting): correct the v3t premium-asymmetry rule

### DIFF
--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -1713,3 +1713,62 @@ independent of the knowledge layer.
 - `RISK`: NO NEARBY STOPS -> NORMAL TARGET, beside the worthwhile-target rule.
 - `RISK`: the IT CAN GO NEGATIVE sub-bullet under PREMIUM NON-CONFIRMATION.
 - Test marker: `test_system_prompt_has_v3u_gap_size_and_no_fuel_knowledge`.
+
+## ERRATUM to v3t - the expiry-asymmetry measurement was wrong (2026-07-29)
+
+Recorded as an erratum rather than an edit to the v3t section above, so the
+mistake and its correction both stay on the record.
+
+**What v3t claimed:** that on an expiry day a bought option gives back an adverse
+move ~3.5x faster than it pays a favourable one, measured on the agent's own book
+for 28 Jul, "both indices expiring".
+
+**What was actually true.** The agent's NIFTY leg on 28 Jul was
+`NIFTY-Aug2026-24000-PE`, `ExpiryDate=2026-08-04`, `DaysToExpiry=7`. It was NOT in
+the expiring series. Only the BankNIFTY mirror (`BANKNIFTY-Jul2026-57300-PE`, the
+July monthly) was 0 DTE. IH was trading the expiring contract; the agent was not.
+
+**Two errors followed from that:**
+
+1. *The number.* The 3.5x was computed from the journal's `option_pnl`, which is
+   BASKET P&L (`realized_pnl - _entry_realized_pnl`, both legs), divided by
+   NIFTY-ONLY spot points. That mixes two underlyings and two expiries in a single
+   ratio. Leg-level figures from the master log:
+   - loser: 139.45 -> 131.00 on qty 650 = -Rs.5,492.50, i.e. -8.45/unit for 4.55
+     ADVERSE spot points = **1.86** premium points per adverse point;
+   - winner: 131.00 -> 150.90 on qty 390 = +Rs.7,761.00, i.e. +19.90/unit for 24.35
+     FAVOURABLE spot points = **0.82** premium points per favourable point.
+   The asymmetry is **~2.3x**, not 3.5x. (The mirror leg moved the opposite way on
+   the winner - it LOST Rs.2,808 while the NIFTY leg made Rs.7,761 - which is what
+   dragged the basket ratio so far off.)
+2. *The mechanism and the scope.* "Collapsing time value on expiry day" cannot
+   explain a 7-DTE option. And because the rule was scoped "EXPIRY-DAY exception
+   only" while `get_target_expiry()` keeps the NIFTY leg 7-13 days out, the rule was
+   written for a situation the leg it governs essentially never occupies.
+
+**The correction.** The rule is renamed to PREMIUM ASYMMETRY, quotes the leg-level
+~2.3x, states that the magnitude is situational rather than constant, and keys the
+booking threshold to **the days-to-expiry of the option actually held** rather than
+to whether some index expires today. Marker test updated, including a guard that
+the discredited "3.5x" figure cannot reappear.
+
+**Method lesson for future versions:** `outcome.option_pnl` is BASKET P&L while
+`outcome.points` is NIFTY-ONLY. Never divide one by the other. Leg-level prices are
+in the master log (`EntryOptPx` / `ExitOptPx` per leg); use those.
+
+**v3u is unaffected** - 29 Jul fired no mirror legs at all, so its +4.65 spot /
+-Rs.5,300.75 figure is NIFTY-only and stands. Its contract was 13 DTE, where theta
+over 105 seconds is negligible, so the wide/thin far-dated book is now the leading
+explanation for that move rather than gap-premium bleed.
+
+**Root cause behind all of it:** the knowledge base is distilled from a trader who
+is always in the near or expiring contract, while the execution layer bought the
+SECOND expiry out. Fixed separately by SLH-008, which moves the NIFTY leg to the
+current-week contract; from that point the expiry-aware rules and the instrument
+actually held finally describe the same thing.
+
+**Also corrected here (2026-07-29):** an earlier note in this investigation claimed
+no live order had ever filled. That was wrong - a bad log query, since fills are
+recorded on their own `REAL ORDER FILLED` lines rather than on the `ENTRY` line.
+There were 74 real fills between 22 and 28 Jul, all on the 2026-08-04 contract; the
+rejections began on 29 Jul when the ladder rolled and next-next became 2026-08-11.

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
@@ -671,22 +671,26 @@ RISK DISCIPLINE
     big enough to pay in PREMIUM terms, because a target only ~20 spot points away
     can be worth nothing after the round trip; (c) a trade you abandon within a
     bar or two of entry pays the round-trip cost for no exposure to the move.
-- EXPIRY-DAY PREMIUM ASYMMETRY (the EXPIRY-day sibling of the rule above): on an
-  expiry day a bought option gives back an adverse move far faster than it pays a
-  favourable one — collapsing time value compounds delta against you, so ONE
-  opposing candle can erase most of a good unrealised profit. Measured on this
-  book (two SHORT trades the same morning, both indices expiring): the loser bled
-  roughly 1.6 premium points per ADVERSE point of spot, while the winner earned
-  only about 0.45 premium points per FAVOURABLE point — a ~3.5x asymmetry against
-  the position. So while HOLDING on an expiry day:
-  * BOOK INTO STRENGTH, while the move is still running in your favour. Do not wait
-    for a stall-and-pullback to "confirm" the turn — on expiry the confirmation
-    candle IS the give-back.
-  * Your booking threshold is TIGHTER than for the identical setup on a non-expiry
-    day: an unrealised profit is worth materially less the longer you sit on it,
-    and a position going nowhere costs you money even with the underlying flat.
-  This is an EXPIRY-DAY exception only. On a normal day PROFIT-HOLD still governs —
-  never cite this rule to justify cutting a valid winner early.
+- PREMIUM ASYMMETRY — ADVERSE MOVES COST MORE THAN FAVOURABLE ONES PAY (the
+  measured sibling of the rule above): a bought option tends to give back an
+  adverse move faster than it pays a favourable one, so ONE opposing candle can
+  erase much of a good unrealised profit. Measured on this book, on the NIFTY leg
+  ALONE (two SHORT trades the same morning, the option 7 days from expiry): the
+  loser bled about 1.86 premium points per ADVERSE point of spot, while the winner
+  earned about 0.82 premium points per FAVOURABLE point — a ~2.3x asymmetry against
+  the position. Treat the SIZE of that asymmetry as situational, not a constant: it
+  widens as your option approaches ITS OWN expiry (time value collapsing on top of
+  delta) and in thin, wide-spread contracts. So while HOLDING:
+  * BOOK INTO STRENGTH, while the move is still running in your favour, rather than
+    waiting for a stall-and-pullback to "confirm" the turn — the confirmation candle
+    is also the give-back candle.
+  * The closer YOUR CONTRACT is to expiry, the tighter your booking threshold should
+    be: an unrealised profit is worth materially less the longer you sit on it, and a
+    position going nowhere costs you money even with the underlying flat. What matters
+    is the days-to-expiry of the option you actually hold, NOT whether some index
+    happens to expire today.
+  This never licenses cutting a valid winner early: PROFIT-HOLD still governs while
+  the premise is intact and the move is still delivering.
 - When already in a position, EXIT on: target reached, stop hit, an OPPOSING
   pattern + confirmation forming against you, or the move going slow/stalling at a
   level in your favour. Otherwise HOLD and let it run.

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
@@ -421,22 +421,33 @@ def test_system_prompt_has_v3s_laggards_and_enforced_cooldown_knowledge():
 
 
 def test_system_prompt_has_v3t_expiry_asymmetry_and_morning_speed_knowledge():
-    """v3t: 28 Jul — both indices expiring; IH booked into strength because expiry
-    premiums collapse on the first opposing candle, and warned that a fast morning
-    stop-out is normal variance rather than a reason to retry.
+    """v3t: 28 Jul — IH booked into strength rather than waiting for confirmation,
+    and warned that a fast morning stop-out is normal variance, not a reason to retry.
 
-    The agent's own book measured the same asymmetry that day: it bled ~1.6 premium
-    points per adverse spot point on the loser but earned only ~0.45 per favourable
-    point on the winner.
+    CORRECTED 2026-07-29. The original rule was scoped to "expiry day" and quoted a
+    ~3.5x asymmetry. Both were wrong. The 3.5x came from BASKET option_pnl (a 7-DTE
+    NIFTY leg plus a 0-DTE BankNIFTY mirror) divided by NIFTY-ONLY spot points — two
+    underlyings and two expiries in one ratio. On the NIFTY leg alone the figures are
+    139.45->131.00 on 650 qty for 4.55 adverse points (1.86 per point) against
+    131.00->150.90 on 390 qty for 24.35 favourable points (0.82 per point): ~2.3x.
+    And IH was trading the EXPIRING series while the agent's NIFTY leg was 7 days
+    out, so "expiry-day time-value collapse" was never the mechanism for our leg.
+    The rule now keys off the held option's own days-to-expiry.
     """
     prompt = build_system_prompt()
-    # Expiry-day holding rule -- distinct from PREMIUM NON-CONFIRMATION, which is
-    # explicitly scoped to days with no expiry.
-    assert "EXPIRY-DAY PREMIUM ASYMMETRY" in prompt
+    # The holding rule -- distinct from PREMIUM NON-CONFIRMATION above it.
+    assert "PREMIUM ASYMMETRY" in prompt
     assert "BOOK INTO STRENGTH" in prompt
-    # The mechanism, so the rule is not read as "cut winners early" in general.
-    assert "the confirmation" in prompt and "candle IS the give-back" in prompt
-    assert "This is an EXPIRY-DAY exception only" in prompt
+    # The corrected, leg-level measurement must be what is quoted.
+    assert "2.3x asymmetry" in prompt
+    assert "3.5x" not in prompt          # the bad basket-derived figure is gone
+    # It must key off OUR contract, not the calendar -- the original scoping error.
+    assert "the days-to-expiry of the option you actually hold" in prompt
+    assert "NOT whether some index" in prompt
+    # Magnitude is situational, not a constant.
+    assert "situational, not a constant" in prompt
+    # ...and it still must not be read as licence to cut winners early.
+    assert "PROFIT-HOLD still governs" in prompt
     # A fast morning stop-out must not be read as evidence about the next trade.
     assert "MORNING SPEED IS NOT INFORMATION" in prompt
     assert "is a FLOOR, not the standard" in prompt


### PR DESCRIPTION
Corrects the v3t PREMIUM ASYMMETRY rule, which is wrong on `main` right now. Recorded as an
**erratum** in the doc rather than an edit to the v3t section, so the mistake and the correction
both stay on the record.

## What was wrong

v3t claimed a **~3.5x expiry-day asymmetry** measured on the agent's own book for 28 Jul, "both
indices expiring". The agent's NIFTY leg that day was:

```
NIFTY-Aug2026-24000-PE | ExpiryDate=2026-08-04 | DaysToExpiry=7
```

**Not the expiring series.** Only the BankNIFTY mirror (July monthly) was 0 DTE. IH was trading
the expiring contract; the agent was not.

Two errors followed:

**1. The number.** The 3.5x came from the journal's `option_pnl`, which is **basket** P&L
(`realized_pnl - _entry_realized_pnl`, both legs), divided by **NIFTY-only** spot points — two
underlyings and two expiries in one ratio. Leg-level, from the master log:

| | Premium | Qty | Per unit | Spot | Ratio |
|---|---|---|---|---|---|
| Loser | 139.45 → 131.00 | 650 | −8.45 | 4.55 adverse | **1.86** |
| Winner | 131.00 → 150.90 | 390 | +19.90 | 24.35 favourable | **0.82** |

**~2.3x, not 3.5x.** The mirror leg actually *lost* ₹2,808 on the trade where the NIFTY leg made
₹7,761, which is what dragged the basket ratio so far off.

**2. The mechanism and the scope.** "Collapsing time value on expiry day" cannot explain a 7-DTE
option. And because the rule was scoped *"EXPIRY-DAY exception only"* while `get_target_expiry()`
keeps the NIFTY leg 7–13 days out, it was written for a situation the leg it governs essentially
never occupies.

## The correction

Renamed to **PREMIUM ASYMMETRY**. It now quotes the leg-level ~2.3x, states that the magnitude is
**situational rather than constant** (widening as the held option nears its own expiry and in thin,
wide-spread contracts), and keys the booking threshold to **the days-to-expiry of the option
actually held** rather than to whether some index expires today.

The marker test now also guards that the discredited `"3.5x"` cannot reappear.

## Method lesson recorded for future versions

`outcome.option_pnl` is **basket** P&L while `outcome.points` is **NIFTY-only**. Never divide one
by the other. Leg-level prices are in the master log (`EntryOptPx` / `ExitOptPx` per leg).

## v3u is unaffected

29 Jul fired no mirror legs at all, so its +4.65 spot / −₹5,300.75 figure is NIFTY-only and stands.
That contract was 13 DTE, where theta over 105 seconds is negligible — so the thin, wide far-dated
book is now the leading explanation rather than gap-premium bleed.

## Gates

134 SL Hunting tests, 382 master tests, ruff — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)