### PR TITLE
feat(sl-hunting): SLH-008 trade the current-week NIFTY expiry

### DIFF
--- a/Nifty Multi Strategy Front Test - Master File.py
+++ b/Nifty Multi Strategy Front Test - Master File.py
@@ -84,12 +84,16 @@ Different strategies pick different expiries. Rather than burying this
 in a single overloaded method, every worker is explicit about which
 expiry rule it uses:
 
-    if strategy belongs to the "Hedged Puts" family, or is the Long Strangle
+    if strategy belongs to the "Hedged Puts" family, is the Long Strangle,
+    or is SL Hunting's NIFTY leg (SLH-008)
         -> use OptionsContractResolver.get_current_week_expiry()
            (the FIRST expiry on or after today)
     else
         -> use OptionsContractResolver.get_target_expiry()
            (the SECOND expiry on or after today, i.e. "next-next")
+
+ATM workers select this via the `_entry_expiry()` hook, which returns None
+(= the resolver's next-next default) unless a subclass overrides it.
 
 (CPR Algo 3 is "else" -- it TRADES the next-next ATM -- even though its read-only
 observation legs use the current-week expiry.)
@@ -106,6 +110,14 @@ the live mirror leg kept failing to fire. Expiry week is handled on the STRIKE
 axis instead -- inside SL_HUNTING_BNF_MIRROR_ROLLOVER_DAYS the mirror buys a
 deep ITM strike (get_itm_option) whose value is mostly intrinsic, rather than a
 near-expiry ATM contract that is almost pure decaying time premium.
+
+SLH-008 (2026-07-29): the same Kotak RMS rule reached the NIFTY leg -- MIS is
+allowed only on the current WEEKLY or the monthly contract, and "next-next"
+is neither in roughly three weeks out of four, so live entries were rejected
+and silently fell back to paper. The NIFTY leg therefore also trades the
+current-week expiry now. Beyond the broker, it is the right instrument: this
+strategy holds for minutes, and its whole knowledge base is distilled from a
+trader who is always in the near/expiring series.
 
 Both methods live on the same resolver so the choice is one line at
 the call site. That keeps the rule visible in the code and easy to
@@ -6155,6 +6167,20 @@ class AtmSingleLegStrategyWorker(BasePaperStrategyWorker):
             lot_size,
         ).lots
 
+    def _entry_expiry(self) -> date | None:
+        """Which expiry this worker's ATM entry uses. None = the resolver default.
+
+        None means `get_target_expiry()` — the SECOND expiry on or after today
+        ("next-next"), the rule the ATM family was built and tuned on. Kept as the
+        default so this hook changes nothing for the seven workers that do not
+        override it.
+
+        SL Hunting overrides it (SLH-008): it holds positions for minutes, so a
+        next-next contract is the wrong instrument, and Kotak's RMS refuses MIS
+        orders on it outright.
+        """
+        return None
+
     def enter_position(
         self,
         direction: str,
@@ -6165,7 +6191,8 @@ class AtmSingleLegStrategyWorker(BasePaperStrategyWorker):
         pending_trailing_exit: bool = False,
     ) -> bool:
         """
-        Open a new paper position on the ATM option of the next-next expiry.
+        Open a new paper position on the ATM option of this worker's entry expiry
+        (`_entry_expiry`; the next-next expiry unless a subclass overrides it).
 
         Steps:
         1. Read the latest NIFTY spot from the central LTP cache.
@@ -6183,7 +6210,7 @@ class AtmSingleLegStrategyWorker(BasePaperStrategyWorker):
             return False
 
         try:
-            contract = self.contract_resolver.get_atm_option(spot, direction)
+            contract = self.contract_resolver.get_atm_option(spot, direction, self._entry_expiry())
         except Exception as exc:
             self.log.warning("Skipping %s entry because ATM option resolution failed: %s", direction, exc)
             return False
@@ -12239,6 +12266,34 @@ if SL_HUNTING_AVAILABLE:
                 # a later bar's journal row.
                 if getattr(self, "_executor", None) is not None:
                     self._executor.last_entry_order = None
+
+        def _entry_expiry(self):
+            """SLH-008: trade the CURRENT-WEEK NIFTY contract, not the next-next one.
+
+            Two independent reasons, found together on 2026-07-29:
+
+            1. Instrument. This strategy holds for two to ten minutes. The next-next
+               expiry is 7-13 days out — wide spreads, a thin book, and low gamma.
+               The method it is distilled from (Intraday Hunter) always trades the
+               near/expiring series; every expiry-aware rule in the knowledge base
+               was written from that reality, so the agent was reasoning about one
+               instrument while holding another.
+            2. Live orders. Kotak's RMS allows MIS (intraday) orders ONLY on the
+               current weekly or the monthly contract. `get_target_expiry()` lands on
+               neither in roughly three weeks out of four, so live entries were
+               rejected outright ("MIS ORDERS ALLOWED ONLY IN CURRENT WEEKY AND
+               MONTHLY EXPIRY CONTRACT") and silently fell back to paper. This is the
+               same failure BNF-002 fixed for the BankNIFTY mirror on 2026-07-23; the
+               fix simply was never extended to the NIFTY leg.
+
+            Deliberately NOT mirrored from BNF-002: the near-expiry deep-ITM strike
+            shift. That exists because the mirror is mechanical and has no judgement.
+            Here the agent decides, and PREMIUM ASYMMETRY in the knowledge base now
+            tells it to tighten its booking threshold as ITS OWN contract nears
+            expiry — so an expiry-day position is handled by the method, not by
+            moving the strike.
+            """
+            return self.contract_resolver.get_current_week_expiry()
 
         # --------------------------------------------------------------
         # BankNIFTY mirror leg (Intraday Hunter style)

--- a/test_nifty_multi_strategy_master.py
+++ b/test_nifty_multi_strategy_master.py
@@ -3588,6 +3588,43 @@ class TestSLHuntingBnfMirror(unittest.TestCase):
         })
         return worker, store
 
+    def test_slh008_nifty_leg_uses_current_week_expiry(self):
+        """SLH-008: the NIFTY leg must resolve the CURRENT-WEEK contract.
+
+        Two failures on 2026-07-29 traced to the next-next default: Kotak's RMS
+        refuses MIS orders on it ("MIS ORDERS ALLOWED ONLY IN CURRENT WEEKY AND
+        MONTHLY EXPIRY CONTRACT"), so every live entry was rejected and fell back
+        to paper; and a 7-13 day contract is the wrong instrument for a strategy
+        that holds for minutes and whose knowledge is distilled from a trader
+        always in the near series.
+        """
+        worker, _store = self._make_worker()
+        current_week = date.today() + timedelta(days=3)
+        worker.contract_resolver.get_current_week_expiry.return_value = current_week
+        worker.contract_resolver.get_target_expiry.return_value = (
+            date.today() + timedelta(days=10)
+        )
+
+        self.assertEqual(worker._entry_expiry(), current_week)
+
+        self.assertTrue(worker.enter_position("LONG", 24300.0, 24290.0, 24330.0))
+        # The resolver was asked for that expiry EXPLICITLY -- not left to default.
+        _args, kwargs = worker.contract_resolver.get_atm_option.call_args
+        passed = kwargs.get("expiry_date", _args[2] if len(_args) > 2 else None)
+        self.assertEqual(passed, current_week)
+        worker.contract_resolver.get_target_expiry.assert_not_called()
+
+    def test_slh008_other_atm_workers_keep_the_next_next_default(self):
+        """The hook must not change the seven ATM workers it does not belong to."""
+        store = master_file.SharedMarketDataStore()
+        broker = MagicMock()
+        broker.fetch_ltp_map.return_value = {}
+        renko = master_file.RenkoStrategyWorker(
+            store=store, stop_event=threading.Event(), broker=broker
+        )
+        # None means "resolver default", i.e. get_target_expiry / next-next.
+        self.assertIsNone(renko._entry_expiry())
+
     def _expected_nifty_lots(self):
         """Expected lots for this class's canonical 10-pt-stop entry.
 


### PR DESCRIPTION
The SL Hunting NIFTY leg now resolves the **current-week** contract instead of the next-next one,
matching Intraday Hunter's convention.

> **Correction to an earlier claim.** I first reported that no live order had ever filled. That was
> wrong — a bad grep: fills are logged on their own `REAL ORDER FILLED` line, not on the `ENTRY`
> line I searched. **74 real fills** occurred between 22 and 28 Jul. Real money has been executing
> on the next-next contract, which makes this change more consequential, not less.

## Two independent problems

**1. Wrong instrument.** The strategy holds for two to ten minutes, but `get_target_expiry()`
returns the SECOND expiry on or after today — **7 to 13 days out**, with wide spreads, a thin book
and low gamma.

IH always trades the near/expiring series. On 28 Jul he was *in* the expiring contract — his whole
exit was about its premium collapse — while the agent held `NIFTY-Aug2026-24000-PE` at 7 DTE. The
agent was reasoning about one instrument and holding another, and every expiry-aware rule in the
prompt was written from his reality rather than ours.

**2. Live entries started being rejected on 29 Jul.** The NIFTY expiry ladder rolled:

| Date | `get_target_expiry()` | Kotak |
|---|---|---|
| 22–28 Jul | 2026-08-04 | accepted — 74 real fills |
| 29 Jul | 2026-08-11 | **rejected 3/3** |

All three 29 Jul entries failed with *"MIS ORDERS ALLOWED ONLY IN CURRENT WEEKY AND MONTHLY EXPIRY
CONTRACT"* and fell back to paper. The nearest weekly is always inside the permitted set, so
current-week removes this failure mode instead of leaving it to where the calendar happens to land.

**I have not characterised Kotak's exact permitted set.** The log shows 08-04 accepted on 22–28 Jul
and 08-11 refused on 29 Jul. That justifies moving to the nearest weekly; it is not enough to state
the broker's rule precisely, and I have not claimed one.

This is the same class of failure **BNF-002** fixed for the BankNIFTY mirror on 2026-07-23 — never
extended to the NIFTY leg.

## Knock-on: the missing BankNIFTY mirror

Because the 29 Jul NIFTY entries fell back to paper, `_should_open_bnf_mirror` correctly refused to
open a **real** BankNIFTY leg beside a **paper** NIFTY leg — logging *"BNF mirror skipped: NIFTY
entry is paper fallback, not a broker-confirmed live fill"* all three times. That gate is working
exactly as designed; no fix is needed there. This change restores the mirror by making the NIFTY
entry fill again.

## Implementation

A single overridable hook. `AtmSingleLegStrategyWorker` gains `_entry_expiry()`, returning `None`
(= the resolver's next-next default), and `enter_position` passes it through. **Only
`SLHuntingAIWorker` overrides it**, so the other seven ATM workers are behaviourally unchanged —
there's a test asserting exactly that.

**Deliberately not copied from BNF-002:** the near-expiry deep-ITM strike shift. That exists
because the mirror is mechanical and has no judgement. Here the agent decides, and the corrected
PREMIUM ASYMMETRY rule (#95) already tells it to tighten its booking threshold as its own contract
nears expiry.

No new env knob, following the BNF-001/002 precedent of an explicit call-site expiry rule.

## Operator note

This changes the contract a **live** strategy trades. Results before and after are not directly
comparable, and on expiry day the leg is now 0 DTE by design — that is IH's convention.

## Gates

384 master tests (2 new), 21 market-data-health, 895 pytest, ruff, mypy (CI scope), compileall —
all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)