### PR TITLE
fix(sl-hunting): harden v3v quote ownership and fill accounting

### DIFF
--- a/Dependencies/Dhan API/dhan_execution.py
+++ b/Dependencies/Dhan API/dhan_execution.py
@@ -174,6 +174,7 @@ _ORDER_ID_KEYS = ("orderId", "order_id", "orderid")
 _ORDER_STATE_KEYS = ("orderStatus", "order_status", "status")
 _FILLED_QTY_KEYS = ("filledQty", "filled_qty", "filledQuantity", "tradedQty")
 _ORDER_QTY_KEYS = ("quantity", "orderQuantity", "qty")
+_AVERAGE_PRICE_KEYS = ("averageTradedPrice",)
 _SYMBOL_KEYS = ("tradingSymbol", "trading_symbol", "symbol")
 _SIDE_KEYS = ("transactionType", "transaction_type")
 _PRODUCT_KEYS = ("productType", "product_type")
@@ -193,6 +194,18 @@ def _exact_int(value: Any) -> int | None:
     if not math.isfinite(number) or not number.is_integer():
         return None
     return int(number)
+
+
+def _positive_price(value: Any) -> float:
+    """Return Dhan's documented average traded price, or zero when absent."""
+
+    if isinstance(value, bool):
+        return 0.0
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    return number if math.isfinite(number) and number > 0 else 0.0
 
 
 def _first_present(row: dict[str, Any], keys: tuple[str, ...]) -> Any:
@@ -1093,8 +1106,8 @@ class DhanExecutionClient:
     def _order_status(
         self,
         order_id: str,
-    ) -> tuple[str | None, int | None, int | None, str]:
-        """Return normalized state, filled qty, order qty, and rejection reason."""
+    ) -> tuple[str | None, int | None, int | None, str, float]:
+        """Return state, quantities, reason, and documented average traded price."""
         envelope = self._call_api(
             "order status",
             lambda client: client.get_order_by_id(str(order_id)),
@@ -1102,7 +1115,7 @@ class DhanExecutionClient:
         )
         outcome, data, reason = _classify_envelope(envelope)
         if outcome != "ok":
-            return (None, None, None, reason)
+            return (None, None, None, reason, 0.0)
         rows = data if isinstance(data, list) else [data]
         for row in rows:
             if not isinstance(row, dict):
@@ -1112,8 +1125,15 @@ class DhanExecutionClient:
                 _exact_int(_first_present(row, _FILLED_QTY_KEYS)),
                 _exact_int(_first_present(row, _ORDER_QTY_KEYS)),
                 str(_first_present(row, _REASON_KEYS) or "").strip(),
+                _positive_price(_first_present(row, _AVERAGE_PRICE_KEYS)),
             )
-        return (None, None, None, f"Unrecognised Dhan order-status payload: {data!r}")
+        return (
+            None,
+            None,
+            None,
+            f"Unrecognised Dhan order-status payload: {data!r}",
+            0.0,
+        )
 
     def get_order_status(
         self,
@@ -1129,7 +1149,9 @@ class DhanExecutionClient:
         if requested is None or requested < 0:
             requested = 0
         try:
-            state, filled, broker_qty, reason = self._order_status(str(order_id))
+            state, filled, broker_qty, reason, average_fill_price = (
+                self._order_status(str(order_id))
+            )
         except Exception as exc:
             return normalize_order_result(
                 order_id=order_id,
@@ -1157,6 +1179,7 @@ class DhanExecutionClient:
             filled_quantity=filled,
             broker_state=state or "",
             reason=reason,
+            average_fill_price=average_fill_price,
         )
 
     def _confirm_fill(self, order_id: str, want_qty: int) -> OrderResult:
@@ -1202,6 +1225,7 @@ class DhanExecutionClient:
                 f"Dhan order {order_id} was not terminal within "
                 f"{_FILL_TIMEOUT_SECONDS:.0f}s; exposure is indeterminate."
             ),
+            average_fill_price=last_result.average_fill_price,
         )
 
     def cancel_order(

--- a/Dependencies/Dhan API/test_dhan_execution.py
+++ b/Dependencies/Dhan API/test_dhan_execution.py
@@ -196,6 +196,59 @@ def test_first_present_tolerates_field_casing_differences() -> None:
     assert de._first_present({}, de._FILLED_QTY_KEYS) is None
 
 
+def test_order_status_exposes_documented_average_traded_price(monkeypatch) -> None:
+    client = de.DhanExecutionClient()
+    envelope = {
+        "status": "success",
+        "remarks": "",
+        "data": {
+            "orderStatus": "TRADED",
+            "filledQty": 65,
+            "quantity": 65,
+            "averageTradedPrice": 125.25,
+        },
+    }
+    monkeypatch.setattr(
+        client,
+        "_call_api",
+        lambda *_args, **_kwargs: envelope,
+    )
+
+    state, filled, quantity, reason, average = client._order_status("DH-1")
+    result = client.get_order_status("DH-1", requested_quantity=65)
+
+    assert (state, filled, quantity, reason, average) == (
+        "TRADED",
+        65,
+        65,
+        "",
+        125.25,
+    )
+    assert result.average_fill_price == 125.25
+
+
+def test_fill_timeout_preserves_last_known_average_price(monkeypatch) -> None:
+    client = de.DhanExecutionClient()
+    partial = de.OrderResult(
+        order_id="DH-1",
+        requested_quantity=65,
+        filled_quantity=20,
+        remaining_quantity=45,
+        status=de.OrderStatus.PARTIAL,
+        broker_state="PARTIAL",
+        reason="partial",
+        average_fill_price=101.5,
+    )
+    monkeypatch.setattr(client, "get_order_status", lambda *_args, **_kwargs: partial)
+    monkeypatch.setattr(de, "_FILL_TIMEOUT_SECONDS", 0.02)
+    monkeypatch.setattr(de, "_FILL_POLL_INTERVAL", 0.005)
+
+    result = client._confirm_fill("DH-1", 65)
+
+    assert result.filled_quantity == 20
+    assert result.average_fill_price == 101.5
+
+
 def test_extract_order_id_searches_nested_payloads() -> None:
     assert de.dhan_execution_client.extract_order_id({"orderId": " DH-1 "}) == "DH-1"
     assert de.dhan_execution_client.extract_order_id({"data": {"orderId": "DH-2"}}) == "DH-2"

--- a/Dependencies/Flattrade API/flattrade_execution.py
+++ b/Dependencies/Flattrade API/flattrade_execution.py
@@ -132,6 +132,18 @@ def _exact_int(value: Any) -> int | None:
     return int(number)
 
 
+def _positive_price(value: Any) -> float:
+    """Return Flattrade's documented ``avgprc`` value, or zero if unavailable."""
+
+    if isinstance(value, bool):
+        return 0.0
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    return number if math.isfinite(number) and number > 0 else 0.0
+
+
 def _is_no_data_envelope(value: Any) -> bool:
     """Recognize only Flattrade's exact, determinate empty-book response."""
 
@@ -978,8 +990,8 @@ class FlattradeExecutionClient:
     def _order_status(
         self,
         order_id: str,
-    ) -> tuple[str | None, int | None, int | None, str]:
-        """Return normalized state, filled qty, order qty, and rejection reason."""
+    ) -> tuple[str | None, int | None, int | None, str, float]:
+        """Return state, quantities, reason, and documented average traded price."""
         response = self._post_api(
             "SingleOrdHist",
             {"uid": self._client_id, "norenordno": str(order_id)},
@@ -998,12 +1010,13 @@ class FlattradeExecutionClient:
                 _exact_int(row.get("fillshares")),
                 _exact_int(row.get("qty")),
                 str(row.get("rejreason") or row.get("emsg") or "").strip(),
+                _positive_price(row.get("avgprc")),
             )
         reason = (
             response.get("emsg", "unrecognised response")
             if isinstance(response, dict) else "unrecognised response"
         )
-        return (None, None, None, str(reason))
+        return (None, None, None, str(reason), 0.0)
 
     def get_order_status(
         self,
@@ -1019,7 +1032,9 @@ class FlattradeExecutionClient:
         if requested is None or requested < 0:
             requested = 0
         try:
-            state, filled, broker_qty, reason = self._order_status(str(order_id))
+            state, filled, broker_qty, reason, average_fill_price = (
+                self._order_status(str(order_id))
+            )
         except Exception as exc:
             return normalize_order_result(
                 order_id=order_id,
@@ -1047,6 +1062,7 @@ class FlattradeExecutionClient:
             filled_quantity=filled,
             broker_state=state or "",
             reason=reason,
+            average_fill_price=average_fill_price,
         )
 
     def _confirm_fill(self, order_id: str, want_qty: int) -> OrderResult:
@@ -1092,6 +1108,7 @@ class FlattradeExecutionClient:
                 f"Flattrade order {order_id} was not terminal within "
                 f"{_FILL_TIMEOUT_SECONDS:.0f}s; exposure is indeterminate."
             ),
+            average_fill_price=last_result.average_fill_price,
         )
 
     def cancel_order(

--- a/Dependencies/Flattrade API/test_flattrade_execution.py
+++ b/Dependencies/Flattrade API/test_flattrade_execution.py
@@ -147,10 +147,24 @@ def test_order_status_parses_the_latest_ok_row(monkeypatch):
     monkeypatch.setattr(
         client,
         "_post_api",
-        lambda *a, **k: [{"stat": "Ok", "status": "COMPLETE", "fillshares": "75", "qty": "75"}],
+        lambda *a, **k: [
+            {
+                "stat": "Ok",
+                "status": "COMPLETE",
+                "fillshares": "75",
+                "qty": "75",
+                "avgprc": "123.45",
+            }
+        ],
     )
-    state, filled, qty, reason = client._order_status("ORD1")
-    assert (state, filled, qty, reason) == ("complete", 75, 75, "")
+    state, filled, qty, reason, average = client._order_status("ORD1")
+    assert (state, filled, qty, reason, average) == (
+        "complete",
+        75,
+        75,
+        "",
+        123.45,
+    )
 
 
 def test_order_status_surfaces_rejection_reason(monkeypatch):
@@ -160,7 +174,7 @@ def test_order_status_surfaces_rejection_reason(monkeypatch):
         "_post_api",
         lambda *a, **k: [{"stat": "Ok", "status": "REJECTED", "rejreason": "RMS limit"}],
     )
-    state, _filled, _qty, reason = client._order_status("ORD1")
+    state, _filled, _qty, reason, _average = client._order_status("ORD1")
     assert state == "rejected" and reason == "RMS limit"
 
 

--- a/Dependencies/Kotak API/kotak_execution.py
+++ b/Dependencies/Kotak API/kotak_execution.py
@@ -1077,13 +1077,10 @@ class KotakExecutionClient:
             self._traded_price(latest),
         )
 
-    # Kotak's order-history rows use abbreviated keys (``ordSt``, ``fldQty``,
-    # ``qty``).  The average traded price is not documented in this repo, so
-    # rather than hard-code one guess we try the plausible spellings and fall
-    # back to 0.0 ("broker reported none"), which leaves the caller exactly where
-    # it was before this field existed.  The key names actually seen are logged
-    # ONCE per process so the operator can pin the real one from a live fill.
-    _TRADED_PRICE_KEYS = ("avgPrc", "avgPrice", "flPrc", "fldPrc", "tradedPrice", "avgPrics")
+    # Kotak Neo v2's official order-history schema names this field ``avgPrc``.
+    # Do not guess aliases: an unrecognized payload is missing evidence, not a
+    # reason to reinterpret some other numeric field as money.
+    _TRADED_PRICE_KEYS = ("avgPrc",)
     _logged_price_keys = False
 
     @classmethod
@@ -1187,6 +1184,7 @@ class KotakExecutionClient:
                 f"Kotak order {order_id} was not terminal within "
                 f"{_FILL_TIMEOUT_SECONDS:.0f}s; exposure is indeterminate."
             ),
+            average_fill_price=last_result.average_fill_price,
         )
 
     def cancel_order(

--- a/Dependencies/Kotak API/kotak_execution.py
+++ b/Dependencies/Kotak API/kotak_execution.py
@@ -1045,35 +1045,69 @@ class KotakExecutionClient:
         """
         Read the latest state of one order via order_history.
 
-        Returns (state, filled_qty, order_qty, reason). `state` is None when the
-        status cannot be read yet (a transient error, or the order not visible
-        yet), in which case the caller should simply keep polling.
+        Returns (state, filled_qty, order_qty, reason, avg_price). `state` is None
+        when the status cannot be read yet (a transient error, or the order not
+        visible yet), in which case the caller should simply keep polling.
+        `avg_price` is 0.0 whenever the broker did not report a traded price.
         """
         with self._lock:
             client = self.client
         if client is None:
-            return (None, None, None, "client not initialised")
+            return (None, None, None, "client not initialised", 0.0)
         try:
             resp = self._sdk_call(
                 "order_history",
                 lambda: client.order_history(order_id=order_id),
             )
         except Exception as exc:
-            return (None, None, None, f"order_history error: {exc}")
+            return (None, None, None, f"order_history error: {exc}", 0.0)
         # Kotak shape: {"data": {"stat": "Ok", "data": [ {rows, newest first} ]}}.
         rows = _response_rows(resp)
         if not isinstance(rows, list) or not rows:
-            return (None, None, None, f"unrecognised order_history: {resp}")
+            return (None, None, None, f"unrecognised order_history: {resp}", 0.0)
         latest = rows[0]  # history is newest-first; row 0 is the current state
         if not isinstance(latest, dict):
-            return (None, None, None, "malformed order_history row")
+            return (None, None, None, "malformed order_history row", 0.0)
 
         return (
             str(latest.get("ordSt", "")).strip().lower(),
             _exact_int(latest.get("fldQty")),
             _exact_int(latest.get("qty")),
             str(latest.get("rejRsn", "")).strip(),
+            self._traded_price(latest),
         )
+
+    # Kotak's order-history rows use abbreviated keys (``ordSt``, ``fldQty``,
+    # ``qty``).  The average traded price is not documented in this repo, so
+    # rather than hard-code one guess we try the plausible spellings and fall
+    # back to 0.0 ("broker reported none"), which leaves the caller exactly where
+    # it was before this field existed.  The key names actually seen are logged
+    # ONCE per process so the operator can pin the real one from a live fill.
+    _TRADED_PRICE_KEYS = ("avgPrc", "avgPrice", "flPrc", "fldPrc", "tradedPrice", "avgPrics")
+    _logged_price_keys = False
+
+    @classmethod
+    def _traded_price(cls, row: dict) -> float:
+        """Best-effort average traded price from one order-history row."""
+
+        for key in cls._TRADED_PRICE_KEYS:
+            if key in row:
+                try:
+                    price = float(str(row[key]).strip())
+                except (TypeError, ValueError):
+                    continue
+                if math.isfinite(price) and price > 0:
+                    return price
+        if not cls._logged_price_keys:
+            cls._logged_price_keys = True
+            # Keys only, never values: safe to share, and enough to identify the
+            # real field name so this guesswork can be replaced with a constant.
+            log.info(
+                "Kotak order-history row carried no recognised traded-price key; "
+                "available keys were: %s",
+                sorted(row.keys()),
+            )
+        return 0.0
 
     def get_order_status(
         self,
@@ -1085,7 +1119,7 @@ class KotakExecutionClient:
         requested = _exact_int(requested_quantity)
         if requested is None or requested < 0:
             requested = 0
-        state, filled, broker_qty, reason = self._order_status(str(order_id))
+        state, filled, broker_qty, reason, avg_price = self._order_status(str(order_id))
         effective_requested = requested or broker_qty or 0
         if requested and broker_qty not in {None, requested}:
             return normalize_order_result(
@@ -1104,6 +1138,7 @@ class KotakExecutionClient:
             filled_quantity=filled,
             broker_state=state or ("SESSION_POISONED" if self.session_poisoned else ""),
             reason=reason,
+            average_fill_price=avg_price,
         )
 
     def _confirm_fill(self, order_id: str, want_qty: int) -> OrderResult:

--- a/Dependencies/Shoonya API/shoonya_execution.py
+++ b/Dependencies/Shoonya API/shoonya_execution.py
@@ -168,6 +168,18 @@ def _exact_int(value: Any) -> int | None:
     return int(number)
 
 
+def _positive_price(value: Any) -> float:
+    """Return one documented traded price, or zero when it is absent/malformed."""
+
+    if isinstance(value, bool):
+        return 0.0
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    return number if math.isfinite(number) and number > 0 else 0.0
+
+
 def _is_no_data_envelope(value: Any) -> bool:
     """Return True only for Shoonya's explicit, determinate empty-book reply."""
 
@@ -791,14 +803,14 @@ class ShoonyaExecutionClient:
                 allow_after_poison=True,
             )
         except Exception as exc:
-            return (None, None, None, f"single_order_history error: {exc}")
+            return (None, None, None, f"single_order_history error: {exc}", 0.0)
         # Shoonya shape: a LIST of history rows (newest first). Prefer a terminal
         # row (complete/rejected/cancelled); otherwise fall back to the newest.
         if not isinstance(rows, list) or not rows:
-            return (None, None, None, f"unrecognised single_order_history: {rows}")
+            return (None, None, None, f"unrecognised single_order_history: {rows}", 0.0)
         valid_rows = [row for row in rows if isinstance(row, dict)]
         if not valid_rows:
-            return (None, None, None, "malformed single_order_history row")
+            return (None, None, None, "malformed single_order_history row", 0.0)
         chosen = None
         for row in valid_rows:
             st = str(row.get("status", "")).strip().lower()
@@ -813,6 +825,7 @@ class ShoonyaExecutionClient:
             _exact_int(chosen.get("fillshares")),
             _exact_int(chosen.get("qty")),
             str(chosen.get("rejreason", "")).strip(),
+            _positive_price(chosen.get("avgprc")),
         )
 
     def get_order_status(
@@ -825,7 +838,9 @@ class ShoonyaExecutionClient:
         requested = _exact_int(requested_quantity)
         if requested is None or requested < 0:
             requested = 0
-        state, filled, broker_qty, reason = self._order_status(str(order_id))
+        state, filled, broker_qty, reason, average_fill_price = self._order_status(
+            str(order_id)
+        )
         effective_requested = requested or broker_qty or 0
         if requested and broker_qty not in {None, requested}:
             return normalize_order_result(
@@ -844,6 +859,7 @@ class ShoonyaExecutionClient:
             filled_quantity=filled,
             broker_state=state or "",
             reason=reason,
+            average_fill_price=average_fill_price,
         )
 
     def _confirm_fill(self, order_id: str, want_qty: int) -> OrderResult:
@@ -891,6 +907,7 @@ class ShoonyaExecutionClient:
                 f"Shoonya order {order_id} was not terminal within "
                 f"{_FILL_TIMEOUT_SECONDS:.0f}s; exposure is indeterminate."
             ),
+            average_fill_price=last_result.average_fill_price,
         )
 
     def cancel_order(

--- a/Dependencies/broker_contract.py
+++ b/Dependencies/broker_contract.py
@@ -47,9 +47,24 @@ class OrderResult:
     status: OrderStatus
     broker_state: str
     reason: str
+    # Volume-weighted price the broker actually traded at, or 0.0 when the broker
+    # did not report one.  0.0 means UNKNOWN, never "free": callers must treat it
+    # as absent and fall back to their own mark.  It exists because a live fill's
+    # true cost is the broker's price, not whatever the local LTP cache happened
+    # to hold -- on 2026-07-30 a stale cached LTP recorded an entry at 112.55
+    # against a real fill of 125.00, turning a Rs.760 loss into a Rs.4,095
+    # "profit" in the journal.
+    average_fill_price: float = 0.0
 
     def __post_init__(self) -> None:
         """Reject impossible or internally inconsistent quantity snapshots."""
+
+        if isinstance(self.average_fill_price, bool) or not isinstance(
+            self.average_fill_price, (int, float)
+        ):
+            raise ValueError("average_fill_price must be a number")
+        if not math.isfinite(self.average_fill_price) or self.average_fill_price < 0:
+            raise ValueError("average_fill_price must be finite and non-negative")
 
         quantities = {
             "requested_quantity": self.requested_quantity,
@@ -114,6 +129,25 @@ def _non_negative_int(value: Any) -> int | None:
     return int(numeric)
 
 
+def _non_negative_price(value: Any) -> float:
+    """Return a usable traded price, or 0.0 meaning "the broker reported none".
+
+    Deliberately lenient: an unparsable or absent price is not an error, it just
+    means the caller must fall back to its own mark.  Only a finite, strictly
+    positive number counts as a real price.
+    """
+
+    if isinstance(value, bool):
+        return 0.0
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    if not math.isfinite(numeric) or numeric <= 0:
+        return 0.0
+    return numeric
+
+
 def normalize_order_result(
     *,
     order_id: object,
@@ -121,6 +155,7 @@ def normalize_order_result(
     filled_quantity: object,
     broker_state: object,
     reason: object = "",
+    average_fill_price: object = 0.0,
 ) -> OrderResult:
     """Normalize broker evidence without guessing that ambiguity is rejection.
 
@@ -197,6 +232,11 @@ def normalize_order_result(
         status=status,
         broker_state=state,
         reason=reason_text,
+        # A price only means something alongside a fill; a rejected order that
+        # somehow carries one must not hand callers a price to trade off.
+        average_fill_price=(
+            _non_negative_price(average_fill_price) if filled > 0 else 0.0
+        ),
     )
 
 

--- a/Dependencies/env.example
+++ b/Dependencies/env.example
@@ -90,6 +90,11 @@ WS_CONN_LIVENESS_SECONDS=5.0
 # this at or below the repo's usual 10s broker deadline.
 MARKET_DATA_HTTP_TIMEOUT_SECONDS=10.0
 
+# How old a cached option LTP may be and still be used to BOOK a trade at (seconds).
+# Marks older than this are refetched from the broker; if that also fails a LIVE
+# entry is refused and a PAPER entry is taken but flagged as approximate.
+MARKET_DATA_MAX_LTP_AGE_SECONDS=60
+
 # Minimum 1-min bars required before strategies start evaluating signals.
 MIN_BARS=120
 

--- a/Dependencies/execution_ledger.py
+++ b/Dependencies/execution_ledger.py
@@ -10,6 +10,7 @@ silently disappear or be counted twice.
 from __future__ import annotations
 
 import hashlib
+import math
 import re
 import threading
 from dataclasses import dataclass
@@ -124,6 +125,7 @@ class OrderAttempt:
     broker_state: str = "SUBMITTING"
     reason: str = "Order submission has started; final outcome is unknown."
     terminal: bool = False
+    average_fill_price: float = 0.0
 
 
 @dataclass(frozen=True, slots=True)
@@ -175,6 +177,33 @@ class LiveLegState:
     latest_attempt: OrderAttempt | None = None
     attempt_count: int = 0
     closing_started: bool = False
+    entry_priced_quantity: int = 0
+    entry_fill_notional: float = 0.0
+    close_priced_quantity: int = 0
+    close_fill_notional: float = 0.0
+
+    @property
+    def entry_average_fill_price(self) -> float:
+        """Weighted broker entry price, or zero until every entry fill is priced."""
+
+        if (
+            self.filled_quantity <= 0
+            or self.entry_priced_quantity != self.filled_quantity
+        ):
+            return 0.0
+        return self.entry_fill_notional / self.filled_quantity
+
+    @property
+    def close_average_fill_price(self) -> float:
+        """Weighted broker close price, or zero until every close fill is priced."""
+
+        closed_quantity = self.filled_quantity - self.confirmed_live_quantity
+        if (
+            closed_quantity <= 0
+            or self.close_priced_quantity != closed_quantity
+        ):
+            return 0.0
+        return self.close_fill_notional / closed_quantity
 
     @property
     def latest_attempt_handle(self) -> OrderAttemptHandle | None:
@@ -285,6 +314,9 @@ class _MutableOrderAttempt:
     broker_state: str = "SUBMITTING"
     reason: str = "Order submission has started; final outcome is unknown."
     terminal: bool = False
+    average_fill_price: float = 0.0
+    priced_quantity: int = 0
+    fill_notional: float = 0.0
 
 
 @dataclass(slots=True)
@@ -301,6 +333,10 @@ class _MutableLiveLeg:
     latest_attempt: _MutableOrderAttempt | None = None
     attempt_count: int = 0
     closing_started: bool = False
+    entry_priced_quantity: int = 0
+    entry_fill_notional: float = 0.0
+    close_priced_quantity: int = 0
+    close_fill_notional: float = 0.0
 
 
 def build_order_tag(
@@ -381,6 +417,7 @@ class ExecutionLedger:
             broker_state=attempt.broker_state,
             reason=attempt.reason,
             terminal=attempt.terminal,
+            average_fill_price=attempt.average_fill_price,
         )
 
     @classmethod
@@ -399,6 +436,10 @@ class ExecutionLedger:
             latest_attempt=(cls._snapshot_attempt(attempt) if attempt is not None else None),
             attempt_count=leg.attempt_count,
             closing_started=leg.closing_started,
+            entry_priced_quantity=leg.entry_priced_quantity,
+            entry_fill_notional=leg.entry_fill_notional,
+            close_priced_quantity=leg.close_priced_quantity,
+            close_fill_notional=leg.close_fill_notional,
         )
 
     @classmethod
@@ -557,15 +598,78 @@ class ExecutionLedger:
                 result.status is OrderStatus.PARTIAL
                 and broker_state in _TERMINAL_BROKER_STATES
             )
-            if (
+            weaker_than_terminal = (
                 attempt.terminal
                 and not terminal
                 and result.filled_quantity == attempt.filled_quantity
+            )
+
+            old_priced_quantity = attempt.priced_quantity
+            old_fill_notional = attempt.fill_notional
+            new_priced_quantity = old_priced_quantity
+            new_fill_notional = old_fill_notional
+            if result.filled_quantity > 0 and result.average_fill_price > 0:
+                new_priced_quantity = result.filled_quantity
+                new_fill_notional = (
+                    result.filled_quantity * result.average_fill_price
+                )
+                if not math.isfinite(new_fill_notional):
+                    raise ValueError("broker cumulative fill notional must be finite")
+                if (
+                    old_priced_quantity == attempt.filled_quantity
+                    and new_priced_quantity >= old_priced_quantity
+                    and new_fill_notional + 1e-9 < old_fill_notional
+                ):
+                    raise ValueError(
+                        "broker cumulative fill notional moved backwards"
+                    )
+
+            priced_quantity_delta = (
+                new_priced_quantity - old_priced_quantity
+            )
+            fill_notional_delta = new_fill_notional - old_fill_notional
+            if attempt.intent is OrderIntent.OPEN:
+                new_entry_priced_quantity = (
+                    leg.entry_priced_quantity + priced_quantity_delta
+                )
+                new_entry_fill_notional = (
+                    leg.entry_fill_notional + fill_notional_delta
+                )
+                new_close_priced_quantity = leg.close_priced_quantity
+                new_close_fill_notional = leg.close_fill_notional
+            else:
+                new_entry_priced_quantity = leg.entry_priced_quantity
+                new_entry_fill_notional = leg.entry_fill_notional
+                new_close_priced_quantity = (
+                    leg.close_priced_quantity + priced_quantity_delta
+                )
+                new_close_fill_notional = (
+                    leg.close_fill_notional + fill_notional_delta
+                )
+            if (
+                new_entry_priced_quantity < 0
+                or new_close_priced_quantity < 0
+                or new_entry_fill_notional < 0
+                or new_close_fill_notional < 0
             ):
-                # Broker/status probes can arrive out of order.  Equal-fill
-                # non-terminal evidence is strictly weaker than a terminal
-                # snapshot already applied to this attempt, so it cannot reopen
-                # uncertainty or undo an entry/flat decision.
+                raise ValueError("broker fill-price evidence became negative")
+
+            # Broker/status probes can arrive out of order. Equal-fill
+            # non-terminal evidence is weaker than a terminal snapshot, so it
+            # cannot reopen quantity uncertainty. It may still add a previously
+            # missing broker price for those already-confirmed fills.
+            if weaker_than_terminal:
+                attempt.priced_quantity = new_priced_quantity
+                attempt.fill_notional = new_fill_notional
+                if (
+                    result.average_fill_price > 0
+                    and new_priced_quantity == result.filled_quantity
+                ):
+                    attempt.average_fill_price = result.average_fill_price
+                leg.entry_priced_quantity = new_entry_priced_quantity
+                leg.entry_fill_notional = new_entry_fill_notional
+                leg.close_priced_quantity = new_close_priced_quantity
+                leg.close_fill_notional = new_close_fill_notional
                 return self._snapshot_leg(leg)
             # The DELTA is what this snapshot newly proves: cumulative report
             # minus what this attempt had already been credited.  Applying
@@ -596,6 +700,10 @@ class ExecutionLedger:
             leg.filled_quantity = new_entry_filled
             leg.remaining_quantity = new_entry_remaining
             leg.confirmed_live_quantity = new_live_quantity
+            leg.entry_priced_quantity = new_entry_priced_quantity
+            leg.entry_fill_notional = new_entry_fill_notional
+            leg.close_priced_quantity = new_close_priced_quantity
+            leg.close_fill_notional = new_close_fill_notional
             attempt.order_id = order_id
             attempt.filled_quantity = result.filled_quantity
             attempt.remaining_quantity = result.remaining_quantity
@@ -603,5 +711,12 @@ class ExecutionLedger:
             attempt.broker_state = broker_state
             attempt.reason = str(result.reason)
             attempt.terminal = terminal
+            attempt.priced_quantity = new_priced_quantity
+            attempt.fill_notional = new_fill_notional
+            if (
+                result.average_fill_price > 0
+                and new_priced_quantity == result.filled_quantity
+            ):
+                attempt.average_fill_price = result.average_fill_price
             leg.exposure_indeterminate = not terminal
             return self._snapshot_leg(leg)

--- a/Dependencies/test_broker_contract.py
+++ b/Dependencies/test_broker_contract.py
@@ -236,6 +236,92 @@ def test_normalization_is_conservative_and_preserves_acknowledgement(
     assert result.remaining_quantity == 75 - filled
 
 
+def test_average_fill_price_defaults_to_zero_meaning_unknown() -> None:
+    """Brokers that report no price must not look like a free fill.
+
+    Every existing call site omits the argument, so the default has to be the
+    "unknown" sentinel that makes callers keep their own mark.
+    """
+
+    contract = _contract_module()
+    result = contract.normalize_order_result(
+        order_id="ACK-NOPRICE",
+        requested_quantity=75,
+        filled_quantity=75,
+        broker_state="COMPLETE",
+    )
+
+    assert result.average_fill_price == 0.0
+
+
+@pytest.mark.parametrize(
+    "supplied,expected",
+    [
+        (125.0, 125.0),
+        ("125.00", 125.0),   # brokers commonly return numbers as strings
+        (0, 0.0),            # explicit zero stays "unknown"
+        (-5.0, 0.0),         # nonsense is discarded, not propagated
+        ("", 0.0),
+        ("n/a", 0.0),
+        (None, 0.0),
+        (float("nan"), 0.0),
+        (float("inf"), 0.0),
+        (True, 0.0),         # bool is not a price
+    ],
+)
+def test_average_fill_price_is_parsed_leniently(supplied, expected) -> None:
+    """An unusable price degrades to 0.0 rather than raising into a live order."""
+
+    contract = _contract_module()
+    result = contract.normalize_order_result(
+        order_id="ACK-PRICE",
+        requested_quantity=75,
+        filled_quantity=75,
+        broker_state="COMPLETE",
+        average_fill_price=supplied,
+    )
+
+    assert result.average_fill_price == expected
+
+
+def test_average_fill_price_is_dropped_when_nothing_filled() -> None:
+    """A price only means something beside a fill.
+
+    A rejected order that somehow carries a price must not hand the caller a
+    number to book a trade at.
+    """
+
+    contract = _contract_module()
+    result = contract.normalize_order_result(
+        order_id="ACK-REJ",
+        requested_quantity=75,
+        filled_quantity=0,
+        broker_state="REJECTED",
+        average_fill_price=125.0,
+    )
+
+    assert result.status.name == "REJECTED"
+    assert result.average_fill_price == 0.0
+
+
+def test_order_result_rejects_impossible_average_fill_price() -> None:
+    """The dataclass itself refuses a non-finite or negative price."""
+
+    contract = _contract_module()
+    for bad in (-1.0, float("nan"), float("inf"), "125.0", True):
+        with pytest.raises(ValueError, match="average_fill_price"):
+            contract.OrderResult(
+                order_id="BAD-PRICE",
+                requested_quantity=75,
+                filled_quantity=75,
+                remaining_quantity=0,
+                status=contract.OrderStatus.FILLED,
+                broker_state="COMPLETE",
+                reason="",
+                average_fill_price=bad,
+            )
+
+
 def test_malformed_quantity_normalizes_to_unknown_instead_of_rejected() -> None:
     """Bad broker data must not manufacture a harmless zero-fill rejection."""
 

--- a/Dependencies/test_execution_ledger.py
+++ b/Dependencies/test_execution_ledger.py
@@ -45,6 +45,7 @@ def _result(
     filled: int,
     status: OrderStatus,
     broker_state: str,
+    average_fill_price: float = 0.0,
 ) -> OrderResult:
     return OrderResult(
         order_id=order_id,
@@ -54,6 +55,7 @@ def _result(
         status=status,
         broker_state=broker_state,
         reason=f"test {broker_state.lower()}",
+        average_fill_price=average_fill_price,
     )
 
 
@@ -143,6 +145,184 @@ def test_partial_open_applies_only_fill_deltas_then_retries_unfinished_quantity(
     assert first_attempt.order_tag != retry_attempt.order_tag
     assert first_attempt.sequence == 1
     assert retry_attempt.sequence == 2
+
+
+def test_fill_notional_is_weighted_across_status_updates_and_retries() -> None:
+    """The leg price represents every confirmed unit, not only the last order."""
+    ledger = ExecutionLedger()
+    leg = ledger.register(_spec())
+    first = ledger.start_attempt(leg.exposure_id, OrderIntent.OPEN, 50)
+    leg = ledger.apply_result(
+        first,
+        _result(
+            order_id="OPEN-1",
+            requested=50,
+            filled=20,
+            status=OrderStatus.PARTIAL,
+            broker_state="PARTIAL",
+            average_fill_price=100.0,
+        ),
+    )
+    assert leg.entry_priced_quantity == 20
+    assert leg.entry_fill_notional == 2_000.0
+    assert leg.entry_average_fill_price == 100.0
+
+    leg = ledger.apply_result(
+        first,
+        _result(
+            order_id="OPEN-1",
+            requested=50,
+            filled=30,
+            status=OrderStatus.PARTIAL,
+            broker_state="CANCELLED",
+            average_fill_price=110.0,
+        ),
+    )
+    retry = ledger.start_attempt(leg.exposure_id, OrderIntent.OPEN, 20)
+    leg = ledger.apply_result(
+        retry,
+        _result(
+            order_id="OPEN-2",
+            requested=20,
+            filled=20,
+            status=OrderStatus.FILLED,
+            broker_state="COMPLETE",
+            average_fill_price=130.0,
+        ),
+    )
+
+    assert leg.entry_priced_quantity == 50
+    assert leg.entry_fill_notional == 5_900.0
+    assert leg.entry_average_fill_price == 118.0
+    assert leg.latest_attempt is not None
+    assert leg.latest_attempt.average_fill_price == 130.0
+
+    close_first = ledger.start_attempt(leg.exposure_id, OrderIntent.CLOSE, 50)
+    leg = ledger.apply_result(
+        close_first,
+        _result(
+            order_id="CLOSE-1",
+            requested=50,
+            filled=10,
+            status=OrderStatus.PARTIAL,
+            broker_state="CANCELLED",
+            average_fill_price=150.0,
+        ),
+    )
+    close_retry = ledger.start_attempt(leg.exposure_id, OrderIntent.CLOSE, 40)
+    leg = ledger.apply_result(
+        close_retry,
+        _result(
+            order_id="CLOSE-2",
+            requested=40,
+            filled=40,
+            status=OrderStatus.FILLED,
+            broker_state="COMPLETE",
+            average_fill_price=140.0,
+        ),
+    )
+
+    assert leg.close_priced_quantity == 50
+    assert leg.close_fill_notional == 7_100.0
+    assert leg.close_average_fill_price == 142.0
+
+
+def test_later_cumulative_price_can_upgrade_previously_unpriced_fills() -> None:
+    ledger = ExecutionLedger()
+    leg = ledger.register(_spec())
+    attempt = ledger.start_attempt(leg.exposure_id, OrderIntent.OPEN, 50)
+    leg = ledger.apply_result(
+        attempt,
+        _result(
+            order_id="OPEN-1",
+            requested=50,
+            filled=20,
+            status=OrderStatus.PARTIAL,
+            broker_state="PARTIAL",
+        ),
+    )
+    assert leg.entry_priced_quantity == 0
+    assert leg.entry_average_fill_price == 0.0
+
+    leg = ledger.apply_result(
+        attempt,
+        _result(
+            order_id="OPEN-1",
+            requested=50,
+            filled=20,
+            status=OrderStatus.PARTIAL,
+            broker_state="CANCELLED",
+            average_fill_price=101.5,
+        ),
+    )
+    assert leg.entry_priced_quantity == 20
+    assert leg.entry_fill_notional == 2_030.0
+    assert leg.entry_average_fill_price == 101.5
+
+
+def test_impossible_cumulative_fill_notional_is_rejected_atomically() -> None:
+    ledger = ExecutionLedger()
+    leg = ledger.register(_spec())
+    attempt = ledger.start_attempt(leg.exposure_id, OrderIntent.OPEN, 50)
+    leg = ledger.apply_result(
+        attempt,
+        _result(
+            order_id="OPEN-1",
+            requested=50,
+            filled=20,
+            status=OrderStatus.PARTIAL,
+            broker_state="PARTIAL",
+            average_fill_price=200.0,
+        ),
+    )
+
+    with pytest.raises(ValueError, match="cumulative fill notional moved backwards"):
+        ledger.apply_result(
+            attempt,
+            _result(
+                order_id="OPEN-1",
+                requested=50,
+                filled=30,
+                status=OrderStatus.PARTIAL,
+                broker_state="PARTIAL",
+                average_fill_price=100.0,
+            ),
+        )
+
+    unchanged = ledger.get(leg.exposure_id)
+    assert unchanged.confirmed_live_quantity == 20
+    assert unchanged.entry_fill_notional == 4_000.0
+    assert unchanged.entry_priced_quantity == 20
+
+
+def test_equal_quantity_cumulative_notional_cannot_regress() -> None:
+    ledger = ExecutionLedger()
+    leg = ledger.register(_spec())
+    attempt = ledger.start_attempt(leg.exposure_id, OrderIntent.OPEN, 50)
+    ledger.apply_result(
+        attempt,
+        _result(
+            order_id="OPEN-1",
+            requested=50,
+            filled=20,
+            status=OrderStatus.PARTIAL,
+            broker_state="PARTIAL",
+            average_fill_price=200.0,
+        ),
+    )
+
+    with pytest.raises(ValueError, match="cumulative fill notional moved backwards"):
+        ledger.apply_result(
+            attempt,
+            _result(
+                order_id="OPEN-1",
+                requested=50,
+                filled=20,
+                status=OrderStatus.PARTIAL,
+                broker_state="CANCELLED",
+                average_fill_price=199.0,
+            ),
+        )
 
 
 def test_partial_close_never_resubmits_original_quantity() -> None:

--- a/Nifty Multi Strategy Front Test - Master File.py
+++ b/Nifty Multi Strategy Front Test - Master File.py
@@ -564,6 +564,14 @@ WS_CONN_LIVENESS_SECONDS = _env_float("WS_CONN_LIVENESS_SECONDS", 5.0)
 # response parked the websocket producer for 59-73s at a time.
 MARKET_DATA_HTTP_TIMEOUT_SECONDS = _env_float("MARKET_DATA_HTTP_TIMEOUT_SECONDS", 10.0)
 
+# How old a cached option LTP may be and still be used to BOOK a trade at.
+# Reads that only need a rough mark are unaffected; this bounds the price that
+# becomes the recorded entry. One minute: a leg that has not printed for longer
+# than that is not a price you can honestly enter on. (2026-07-30: a snapshot
+# left behind by an earlier trade on the same strike was reused ~24 minutes
+# later and recorded an entry at 112.55 against a real fill of 125.00.)
+MARKET_DATA_MAX_LTP_AGE_SECONDS = _env_float("MARKET_DATA_MAX_LTP_AGE_SECONDS", 60.0)
+
 # Bounded join timeout for each thread on shutdown.
 SHUTDOWN_JOIN_SECONDS = _env_float("SHUTDOWN_JOIN_SECONDS", 6.0)
 
@@ -2069,6 +2077,8 @@ class SharedMarketDataStore:
         segment: str,
         security_id: int,
         fallback: float = 0.0,
+        *,
+        max_age_seconds: float | None = None,
     ) -> float:
         """
         Read the newest cached LTP for one (segment, security_id) pair.
@@ -2076,28 +2086,57 @@ class SharedMarketDataStore:
         This method NEVER calls the broker; it just returns whatever the
         fetcher has already cached, falling back to `fallback` when nothing
         positive is available yet.
+
+        `max_age_seconds` bounds how old that cached price may be. The default
+        (None) keeps the historical behaviour -- any positive price, at any age.
+        Callers that are about to BOOK a trade at this price pass a bound,
+        because a mark is only worth what its age allows: on 2026-07-30 a
+        snapshot left behind by an earlier trade on the SAME strike was returned
+        ~24 minutes later and recorded a NIFTY entry at 112.55 against a real
+        fill of 125.00. A leg that is no longer subscribed stops being
+        re-stamped by `touch_ltp_freshness`, so age is a true signal here.
         """
         key = (str(segment), int(security_id))
+        now = datetime.now(ZoneInfo("Asia/Kolkata"))
         with self._lock:
             snapshot = self._ltp_snapshots.get(key)
             if snapshot is not None and snapshot.ltp > 0:
-                return snapshot.ltp
+                if max_age_seconds is None:
+                    return snapshot.ltp
+                if (now - snapshot.fetched_at).total_seconds() <= float(max_age_seconds):
+                    return snapshot.ltp
         return float(fallback)
 
     # ------------------------------------------------------------------
     # Option-leg subscription pool
     # ------------------------------------------------------------------
-    def register_option_subscription(self, subscription: OptionSubscription) -> None:
-        """Tell the fetcher to keep polling LTP for this option leg."""
+    def register_option_subscription(self, subscription: OptionSubscription) -> bool:
+        """Tell the fetcher to keep polling LTP for this option leg.
+
+        Returns True when THIS call added the leg, False when it was already
+        subscribed (legs are shared: several workers can sit on one strike).
+        Callers use that to know whether they own the subscription and may
+        withdraw it if their own entry then falls through.
+        """
         key = (str(subscription.exchange_segment), int(subscription.security_id))
         with self._lock:
+            newly_added = key not in self._option_subscriptions
             self._option_subscriptions[key] = subscription
+            return newly_added
 
     def unregister_option_subscription(self, segment: str, security_id: int) -> None:
-        """Drop a leg once a paper trade has been closed."""
+        """Drop a leg once a paper trade has been closed.
+
+        The cached LTP goes with it. Leaving the snapshot behind is what made a
+        closed leg's last price look usable to the next trade on the same strike
+        (2026-07-30): the subscription stopped, so nothing refreshed it, but
+        `get_ltp_by_secid` still handed it out. Every caller already treats a
+        missing price as "fetch it directly", which is the correct behaviour.
+        """
         key = (str(segment), int(security_id))
         with self._lock:
             self._option_subscriptions.pop(key, None)
+            self._ltp_snapshots.pop(key, None)
 
     def snapshot_option_subscriptions(self) -> list[OptionSubscription]:
         """Return a list copy of all currently subscribed option legs."""
@@ -5526,6 +5565,50 @@ class BasePaperStrategyWorker(threading.Thread):
         self.paper_order_counter += 1
         return f"PAPER-{side}-{datetime.now():%Y%m%d%H%M%S}-{self.paper_order_counter:04d}"
 
+    def _get_dealable_option_ltp(
+        self, segment: str, security_id: int
+    ) -> tuple[float, bool]:
+        """Return ``(price, is_fresh)`` for a mark we are about to TRADE on.
+
+        Unlike `_get_option_ltp`, a cached price is only accepted while it is
+        within `MARKET_DATA_MAX_LTP_AGE_SECONDS`. Anything older is treated as no
+        price at all and the broker is asked directly -- that answer is current by
+        construction. Only if BOTH fail does this fall back to the stale cached
+        value, and it says so via ``is_fresh=False`` rather than passing an old
+        number off as a mark. The caller decides what that means: paper can live
+        with it, real money cannot.
+        """
+        fresh = self.store.get_ltp_by_secid(
+            segment,
+            security_id,
+            fallback=0.0,
+            max_age_seconds=MARKET_DATA_MAX_LTP_AGE_SECONDS,
+        )
+        if fresh > 0:
+            return fresh, True
+
+        try:
+            ltp_map = self.broker.fetch_ltp_map({segment: [security_id]})
+        except Exception as exc:
+            self.log.warning(
+                "Direct LTP fetch failed for segment=%s security_id=%s: %s",
+                segment,
+                security_id,
+                exc,
+            )
+            ltp_map = {}
+        try:
+            price = _safe_float(ltp_map.get((str(segment), int(security_id)), 0.0), 0.0)
+        except (AttributeError, TypeError):
+            price = 0.0
+        if price > 0:
+            self.store.update_ltp_map({(str(segment), int(security_id)): price})
+            return price, True
+
+        # Neither a recent tick nor a live quote. Surface whatever is cached so
+        # the caller can decide, but never call it fresh.
+        return self.store.get_ltp_by_secid(segment, security_id, fallback=0.0), False
+
     def _entry_fill_price(self, order_result: object, ltp_price: float) -> float:
         """Prefer the broker's ACTUAL traded price over the local LTP for a live fill.
 
@@ -6263,7 +6346,30 @@ class AtmSingleLegStrategyWorker(BasePaperStrategyWorker):
             )
             return False
 
-        option_ltp = self._get_option_ltp(option_segment, option_sec_id, fallback=0.0)
+        # Subscribe BEFORE pricing, so the leg is in the feed from the moment we
+        # commit to it rather than only after the order goes out. `owns_feed_leg`
+        # is True only when THIS entry added it -- a strike shared with another
+        # worker must never be unsubscribed by our abort path.
+        owns_feed_leg = self.store.register_option_subscription(
+            OptionSubscription(
+                security_id=option_sec_id,
+                exchange_segment=option_segment,
+                trading_symbol=trading_symbol,
+                right=option_right,
+                strike=option_strike,
+                expiry=expiry_date,
+            )
+        )
+
+        def _abort_entry() -> bool:
+            """Withdraw a subscription this entry opened, then decline the trade."""
+            if owns_feed_leg:
+                self.store.unregister_option_subscription(option_segment, option_sec_id)
+            return False
+
+        option_ltp, mark_is_fresh = self._get_dealable_option_ltp(
+            option_segment, option_sec_id
+        )
         if option_ltp <= 0:
             self.log.warning(
                 "Skipping %s entry because option LTP was not available for %s (security_id=%s).",
@@ -6271,7 +6377,30 @@ class AtmSingleLegStrategyWorker(BasePaperStrategyWorker):
                 trading_symbol,
                 option_sec_id,
             )
-            return False
+            return _abort_entry()
+        if not mark_is_fresh:
+            if self.live_trading:
+                # Real money: a trade we cannot price is a trade we cannot risk
+                # manage, so decline it rather than book it at a guess.
+                self.log.error(
+                    "REFUSING LIVE %s ENTRY on %s: no mark newer than %.0fs and the "
+                    "direct quote failed; the only price available is stale.",
+                    direction,
+                    trading_symbol,
+                    MARKET_DATA_MAX_LTP_AGE_SECONDS,
+                )
+                return _abort_entry()
+            # Paper: keep the data point rather than losing the observation, but
+            # make the record say the mark was stale.
+            self.log.warning(
+                "PAPER %s entry on %s is marked at a STALE price %.2f (no tick "
+                "within %.0fs and the direct quote failed); P&L for this trade is "
+                "approximate.",
+                direction,
+                trading_symbol,
+                option_ltp,
+                MARKET_DATA_MAX_LTP_AGE_SECONDS,
+            )
 
         sizing = self._compute_entry_sizing(
             float(entry_underlying), float(stop_underlying), lot_size
@@ -6289,7 +6418,7 @@ class AtmSingleLegStrategyWorker(BasePaperStrategyWorker):
                 sizing.one_lot_risk,
                 sizing.reason,
             )
-            return False
+            return _abort_entry()
         lots_for_entry = sizing.lots
         quantity = sizing.quantity
         entry_side = "BUY"  # Both LONG (CE) and SHORT (PE) open as BUY legs.
@@ -6313,25 +6442,18 @@ class AtmSingleLegStrategyWorker(BasePaperStrategyWorker):
             if isinstance(live_leg, LiveLegState) and live_leg.exposure_possible:
                 # No PaperPosition will be created for an incomplete live entry,
                 # so the generic recovery sweep owns it until a later signal
-                # completes and adopts the same ledger state.
+                # completes and adopts the same ledger state. KEEP the feed leg
+                # subscribed: unresolved exposure still has to be marked.
                 self._track_orphan_live_leg(entry_leg)
-            return False
+                return False
+            return _abort_entry()
         self._untrack_orphan_live_leg(entry_leg)
         quantity = int(entry_leg["quantity"])
         exec_mode = self._exec_mode_tag(order_result)
         option_ltp = self._entry_fill_price(order_result, option_ltp)
 
-        # Keep the fetcher refreshing this option's LTP for the trade lifetime.
-        self.store.register_option_subscription(
-            OptionSubscription(
-                security_id=option_sec_id,
-                exchange_segment=option_segment,
-                trading_symbol=trading_symbol,
-                right=option_right,
-                strike=option_strike,
-                expiry=expiry_date,
-            )
-        )
+        # The leg was subscribed before it was priced (above); the fetcher has been
+        # refreshing it since, and keeps doing so until exit_position drops it.
 
         self.pos = PaperPosition(
             active=True,

--- a/Nifty Multi Strategy Front Test - Master File.py
+++ b/Nifty Multi Strategy Front Test - Master File.py
@@ -1704,6 +1704,16 @@ class MarketSnapshot:
     fetched_at: datetime
 
 
+PRICE_QUALITY_BROKER_FILL = "BROKER_FILL"
+PRICE_QUALITY_PAPER_FRESH_MARK = "PAPER_FRESH_MARK"
+PRICE_QUALITY_MARK_FALLBACK = "MARK_FALLBACK"
+PRICE_QUALITY_STALE_MARK = "STALE_MARK"
+PRICE_QUALITY_UNKNOWN = "UNKNOWN"
+COACH_ELIGIBLE_PRICE_QUALITIES = frozenset(
+    {PRICE_QUALITY_BROKER_FILL, PRICE_QUALITY_PAPER_FRESH_MARK}
+)
+
+
 @dataclass
 class PaperPosition:
     """
@@ -1738,6 +1748,8 @@ class PaperPosition:
     bars_in_trade: int = 0
     # Actual paper-fill price on the option leg (used for PnL).
     entry_trade_price: float = 0.0
+    entry_price_quality: str = "UNKNOWN"
+    exit_price_quality: str = "UNKNOWN"
     # Option-leg metadata, locked at entry and reused on exit.
     option_security_id: int = 0
     option_exchange_segment: str = ""
@@ -1794,6 +1806,7 @@ class HedgedPaperPosition:
     main_lot_size: int = 0
     main_quantity: int = 0
     main_entry_price: float = 0.0
+    main_entry_price_quality: str = "UNKNOWN"
     main_entry_order_id: str = ""
 
     # -- Hedge leg (BUY PE for bullish, BUY CE for bearish) -----------------
@@ -1807,6 +1820,7 @@ class HedgedPaperPosition:
     hedge_lot_size: int = 0
     hedge_quantity: int = 0
     hedge_entry_price: float = 0.0
+    hedge_entry_price_quality: str = "UNKNOWN"
     hedge_entry_order_id: str = ""
 
     # Per-leg immutable snapshots.  One leg may be flat while the other still
@@ -1966,6 +1980,10 @@ class SharedMarketDataStore:
         self._snapshots: dict[str, MarketSnapshot] = {}
         self._ltp_snapshots: dict[tuple[str, int], LTPSnapshot] = {}
         self._option_subscriptions: dict[tuple[str, int], OptionSubscription] = {}
+        # A physical quote is shared by every worker holding the same contract.
+        # Track logical owners separately so one worker's exit cannot tear down
+        # another worker's still-open market-data leg.
+        self._option_subscription_owners: dict[tuple[str, int], set[str]] = {}
         self.market_data_health = MarketDataHealth()
         self.execution_safety = ExecutionSafetyCoordinator()
         # The execution ledger is separate from market-data snapshots because it
@@ -2097,35 +2115,60 @@ class SharedMarketDataStore:
         re-stamped by `touch_ltp_freshness`, so age is a true signal here.
         """
         key = (str(segment), int(security_id))
+        if max_age_seconds is not None:
+            try:
+                maximum_age = float(max_age_seconds)
+            except (TypeError, ValueError):
+                return float(fallback)
+            if not math.isfinite(maximum_age) or maximum_age <= 0:
+                return float(fallback)
+        else:
+            maximum_age = None
         now = datetime.now(ZoneInfo("Asia/Kolkata"))
         with self._lock:
             snapshot = self._ltp_snapshots.get(key)
             if snapshot is not None and snapshot.ltp > 0:
-                if max_age_seconds is None:
+                if maximum_age is None:
                     return snapshot.ltp
-                if (now - snapshot.fetched_at).total_seconds() <= float(max_age_seconds):
+                age_seconds = (now - snapshot.fetched_at).total_seconds()
+                if 0 <= age_seconds <= maximum_age:
                     return snapshot.ltp
         return float(fallback)
 
     # ------------------------------------------------------------------
     # Option-leg subscription pool
     # ------------------------------------------------------------------
-    def register_option_subscription(self, subscription: OptionSubscription) -> bool:
+    def register_option_subscription(
+        self,
+        subscription: OptionSubscription,
+        *,
+        owner_id: str,
+    ) -> bool:
         """Tell the fetcher to keep polling LTP for this option leg.
 
-        Returns True when THIS call added the leg, False when it was already
-        subscribed (legs are shared: several workers can sit on one strike).
-        Callers use that to know whether they own the subscription and may
-        withdraw it if their own entry then falls through.
+        Returns True when this owner acquired the leg, False when the same owner
+        already held it. Different workers may share one physical subscription;
+        releasing one owner never removes the feed or snapshot for the others.
         """
+        normalized_owner = str(owner_id).strip()
+        if not normalized_owner:
+            raise ValueError("option subscription owner_id must not be blank")
         key = (str(subscription.exchange_segment), int(subscription.security_id))
         with self._lock:
-            newly_added = key not in self._option_subscriptions
+            owners = self._option_subscription_owners.setdefault(key, set())
+            newly_owned = normalized_owner not in owners
+            owners.add(normalized_owner)
             self._option_subscriptions[key] = subscription
-            return newly_added
+            return newly_owned
 
-    def unregister_option_subscription(self, segment: str, security_id: int) -> None:
-        """Drop a leg once a paper trade has been closed.
+    def unregister_option_subscription(
+        self,
+        segment: str,
+        security_id: int,
+        *,
+        owner_id: str,
+    ) -> None:
+        """Release one owner's leg and evict it after the final owner leaves.
 
         The cached LTP goes with it. Leaving the snapshot behind is what made a
         closed leg's last price look usable to the next trade on the same strike
@@ -2133,8 +2176,18 @@ class SharedMarketDataStore:
         `get_ltp_by_secid` still handed it out. Every caller already treats a
         missing price as "fetch it directly", which is the correct behaviour.
         """
+        normalized_owner = str(owner_id).strip()
+        if not normalized_owner:
+            raise ValueError("option subscription owner_id must not be blank")
         key = (str(segment), int(security_id))
         with self._lock:
+            owners = self._option_subscription_owners.get(key)
+            if owners is None:
+                return
+            owners.discard(normalized_owner)
+            if owners:
+                return
+            self._option_subscription_owners.pop(key, None)
             self._option_subscriptions.pop(key, None)
             self._ltp_snapshots.pop(key, None)
 
@@ -4475,6 +4528,7 @@ class BasePaperStrategyWorker(threading.Thread):
             status=attempt.status,
             broker_state=attempt.broker_state,
             reason=reason,
+            average_fill_price=attempt.average_fill_price,
         )
 
     def _refresh_live_leg_attempt(self, leg: dict) -> OrderResult | None:
@@ -5442,6 +5496,13 @@ class BasePaperStrategyWorker(threading.Thread):
             state = self.store.execution_ledger.get(state.exposure_id)
             leg["live_leg"] = state
             if state.broker_confirmed_flat:
+                subscription = leg.get("option_subscription")
+                if isinstance(subscription, OptionSubscription):
+                    self.store.unregister_option_subscription(
+                        subscription.exchange_segment,
+                        subscription.security_id,
+                        owner_id=self._execution_owner_id,
+                    )
                 continue
             if state.spec.role == "H":
                 # A protective long hedge is the last leg of a short-option
@@ -5472,6 +5533,13 @@ class BasePaperStrategyWorker(threading.Thread):
                 self.log.error("Orphan unwind retry raised unexpectedly: %s", exc)
             state = leg.get("live_leg")
             if isinstance(state, LiveLegState) and state.broker_confirmed_flat:
+                subscription = leg.get("option_subscription")
+                if isinstance(subscription, OptionSubscription):
+                    self.store.unregister_option_subscription(
+                        subscription.exchange_segment,
+                        subscription.security_id,
+                        owner_id=self._execution_owner_id,
+                    )
                 self.log.warning(
                     "Orphaned live leg RECOVERED (%s to close) | %s strike=%s qty=%s",
                     close_side,
@@ -5609,19 +5677,60 @@ class BasePaperStrategyWorker(threading.Thread):
         # the caller can decide, but never call it fresh.
         return self.store.get_ltp_by_secid(segment, security_id, fallback=0.0), False
 
-    def _entry_fill_price(self, order_result: object, ltp_price: float) -> float:
-        """Prefer the broker's ACTUAL traded price over the local LTP for a live fill.
+    def _accounting_price(
+        self,
+        live_leg: LiveLegState | None,
+        mark_price: float,
+        *,
+        mark_is_fresh: bool,
+        phase: str,
+    ) -> tuple[float, str]:
+        """Choose a P&L price and expose the quality of its evidence.
 
-        A paper fill has no broker price, so it keeps the LTP. A LIVE fill does have
-        one, and it is the only honest cost of the trade: the LTP cache can be stale,
-        and a stale mark writes a fiction into the position, the journal, the Sheet
-        and the coach's training data. On 2026-07-30 a cached LTP recorded a NIFTY
-        entry at 112.55 against a broker fill of 125.00, turning a Rs.760.50 loss into
-        a Rs.4,095 "profit".
-
-        Fail-soft by design: brokers that do not report a price return 0.0 and the
-        LTP is kept, so this can only ever improve accuracy, never block a trade.
+        Weighted broker fills are authoritative for live entry and close
+        accounting. If a broker omits the price, the best available mark keeps
+        risk-reducing exits operational but is explicitly approximate. Paper
+        trades retain fresh marks as coach-eligible evidence; stale paper marks
+        remain visible operationally but are excluded from learning.
         """
+        mark = _safe_float(mark_price, 0.0)
+        if mark <= 0 or not math.isfinite(mark):
+            mark = 0.0
+
+        broker_price = 0.0
+        if isinstance(live_leg, LiveLegState):
+            if str(phase).upper() == "ENTRY":
+                broker_price = live_leg.entry_average_fill_price
+            elif str(phase).upper() == "EXIT":
+                broker_price = live_leg.close_average_fill_price
+            else:
+                raise ValueError("phase must be ENTRY or EXIT")
+        if broker_price > 0 and math.isfinite(broker_price):
+            if mark > 0 and abs(broker_price - mark) / mark > 0.02:
+                # Not an error -- just the divergence that makes the broker
+                # evidence necessary.
+                self.log.warning(
+                    "Live fill price %.2f differs from the local mark %.2f by %.1f%%; "
+                    "recording the BROKER price.",
+                    broker_price,
+                    mark,
+                    abs(broker_price - mark) / mark * 100.0,
+                )
+            return float(broker_price), PRICE_QUALITY_BROKER_FILL
+
+        if isinstance(live_leg, LiveLegState):
+            return mark, (
+                PRICE_QUALITY_MARK_FALLBACK if mark > 0 else PRICE_QUALITY_UNKNOWN
+            )
+        if mark <= 0:
+            return 0.0, PRICE_QUALITY_UNKNOWN
+        if mark_is_fresh:
+            return mark, PRICE_QUALITY_PAPER_FRESH_MARK
+        return mark, PRICE_QUALITY_STALE_MARK
+
+    def _entry_fill_price(self, order_result: object, ltp_price: float) -> float:
+        """Compatibility helper for older callers; prefer ledger evidence."""
+
         broker_price = float(getattr(order_result, "average_fill_price", 0.0) or 0.0)
         if broker_price <= 0 or not math.isfinite(broker_price):
             return float(ltp_price)
@@ -6350,21 +6459,27 @@ class AtmSingleLegStrategyWorker(BasePaperStrategyWorker):
         # commit to it rather than only after the order goes out. `owns_feed_leg`
         # is True only when THIS entry added it -- a strike shared with another
         # worker must never be unsubscribed by our abort path.
+        option_subscription = OptionSubscription(
+            security_id=option_sec_id,
+            exchange_segment=option_segment,
+            trading_symbol=trading_symbol,
+            right=option_right,
+            strike=option_strike,
+            expiry=expiry_date,
+        )
         owns_feed_leg = self.store.register_option_subscription(
-            OptionSubscription(
-                security_id=option_sec_id,
-                exchange_segment=option_segment,
-                trading_symbol=trading_symbol,
-                right=option_right,
-                strike=option_strike,
-                expiry=expiry_date,
-            )
+            option_subscription,
+            owner_id=self._execution_owner_id,
         )
 
         def _abort_entry() -> bool:
             """Withdraw a subscription this entry opened, then decline the trade."""
             if owns_feed_leg:
-                self.store.unregister_option_subscription(option_segment, option_sec_id)
+                self.store.unregister_option_subscription(
+                    option_segment,
+                    option_sec_id,
+                    owner_id=self._execution_owner_id,
+                )
             return False
 
         option_ltp, mark_is_fresh = self._get_dealable_option_ltp(
@@ -6431,6 +6546,7 @@ class AtmSingleLegStrategyWorker(BasePaperStrategyWorker):
             "option_type": option_right, "strike": option_strike,
             "expiry": expiry_date, "quantity": quantity, "dhan_symbol": trading_symbol,
             "role": "N",
+            "option_subscription": option_subscription,
         }
         order_result = self._place_real_leg(
             entry_side,
@@ -6450,7 +6566,17 @@ class AtmSingleLegStrategyWorker(BasePaperStrategyWorker):
         self._untrack_orphan_live_leg(entry_leg)
         quantity = int(entry_leg["quantity"])
         exec_mode = self._exec_mode_tag(order_result)
-        option_ltp = self._entry_fill_price(order_result, option_ltp)
+        position_live_leg = (
+            live_leg
+            if isinstance(live_leg, LiveLegState) and live_leg.entry_complete
+            else None
+        )
+        option_ltp, entry_price_quality = self._accounting_price(
+            position_live_leg,
+            option_ltp,
+            mark_is_fresh=mark_is_fresh,
+            phase="ENTRY",
+        )
 
         # The leg was subscribed before it was priced (above); the fetcher has been
         # refreshing it since, and keeps doing so until exit_position drops it.
@@ -6458,11 +6584,7 @@ class AtmSingleLegStrategyWorker(BasePaperStrategyWorker):
         self.pos = PaperPosition(
             active=True,
             direction=direction,
-            live_leg=(
-                live_leg
-                if isinstance(live_leg, LiveLegState) and live_leg.entry_complete
-                else None
-            ),
+            live_leg=position_live_leg,
             symbol=trading_symbol,
             quantity=quantity,
             entry_order_id=str(order_id),
@@ -6473,6 +6595,7 @@ class AtmSingleLegStrategyWorker(BasePaperStrategyWorker):
             trailing_active=bool(trailing_active),
             pending_trailing_exit=bool(pending_trailing_exit),
             entry_trade_price=float(option_ltp),
+            entry_price_quality=entry_price_quality,
             option_security_id=option_sec_id,
             option_exchange_segment=option_segment,
             option_right=option_right,
@@ -6518,6 +6641,7 @@ class AtmSingleLegStrategyWorker(BasePaperStrategyWorker):
                         "right": option_right,
                         "strike": option_strike,
                         "entry_price": option_ltp,
+                        "entry_price_quality": entry_price_quality,
                     }
                 ],
             }
@@ -6542,11 +6666,13 @@ class AtmSingleLegStrategyWorker(BasePaperStrategyWorker):
         closed_position = self.pos
         exit_side = "SELL"
         order_id = self._next_paper_order_id(exit_side)
-        exit_trade_price = self._get_option_ltp(
+        exit_trade_price, exit_mark_is_fresh = self._get_dealable_option_ltp(
             closed_position.option_exchange_segment,
             closed_position.option_security_id,
-            fallback=closed_position.entry_trade_price,
         )
+        if exit_trade_price <= 0:
+            exit_trade_price = closed_position.entry_trade_price
+            exit_mark_is_fresh = False
 
         # Real execution -- but ONLY when this position actually opened a real leg
         # at the broker. A live entry that fell back to paper (rejected order or a
@@ -6612,6 +6738,14 @@ class AtmSingleLegStrategyWorker(BasePaperStrategyWorker):
             })
             return
 
+        exit_trade_price, exit_price_quality = self._accounting_price(
+            closed_position.live_leg if had_live_leg else None,
+            exit_trade_price,
+            mark_is_fresh=exit_mark_is_fresh,
+            phase="EXIT",
+        )
+        closed_position.exit_price_quality = exit_price_quality
+
         pnl = (exit_trade_price - closed_position.entry_trade_price) * closed_position.quantity
 
         pnl_colored = self._color_pnl_text(pnl)
@@ -6650,6 +6784,7 @@ class AtmSingleLegStrategyWorker(BasePaperStrategyWorker):
         self.store.unregister_option_subscription(
             closed_position.option_exchange_segment,
             closed_position.option_security_id,
+            owner_id=self._execution_owner_id,
         )
 
         self.publish_trade_event(
@@ -6675,7 +6810,9 @@ class AtmSingleLegStrategyWorker(BasePaperStrategyWorker):
                         "right": closed_position.option_right,
                         "strike": closed_position.option_strike,
                         "entry_price": closed_position.entry_trade_price,
+                        "entry_price_quality": closed_position.entry_price_quality,
                         "exit_price": exit_trade_price,
+                        "exit_price_quality": exit_price_quality,
                     }
                 ],
             }
@@ -8783,6 +8920,18 @@ class SupertrendBullishWorker(BasePaperStrategyWorker):
                 hedge_entry_price,
             )
             return False
+        main_entry_price, main_mark_is_fresh = self._get_dealable_option_ltp(
+            str(main["exchange_segment"]), int(main["security_id"])
+        )
+        hedge_entry_price, hedge_mark_is_fresh = self._get_dealable_option_ltp(
+            str(hedge["exchange_segment"]), int(hedge["security_id"])
+        )
+        if main_entry_price <= 0 or hedge_entry_price <= 0:
+            self.log.warning("Skipping bullish entry because a dealable leg price is unavailable.")
+            return False
+        if self.live_trading and not (main_mark_is_fresh and hedge_mark_is_fresh):
+            self.log.error("REFUSING LIVE bullish spread entry because a leg price is stale.")
+            return False
 
         main_live_order = {
             "option_type": str(main["option_type"]),
@@ -8807,6 +8956,30 @@ class SupertrendBullishWorker(BasePaperStrategyWorker):
         main_qty = int(main_live_order["quantity"])
         hedge_qty = int(hedge_live_order["quantity"])
         exec_mode = self._exec_mode_tag(order_result)
+        main_live_leg = (
+            main_live_order.get("live_leg")
+            if isinstance(main_live_order.get("live_leg"), LiveLegState)
+            and main_live_order["live_leg"].entry_complete
+            else None
+        )
+        hedge_live_leg = (
+            hedge_live_order.get("live_leg")
+            if isinstance(hedge_live_order.get("live_leg"), LiveLegState)
+            and hedge_live_order["live_leg"].entry_complete
+            else None
+        )
+        main_entry_price, main_entry_price_quality = self._accounting_price(
+            main_live_leg,
+            main_entry_price,
+            mark_is_fresh=main_mark_is_fresh,
+            phase="ENTRY",
+        )
+        hedge_entry_price, hedge_entry_price_quality = self._accounting_price(
+            hedge_live_leg,
+            hedge_entry_price,
+            mark_is_fresh=hedge_mark_is_fresh,
+            phase="ENTRY",
+        )
 
         # Subscribe both legs so the fetcher keeps refreshing their LTPs.
         self.store.register_option_subscription(
@@ -8817,7 +8990,8 @@ class SupertrendBullishWorker(BasePaperStrategyWorker):
                 right=str(main["option_type"]),
                 strike=float(main["strike"]),
                 expiry=main["expiry_date"],
-            )
+            ),
+            owner_id=self._execution_owner_id,
         )
         self.store.register_option_subscription(
             OptionSubscription(
@@ -8827,7 +9001,8 @@ class SupertrendBullishWorker(BasePaperStrategyWorker):
                 right=str(hedge["option_type"]),
                 strike=float(hedge["strike"]),
                 expiry=hedge["expiry_date"],
-            )
+            ),
+            owner_id=self._execution_owner_id,
         )
 
         main_order_id = self._next_paper_order_id("SELL")
@@ -8836,18 +9011,8 @@ class SupertrendBullishWorker(BasePaperStrategyWorker):
         self.pos = HedgedPaperPosition(
             active=True,
             direction="LONG",
-            main_live_leg=(
-                main_live_order.get("live_leg")
-                if isinstance(main_live_order.get("live_leg"), LiveLegState)
-                and main_live_order["live_leg"].entry_complete
-                else None
-            ),
-            hedge_live_leg=(
-                hedge_live_order.get("live_leg")
-                if isinstance(hedge_live_order.get("live_leg"), LiveLegState)
-                and hedge_live_order["live_leg"].entry_complete
-                else None
-            ),
+            main_live_leg=main_live_leg,
+            hedge_live_leg=hedge_live_leg,
             entry_underlying=float(entry_underlying),
             entry_timestamp=datetime.now(),
             main_symbol=str(main["trading_symbol"]),
@@ -8860,6 +9025,7 @@ class SupertrendBullishWorker(BasePaperStrategyWorker):
             main_lot_size=main_lot_size,
             main_quantity=main_qty,
             main_entry_price=main_entry_price,
+            main_entry_price_quality=main_entry_price_quality,
             main_entry_order_id=main_order_id,
             hedge_symbol=str(hedge["trading_symbol"]),
             hedge_side="BUY",
@@ -8871,6 +9037,7 @@ class SupertrendBullishWorker(BasePaperStrategyWorker):
             hedge_lot_size=hedge_lot_size,
             hedge_quantity=hedge_qty,
             hedge_entry_price=hedge_entry_price,
+            hedge_entry_price_quality=hedge_entry_price_quality,
             hedge_entry_order_id=hedge_order_id,
         )
 
@@ -8894,6 +9061,7 @@ class SupertrendBullishWorker(BasePaperStrategyWorker):
                         "right": self.pos.main_right,
                         "strike": self.pos.main_strike,
                         "entry_price": self.pos.main_entry_price,
+                        "entry_price_quality": self.pos.main_entry_price_quality,
                     },
                     {
                         "symbol": self.pos.hedge_symbol,
@@ -8901,6 +9069,7 @@ class SupertrendBullishWorker(BasePaperStrategyWorker):
                         "right": self.pos.hedge_right,
                         "strike": self.pos.hedge_strike,
                         "entry_price": self.pos.hedge_entry_price,
+                        "entry_price_quality": self.pos.hedge_entry_price_quality,
                     },
                 ],
             }
@@ -8962,16 +9131,20 @@ class SupertrendBullishWorker(BasePaperStrategyWorker):
             return
 
         closed = self.pos
-        main_exit_price = self._get_option_ltp(
+        main_exit_price, main_exit_mark_is_fresh = self._get_dealable_option_ltp(
             closed.main_exchange_segment,
             closed.main_security_id,
-            fallback=closed.main_entry_price,
         )
-        hedge_exit_price = self._get_option_ltp(
+        hedge_exit_price, hedge_exit_mark_is_fresh = self._get_dealable_option_ltp(
             closed.hedge_exchange_segment,
             closed.hedge_security_id,
-            fallback=closed.hedge_entry_price,
         )
+        if main_exit_price <= 0:
+            main_exit_price = closed.main_entry_price
+            main_exit_mark_is_fresh = False
+        if hedge_exit_price <= 0:
+            hedge_exit_price = closed.hedge_entry_price
+            hedge_exit_mark_is_fresh = False
 
         had_live_exposure = closed.live_legs_open
         main_live_order = {
@@ -9028,6 +9201,19 @@ class SupertrendBullishWorker(BasePaperStrategyWorker):
             })
             return
 
+        main_exit_price, main_exit_price_quality = self._accounting_price(
+            closed.main_live_leg if had_live_exposure else None,
+            main_exit_price,
+            mark_is_fresh=main_exit_mark_is_fresh,
+            phase="EXIT",
+        )
+        hedge_exit_price, hedge_exit_price_quality = self._accounting_price(
+            closed.hedge_live_leg if had_live_exposure else None,
+            hedge_exit_price,
+            mark_is_fresh=hedge_exit_mark_is_fresh,
+            phase="EXIT",
+        )
+
         main_pnl = (closed.main_entry_price - main_exit_price) * closed.main_quantity
         hedge_pnl = (hedge_exit_price - closed.hedge_entry_price) * closed.hedge_quantity
         total_pnl = main_pnl + hedge_pnl
@@ -9078,10 +9264,12 @@ class SupertrendBullishWorker(BasePaperStrategyWorker):
         self.store.unregister_option_subscription(
             closed.main_exchange_segment,
             closed.main_security_id,
+            owner_id=self._execution_owner_id,
         )
         self.store.unregister_option_subscription(
             closed.hedge_exchange_segment,
             closed.hedge_security_id,
+            owner_id=self._execution_owner_id,
         )
 
         self.publish_trade_event(
@@ -9105,7 +9293,9 @@ class SupertrendBullishWorker(BasePaperStrategyWorker):
                         "right": closed.main_right,
                         "strike": closed.main_strike,
                         "entry_price": closed.main_entry_price,
+                        "entry_price_quality": closed.main_entry_price_quality,
                         "exit_price": main_exit_price,
+                        "exit_price_quality": main_exit_price_quality,
                     },
                     {
                         "symbol": closed.hedge_symbol,
@@ -9113,7 +9303,9 @@ class SupertrendBullishWorker(BasePaperStrategyWorker):
                         "right": closed.hedge_right,
                         "strike": closed.hedge_strike,
                         "entry_price": closed.hedge_entry_price,
+                        "entry_price_quality": closed.hedge_entry_price_quality,
                         "exit_price": hedge_exit_price,
+                        "exit_price_quality": hedge_exit_price_quality,
                     },
                 ],
             }
@@ -9376,6 +9568,18 @@ class DonchianBearishWorker(BasePaperStrategyWorker):
                 hedge_entry_price,
             )
             return False
+        main_entry_price, main_mark_is_fresh = self._get_dealable_option_ltp(
+            str(main["exchange_segment"]), int(main["security_id"])
+        )
+        hedge_entry_price, hedge_mark_is_fresh = self._get_dealable_option_ltp(
+            str(hedge["exchange_segment"]), int(hedge["security_id"])
+        )
+        if main_entry_price <= 0 or hedge_entry_price <= 0:
+            self.log.warning("Skipping bearish entry because a dealable leg price is unavailable.")
+            return False
+        if self.live_trading and not (main_mark_is_fresh and hedge_mark_is_fresh):
+            self.log.error("REFUSING LIVE bearish spread entry because a leg price is stale.")
+            return False
 
         main_live_order = {
             "option_type": str(main["option_type"]),
@@ -9400,6 +9604,30 @@ class DonchianBearishWorker(BasePaperStrategyWorker):
         main_qty = int(main_live_order["quantity"])
         hedge_qty = int(hedge_live_order["quantity"])
         exec_mode = self._exec_mode_tag(order_result)
+        main_live_leg = (
+            main_live_order.get("live_leg")
+            if isinstance(main_live_order.get("live_leg"), LiveLegState)
+            and main_live_order["live_leg"].entry_complete
+            else None
+        )
+        hedge_live_leg = (
+            hedge_live_order.get("live_leg")
+            if isinstance(hedge_live_order.get("live_leg"), LiveLegState)
+            and hedge_live_order["live_leg"].entry_complete
+            else None
+        )
+        main_entry_price, main_entry_price_quality = self._accounting_price(
+            main_live_leg,
+            main_entry_price,
+            mark_is_fresh=main_mark_is_fresh,
+            phase="ENTRY",
+        )
+        hedge_entry_price, hedge_entry_price_quality = self._accounting_price(
+            hedge_live_leg,
+            hedge_entry_price,
+            mark_is_fresh=hedge_mark_is_fresh,
+            phase="ENTRY",
+        )
 
         self.store.register_option_subscription(
             OptionSubscription(
@@ -9409,7 +9637,8 @@ class DonchianBearishWorker(BasePaperStrategyWorker):
                 right=str(main["option_type"]),
                 strike=float(main["strike"]),
                 expiry=main["expiry_date"],
-            )
+            ),
+            owner_id=self._execution_owner_id,
         )
         self.store.register_option_subscription(
             OptionSubscription(
@@ -9419,7 +9648,8 @@ class DonchianBearishWorker(BasePaperStrategyWorker):
                 right=str(hedge["option_type"]),
                 strike=float(hedge["strike"]),
                 expiry=hedge["expiry_date"],
-            )
+            ),
+            owner_id=self._execution_owner_id,
         )
 
         main_order_id = self._next_paper_order_id("SELL")
@@ -9429,18 +9659,8 @@ class DonchianBearishWorker(BasePaperStrategyWorker):
         self.pos = HedgedPaperPosition(
             active=True,
             direction="SHORT",
-            main_live_leg=(
-                main_live_order.get("live_leg")
-                if isinstance(main_live_order.get("live_leg"), LiveLegState)
-                and main_live_order["live_leg"].entry_complete
-                else None
-            ),
-            hedge_live_leg=(
-                hedge_live_order.get("live_leg")
-                if isinstance(hedge_live_order.get("live_leg"), LiveLegState)
-                and hedge_live_order["live_leg"].entry_complete
-                else None
-            ),
+            main_live_leg=main_live_leg,
+            hedge_live_leg=hedge_live_leg,
             entry_underlying=float(spot),
             entry_timestamp=datetime.now(),
             main_symbol=str(main["trading_symbol"]),
@@ -9453,6 +9673,7 @@ class DonchianBearishWorker(BasePaperStrategyWorker):
             main_lot_size=main_lot_size,
             main_quantity=main_qty,
             main_entry_price=main_entry_price,
+            main_entry_price_quality=main_entry_price_quality,
             main_entry_order_id=main_order_id,
             hedge_symbol=str(hedge["trading_symbol"]),
             hedge_side="BUY",
@@ -9464,6 +9685,7 @@ class DonchianBearishWorker(BasePaperStrategyWorker):
             hedge_lot_size=hedge_lot_size,
             hedge_quantity=hedge_qty,
             hedge_entry_price=hedge_entry_price,
+            hedge_entry_price_quality=hedge_entry_price_quality,
             hedge_entry_order_id=hedge_order_id,
         )
 
@@ -9487,6 +9709,7 @@ class DonchianBearishWorker(BasePaperStrategyWorker):
                         "right": self.pos.main_right,
                         "strike": self.pos.main_strike,
                         "entry_price": self.pos.main_entry_price,
+                        "entry_price_quality": self.pos.main_entry_price_quality,
                     },
                     {
                         "symbol": self.pos.hedge_symbol,
@@ -9494,6 +9717,7 @@ class DonchianBearishWorker(BasePaperStrategyWorker):
                         "right": self.pos.hedge_right,
                         "strike": self.pos.hedge_strike,
                         "entry_price": self.pos.hedge_entry_price,
+                        "entry_price_quality": self.pos.hedge_entry_price_quality,
                     },
                 ],
             }
@@ -9682,16 +9906,20 @@ class DonchianBearishWorker(BasePaperStrategyWorker):
             return
 
         closed = self.pos
-        main_exit_price = self._get_option_ltp(
+        main_exit_price, main_exit_mark_is_fresh = self._get_dealable_option_ltp(
             closed.main_exchange_segment,
             closed.main_security_id,
-            fallback=closed.main_entry_price,
         )
-        hedge_exit_price = self._get_option_ltp(
+        hedge_exit_price, hedge_exit_mark_is_fresh = self._get_dealable_option_ltp(
             closed.hedge_exchange_segment,
             closed.hedge_security_id,
-            fallback=closed.hedge_entry_price,
         )
+        if main_exit_price <= 0:
+            main_exit_price = closed.main_entry_price
+            main_exit_mark_is_fresh = False
+        if hedge_exit_price <= 0:
+            hedge_exit_price = closed.hedge_entry_price
+            hedge_exit_mark_is_fresh = False
 
         had_live_exposure = closed.live_legs_open
         main_live_order = {
@@ -9748,6 +9976,19 @@ class DonchianBearishWorker(BasePaperStrategyWorker):
             })
             return
 
+        main_exit_price, main_exit_price_quality = self._accounting_price(
+            closed.main_live_leg if had_live_exposure else None,
+            main_exit_price,
+            mark_is_fresh=main_exit_mark_is_fresh,
+            phase="EXIT",
+        )
+        hedge_exit_price, hedge_exit_price_quality = self._accounting_price(
+            closed.hedge_live_leg if had_live_exposure else None,
+            hedge_exit_price,
+            mark_is_fresh=hedge_exit_mark_is_fresh,
+            phase="EXIT",
+        )
+
         main_pnl = (closed.main_entry_price - main_exit_price) * closed.main_quantity
         hedge_pnl = (hedge_exit_price - closed.hedge_entry_price) * closed.hedge_quantity
         total_pnl = main_pnl + hedge_pnl
@@ -9796,10 +10037,12 @@ class DonchianBearishWorker(BasePaperStrategyWorker):
         self.store.unregister_option_subscription(
             closed.main_exchange_segment,
             closed.main_security_id,
+            owner_id=self._execution_owner_id,
         )
         self.store.unregister_option_subscription(
             closed.hedge_exchange_segment,
             closed.hedge_security_id,
+            owner_id=self._execution_owner_id,
         )
 
         self.publish_trade_event(
@@ -9823,7 +10066,9 @@ class DonchianBearishWorker(BasePaperStrategyWorker):
                         "right": closed.main_right,
                         "strike": closed.main_strike,
                         "entry_price": closed.main_entry_price,
+                        "entry_price_quality": closed.main_entry_price_quality,
                         "exit_price": main_exit_price,
+                        "exit_price_quality": main_exit_price_quality,
                     },
                     {
                         "symbol": closed.hedge_symbol,
@@ -9831,7 +10076,9 @@ class DonchianBearishWorker(BasePaperStrategyWorker):
                         "right": closed.hedge_right,
                         "strike": closed.hedge_strike,
                         "entry_price": closed.hedge_entry_price,
+                        "entry_price_quality": closed.hedge_entry_price_quality,
                         "exit_price": hedge_exit_price,
+                        "exit_price_quality": hedge_exit_price_quality,
                     },
                 ],
             }
@@ -10354,7 +10601,8 @@ class Delta20HedgedSpreadWorker(BasePaperStrategyWorker):
                     right=str(meta["option_type"]),
                     strike=float(meta["strike"]),
                     expiry=meta["expiry_date"],
-                )
+                ),
+                owner_id=self._execution_owner_id,
             )
 
         self.reference_captured = True
@@ -10684,20 +10932,28 @@ class Delta20HedgedSpreadWorker(BasePaperStrategyWorker):
         if monitor_meta is None or hedge_meta is None:
             return False
 
-        # The hedge leg's LTP is needed to record a realistic paper fill
-        # price. If it isn't available yet we skip the entry rather than
-        # entering with stale / synthetic data.
-        hedge_live = self._get_option_ltp(
+        monitor_live, monitor_mark_is_fresh = self._get_dealable_option_ltp(
+            str(monitor_meta["exchange_segment"]),
+            int(monitor_meta["security_id"]),
+        )
+        hedge_live, hedge_mark_is_fresh = self._get_dealable_option_ltp(
             str(hedge_meta["exchange_segment"]),
             int(hedge_meta["security_id"]),
-            fallback=0.0,
         )
-        if hedge_live <= 0:
+        if monitor_live <= 0 or hedge_live <= 0:
             self.log.warning(
-                "Skipping %s entry: hedge LTP unavailable (sym=%s sec=%s).",
+                "Skipping %s entry: a dealable leg LTP is unavailable (hedge=%s sec=%s).",
                 side,
                 hedge_meta.get("trading_symbol"),
                 hedge_meta.get("security_id"),
+            )
+            return False
+        if self.live_trading and not (
+            monitor_mark_is_fresh and hedge_mark_is_fresh
+        ):
+            self.log.error(
+                "REFUSING LIVE %s spread entry because a leg price is stale.",
+                side,
             )
             return False
 
@@ -10741,6 +10997,30 @@ class Delta20HedgedSpreadWorker(BasePaperStrategyWorker):
         monitor_qty = int(main_live_order["quantity"])
         hedge_qty = int(hedge_live_order["quantity"])
         exec_mode = self._exec_mode_tag(order_result)
+        main_live_leg = (
+            main_live_order.get("live_leg")
+            if isinstance(main_live_order.get("live_leg"), LiveLegState)
+            and main_live_order["live_leg"].entry_complete
+            else None
+        )
+        hedge_live_leg = (
+            hedge_live_order.get("live_leg")
+            if isinstance(hedge_live_order.get("live_leg"), LiveLegState)
+            and hedge_live_order["live_leg"].entry_complete
+            else None
+        )
+        monitor_live, main_entry_price_quality = self._accounting_price(
+            main_live_leg,
+            monitor_live,
+            mark_is_fresh=monitor_mark_is_fresh,
+            phase="ENTRY",
+        )
+        hedge_live, hedge_entry_price_quality = self._accounting_price(
+            hedge_live_leg,
+            hedge_live,
+            mark_is_fresh=hedge_mark_is_fresh,
+            phase="ENTRY",
+        )
         # Synthetic order ids for paper-trade audit trail. These are
         # unique within the worker and timestamp-encoded so a human
         # scanning the log can correlate ENTRY and EXIT lines easily.
@@ -10754,18 +11034,8 @@ class Delta20HedgedSpreadWorker(BasePaperStrategyWorker):
         new_pos = HedgedPaperPosition(
             active=True,
             direction=side,  # "CE" or "PE" (used purely for log labelling)
-            main_live_leg=(
-                main_live_order.get("live_leg")
-                if isinstance(main_live_order.get("live_leg"), LiveLegState)
-                and main_live_order["live_leg"].entry_complete
-                else None
-            ),
-            hedge_live_leg=(
-                hedge_live_order.get("live_leg")
-                if isinstance(hedge_live_order.get("live_leg"), LiveLegState)
-                and hedge_live_order["live_leg"].entry_complete
-                else None
-            ),
+            main_live_leg=main_live_leg,
+            hedge_live_leg=hedge_live_leg,
             entry_underlying=float(spot),
             entry_timestamp=datetime.now(),
             main_symbol=str(monitor_meta["trading_symbol"]),
@@ -10778,6 +11048,7 @@ class Delta20HedgedSpreadWorker(BasePaperStrategyWorker):
             main_lot_size=monitor_lot_size,
             main_quantity=monitor_qty,
             main_entry_price=float(monitor_live),
+            main_entry_price_quality=main_entry_price_quality,
             main_entry_order_id=main_order_id,
             hedge_symbol=str(hedge_meta["trading_symbol"]),
             hedge_side="BUY",
@@ -10789,6 +11060,7 @@ class Delta20HedgedSpreadWorker(BasePaperStrategyWorker):
             hedge_lot_size=hedge_lot_size,
             hedge_quantity=hedge_qty,
             hedge_entry_price=float(hedge_live),
+            hedge_entry_price_quality=hedge_entry_price_quality,
             hedge_entry_order_id=hedge_order_id,
         )
         if side == "CE":
@@ -10817,6 +11089,7 @@ class Delta20HedgedSpreadWorker(BasePaperStrategyWorker):
                         "right": new_pos.main_right,
                         "strike": new_pos.main_strike,
                         "entry_price": new_pos.main_entry_price,
+                        "entry_price_quality": new_pos.main_entry_price_quality,
                     },
                     {
                         "symbol": new_pos.hedge_symbol,
@@ -10824,6 +11097,7 @@ class Delta20HedgedSpreadWorker(BasePaperStrategyWorker):
                         "right": new_pos.hedge_right,
                         "strike": new_pos.hedge_strike,
                         "entry_price": new_pos.hedge_entry_price,
+                        "entry_price_quality": new_pos.hedge_entry_price_quality,
                     },
                 ],
             }
@@ -10890,16 +11164,20 @@ class Delta20HedgedSpreadWorker(BasePaperStrategyWorker):
         # price keeps the math defined even on the rare poll where the
         # LTP cache is briefly empty - a no-op PnL for that leg, which
         # an operator can easily spot in the log.
-        main_exit_price = self._get_option_ltp(
+        main_exit_price, main_exit_mark_is_fresh = self._get_dealable_option_ltp(
             closed.main_exchange_segment,
             closed.main_security_id,
-            fallback=closed.main_entry_price,
         )
-        hedge_exit_price = self._get_option_ltp(
+        hedge_exit_price, hedge_exit_mark_is_fresh = self._get_dealable_option_ltp(
             closed.hedge_exchange_segment,
             closed.hedge_security_id,
-            fallback=closed.hedge_entry_price,
         )
+        if main_exit_price <= 0:
+            main_exit_price = closed.main_entry_price
+            main_exit_mark_is_fresh = False
+        if hedge_exit_price <= 0:
+            hedge_exit_price = closed.hedge_entry_price
+            hedge_exit_mark_is_fresh = False
 
         had_live_exposure = closed.live_legs_open
         main_live_order = {
@@ -10955,6 +11233,18 @@ class Delta20HedgedSpreadWorker(BasePaperStrategyWorker):
                 ],
             })
             return
+        main_exit_price, main_exit_price_quality = self._accounting_price(
+            closed.main_live_leg if had_live_exposure else None,
+            main_exit_price,
+            mark_is_fresh=main_exit_mark_is_fresh,
+            phase="EXIT",
+        )
+        hedge_exit_price, hedge_exit_price_quality = self._accounting_price(
+            closed.hedge_live_leg if had_live_exposure else None,
+            hedge_exit_price,
+            mark_is_fresh=hedge_exit_mark_is_fresh,
+            phase="EXIT",
+        )
         # Main was SOLD -> profit if exit < entry  ->  (entry - exit) * qty
         # Hedge was BOUGHT -> profit if exit > entry -> (exit - entry) * qty
         main_pnl = (closed.main_entry_price - main_exit_price) * closed.main_quantity
@@ -11006,10 +11296,12 @@ class Delta20HedgedSpreadWorker(BasePaperStrategyWorker):
         self.store.unregister_option_subscription(
             closed.main_exchange_segment,
             closed.main_security_id,
+            owner_id=self._execution_owner_id,
         )
         self.store.unregister_option_subscription(
             closed.hedge_exchange_segment,
             closed.hedge_security_id,
+            owner_id=self._execution_owner_id,
         )
         self.publish_trade_event(
             {
@@ -11032,7 +11324,9 @@ class Delta20HedgedSpreadWorker(BasePaperStrategyWorker):
                         "right": closed.main_right,
                         "strike": closed.main_strike,
                         "entry_price": closed.main_entry_price,
+                        "entry_price_quality": closed.main_entry_price_quality,
                         "exit_price": main_exit_price,
+                        "exit_price_quality": main_exit_price_quality,
                     },
                     {
                         "symbol": closed.hedge_symbol,
@@ -11040,7 +11334,9 @@ class Delta20HedgedSpreadWorker(BasePaperStrategyWorker):
                         "right": closed.hedge_right,
                         "strike": closed.hedge_strike,
                         "entry_price": closed.hedge_entry_price,
+                        "entry_price_quality": closed.hedge_entry_price_quality,
                         "exit_price": hedge_exit_price,
+                        "exit_price_quality": hedge_exit_price_quality,
                     },
                 ],
             }
@@ -11121,6 +11417,7 @@ class Delta20HedgedSpreadWorker(BasePaperStrategyWorker):
                     self.store.unregister_option_subscription(
                         str(meta["exchange_segment"]),
                         int(meta["security_id"]),
+                        owner_id=self._execution_owner_id,
                     )
         if not self.pe_pos.active and not self.pe_side_done:
             for meta in (self.pe_monitor_meta, self.pe_hedge_meta):
@@ -11128,6 +11425,7 @@ class Delta20HedgedSpreadWorker(BasePaperStrategyWorker):
                     self.store.unregister_option_subscription(
                         str(meta["exchange_segment"]),
                         int(meta["security_id"]),
+                        owner_id=self._execution_owner_id,
                     )
 
 
@@ -11506,11 +11804,19 @@ class LongStrangleWorker(BasePaperStrategyWorker):
             )
             return False
 
-        option_ltp = self._get_option_ltp(option_segment, option_sec_id, fallback=0.0)
+        option_ltp, mark_is_fresh = self._get_dealable_option_ltp(
+            option_segment, option_sec_id
+        )
         if option_ltp <= 0:
             self.log.warning(
                 "Strangle %s entry skipped: option LTP unavailable for %s (security_id=%s).",
                 side, trading_symbol, option_sec_id,
+            )
+            return False
+        if self.live_trading and not mark_is_fresh:
+            self.log.error(
+                "REFUSING LIVE strangle %s entry because the option mark is stale.",
+                side,
             )
             return False
 
@@ -11545,8 +11851,14 @@ class LongStrangleWorker(BasePaperStrategyWorker):
         # must not make a later paper exit submit a naked SELL.
         position_live_leg = (
             live_leg
-            if live_leg is not None and not live_leg.broker_confirmed_flat
+            if live_leg is not None and live_leg.entry_complete
             else None
+        )
+        option_ltp, entry_price_quality = self._accounting_price(
+            position_live_leg,
+            option_ltp,
+            mark_is_fresh=mark_is_fresh,
+            phase="ENTRY",
         )
 
         # Keep the fetcher refreshing this leg's LTP for its whole lifetime. On a
@@ -11560,7 +11872,8 @@ class LongStrangleWorker(BasePaperStrategyWorker):
                 right=option_right,
                 strike=option_strike,
                 expiry=expiry_date,
-            )
+            ),
+            owner_id=self._execution_owner_id,
         )
 
         new_pos = PaperPosition(
@@ -11571,6 +11884,7 @@ class LongStrangleWorker(BasePaperStrategyWorker):
             quantity=quantity,
             entry_order_id=str(order_id),
             entry_trade_price=float(option_ltp),
+            entry_price_quality=entry_price_quality,
             option_security_id=option_sec_id,
             option_exchange_segment=option_segment,
             option_right=option_right,
@@ -11629,6 +11943,7 @@ class LongStrangleWorker(BasePaperStrategyWorker):
                 "symbol": trading_symbol, "side": "BUY",
                 "right": option_right, "strike": option_strike,
                 "entry_price": option_ltp,
+                "entry_price_quality": entry_price_quality,
             }],
         })
         return True
@@ -11690,7 +12005,9 @@ class LongStrangleWorker(BasePaperStrategyWorker):
             awaiting, _, contract, _ = self._reentry_state(side)
             if not leg_pos.active and awaiting and contract is not None:
                 self.store.unregister_option_subscription(
-                    str(contract["exchange_segment"]), int(contract["security_id"])
+                    str(contract["exchange_segment"]),
+                    int(contract["security_id"]),
+                    owner_id=self._execution_owner_id,
                 )
 
     # ------------------------------------------------------------------
@@ -11789,11 +12106,13 @@ class LongStrangleWorker(BasePaperStrategyWorker):
 
         closed = leg_pos
         order_id = self._next_paper_order_id("SELL")
-        exit_price = self._get_option_ltp(
+        exit_price, exit_mark_is_fresh = self._get_dealable_option_ltp(
             closed.option_exchange_segment,
             closed.option_security_id,
-            fallback=closed.entry_trade_price,
         )
+        if exit_price <= 0:
+            exit_price = closed.entry_trade_price
+            exit_mark_is_fresh = False
 
         # Real execution -- but ONLY when this leg actually opened a real leg at the
         # broker. A live entry that fell back to paper (rejected order or symbol-master
@@ -11866,6 +12185,13 @@ class LongStrangleWorker(BasePaperStrategyWorker):
             })
             return
 
+        exit_price, exit_price_quality = self._accounting_price(
+            closed.live_leg if had_live_leg else None,
+            exit_price,
+            mark_is_fresh=exit_mark_is_fresh,
+            phase="EXIT",
+        )
+        closed.exit_price_quality = exit_price_quality
         pnl = (exit_price - closed.entry_trade_price) * closed.quantity
         self.completed_trades += 1
         self.exit_count += 1
@@ -11894,7 +12220,10 @@ class LongStrangleWorker(BasePaperStrategyWorker):
             "pnl": pnl, "expiry": expiry_txt,
             "legs": [{"symbol": closed.symbol, "side": "SELL",
                       "right": closed.option_right, "strike": closed.option_strike,
-                      "entry_price": closed.entry_trade_price, "exit_price": exit_price}],
+                      "entry_price": closed.entry_trade_price,
+                      "entry_price_quality": closed.entry_price_quality,
+                      "exit_price": exit_price,
+                      "exit_price_quality": exit_price_quality}],
         })
 
         # Decide whether to ARM this leg for a momentum re-entry. Only per-leg
@@ -11917,7 +12246,9 @@ class LongStrangleWorker(BasePaperStrategyWorker):
         else:
             # No re-entry: stop watching this strike.
             self.store.unregister_option_subscription(
-                closed.option_exchange_segment, closed.option_security_id,
+                closed.option_exchange_segment,
+                closed.option_security_id,
+                owner_id=self._execution_owner_id,
             )
 
         if side == "CE":
@@ -12346,6 +12677,7 @@ if SL_HUNTING_AVAILABLE:
             )
             self._open_trade_id = None
             self._entry_realized_pnl = 0.0
+            self._journal_pnl_evidence_eligible = True
             # When the NIFTY leg is cut alone (exit_leg=NIFTY) but the mirror survives,
             # we DEFER the journal close so option_pnl captures BOTH legs. This holds the
             # NIFTY-leg exit context until the mirror finally closes (BNF exit / square-off
@@ -12406,6 +12738,16 @@ if SL_HUNTING_AVAILABLE:
                     entry_underlying=float(getattr(self.pos, "entry_underlying", 0.0)),
                     lots=int(getattr(self.pos, "quantity", 0)) // lot_size,
                     nifty_df=nifty_df, bnf_df=bnf_df,
+                    entry_price_quality=str(
+                        getattr(self.pos, "entry_price_quality", PRICE_QUALITY_UNKNOWN)
+                    ),
+                )
+                entry_qualities = [self.pos.entry_price_quality]
+                if self._mirror_pos.active:
+                    entry_qualities.append(self._mirror_pos.entry_price_quality)
+                self._journal_pnl_evidence_eligible = all(
+                    quality in COACH_ELIGIBLE_PRICE_QUALITIES
+                    for quality in entry_qualities
                 )
                 self._open_trade_id = self._journal.open_trade(entry)
                 self._entry_realized_pnl = self.realized_pnl
@@ -12536,9 +12878,14 @@ if SL_HUNTING_AVAILABLE:
             if not symbol or sec_id <= 0 or lot_size <= 0:
                 self.log.warning("BNF mirror skipped: unusable contract %r.", symbol)
                 return
-            option_ltp = self._get_option_ltp(segment, sec_id, fallback=0.0)
+            option_ltp, mark_is_fresh = self._get_dealable_option_ltp(segment, sec_id)
             if option_ltp <= 0:
                 self.log.warning("BNF mirror skipped: no LTP for %s (security_id=%s).", symbol, sec_id)
+                return
+            if self.live_trading and not mark_is_fresh:
+                self.log.error(
+                    "BNF mirror skipped: refusing a LIVE entry on a stale option mark."
+                )
                 return
 
             quantity = lot_size * lots
@@ -12571,6 +12918,17 @@ if SL_HUNTING_AVAILABLE:
             )
             if not entry_bookkeeping_allowed and recovery_live_leg is None:
                 return
+            position_live_leg = (
+                live_leg
+                if isinstance(live_leg, LiveLegState) and live_leg.entry_complete
+                else None
+            )
+            option_ltp, entry_price_quality = self._accounting_price(
+                position_live_leg or recovery_live_leg,
+                option_ltp,
+                mark_is_fresh=mark_is_fresh,
+                phase="ENTRY",
+            )
             tracked_quantity = quantity
             if not entry_bookkeeping_allowed:
                 # The guard above proves this is a quantity-bearing recovery
@@ -12580,11 +12938,17 @@ if SL_HUNTING_AVAILABLE:
                 # may still fill.  MTM/max-loss must use the conservative risk
                 # quantity so indeterminate BankNIFTY exposure never looks flat.
                 tracked_quantity = recovery_live_leg.risk_quantity
-            self.store.register_option_subscription(OptionSubscription(
-                security_id=sec_id, exchange_segment=segment, trading_symbol=symbol,
-                right=str(contract["option_type"]), strike=float(contract["strike"]),
-                expiry=contract["expiry_date"],
-            ))
+            self.store.register_option_subscription(
+                OptionSubscription(
+                    security_id=sec_id,
+                    exchange_segment=segment,
+                    trading_symbol=symbol,
+                    right=str(contract["option_type"]),
+                    strike=float(contract["strike"]),
+                    expiry=contract["expiry_date"],
+                ),
+                owner_id=self._execution_owner_id,
+            )
             self._mirror_pos = PaperPosition(
                 active=True,
                 direction=direction,
@@ -12600,7 +12964,9 @@ if SL_HUNTING_AVAILABLE:
                     else None
                 ),
                 entry_order_id=str(order_id), entry_underlying=bnf_spot,
-                entry_trade_price=float(option_ltp), option_security_id=sec_id,
+                entry_trade_price=float(option_ltp),
+                entry_price_quality=entry_price_quality,
+                option_security_id=sec_id,
                 option_exchange_segment=segment, option_right=str(contract["option_type"]),
                 option_strike=float(contract["strike"]), option_expiry=contract["expiry_date"],
                 option_lot_size=lot_size,
@@ -12635,6 +13001,7 @@ if SL_HUNTING_AVAILABLE:
                 "legs": [{
                     "symbol": symbol, "side": "BUY", "right": str(contract["option_type"]),
                     "strike": float(contract["strike"]), "entry_price": option_ltp,
+                    "entry_price_quality": entry_price_quality,
                 }],
             })
 
@@ -12648,10 +13015,12 @@ if SL_HUNTING_AVAILABLE:
             if not self._mirror_pos.active:
                 return
             mirror = self._mirror_pos
-            exit_ltp = self._get_option_ltp(
-                mirror.option_exchange_segment, mirror.option_security_id,
-                fallback=mirror.entry_trade_price,
+            exit_ltp, exit_mark_is_fresh = self._get_dealable_option_ltp(
+                mirror.option_exchange_segment, mirror.option_security_id
             )
+            if exit_ltp <= 0:
+                exit_ltp = mirror.entry_trade_price
+                exit_mark_is_fresh = False
             # Only close a REAL mirror leg. A live mirror BUY that fell back to
             # paper (rejected / symbol-master miss) opened nothing at the broker,
             # so a SELL now would be a phantom BankNIFTY short. A live position,
@@ -12718,10 +13087,6 @@ if SL_HUNTING_AVAILABLE:
                 )
                 closed_quantity = mirror.quantity
 
-            # Book only the quantity the ledger proves was reduced. This avoids
-            # both losing a partial fill and double-counting it on the retry.
-            pnl = (exit_ltp - mirror.entry_trade_price) * closed_quantity
-            self.realized_pnl += pnl
             if had_live_leg and (
                 mirror.live_leg is None or not mirror.live_leg.broker_confirmed_flat
             ):
@@ -12742,8 +13107,41 @@ if SL_HUNTING_AVAILABLE:
                     "legs": [{"symbol": mirror.symbol, "side": "SELL"}],
                 })
                 return
+            if had_live_leg and mirror.live_leg is not None:
+                closed_quantity = mirror.live_leg.filled_quantity
+                (
+                    mirror.entry_trade_price,
+                    mirror.entry_price_quality,
+                ) = self._accounting_price(
+                    mirror.live_leg,
+                    mirror.entry_trade_price,
+                    mark_is_fresh=(
+                        mirror.entry_price_quality
+                        == PRICE_QUALITY_PAPER_FRESH_MARK
+                    ),
+                    phase="ENTRY",
+                )
+            exit_ltp, exit_price_quality = self._accounting_price(
+                mirror.live_leg if had_live_leg else None,
+                exit_ltp,
+                mark_is_fresh=exit_mark_is_fresh,
+                phase="EXIT",
+            )
+            mirror.exit_price_quality = exit_price_quality
+            self._journal_pnl_evidence_eligible = (
+                self._journal_pnl_evidence_eligible
+                and mirror.entry_price_quality in COACH_ELIGIBLE_PRICE_QUALITIES
+                and exit_price_quality in COACH_ELIGIBLE_PRICE_QUALITIES
+            )
+            # Wait for broker-confirmed flat before booking the live leg. This
+            # lets the ledger's cumulative weighted close price account for
+            # every partial/retry exactly once.
+            pnl = (exit_ltp - mirror.entry_trade_price) * closed_quantity
+            self.realized_pnl += pnl
             self.store.unregister_option_subscription(
-                mirror.option_exchange_segment, mirror.option_security_id,
+                mirror.option_exchange_segment,
+                mirror.option_security_id,
+                owner_id=self._execution_owner_id,
             )
             self.log.info(
                 "MIRROR EXIT %s | OptionSymbol=%s | Qty=%s | Reason=%s | EntryOptPx=%.2f | "
@@ -12762,7 +13160,11 @@ if SL_HUNTING_AVAILABLE:
                 "quantity": closed_quantity,
                 "legs": [{
                     "symbol": mirror.symbol, "side": "SELL", "right": mirror.option_right,
-                    "strike": mirror.option_strike, "exit_price": exit_ltp,
+                    "strike": mirror.option_strike,
+                    "entry_price": mirror.entry_trade_price,
+                    "entry_price_quality": mirror.entry_price_quality,
+                    "exit_price": exit_ltp,
+                    "exit_price_quality": exit_price_quality,
                 }],
             })
             self._mirror_pos = PaperPosition()
@@ -12877,6 +13279,20 @@ if SL_HUNTING_AVAILABLE:
                 "exit_reason": reason,
                 "points": round(points, 2),
                 "lots": int(getattr(closed_position, "quantity", 0)) // lot_size,
+                "entry_price_quality": str(
+                    getattr(
+                        closed_position,
+                        "entry_price_quality",
+                        PRICE_QUALITY_UNKNOWN,
+                    )
+                ),
+                "exit_price_quality": str(
+                    getattr(
+                        closed_position,
+                        "exit_price_quality",
+                        PRICE_QUALITY_UNKNOWN,
+                    )
+                ),
             }
 
         def _finalize_journal(self, static: dict) -> None:
@@ -12886,15 +13302,24 @@ if SL_HUNTING_AVAILABLE:
                 self._pending_journal_exit = None
                 return
             try:
+                self._journal_pnl_evidence_eligible = (
+                    self._journal_pnl_evidence_eligible
+                    and static.get("entry_price_quality")
+                    in COACH_ELIGIBLE_PRICE_QUALITIES
+                    and static.get("exit_price_quality")
+                    in COACH_ELIGIBLE_PRICE_QUALITIES
+                )
                 self._journal.close_trade(self._open_trade_id, {
                     **static,
                     "option_pnl": round(self.realized_pnl - self._entry_realized_pnl, 2),
+                    "pnl_evidence_eligible": self._journal_pnl_evidence_eligible,
                 })
             except Exception as exc:  # noqa: BLE001
                 self.log.warning("SL Hunting journal close failed: %s", exc)
             finally:
                 self._open_trade_id = None
                 self._pending_journal_exit = None
+                self._journal_pnl_evidence_eligible = True
 
         def after_exit(self, closed_position, reason: str) -> None:
             """Universal post-close hook for the NIFTY leg (fires for stop/target,
@@ -14025,6 +14450,7 @@ def _live_config_errors(
     )
 
     raw_rules = {
+        "MARKET_DATA_MAX_LTP_AGE_SECONDS": ("positive", None),
         f"{normalized_prefix}_LOTS": ("positive_integer", None),
         f"{start_clock_prefix}_TRADING_START_HOUR": (
             "integer_range",
@@ -14117,6 +14543,17 @@ def _live_config_errors(
         or float(max_loss) <= 0
     ):
         errors.append("resolved max-loss must be finite and positive")
+
+    ltp_age_bound = globals().get("MARKET_DATA_MAX_LTP_AGE_SECONDS")
+    if (
+        isinstance(ltp_age_bound, bool)
+        or not isinstance(ltp_age_bound, (int, float))
+        or not math.isfinite(float(ltp_age_bound))
+        or float(ltp_age_bound) <= 0
+    ):
+        errors.append(
+            "resolved MARKET_DATA_MAX_LTP_AGE_SECONDS must be finite and positive"
+        )
 
     start_hour = getattr(worker, "trading_start_hour", None)
     start_minute = getattr(worker, "trading_start_minute", None)

--- a/Nifty Multi Strategy Front Test - Master File.py
+++ b/Nifty Multi Strategy Front Test - Master File.py
@@ -15275,7 +15275,20 @@ def main() -> None:
     #       paper unless SL_HUNTING_LIVE_TRADING + LIVE_TRADING_ENABLED are both on
     #       (the live-wiring below applies the same double-gate as every strategy).
     if SLHuntingAIWorker is not None:
-        workers.append(SLHuntingAIWorker(store, stop_event, broker))
+        # Constructing this worker builds the agent, which validates its own
+        # system prompt (size cap) and reads the optional lessons / pre-open note.
+        # Any failure there must disable the OPTIONAL agent only -- never take the
+        # other strategies down with it. Without this guard an over-long prompt
+        # raises straight out of main() and the whole runner fails to start.
+        try:
+            workers.append(SLHuntingAIWorker(store, stop_event, broker))
+        except Exception as exc:  # noqa: BLE001 - optional strategy, never fatal
+            logging.getLogger(__name__).error(
+                "SL Hunting AI worker could not be created (%s); continuing WITHOUT it. "
+                "Every other strategy is unaffected.",
+                exc,
+                exc_info=True,
+            )
 
     # -------------------------------------------------------------------------
     # Per-strategy virtual (paper) trading gate.

--- a/Nifty Multi Strategy Front Test - Master File.py
+++ b/Nifty Multi Strategy Front Test - Master File.py
@@ -5526,6 +5526,33 @@ class BasePaperStrategyWorker(threading.Thread):
         self.paper_order_counter += 1
         return f"PAPER-{side}-{datetime.now():%Y%m%d%H%M%S}-{self.paper_order_counter:04d}"
 
+    def _entry_fill_price(self, order_result: object, ltp_price: float) -> float:
+        """Prefer the broker's ACTUAL traded price over the local LTP for a live fill.
+
+        A paper fill has no broker price, so it keeps the LTP. A LIVE fill does have
+        one, and it is the only honest cost of the trade: the LTP cache can be stale,
+        and a stale mark writes a fiction into the position, the journal, the Sheet
+        and the coach's training data. On 2026-07-30 a cached LTP recorded a NIFTY
+        entry at 112.55 against a broker fill of 125.00, turning a Rs.760.50 loss into
+        a Rs.4,095 "profit".
+
+        Fail-soft by design: brokers that do not report a price return 0.0 and the
+        LTP is kept, so this can only ever improve accuracy, never block a trade.
+        """
+        broker_price = float(getattr(order_result, "average_fill_price", 0.0) or 0.0)
+        if broker_price <= 0 or not math.isfinite(broker_price):
+            return float(ltp_price)
+        if ltp_price > 0 and abs(broker_price - ltp_price) / ltp_price > 0.02:
+            # Not an error -- just the divergence that makes this fix necessary.
+            self.log.warning(
+                "Live fill price %.2f differs from the local LTP %.2f by %.1f%%; "
+                "recording the BROKER price.",
+                broker_price,
+                ltp_price,
+                abs(broker_price - ltp_price) / ltp_price * 100.0,
+            )
+        return broker_price
+
     def _get_option_ltp(self, segment: str, security_id: int, fallback: float) -> float:
         """
         Latest option LTP, with a 3-step preference:
@@ -6292,6 +6319,7 @@ class AtmSingleLegStrategyWorker(BasePaperStrategyWorker):
         self._untrack_orphan_live_leg(entry_leg)
         quantity = int(entry_leg["quantity"])
         exec_mode = self._exec_mode_tag(order_result)
+        option_ltp = self._entry_fill_price(order_result, option_ltp)
 
         # Keep the fetcher refreshing this option's LTP for the trade lifetime.
         self.store.register_option_subscription(

--- a/Signal Generators/SL Hunting AI Agent/premarket_note.json
+++ b/Signal Generators/SL Hunting AI Agent/premarket_note.json
@@ -1,30 +1,29 @@
 {
-  "for_date": "2026-07-29",
-  "source": "Intraday Hunter, 'Prediction For 29 JULY 2026' (video 3yhXRT6Sc5Y)",
-  "context": "27 Jul's gap-up was rejected and 28 Jul was rejected again, yet NIFTY and Sensex still closed holding above their own closing points - so BankNIFTY shows selling without real momentum and neither side is clearly trapped.",
+  "for_date": "2026-07-31",
+  "source": "Intraday Hunter, 'Prediction For 31 JULY 2026' (video B0mG5R2JsFs)",
+  "context": "Momentum is shrinking across all three indices. Buyers have come in over the last two-three days but the market has repeatedly changed their mindset, so the crowd is not cleanly seated; NIFTY's advance came with retracements.",
   "plan": [
-    "Neither side is clearly positioned and the confusion is deliberate; few traders are carrying a trade into today, so there is no obvious trapped crowd to hunt.",
-    "When nothing is readable, do what the market is ALREADY doing - it has spent two to three days trying to cover and hold itself up.",
-    "GAP-UP or GAP-DOWN open: the plan is the same either way - look for BUY-side setups and go with the market.",
-    "FLAT open: the same buy-side plan can apply, but ONLY if momentum is genuinely good; flat is the riskier case.",
-    "The named risk is a SIDEWAYS range building here - if the market stalls and ranges instead of moving, the problem gets big.",
-    "All three indices read alike: little momentum, price staying and working in the same area it has been in."
+    "FLAT or GAP-UP open: follow the existing momentum - identify BUY-side setups and go with the market.",
+    "SMALL GAP-DOWN open: no plan can be made for this case. Abstain and let the market show its hand rather than forcing a trade.",
+    "BIG GAP-DOWN open: the buyers who stayed seated are the ones in trouble - identify SELL-side setups targeting them.",
+    "The distinction that matters is the SIZE of the gap-down, not merely its direction: a small one strands nobody, a large one leaves the seated buyers exposed.",
+    "When momentum does come it can look like a breakout, pull buyers in, and then have their mindset changed again - treat a first thrust with suspicion."
   ],
   "levels": [
     {
       "index": "NIFTY",
-      "resistance": [24038, 24116],
-      "support": [23857, 23734]
+      "resistance": [24400, 24482],
+      "support": [24207, 24140]
     },
     {
       "index": "BANKNIFTY",
-      "resistance": [56930, 57126],
-      "support": [56430, 56076]
+      "resistance": [57258, 57684],
+      "support": [56856, 56533]
     },
     {
       "index": "SENSEX",
-      "resistance": [76966, 77201],
-      "support": [76441, 76102]
+      "resistance": [78207, 78505],
+      "support": [77500, 77201]
     }
   ]
 }

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_agent.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_agent.py
@@ -44,7 +44,11 @@ from pydantic import Field, ValidationError, field_validator, model_validator
 from sl_hunting_ai_validation import StrictAIModel
 from sl_hunting_executor import TradeExecutor
 from sl_hunting_indicators import SLHuntingIndicatorConfig, prepare_candles
-from sl_hunting_knowledge import FINAL_OUTPUT_INSTRUCTION, build_system_prompt
+from sl_hunting_knowledge import (
+    FINAL_OUTPUT_INSTRUCTION,
+    MAX_SYSTEM_PROMPT_CHARS,
+    build_system_prompt,
+)
 from sl_hunting_tools import SLHuntingToolContext, build_sl_hunting_mcp_server
 
 logger = logging.getLogger(__name__)
@@ -344,6 +348,10 @@ class SLHuntingAgent:
         self._system_prompt = (
             build_system_prompt() + learned + premarket + FINAL_OUTPUT_INSTRUCTION
         )
+        if len(self._system_prompt) > MAX_SYSTEM_PROMPT_CHARS:
+            raise ValueError(
+                f"SL Hunting system prompt exceeds {MAX_SYSTEM_PROMPT_CHARS} characters"
+            )
         # SLH-003: cache for the system-prompt temp FILE handed to the SDK by
         # `_default_run` (written once per unique text, reused every bar) — see
         # `_system_prompt_as_file` for why a string system prompt cannot be used.

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_coach.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_coach.py
@@ -221,6 +221,15 @@ def load_journal(path: str, since: str | None = None) -> list[dict[str, Any]]:
                 if not isinstance(row, dict):
                     rejected += 1
                     continue
+                outcome = row.get("outcome")
+                if (
+                    isinstance(outcome, dict)
+                    and outcome.get("pnl_evidence_eligible") is False
+                ):
+                    # Approximate P&L stays in the operational journal but must
+                    # never teach the reflection coach. Historical rows omit
+                    # this field and remain compatible.
+                    continue
                 try:
                     projected = _project_journal_row(row)
                 except (TypeError, ValidationError, ValueError):

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -1772,3 +1772,84 @@ no live order had ever filled. That was wrong - a bad log query, since fills are
 recorded on their own `REAL ORDER FILLED` lines rather than on the `ENTRY` line.
 There were 74 real fills between 22 and 28 Jul, all on the 2026-08-04 contract; the
 rejections began on 29 Jul when the ladder rolled and next-next became 2026-08-11.
+
+## Video addendum - 30 Jul seated-crowd-over-gap + session-character carry-over (v3v)
+
+**Source:** Intraday Hunter live session, 30 Jul 2026 (`LvA_VPLdm6Q`, 7:37).
+
+**IMPORTANT - distilled from the VIDEO ONLY.** Unlike v3t and v3u, the agent's own
+30 Jul book supplied no usable measurement, and deliberately none is quoted here:
+- the 09:18 LONG has NO journal row (its live exit was rejected, then the runner was
+  interrupted and restarted, so `after_exit` never fired);
+- the operator exited that position MANUALLY, so its NIFTY P&L is in no log;
+- market data was unhealthy 09:05-09:18, again 09:30-09:49, and again around 10:25,
+  with option LTPs stale by up to 287s;
+- the 10:14 trade recorded a NIFTY entry of 112.55 while the broker-confirmed fill
+  was 125.00, which fabricated a +Rs.4,095 leg profit out of a -Rs.760.50 loss. The
+  journal row was corrected by hand (basket 3636.0 -> -1219.5); journalled net for
+  the day is -Rs.8,072.50, not -Rs.3,217.00.
+
+The last point is a standing defect rather than a one-off: `broker_contract.py` has
+no fill-price field at all, so LIVE P&L is always computed from the local LTP and
+never from the broker's actual fill.
+
+**What IH did:** open was almost FLAT to slightly GAP-DOWN, with Sensex and NIFTY
+mildly positive but BankNIFTY already selling. He bought PUTS across all three within
+minutes of the open (BNF 1170, Sensex 900, NIFTY), then booked on the first real
+momentum leg.
+
+His reasoning, close to verbatim:
+- "For two-three days the market had very good positive momentum, and today we are
+  directly selling, just minutes after the open... because of what happened over
+  those days, BUYERS are seated, and to target those buyers we are selling here."
+- "Even if it had opened slightly GAP-UP we would still have targeted the buyers.
+  Now we got a gap-down, and we are still targeting the buyers."
+- On booking: "It is not that they will just keep going down. They could still go
+  SIDEWAYS... **yesterday we did not make much profit, we took a small profit and
+  left, because yesterday too it looked sideways at the start.** So today it could
+  also happen that momentum comes and then the market stays sideways. So booking the
+  target was very necessary."
+- Also present, and already covered by existing rules: a pre-set loss limit
+  ("we will see what our limit is and handle the trade accordingly"), and expiry as
+  a trap-context caveat (Sensex expiry that day).
+
+**Net-new method distilled:**
+- A SMALL GAP DOES NOT RESCUE A SEATED CROWD. RECRUITMENT HISTORY already said that
+  on a gap-up the seated buyers "are already in profit and cannot be targeted, so go
+  WITH the market". IH's session qualifies that: the escape hatch needs a gap large
+  enough to genuinely release them. Judge the gap against the SIZE OF THE RUN that
+  recruited the crowd, not against zero; a few tens of points does not free buyers
+  seated over several days. Stated consequence: when a multi-day run has seated an
+  identifiable crowd, the OPEN direction does not pick your side - the trapped crowd
+  does, and flat / slightly-gap-down / slightly-gap-up can be the same trade.
+  Deliberately written as a sub-bullet INSIDE RECRUITMENT HISTORY, with a test
+  pinning it there, because read alone it would contradict the branch it qualifies.
+- YESTERDAY'S MOMENTUM CHARACTER CALIBRATES TODAY'S PATIENCE. How far a move RUNS
+  carries over between sessions, separately from direction. If the previous session
+  gave an early move then went sideways, plan for the same shape today and take the
+  momentum when it arrives. A direction that is working is not a promise that it
+  keeps working - a market can be selling all day and still chop for hours inside
+  that. Explicitly separated from PREVIOUS-CHART LINKAGE (who was recruited) and
+  RECRUITMENT HISTORY (which way to trade): this one governs only HOW LONG to hold,
+  and it tightens the target rather than loosening it.
+
+**Considered and deliberately NOT encoded:** IH said he expected to "take some loss
+in NIFTY and Sensex" while BankNIFTY carried the thesis. A "a red leg is not by
+itself premise-invalidation" rule would sit uncomfortably close to LAGGARDS NEVER
+JOINED (v3s), which tells the agent to BOOK when the leader is spent and the
+laggards never broke. Rather than risk muddling a rule that already governs the
+per-leg `exit_leg` decision, this is left out pending a session that separates the
+two cleanly.
+
+**Confirmed but already present:** pre-computing the loss limit before entry is v3t's
+PRE-COMPUTE BOTH NUMBERS; expiry-as-trap-context is EXPIRY IS CONTEXT, NOT A PREMISE;
+booking into an early move with no fuel behind it is v3u's NO NEARBY STOPS -> NORMAL
+TARGET.
+
+**Knowledge changes (v3v, all prose):**
+- `RETAIL_POSITIONING`: A SMALL GAP DOES NOT RESCUE A SEATED CROWD, as a sub-bullet
+  of RECRUITMENT HISTORY.
+- `RISK`: YESTERDAY'S MOMENTUM CHARACTER CALIBRATES TODAY'S PATIENCE, beside the
+  other booking rules.
+- Test markers: `test_system_prompt_has_v3v_small_gap_and_carryover_knowledge` and
+  `test_v3v_small_gap_rule_sits_inside_recruitment_history`.

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_executor.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_executor.py
@@ -60,6 +60,16 @@ VALID_DIRECTIONS = ("LONG", "SHORT")
 # does NOT choose the lot count — it is computed so the worst-case underlying-points
 # loss never exceeds this budget, exactly like the repo's Profit Shooter sizer.
 DEFAULT_RISK_BUDGET = 2500.0
+MAX_ORDER_REASON_CHARS = 120
+
+
+def _single_line_reason(value: object, fallback: str = "") -> str:
+    """Normalize an already-approved reason for logs and journal snapshots."""
+
+    cleaned = " ".join(
+        "".join(char if char.isprintable() else " " for char in str(value or "")).split()
+    )
+    return cleaned[:MAX_ORDER_REASON_CHARS] or fallback
 
 
 def risk_based_lots(
@@ -222,7 +232,7 @@ class StandaloneExecutor:
             stop=round(float(stop), 2),
             target=round(float(target), 2),
             entry_time=datetime.now().isoformat(timespec="seconds"),
-            reason=str(reason)[:300],
+            reason=_single_line_reason(reason),
             lots=lots,
         )
         return {
@@ -259,7 +269,7 @@ class StandaloneExecutor:
             "pnl_proxy": pnl,
             "entry_time": self.pos.entry_time,
             "exit_time": datetime.now().isoformat(timespec="seconds"),
-            "exit_reason": str(reason)[:300],
+            "exit_reason": _single_line_reason(reason, "AI_EXIT"),
         }
         self.closed_trades.append(trade)
         self.pos = _PaperPosition()
@@ -384,7 +394,7 @@ class MasterWorkerExecutor:
         # this ENTER has already fired. reason is dropped from enter_position (the safe
         # path takes only levels); this is the one place it survives for journaling.
         self.last_entry_order = {
-            "action": f"ENTER_{direction}", "reason": str(reason)[:300],
+            "action": f"ENTER_{direction}", "reason": _single_line_reason(reason),
             "stop": round(float(stop), 2), "target": round(float(target), 2),
         }
         return {
@@ -404,7 +414,7 @@ class MasterWorkerExecutor:
         closes both. Falls back gracefully when the worker has no mirror hooks.
         """
         leg = (leg or "BOTH").strip().upper()
-        reason_s = str(reason)[:300] or "AI_EXIT"
+        reason_s = _single_line_reason(reason, "AI_EXIT")
         pos = getattr(self._w, "pos", None)
         nifty_active = pos is not None and getattr(pos, "active", False)
         mirror = getattr(self._w, "_mirror_pos", None)

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_executor.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_executor.py
@@ -60,7 +60,16 @@ VALID_DIRECTIONS = ("LONG", "SHORT")
 # does NOT choose the lot count — it is computed so the worst-case underlying-points
 # loss never exceeds this budget, exactly like the repo's Profit Shooter sizer.
 DEFAULT_RISK_BUDGET = 2500.0
-MAX_ORDER_REASON_CHARS = 120
+
+# THE single bound on a model-written order reason. `sl_hunting_tools` imports this
+# rather than declaring its own, because two independent caps on the same string
+# drift apart and then silently disagree about what was recorded.
+#
+# 300 matches the width the journal keeps. Measured on the shipped journal the model
+# writes a median of 300 characters, so a tighter cap would amputate the sentence the
+# reflection coach later reads -- and, when it was enforced by REJECTING the order,
+# would have bounced 38 of 39 real entry reasons into a retry inside a 1-minute bar.
+MAX_ORDER_REASON_CHARS = 300
 
 
 def _single_line_reason(value: object, fallback: str = "") -> str:

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_journal.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_journal.py
@@ -91,10 +91,11 @@ def make_entry_record(
     nifty_df: pd.DataFrame,
     bnf_df: pd.DataFrame | None = None,
     cfg: SLHuntingIndicatorConfig | None = None,
+    entry_price_quality: str | None = None,
 ) -> dict[str, Any]:
     """Assemble the ENTRY half of a journal row (shared by worker + runner)."""
     ctx = build_entry_context(nifty_df, bnf_df, cfg)
-    return {
+    record = {
         "direction": direction,
         "setup": setup,
         "confidence": confidence,
@@ -106,6 +107,9 @@ def make_entry_record(
         "context": ctx,
         "followed_method": followed_method(ctx, direction),
     }
+    if entry_price_quality is not None:
+        record["entry_price_quality"] = str(entry_price_quality)
+    return record
 
 
 def resolve_entry_narrative(

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
@@ -241,6 +241,17 @@ retail's stop-losses sit so you can trade where the operator will hunt them.
   forward just because today's chart "looks the same"; re-derive who was recruited.
   (This is the principle underneath the two-day AVERAGING TRAP trigger above, which is
   its gap-down-specific case.)
+  * A SMALL GAP DOES NOT RESCUE A SEATED CROWD. The "on a gap-up they are already in
+    profit and cannot be targeted" branch above needs a gap BIG enough to genuinely
+    put the seated crowd in profit and move their stops out of play. After a
+    multi-day with-trend run, a SLIGHT gap in their favour changes nothing: those
+    buyers were seated over days, a few tens of points does not release them, and
+    they remain the target. Judge the gap against the SIZE OF THE RUN that recruited
+    them, not against zero — and cross-check with the SL-REACHABILITY TEST, which is
+    the question this is really asking. Consequence worth stating plainly: when a
+    multi-day run has seated an identifiable crowd, the OPEN direction does not
+    decide your side — the trapped crowd does. Flat, slightly-gap-down and
+    slightly-gap-up can all be the SAME trade.
 - WEEKEND / HOLIDAY CARRY-RISK: before a Friday close, weekend, or multi-day market
   holiday, large retail inventory may be absent or reduced because traders avoid
   overnight/news risk. Do not hunt a crowd that likely exited or never entered; use
@@ -632,6 +643,16 @@ RISK DISCIPLINE
   sit (the long-wicked candle / opposite side of the first candle / the trapped
   crowd's stops). If the nearest opposing level is too close, the target is too
   small — HOLD.
+- YESTERDAY'S MOMENTUM CHARACTER CALIBRATES TODAY'S PATIENCE: how far a move RUNS
+  tends to carry over between sessions, separately from its direction. If the
+  previous session gave an early move and then spent the rest of the day sideways,
+  plan for the same SHAPE today — take the momentum when it arrives instead of
+  holding for the extended leg, because the realistic alternative to "more move" is
+  not a bigger win, it is chop. A direction that is working is NOT a promise that it
+  keeps working: a market can be selling all day and still go sideways for hours
+  inside that. This is distinct from PREVIOUS-CHART LINKAGE (which asks WHO was
+  recruited) and RECRUITMENT HISTORY (which asks WHICH WAY to trade) — this one asks
+  only HOW LONG to hold, and it tightens rather than loosens the target.
 - NO NEARBY STOPS → NORMAL TARGET, AND SAY SO BEFORE YOU ENTER: sometimes you are
   FOLLOWING the market (nobody clearly trapped, so the with-trend continuation is
   the trade) rather than HUNTING a named crowd. In that case there is no stop

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
@@ -1083,6 +1083,8 @@ keys:
 
 Emit ONLY this JSON object as your final answer."""
 
+MAX_SYSTEM_PROMPT_CHARS = 75_000
+
 
 def build_system_prompt() -> str:
     """Compose the full SL-Hunting system prompt from the sections above.
@@ -1109,4 +1111,9 @@ def build_system_prompt() -> str:
         DECISION_RULES,
     ]
     # A blank line between sections keeps the prompt readable for the model.
-    return "\n\n".join(section.strip() for section in sections)
+    prompt = "\n\n".join(section.strip() for section in sections)
+    if len(prompt) > MAX_SYSTEM_PROMPT_CHARS:
+        raise ValueError(
+            f"SL Hunting system prompt exceeds {MAX_SYSTEM_PROMPT_CHARS} characters"
+        )
+    return prompt

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_lessons.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_lessons.py
@@ -27,6 +27,7 @@ from pydantic import Field, ValidationError, field_validator, model_validator
 from sl_hunting_ai_validation import StrictAIModel
 
 logger = logging.getLogger(__name__)
+MAX_LESSONS_FILE_CHARS = 256 * 1024
 
 # Cap how many APPROVED lessons are injected into the prompt (keep it bounded).
 MAX_LIVE_LESSONS = 12
@@ -289,7 +290,15 @@ def load_lessons(path: str) -> list[dict[str, Any]]:
         return []
     try:
         with open(path, encoding="utf-8") as f:
-            data = json.load(f)
+            raw = f.read(MAX_LESSONS_FILE_CHARS + 1)
+        if len(raw) > MAX_LESSONS_FILE_CHARS:
+            logger.warning(
+                "Lessons file %s exceeds the %d-character input limit; ignoring it.",
+                path,
+                MAX_LESSONS_FILE_CHARS,
+            )
+            return []
+        data = json.loads(raw)
         if not isinstance(data, list):
             logger.warning("Lessons file %s must contain a JSON list; ignoring it.", path)
             return []

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_premarket.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_premarket.py
@@ -43,6 +43,7 @@ from pydantic import Field, ValidationError, field_validator
 from sl_hunting_ai_validation import StrictAIModel
 
 logger = logging.getLogger(__name__)
+MAX_PREMARKET_FILE_CHARS = 64 * 1024
 
 # Keep the injected block small and predictable.
 MAX_PLAN_ITEMS = 8
@@ -147,7 +148,15 @@ def load_premarket_note(path: str) -> PremarketNote | None:
         return None
     try:
         with open(path, encoding="utf-8") as handle:
-            data = json.load(handle)
+            raw = handle.read(MAX_PREMARKET_FILE_CHARS + 1)
+        if len(raw) > MAX_PREMARKET_FILE_CHARS:
+            logger.warning(
+                "Pre-open note %s exceeds the %d-character input limit; ignoring it.",
+                path,
+                MAX_PREMARKET_FILE_CHARS,
+            )
+            return None
+        data = json.loads(raw)
     except (OSError, UnicodeError, json.JSONDecodeError):
         logger.warning("Could not read pre-open note %s", path, exc_info=True)
         return None

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_tools.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_tools.py
@@ -94,6 +94,7 @@ def _entry_levels_error(direction: str, stop: float, target: float, price: float
 # blemish. Four of the first 46 journal rows recorded "placeholder" (or "placeholder
 # - will not call, holding") as the permanent reason for a real trade.
 MIN_REASON_CHARS = 12
+MAX_REASON_CHARS = 120
 _PLACEHOLDER_REASONS = frozenset(
     {"placeholder", "n/a", "na", "tbd", "none", "-", "test", "todo", "reason", "exit", "entry"}
 )
@@ -119,7 +120,8 @@ def order_tool_description(venue: str) -> str:
         "trade journal, the log and the operator's alert, and it is what the reflection "
         "coach reads later to work out what worked. The reasoning in your final JSON is "
         "NOT saved there, so this is your only chance to say why you acted. Give a real "
-        "one-line justification naming the setup and the trigger -- a placeholder or an "
+        f"one-line justification of at most {MAX_REASON_CHARS} printable characters naming "
+        "the setup and the trigger -- a placeholder or an "
         "empty string is REJECTED on entries, and on an exit it is replaced by a sentinel "
         "recording that you supplied nothing. exit_leg (EXIT only) is NIFTY, BNF or BOTH "
         "(default BOTH): every NIFTY entry is mirrored by an equal-lot BankNIFTY ATM leg, "
@@ -140,7 +142,33 @@ def _reason_problem(reason: str) -> str | None:
         return f"{cleaned!r} is a placeholder, not a justification"
     if len(cleaned) < MIN_REASON_CHARS:
         return f"reason is too short to be a justification (min {MIN_REASON_CHARS} characters)"
+    if len(cleaned) > MAX_REASON_CHARS:
+        return f"reason must be at most {MAX_REASON_CHARS} characters"
+    if any(not char.isprintable() for char in cleaned):
+        return "reason must be one printable line"
     return None
+
+
+def _safe_exit_reason(reason: str) -> str:
+    """Return a bounded printable exit record without ever blocking the exit."""
+
+    if _reason_problem(reason) is None:
+        return str(reason).strip()
+    raw = str(reason or "")
+    cleaned = " ".join(
+        "".join(
+            char if char.isprintable() else " "
+            for char in raw
+        ).split()
+    )[:MAX_REASON_CHARS].strip()
+    if (
+        not cleaned
+        or cleaned.lower().rstrip(".") in _PLACEHOLDER_REASONS
+        or cleaned.lower().startswith("placeholder")
+        or len(cleaned) < MIN_REASON_CHARS
+    ):
+        return NO_REASON_SENTINEL
+    return cleaned
 
 # Read-only context tools are always present; the action tool's name is decided at
 # build time by the environment, so it is appended in `build_sl_hunting_mcp_server`.
@@ -368,7 +396,7 @@ class SLHuntingToolContext:
             # strand an open position -- the one thing the risk rules forbid. Record an
             # explicit sentinel instead, so the journal and the coach are told plainly
             # that no justification was given rather than being handed a lie.
-            exit_reason = NO_REASON_SENTINEL if _reason_problem(reason) else str(reason).strip()
+            exit_reason = _safe_exit_reason(reason)
             def executor_call() -> dict[str, Any]:
                 return self.executor.exit(exit_reason, self.last_price, leg=leg)
         else:

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_tools.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_tools.py
@@ -40,7 +40,11 @@ from enum import StrEnum
 from typing import Any
 
 import pandas as pd
-from sl_hunting_executor import TradeExecutor, execution_tool_name
+from sl_hunting_executor import (
+    MAX_ORDER_REASON_CHARS,
+    TradeExecutor,
+    execution_tool_name,
+)
 from sl_hunting_indicators import (
     SLHuntingIndicatorConfig,
     candle_patterns,
@@ -94,7 +98,10 @@ def _entry_levels_error(direction: str, stop: float, target: float, price: float
 # blemish. Four of the first 46 journal rows recorded "placeholder" (or "placeholder
 # - will not call, holding") as the permanent reason for a real trade.
 MIN_REASON_CHARS = 12
-MAX_REASON_CHARS = 120
+# One bound, defined next to the executor that ultimately records the string.
+# Importing it (rather than repeating the number) keeps the tool's trimming and the
+# executor's trimming from ever disagreeing about what was written down.
+MAX_REASON_CHARS = MAX_ORDER_REASON_CHARS
 _PLACEHOLDER_REASONS = frozenset(
     {"placeholder", "n/a", "na", "tbd", "none", "-", "test", "todo", "reason", "exit", "entry"}
 )
@@ -120,10 +127,11 @@ def order_tool_description(venue: str) -> str:
         "trade journal, the log and the operator's alert, and it is what the reflection "
         "coach reads later to work out what worked. The reasoning in your final JSON is "
         "NOT saved there, so this is your only chance to say why you acted. Give a real "
-        f"one-line justification of at most {MAX_REASON_CHARS} printable characters naming "
-        "the setup and the trigger -- a placeholder or an "
-        "empty string is REJECTED on entries, and on an exit it is replaced by a sentinel "
-        "recording that you supplied nothing. exit_leg (EXIT only) is NIFTY, BNF or BOTH "
+        f"one-line justification naming the setup and the trigger; it is trimmed to "
+        f"{MAX_REASON_CHARS} printable characters, so put the point FIRST. A placeholder "
+        "or an empty string is REJECTED on entries (resend a real one), and on an exit it "
+        "is replaced by a sentinel recording that you supplied nothing. "
+        "exit_leg (EXIT only) is NIFTY, BNF or BOTH "
         "(default BOTH): every NIFTY entry is mirrored by an equal-lot BankNIFTY ATM leg, "
         "and you may cut ONE leg on premise-invalidation while the other runs — but hard "
         "risk (stop/target/max-loss/square-off) always closes both. Returns whether "
@@ -131,9 +139,30 @@ def order_tool_description(venue: str) -> str:
     )
 
 
-def _reason_problem(reason: str) -> str | None:
-    """Explain why this justification is unusable as a permanent record, else None."""
-    cleaned = str(reason or "").strip()
+def _printable_one_line(reason: str) -> str:
+    """Collapse any input to one printable, whitespace-normalised line.
+
+    Control characters become spaces rather than surviving into the journal, the
+    log or an operator's Telegram alert, where they could reflow or colour text.
+    """
+
+    raw = "".join(char if char.isprintable() else " " for char in str(reason or ""))
+    return " ".join(raw.split())
+
+
+def _reason_meaning_problem(reason: str) -> str | None:
+    """Explain why this justification says NOTHING, else None.
+
+    Deliberately separate from length. A blank, placeholder or two-word reason is
+    a defect the model must FIX, so entries are rejected and it gets to retry
+    within the same pass. Being verbose is not a defect of meaning -- it is
+    trimmed (see `bounded_reason`), never bounced. Measured on the shipped
+    journal, 38 of 39 model-written reasons ran past 120 characters, so rejecting
+    on length would have cost an extra SDK round-trip on essentially every entry
+    inside a one-minute bar.
+    """
+
+    cleaned = _printable_one_line(reason)
     if not cleaned:
         return "reason must not be blank"
     if cleaned.lower().rstrip(".") in _PLACEHOLDER_REASONS:
@@ -142,6 +171,27 @@ def _reason_problem(reason: str) -> str | None:
         return f"{cleaned!r} is a placeholder, not a justification"
     if len(cleaned) < MIN_REASON_CHARS:
         return f"reason is too short to be a justification (min {MIN_REASON_CHARS} characters)"
+    return None
+
+
+def bounded_reason(reason: str) -> str:
+    """The exact string that will be recorded: printable, one line, length-capped."""
+
+    return _printable_one_line(reason)[:MAX_REASON_CHARS].strip()
+
+
+def _reason_problem(reason: str) -> str | None:
+    """Every way a reason can be unusable, including length.
+
+    Retained for callers that want the strict question ("is this string already
+    fit to record verbatim?"). The order path does NOT gate entries on this --
+    see `_reason_meaning_problem`.
+    """
+
+    meaning = _reason_meaning_problem(reason)
+    if meaning is not None:
+        return meaning
+    cleaned = str(reason or "").strip()
     if len(cleaned) > MAX_REASON_CHARS:
         return f"reason must be at most {MAX_REASON_CHARS} characters"
     if any(not char.isprintable() for char in cleaned):
@@ -152,21 +202,8 @@ def _reason_problem(reason: str) -> str | None:
 def _safe_exit_reason(reason: str) -> str:
     """Return a bounded printable exit record without ever blocking the exit."""
 
-    if _reason_problem(reason) is None:
-        return str(reason).strip()
-    raw = str(reason or "")
-    cleaned = " ".join(
-        "".join(
-            char if char.isprintable() else " "
-            for char in raw
-        ).split()
-    )[:MAX_REASON_CHARS].strip()
-    if (
-        not cleaned
-        or cleaned.lower().rstrip(".") in _PLACEHOLDER_REASONS
-        or cleaned.lower().startswith("placeholder")
-        or len(cleaned) < MIN_REASON_CHARS
-    ):
+    cleaned = bounded_reason(reason)
+    if _reason_meaning_problem(cleaned) is not None:
         return NO_REASON_SENTINEL
     return cleaned
 
@@ -375,8 +412,11 @@ class SLHuntingToolContext:
                 return {"accepted": False, "reason": f"invalid entry levels: {problem}"}
             # SLH-007: an ENTRY may be refused so the model rewrites its justification
             # within the same pass -- exactly how the levels check above works. Nothing
-            # is at risk yet, because no position exists.
-            reason_problem = _reason_problem(reason)
+            # is at risk yet, because no position exists. Only MEANING is grounds for
+            # refusal; an over-long or non-printable reason is trimmed rather than
+            # bounced, because bouncing it would cost an SDK round-trip on nearly
+            # every entry without protecting anything.
+            reason_problem = _reason_meaning_problem(reason)
             if reason_problem:
                 return {
                     "accepted": False,
@@ -386,8 +426,11 @@ class SLHuntingToolContext:
                         "with a one-line justification naming the setup and why you are acting."
                     ),
                 }
+            entry_reason = bounded_reason(reason)
             def executor_call() -> dict[str, Any]:
-                return self.executor.enter(direction, stop, target, reason, self.last_price)
+                return self.executor.enter(
+                    direction, stop, target, entry_reason, self.last_price
+                )
         elif action == "EXIT":
             leg = (exit_leg or "BOTH").strip().upper()
             if leg not in ("NIFTY", "BNF", "BOTH"):

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_agent.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_agent.py
@@ -618,14 +618,24 @@ def test_do_order_rejects_placeholder_reason_on_entry():
     assert ex.snapshot()["in_position"] is True
 
 
-def test_do_order_rejects_multiline_control_or_oversized_entry_reasons():
+def test_do_order_sanitises_rather_than_rejects_verbose_entry_reasons():
+    """Length and control characters are TRIMMED on entry, never bounced.
+
+    Rejecting on length would cost an SDK round-trip inside a one-minute bar on
+    essentially every trade: measured on the shipped journal, 38 of 39
+    model-written reasons run past 120 characters (median 300). Only a reason
+    that says NOTHING is grounds for refusal -- see the placeholder test below.
+    """
+    from sl_hunting_tools import MAX_REASON_CHARS
+
     ex = StandaloneExecutor()
     price = SLHuntingToolContext.build(_candles(), ex).last_price
-    for reason in (
-        "pivot bounce\nwith confirmation",
-        "pivot bounce\twith confirmation",
-        "x" * 121,
+    for reason, expected in (
+        ("pivot bounce\nwith confirmation", "pivot bounce with confirmation"),
+        ("pivot bounce\twith confirmation", "pivot bounce with confirmation"),
+        ("x" * (MAX_REASON_CHARS + 50), "x" * MAX_REASON_CHARS),
     ):
+        ex = StandaloneExecutor()
         ctx = SLHuntingToolContext.build(_candles(), ex)
         result = ctx.do_order(
             "ENTER_LONG",
@@ -633,8 +643,27 @@ def test_do_order_rejects_multiline_control_or_oversized_entry_reasons():
             target=price + 60,
             reason=reason,
         )
-        assert result["accepted"] is False
-    assert ex.snapshot()["in_position"] is False
+        assert result["accepted"] is True, reason
+        # What was RECORDED is the sanitised one-liner, not the raw input.
+        assert ex.pos.reason == expected
+
+
+def test_a_realistic_model_reason_is_accepted_unchanged():
+    """Regression guard for the 120-char cap that would have bounced real traffic."""
+    ex = StandaloneExecutor()
+    ctx = SLHuntingToolContext.build(_candles(), ex)
+    price = ctx.last_price
+    realistic = (
+        "NIFTY formed a double top at ~24039 after the opening gap-fill spike, with a "
+        "confirmed shooting star trapping breakout buyers; price then failed to reclaim "
+        "the 50% fibo and is rolling over, with BankNIFTY corroborating below its pivot."
+    )
+    assert len(realistic) > 120
+    result = ctx.do_order(
+        "ENTER_LONG", stop=price - 30, target=price + 60, reason=realistic
+    )
+    assert result["accepted"] is True
+    assert ex.pos.reason == realistic
 
 
 def test_do_order_never_rejects_an_exit_for_a_bad_reason():
@@ -681,7 +710,9 @@ def test_do_order_sanitizes_and_truncates_exit_reason_without_blocking():
         reason="pivot bounce with confirmation",
     )["accepted"] is True
 
-    raw = "Premise failed\n" + ("x" * 200)
+    from sl_hunting_tools import MAX_REASON_CHARS
+
+    raw = "Premise failed\n" + ("x" * (MAX_REASON_CHARS + 100))
     result = SLHuntingToolContext.build(_candles(), ex).do_order(
         "EXIT", stop=0.0, target=0.0, reason=raw
     )
@@ -689,7 +720,19 @@ def test_do_order_sanitizes_and_truncates_exit_reason_without_blocking():
     assert result["accepted"] is True
     recorded = ex.closed_trades[-1]["exit_reason"]
     assert "\n" not in recorded
-    assert len(recorded) == 120
+    assert len(recorded) == MAX_REASON_CHARS
+
+
+def test_reason_bound_has_exactly_one_definition():
+    """The tool and the executor must never disagree about what was recorded.
+
+    They trim the same string in two places; if the two caps drift, the tool
+    reports one width while the journal keeps another.
+    """
+    from sl_hunting_executor import MAX_ORDER_REASON_CHARS
+    from sl_hunting_tools import MAX_REASON_CHARS
+
+    assert MAX_REASON_CHARS is MAX_ORDER_REASON_CHARS
 
 
 def test_order_tool_description_tells_the_model_the_reason_is_permanent():

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_agent.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_agent.py
@@ -618,6 +618,25 @@ def test_do_order_rejects_placeholder_reason_on_entry():
     assert ex.snapshot()["in_position"] is True
 
 
+def test_do_order_rejects_multiline_control_or_oversized_entry_reasons():
+    ex = StandaloneExecutor()
+    price = SLHuntingToolContext.build(_candles(), ex).last_price
+    for reason in (
+        "pivot bounce\nwith confirmation",
+        "pivot bounce\twith confirmation",
+        "x" * 121,
+    ):
+        ctx = SLHuntingToolContext.build(_candles(), ex)
+        result = ctx.do_order(
+            "ENTER_LONG",
+            stop=price - 30,
+            target=price + 60,
+            reason=reason,
+        )
+        assert result["accepted"] is False
+    assert ex.snapshot()["in_position"] is False
+
+
 def test_do_order_never_rejects_an_exit_for_a_bad_reason():
     """An exit must always be available -- blocking it would strand a position."""
     ex = StandaloneExecutor()
@@ -644,14 +663,33 @@ def test_do_order_preserves_a_real_exit_reason_verbatim():
     ctx = SLHuntingToolContext.build(_candles(), ex)
     price = ctx.last_price
     ctx.do_order("ENTER_LONG", stop=price - 30, target=price + 60, reason="pivot bounce confirmed")
-    real = (
-        "Long thesis stalling: price failed repeatedly to exceed the swing high and "
-        "market_structure flipped to a downtrend; booking before the give-back."
-    )
+    real = "Long thesis stalled below the swing high; market structure flipped down."
     exit_ctx = SLHuntingToolContext.build(_candles(), ex)
     out = exit_ctx.do_order("EXIT", stop=0.0, target=0.0, reason=real)
     assert out["accepted"] is True
     assert ex.closed_trades[-1]["exit_reason"] == real
+
+
+def test_do_order_sanitizes_and_truncates_exit_reason_without_blocking():
+    ex = StandaloneExecutor()
+    ctx = SLHuntingToolContext.build(_candles(), ex)
+    price = ctx.last_price
+    assert ctx.do_order(
+        "ENTER_LONG",
+        stop=price - 30,
+        target=price + 60,
+        reason="pivot bounce with confirmation",
+    )["accepted"] is True
+
+    raw = "Premise failed\n" + ("x" * 200)
+    result = SLHuntingToolContext.build(_candles(), ex).do_order(
+        "EXIT", stop=0.0, target=0.0, reason=raw
+    )
+
+    assert result["accepted"] is True
+    recorded = ex.closed_trades[-1]["exit_reason"]
+    assert "\n" not in recorded
+    assert len(recorded) == 120
 
 
 def test_order_tool_description_tells_the_model_the_reason_is_permanent():

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_journal.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_journal.py
@@ -77,10 +77,12 @@ def test_build_entry_context_and_make_record():
     rec = make_entry_record(
         direction="LONG", setup="s", confidence=6, stop=24985, target=25060,
         reasoning="r", entry_underlying=25000, lots=2, nifty_df=df, bnf_df=None,
+        entry_price_quality="PAPER_FRESH_MARK",
     )
     assert rec["direction"] == "LONG" and rec["lots"] == 2
     assert "context" in rec and "followed_method" in rec
     assert rec["stop"] == 24985.0 and rec["target"] == 25060.0
+    assert rec["entry_price_quality"] == "PAPER_FRESH_MARK"
 
 
 def test_timeout_entry_journals_order_reason_not_placeholder(tmp_path):

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_lessons.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_lessons.py
@@ -18,6 +18,7 @@ from sl_hunting_coach import (
     summarize_journal,
 )
 from sl_hunting_lessons import (
+    MAX_LESSONS_FILE_CHARS,
     ProposedLesson,
     add_proposed,
     consolidate,
@@ -102,6 +103,12 @@ def test_malformed_stored_lesson_is_rejected(tmp_path):
     path = tmp_path / "lessons.json"
     path.write_text(json.dumps([{"id": "looks-valid", "status": "approved"}]), encoding="utf-8")
 
+    assert load_lessons(str(path)) == []
+
+
+def test_oversized_lessons_file_is_rejected_before_json_parsing(tmp_path):
+    path = tmp_path / "lessons.json"
+    path.write_text(" " * (MAX_LESSONS_FILE_CHARS + 1), encoding="utf-8")
     assert load_lessons(str(path)) == []
 
 
@@ -252,6 +259,33 @@ def test_load_journal_rejects_invalid_or_oversized_rows(tmp_path):
 
     assert len(rows) == 1
     assert rows[0]["setup"] == "pivot"
+
+
+def test_load_journal_skips_explicitly_ineligible_pnl_but_keeps_historical_rows(
+    tmp_path,
+):
+    historical = {
+        "opened_at": "2026-06-26T10:15:00",
+        "direction": "LONG",
+        "setup": "pivot",
+        "confidence": 7,
+        "context": {"cross_index": {"bias": "up"}},
+        "followed_method": True,
+        "outcome": {"points": 30.0, "exit_reason": "target", "r_multiple": 2.0},
+    }
+    approximate = json.loads(json.dumps(historical))
+    approximate["opened_at"] = "2026-06-27T10:15:00"
+    approximate["outcome"]["pnl_evidence_eligible"] = False
+    path = tmp_path / "journal.jsonl"
+    path.write_text(
+        json.dumps(historical) + "\n" + json.dumps(approximate) + "\n",
+        encoding="utf-8",
+    )
+
+    rows = load_journal(str(path))
+
+    assert len(rows) == 1
+    assert rows[0]["opened_at"] == historical["opened_at"]
 
 
 # --------------------------------------------------------------------------

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_premarket.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_premarket.py
@@ -11,6 +11,7 @@ import json
 from datetime import date
 
 from sl_hunting_premarket import (
+    MAX_PREMARKET_FILE_CHARS,
     PremarketNote,
     format_premarket_note,
     load_premarket_block,
@@ -141,6 +142,12 @@ def test_load_malformed_json_returns_none(tmp_path):
 def test_load_non_object_returns_none(tmp_path):
     path = tmp_path / "premarket_note.json"
     path.write_text("[1, 2, 3]", encoding="utf-8")
+    assert load_premarket_note(str(path)) is None
+
+
+def test_load_oversized_note_is_rejected_before_json_parsing(tmp_path):
+    path = tmp_path / "premarket_note.json"
+    path.write_text(" " * (MAX_PREMARKET_FILE_CHARS + 1), encoding="utf-8")
     assert load_premarket_note(str(path)) is None
 
 

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
@@ -4,7 +4,16 @@ from __future__ import annotations
 
 import pytest
 from sl_hunting_agent import SLHuntingDecision
-from sl_hunting_knowledge import FINAL_OUTPUT_INSTRUCTION, build_system_prompt
+from sl_hunting_knowledge import (
+    FINAL_OUTPUT_INSTRUCTION,
+    MAX_SYSTEM_PROMPT_CHARS,
+    build_system_prompt,
+)
+
+
+def test_system_prompt_stays_inside_regression_budget():
+    prompt = build_system_prompt() + FINAL_OUTPUT_INSTRUCTION
+    assert len(prompt) <= MAX_SYSTEM_PROMPT_CHARS
 
 
 def _valid_payload(**overrides):

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
@@ -484,6 +484,45 @@ def test_system_prompt_has_v3u_gap_size_and_no_fuel_knowledge():
     assert "pays the round-trip cost for no exposure" in prompt
 
 
+def test_system_prompt_has_v3v_small_gap_and_carryover_knowledge():
+    """v3v: 30 Jul — after 2-3 positive days IH sold puts minutes after a flat /
+    slightly-gap-down open, and said he would have targeted the SAME seated buyers
+    even on a slight gap-up. He then booked early, citing yesterday's session going
+    sideways after its opening move.
+
+    Distilled from the VIDEO only: the agent's own 30 Jul book is unusable (an
+    unjournalled trade, a manual intervention, repeated market-data outages, and a
+    stale entry LTP that overstated one trade by ~Rs.4,855).
+    """
+    prompt = build_system_prompt()
+    # The gap-up escape hatch needs a gap proportional to the run that seated them.
+    assert "A SMALL GAP DOES NOT RESCUE A SEATED CROWD" in prompt
+    assert "against the SIZE OF THE RUN" in prompt
+    # The plain consequence: the crowd picks the side, not the open.
+    assert "the OPEN direction does not" in prompt
+    assert "the trapped crowd does" in prompt
+    # Session character carries over and TIGHTENS the target.
+    assert "YESTERDAY'S MOMENTUM CHARACTER CALIBRATES TODAY'S PATIENCE" in prompt
+    assert "it is chop" in prompt
+    # It must not be confused with the two existing previous-session rules.
+    assert "which asks WHO was" in prompt and "which asks WHICH WAY" in prompt
+
+
+def test_v3v_small_gap_rule_sits_inside_recruitment_history():
+    """The refinement must stay attached to the rule it qualifies.
+
+    Read alone it would contradict the gap-up branch ("already in profit and cannot
+    be targeted"); it only makes sense as a size qualifier on that same branch.
+    """
+    prompt = build_system_prompt()
+    start = prompt.index("RECRUITMENT HISTORY")
+    small_gap = prompt.index("A SMALL GAP DOES NOT RESCUE A SEATED CROWD")
+    assert small_gap > start
+    # ...and before the NEXT top-level bullet after the block it qualifies.
+    nxt = prompt.index("WEEKEND / HOLIDAY CARRY-RISK")
+    assert small_gap < nxt
+
+
 def test_reentry_gate_does_not_contradict_the_exit_rules():
     """The re-entry gate must never be readable as a reason to delay an EXIT.
 

--- a/test_nifty_multi_strategy_master.py
+++ b/test_nifty_multi_strategy_master.py
@@ -3884,6 +3884,32 @@ class TestSLHuntingBnfMirror(unittest.TestCase):
         })
         return worker, store
 
+    def test_sl_hunting_worker_construction_cannot_kill_the_runner(self):
+        """The OPTIONAL agent must never take the other 26 strategies down with it.
+
+        Constructing SLHuntingAIWorker builds the agent, which validates its own
+        system-prompt size and reads the optional lessons / pre-open note. Any of
+        those can raise. Unguarded, that propagates out of main() and the whole
+        runner fails to start -- so a knowledge-only edit that pushed the prompt
+        past its cap would stop every strategy, not just this one.
+
+        Structural check because main() needs a full live environment to run.
+        """
+        source = file_path.read_text(encoding="utf-8")
+        marker = "workers.append(SLHuntingAIWorker(store, stop_event, broker))"
+        self.assertIn(marker, source)
+        window = "\n".join(source[: source.index(marker)].split("\n")[-6:])
+        self.assertIn("try:", window, "the optional agent's construction must be guarded")
+        following = source[source.index(marker):].split("\n")[:12]
+        self.assertTrue(
+            any("except" in line for line in following),
+            "a failed agent build must be caught and logged, not raised into main()",
+        )
+        self.assertTrue(
+            any("continuing WITHOUT it" in line for line in following),
+            "the operator must be told the agent was dropped",
+        )
+
     def test_stale_cached_ltp_is_not_dealable(self):
         """MAT-112: a mark older than the bound must not be usable to book a trade.
 

--- a/test_nifty_multi_strategy_master.py
+++ b/test_nifty_multi_strategy_master.py
@@ -190,13 +190,17 @@ class TestSharedMarketDataStore(unittest.TestCase):
             security_id=123, exchange_segment="NSE_FNO", trading_symbol="OPT1",
             right="CE", strike=20000.0, expiry=date(2023, 1, 26)
         )
-        self.store.register_option_subscription(sub)
+        self.store.register_option_subscription(sub, owner_id="TEST")
 
         subs = self.store.snapshot_option_subscriptions()
         self.assertEqual(len(subs), 1)
         self.assertEqual(subs[0].security_id, 123)
 
-        self.store.unregister_option_subscription("NSE_FNO", 123)
+        self.store.unregister_option_subscription(
+            "NSE_FNO",
+            123,
+            owner_id="TEST",
+        )
         self.assertEqual(len(self.store.snapshot_option_subscriptions()), 0)
 
 
@@ -1293,8 +1297,8 @@ class TestCentralMarketDataFetcher(unittest.TestCase):
             trading_symbol="OPT_PE", right="PE", strike=22500.0,
             expiry=date.today() + timedelta(days=7),
         )
-        self.store.register_option_subscription(sub_ce)
-        self.store.register_option_subscription(sub_pe)
+        self.store.register_option_subscription(sub_ce, owner_id="TEST")
+        self.store.register_option_subscription(sub_pe, owner_id="TEST")
         self.broker.fetch_ltp_map.return_value = {
             (master_file.NIFTY_INDEX_EXCHANGE_SEGMENT,
              master_file.NIFTY_INDEX_SECURITY_ID): 22500.0,
@@ -1465,7 +1469,8 @@ class TestWebSocketMarketDataFetcher(unittest.TestCase):
                 security_id=security_id, exchange_segment="NSE_FNO",
                 trading_symbol="OPT_CE", right="CE", strike=22500.0,
                 expiry=date.today() + timedelta(days=7),
-            )
+            ),
+            owner_id="TEST",
         )
 
     def test_thread_name_matches_rest_fetcher(self):
@@ -1556,7 +1561,11 @@ class TestWebSocketMarketDataFetcher(unittest.TestCase):
         added = feed.subscribe_symbols.call_args[0][0]
         self.assertEqual([(t[0], t[1]) for t in added], [(2, "49081")])
 
-        self.store.unregister_option_subscription("NSE_FNO", 49081)
+        self.store.unregister_option_subscription(
+            "NSE_FNO",
+            49081,
+            owner_id="TEST",
+        )
         self.fetcher._sync_subscriptions()
         feed.unsubscribe_symbols.assert_called_once()
         removed = feed.unsubscribe_symbols.call_args[0][0]
@@ -1574,7 +1583,8 @@ class TestWebSocketMarketDataFetcher(unittest.TestCase):
             master_file.OptionSubscription(
                 security_id=777, exchange_segment="MCX_WEIRD",
                 trading_symbol="ODD", right="CE", strike=1.0, expiry=None,
-            )
+            ),
+            owner_id="TEST",
         )
         self.fetcher._sync_subscriptions()
         feed.subscribe_symbols.assert_not_called()
@@ -2127,6 +2137,30 @@ class TestAtmSingleLegStrategyWorker(unittest.TestCase):
         subs = self.store.snapshot_option_subscriptions()
         self.assertTrue(any(s.security_id == 49081 for s in subs))
 
+    def test_live_atm_pnl_uses_broker_entry_and_exit_fill_prices(self):
+        """The ledger's broker fills, not local marks, drive live P&L."""
+        self.worker.live_trading = True
+        client = _FakeShoonya(fill_prices=[125.0, 115.0])
+        with patch.object(master_file, "execution_client", client):
+            self.assertTrue(
+                self.worker.enter_position(
+                    direction="LONG",
+                    entry_underlying=22500.0,
+                    stop_underlying=22400.0,
+                    target_underlying=22700.0,
+                )
+            )
+            self.assertEqual(self.worker.pos.entry_trade_price, 125.0)
+            self.assertEqual(
+                self.worker.pos.entry_price_quality,
+                master_file.PRICE_QUALITY_BROKER_FILL,
+            )
+            quantity = self.worker.pos.quantity
+            self.worker.exit_position("TEST")
+
+        self.assertAlmostEqual(self.worker.realized_pnl, -10.0 * quantity)
+        self.assertFalse(self.worker.pos.active)
+
     def test_enter_position_skips_when_spot_unavailable(self):
         """No spot LTP -> no entry. The broker fallback also returns 0."""
         self.broker.fetch_ltp_map.return_value = {}
@@ -2149,6 +2183,27 @@ class TestAtmSingleLegStrategyWorker(unittest.TestCase):
             direction="LONG", entry_underlying=22500.0,
         )
         self.assertFalse(result)
+
+    def test_live_entry_refuses_a_stale_option_mark(self):
+        self.worker.live_trading = True
+        snapshot = self.store._ltp_snapshots[
+            (master_file.OPTION_EXCHANGE_SEGMENT, 49081)
+        ]
+        snapshot.fetched_at -= timedelta(
+            seconds=master_file.MARKET_DATA_MAX_LTP_AGE_SECONDS + 30
+        )
+        self.broker.fetch_ltp_map.return_value = {}
+        client = _FakeShoonya()
+
+        with patch.object(master_file, "execution_client", client):
+            result = self.worker.enter_position(
+                direction="LONG",
+                entry_underlying=22500.0,
+                stop_underlying=22400.0,
+            )
+
+        self.assertFalse(result)
+        self.assertEqual(client.calls, [])
 
     def test_rejected_sizing_decision_skips_entry_before_order_routing(self):
         decision = master_file.SizingDecision.from_risk_budget(
@@ -2213,6 +2268,184 @@ class TestAtmSingleLegStrategyWorker(unittest.TestCase):
 # =============================================================================
 # TEST SUITE: PROFIT SHOOTER DYNAMIC LOT SIZING
 # =============================================================================
+class TestSpreadEntryPriceFreshness(unittest.TestCase):
+    """Every multi-leg entry family fails closed on an unbounded option mark."""
+
+    def _store_and_broker(self):
+        store = master_file.SharedMarketDataStore()
+        broker = MagicMock()
+        broker.fetch_ltp_map.return_value = {}
+        store.update_ltp_map(
+            {
+                (
+                    master_file.NIFTY_INDEX_EXCHANGE_SEGMENT,
+                    master_file.NIFTY_INDEX_SECURITY_ID,
+                ): 22500.0,
+                (master_file.OPTION_EXCHANGE_SEGMENT, 1001): 100.0,
+                (master_file.OPTION_EXCHANGE_SEGMENT, 2002): 10.0,
+            }
+        )
+        for security_id in (1001, 2002):
+            store._ltp_snapshots[
+                (master_file.OPTION_EXCHANGE_SEGMENT, security_id)
+            ].fetched_at -= timedelta(
+                seconds=master_file.MARKET_DATA_MAX_LTP_AGE_SECONDS + 30
+            )
+        return store, broker
+
+    @staticmethod
+    def _leg(security_id, right, strike, entry_ltp):
+        return {
+            "security_id": security_id,
+            "exchange_segment": master_file.OPTION_EXCHANGE_SEGMENT,
+            "trading_symbol": f"NIFTY-{strike}-{right}",
+            "strike": float(strike),
+            "option_type": right,
+            "expiry_date": date.today() + timedelta(days=3),
+            "lot_size": 50,
+            "entry_ltp": float(entry_ltp),
+        }
+
+    def test_bullish_hedged_entry_refuses_stale_leg_marks(self):
+        store, broker = self._store_and_broker()
+        worker = master_file.SupertrendBullishWorker(
+            store=store, stop_event=threading.Event(), broker=broker
+        )
+        worker.live_trading = True
+        picked = (
+            self._leg(1001, "PE", 22000, 100),
+            self._leg(2002, "PE", 21000, 10),
+            date.today() + timedelta(days=3),
+        )
+        with (
+            patch.object(worker, "_pick_hedged_puts", return_value=picked),
+            patch.object(worker, "_place_real_hedged_entry") as place,
+        ):
+            accepted = worker._enter_hedged_bullish_position(22500.0, None)
+        self.assertFalse(accepted)
+        place.assert_not_called()
+
+    def test_bearish_hedged_entry_refuses_stale_leg_marks(self):
+        store, broker = self._store_and_broker()
+        worker = master_file.DonchianBearishWorker(
+            store=store, stop_event=threading.Event(), broker=broker
+        )
+        worker.live_trading = True
+        picked = (
+            self._leg(1001, "CE", 23000, 100),
+            self._leg(2002, "CE", 24000, 10),
+            date.today() + timedelta(days=3),
+        )
+        with (
+            patch.object(worker, "_pick_hedged_calls", return_value=picked),
+            patch.object(worker, "_place_real_hedged_entry") as place,
+        ):
+            accepted = worker._enter_hedged_bearish_position(22500.0, None)
+        self.assertFalse(accepted)
+        place.assert_not_called()
+
+    def test_delta20_entry_refuses_stale_leg_marks(self):
+        store, broker = self._store_and_broker()
+        worker = master_file.Delta20HedgedSpreadWorker(
+            store=store, stop_event=threading.Event(), broker=broker
+        )
+        worker.live_trading = True
+        worker.ce_monitor_meta = self._leg(1001, "CE", 23000, 100)
+        worker.ce_hedge_meta = self._leg(2002, "CE", 23200, 10)
+        with patch.object(worker, "_place_real_hedged_entry") as place:
+            accepted = worker._enter_side("CE", 100.0, 95.0)
+        self.assertFalse(accepted)
+        place.assert_not_called()
+
+    def test_bullish_hedged_pnl_uses_each_broker_leg_fill(self):
+        store, broker = self._store_and_broker()
+        store.update_ltp_map(
+            {
+                (master_file.OPTION_EXCHANGE_SEGMENT, 1001): 100.0,
+                (master_file.OPTION_EXCHANGE_SEGMENT, 2002): 10.0,
+            }
+        )
+        worker = master_file.SupertrendBullishWorker(
+            store=store, stop_event=threading.Event(), broker=broker
+        )
+        worker.live_trading = True
+        picked = (
+            self._leg(1001, "PE", 22000, 100),
+            self._leg(2002, "PE", 21000, 10),
+            date.today() + timedelta(days=3),
+        )
+        client = _FakeShoonya(fill_prices=[8.0, 120.0, 110.0, 7.0])
+        with (
+            patch.object(worker, "_pick_hedged_puts", return_value=picked),
+            patch.object(master_file, "execution_client", client),
+        ):
+            self.assertTrue(
+                worker._enter_hedged_bullish_position(22500.0, None)
+            )
+            self.assertEqual(worker.pos.main_entry_price, 120.0)
+            self.assertEqual(worker.pos.hedge_entry_price, 8.0)
+            quantity = worker.pos.main_quantity
+            worker.exit_position("TEST")
+
+        self.assertAlmostEqual(worker.realized_pnl, 9.0 * quantity)
+
+    def test_delta20_pnl_uses_each_broker_leg_fill(self):
+        store, broker = self._store_and_broker()
+        store.update_ltp_map(
+            {
+                (master_file.OPTION_EXCHANGE_SEGMENT, 1001): 100.0,
+                (master_file.OPTION_EXCHANGE_SEGMENT, 2002): 10.0,
+            }
+        )
+        worker = master_file.Delta20HedgedSpreadWorker(
+            store=store, stop_event=threading.Event(), broker=broker
+        )
+        worker.live_trading = True
+        worker.ce_monitor_meta = self._leg(1001, "CE", 23000, 100)
+        worker.ce_hedge_meta = self._leg(2002, "CE", 23200, 10)
+        client = _FakeShoonya(fill_prices=[8.0, 120.0, 110.0, 7.0])
+        with patch.object(master_file, "execution_client", client):
+            self.assertTrue(worker._enter_side("CE", 100.0, 95.0))
+            self.assertEqual(worker.ce_pos.main_entry_price, 120.0)
+            self.assertEqual(worker.ce_pos.hedge_entry_price, 8.0)
+            quantity = worker.ce_pos.main_quantity
+            worker._exit_side("CE", "TEST")
+
+        self.assertAlmostEqual(worker.realized_pnl, 9.0 * quantity)
+
+    def test_bearish_hedged_pnl_uses_each_broker_leg_fill(self):
+        store, broker = self._store_and_broker()
+        store.update_ltp_map(
+            {
+                (master_file.OPTION_EXCHANGE_SEGMENT, 1001): 100.0,
+                (master_file.OPTION_EXCHANGE_SEGMENT, 2002): 10.0,
+            }
+        )
+        worker = master_file.DonchianBearishWorker(
+            store=store, stop_event=threading.Event(), broker=broker
+        )
+        worker.live_trading = True
+        picked = (
+            self._leg(1001, "CE", 23000, 100),
+            self._leg(2002, "CE", 24000, 10),
+            date.today() + timedelta(days=3),
+        )
+        client = _FakeShoonya(fill_prices=[8.0, 120.0, 110.0, 7.0])
+        with (
+            patch.object(worker, "_pick_hedged_calls", return_value=picked),
+            patch.object(master_file, "execution_client", client),
+        ):
+            self.assertTrue(
+                worker._enter_hedged_bearish_position(22500.0, None)
+            )
+            self.assertEqual(worker.pos.main_entry_price, 120.0)
+            self.assertEqual(worker.pos.hedge_entry_price, 8.0)
+            quantity = worker.pos.main_quantity
+            worker.exit_position("TEST")
+
+        self.assertAlmostEqual(worker.realized_pnl, 9.0 * quantity)
+
+
 class TestProfitShooterStrategyWorker(unittest.TestCase):
     """
     Tests the Profit Shooter override that picks lots dynamically based on
@@ -2584,13 +2817,20 @@ class _FakeShoonya:
     - `resolve_returns` overrides the resolved Shoonya symbol; pass "" to simulate
       a symbol-master resolution miss."""
 
-    def __init__(self, fail_on=None, resolve_returns=None, result_status=OrderStatus.FILLED):
+    def __init__(
+        self,
+        fail_on=None,
+        resolve_returns=None,
+        result_status=OrderStatus.FILLED,
+        fill_prices=None,
+    ):
         self.calls = []      # (shoonya_symbol, side, quantity)
         self.order_tags = []
         self.resolved = []   # (underlying, option_type, strike)
         self._fail_on = fail_on or (lambda symbol, side: False)
         self._resolve_returns = resolve_returns
         self._result_status = result_status
+        self._fill_prices = list(fill_prices or [])
 
     def resolve_option_symbol(self, underlying, expiry, option_type, strike,
                               exchange_segment="NFO"):
@@ -2625,6 +2865,11 @@ class _FakeShoonya:
             status=status,
             broker_state=status.value,
             reason=f"simulated {status.value.lower()} outcome",
+            average_fill_price=(
+                float(self._fill_prices[len(self.calls) - 1])
+                if len(self._fill_prices) >= len(self.calls)
+                else 0.0
+            ),
         )
 
     def extract_order_id(self, resp):
@@ -3094,6 +3339,56 @@ class TestLongStrangleWorker(unittest.TestCase):
         self.assertEqual(worker.ce_pos.entry_trade_price, 100.0)
         self.assertEqual(worker.pe_pos.entry_trade_price, 90.0)
         self.assertEqual(worker.ce_pos.quantity, 75)  # 1 lot * 75
+
+    def test_live_strangle_entry_refuses_a_stale_leg_mark(self):
+        worker, store = self._make_worker()
+        worker.live_trading = True
+        store.update_ltp_map(
+            {
+                (
+                    master_file.NIFTY_INDEX_EXCHANGE_SEGMENT,
+                    master_file.NIFTY_INDEX_SECURITY_ID,
+                ): 22510.0,
+                (master_file.OPTION_EXCHANGE_SEGMENT, 1001): 100.0,
+            }
+        )
+        snapshot = store._ltp_snapshots[
+            (master_file.OPTION_EXCHANGE_SEGMENT, 1001)
+        ]
+        snapshot.fetched_at -= timedelta(
+            seconds=master_file.MARKET_DATA_MAX_LTP_AGE_SECONDS + 30
+        )
+        client = _FakeShoonya()
+
+        with patch.object(master_file, "execution_client", client):
+            worker._enter_both_legs()
+
+        self.assertFalse(worker.ce_pos.active)
+        self.assertEqual(client.calls, [])
+
+    def test_live_strangle_uses_broker_prices_for_each_leg(self):
+        worker, store = self._make_worker()
+        worker.live_trading = True
+        store.update_ltp_map(
+            {
+                (
+                    master_file.NIFTY_INDEX_EXCHANGE_SEGMENT,
+                    master_file.NIFTY_INDEX_SECURITY_ID,
+                ): 22510.0,
+                (master_file.OPTION_EXCHANGE_SEGMENT, 1001): 100.0,
+                (master_file.OPTION_EXCHANGE_SEGMENT, 2002): 90.0,
+            }
+        )
+        client = _FakeShoonya(fill_prices=[125.0, 95.0, 115.0])
+
+        with patch.object(master_file, "execution_client", client):
+            worker._enter_both_legs()
+            self.assertEqual(worker.ce_pos.entry_trade_price, 125.0)
+            self.assertEqual(worker.pe_pos.entry_trade_price, 95.0)
+            quantity = worker.ce_pos.quantity
+            worker._exit_leg("CE", "TEST")
+
+        self.assertAlmostEqual(worker.realized_pnl, -10.0 * quantity)
 
     def test_stopping_ce_leaves_pe_active(self):
         """Independent legs: a CE stop-out must not disturb the PE leg."""
@@ -3633,17 +3928,54 @@ class TestSLHuntingBnfMirror(unittest.TestCase):
         self.assertEqual(price, 112.55)
         self.assertFalse(fresh)
 
-    def test_unsubscribing_a_leg_drops_its_cached_price(self):
-        """The residue that made a closed leg's last price look usable is gone."""
+    def test_live_mirror_entry_refuses_a_stale_mark(self):
+        worker, store = self._make_worker()
+        worker.live_trading = True
+        worker._mirror_enabled = False
+        client = _FakeShoonya(fill_prices=[100.0])
+        with patch.object(master_file, "execution_client", client):
+            self.assertTrue(
+                worker.enter_position("LONG", 24300.0, 24290.0, 24400.0)
+            )
+        worker._mirror_enabled = True
+        snapshot = store._ltp_snapshots[
+            (master_file.OPTION_EXCHANGE_SEGMENT, 3003)
+        ]
+        snapshot.fetched_at -= timedelta(
+            seconds=master_file.MARKET_DATA_MAX_LTP_AGE_SECONDS + 30
+        )
+        worker.broker.fetch_ltp_map.return_value = {}
+
+        with patch.object(master_file, "execution_client", client):
+            worker._open_bnf_mirror("LONG")
+
+        self.assertFalse(worker._mirror_pos.active)
+        self.assertEqual(len(client.calls), 1)
+
+    def test_last_subscription_owner_drops_the_cached_price(self):
+        """The physical feed leg and its cached price leave with the final owner."""
         _worker, store = self._make_worker()
         key_segment, key_secid = master_file.OPTION_EXCHANGE_SEGMENT, 1001
+        sub = master_file.OptionSubscription(
+            security_id=key_secid,
+            exchange_segment=key_segment,
+            trading_symbol="NIFTY-24300-CE",
+            right="CE",
+            strike=24300.0,
+            expiry=date.today(),
+        )
+        store.register_option_subscription(sub, owner_id="WORKER-A")
         store.update_ltp_map({(key_segment, key_secid): 112.55})
         self.assertEqual(store.get_ltp_by_secid(key_segment, key_secid, 0.0), 112.55)
-        store.unregister_option_subscription(key_segment, key_secid)
+        store.unregister_option_subscription(
+            key_segment,
+            key_secid,
+            owner_id="WORKER-A",
+        )
         self.assertEqual(store.get_ltp_by_secid(key_segment, key_secid, 0.0), 0.0)
 
-    def test_register_option_subscription_reports_first_owner_only(self):
-        """Only the caller that ADDED a shared leg may later withdraw it."""
+    def test_shared_subscription_survives_until_every_owner_releases_it(self):
+        """One worker's exit cannot cut market data for another open position."""
         _worker, store = self._make_worker()
         sub = master_file.OptionSubscription(
             security_id=1001,
@@ -3653,8 +3985,146 @@ class TestSLHuntingBnfMirror(unittest.TestCase):
             strike=24300.0,
             expiry=date.today(),
         )
-        self.assertTrue(store.register_option_subscription(sub))
-        self.assertFalse(store.register_option_subscription(sub))
+        self.assertTrue(store.register_option_subscription(sub, owner_id="WORKER-A"))
+        self.assertTrue(store.register_option_subscription(sub, owner_id="WORKER-B"))
+        self.assertFalse(store.register_option_subscription(sub, owner_id="WORKER-A"))
+        store.update_ltp_map(
+            {(master_file.OPTION_EXCHANGE_SEGMENT, 1001): 112.55}
+        )
+
+        store.unregister_option_subscription(
+            master_file.OPTION_EXCHANGE_SEGMENT,
+            1001,
+            owner_id="WORKER-A",
+        )
+
+        self.assertEqual(len(store.snapshot_option_subscriptions()), 1)
+        self.assertEqual(
+            store.get_ltp_by_secid(
+                master_file.OPTION_EXCHANGE_SEGMENT,
+                1001,
+                0.0,
+            ),
+            112.55,
+        )
+
+    def test_invalid_or_future_freshness_evidence_fails_closed(self):
+        """A corrupt bound or timestamp must never make an old mark dealable."""
+        _worker, store = self._make_worker()
+        segment, security_id = master_file.OPTION_EXCHANGE_SEGMENT, 1001
+        store.update_ltp_map({(segment, security_id): 112.55})
+
+        for invalid_bound in (0.0, -1.0, float("nan"), float("inf")):
+            with self.subTest(bound=invalid_bound):
+                self.assertEqual(
+                    store.get_ltp_by_secid(
+                        segment,
+                        security_id,
+                        0.0,
+                        max_age_seconds=invalid_bound,
+                    ),
+                    0.0,
+                )
+
+        store._ltp_snapshots[(segment, security_id)].fetched_at += timedelta(
+            seconds=30
+        )
+        self.assertEqual(
+            store.get_ltp_by_secid(
+                segment,
+                security_id,
+                0.0,
+                max_age_seconds=60.0,
+            ),
+            0.0,
+        )
+
+    def test_confirmed_flat_orphan_releases_its_subscription(self):
+        """Recovery owns the early subscription when no PaperPosition was created."""
+        worker, store = self._make_worker()
+        sub = master_file.OptionSubscription(
+            security_id=1001,
+            exchange_segment=master_file.OPTION_EXCHANGE_SEGMENT,
+            trading_symbol="NIFTY-24300-CE",
+            right="CE",
+            strike=24300.0,
+            expiry=date.today(),
+        )
+        store.register_option_subscription(
+            sub,
+            owner_id=worker._execution_owner_id,
+        )
+        store.update_ltp_map(
+            {(master_file.OPTION_EXCHANGE_SEGMENT, 1001): 112.55}
+        )
+        spec = master_file.LegSpec(
+            strategy=worker.strategy_name,
+            correlation_id="ABC12345",
+            role="N",
+            underlying="NIFTY",
+            symbol=sub.trading_symbol,
+            option_type="CE",
+            strike=sub.strike,
+            expiry=sub.expiry,
+            opening_side="BUY",
+            target_quantity=75,
+            owner_id=worker._execution_owner_id,
+        )
+        state = store.execution_ledger.register(spec)
+        open_handle = store.execution_ledger.start_attempt(
+            state.exposure_id,
+            master_file.OrderIntent.OPEN,
+            75,
+        )
+        state = store.execution_ledger.apply_result(
+            open_handle,
+            master_file.OrderResult(
+                order_id="OPEN-1",
+                requested_quantity=75,
+                filled_quantity=75,
+                remaining_quantity=0,
+                status=master_file.OrderStatus.FILLED,
+                broker_state="COMPLETE",
+                reason="filled",
+            ),
+        )
+        close_handle = store.execution_ledger.start_attempt(
+            state.exposure_id,
+            master_file.OrderIntent.CLOSE,
+            75,
+        )
+        state = store.execution_ledger.apply_result(
+            close_handle,
+            master_file.OrderResult(
+                order_id="CLOSE-1",
+                requested_quantity=75,
+                filled_quantity=75,
+                remaining_quantity=0,
+                status=master_file.OrderStatus.FILLED,
+                broker_state="COMPLETE",
+                reason="filled",
+            ),
+        )
+        worker._orphan_live_legs = [
+            {
+                "live_leg": state,
+                "option_type": "CE",
+                "strike": sub.strike,
+                "option_subscription": sub,
+            }
+        ]
+
+        worker._sweep_orphan_live_legs(force=True)
+
+        self.assertEqual(store.snapshot_option_subscriptions(), [])
+        self.assertEqual(
+            store.get_ltp_by_secid(
+                master_file.OPTION_EXCHANGE_SEGMENT,
+                1001,
+                0.0,
+            ),
+            0.0,
+        )
 
     def test_live_fill_price_beats_a_stale_ltp(self):
         """MAT-112: a LIVE entry is recorded at the BROKER's price, not the LTP.
@@ -3748,6 +4218,23 @@ class TestSLHuntingBnfMirror(unittest.TestCase):
         )
         # Far from expiry -> ATM, never the expiry-week ITM branch.
         worker._bnf_resolver.get_itm_option.assert_not_called()
+
+    def test_live_basket_pnl_uses_nifty_and_bnf_broker_fills(self):
+        worker, _store = self._make_worker()
+        worker.live_trading = True
+        client = _FakeShoonya(fill_prices=[125.0, 510.0, 115.0, 520.0])
+        with patch.object(master_file, "execution_client", client):
+            self.assertTrue(
+                worker.enter_position("LONG", 24300.0, 24290.0, 24400.0)
+            )
+            nifty_quantity = worker.pos.quantity
+            bnf_quantity = worker._mirror_pos.quantity
+            self.assertEqual(worker.pos.entry_trade_price, 125.0)
+            self.assertEqual(worker._mirror_pos.entry_trade_price, 510.0)
+            worker.exit_position("TEST")
+
+        expected = (-10.0 * nifty_quantity) + (10.0 * bnf_quantity)
+        self.assertAlmostEqual(worker.realized_pnl, expected)
 
     def test_mirror_uses_itm_strike_inside_expiry_week(self):
         """BNF-002: inside the near-expiry window the mirror buys a deep ITM
@@ -4117,8 +4604,32 @@ class TestSLHuntingBnfMirror(unittest.TestCase):
         _tid, payload = worker._journal.close_trade.call_args[0]
         self.assertEqual(_tid, "t1")
         self.assertGreater(payload["option_pnl"], 0.0)    # mirror P&L is captured
+        self.assertTrue(payload["pnl_evidence_eligible"])
         self.assertIsNone(worker._pending_journal_exit)
         self.assertIsNone(worker._open_trade_id)
+
+    def test_stale_paper_exit_stays_operational_but_is_not_coach_eligible(self):
+        worker, store = self._make_worker()
+        worker.enter_position("LONG", 24300.0, 24290.0, 24400.0)
+        worker._journal = MagicMock()
+        worker._open_trade_id = "stale"
+        worker._entry_realized_pnl = 0.0
+        worker._journal_pnl_evidence_eligible = True
+        for security_id in (1001, 3003):
+            snapshot = store._ltp_snapshots[
+                (master_file.OPTION_EXCHANGE_SEGMENT, security_id)
+            ]
+            snapshot.fetched_at -= timedelta(
+                seconds=master_file.MARKET_DATA_MAX_LTP_AGE_SECONDS + 30
+            )
+        worker.broker.fetch_ltp_map.return_value = {}
+
+        worker.exit_position("stale paper mark test")
+
+        worker._journal.close_trade.assert_called_once()
+        _trade_id, payload = worker._journal.close_trade.call_args[0]
+        self.assertEqual(_trade_id, "stale")
+        self.assertFalse(payload["pnl_evidence_eligible"])
 
     # ----- P1: a paper-fallback mirror must not phantom-short (sibling of PR #42) --
     def test_mirror_paper_fallback_close_sends_no_real_order(self):
@@ -6418,14 +6929,28 @@ class TestShoonyaFillConfirmation(unittest.TestCase):
         return c
 
     @staticmethod
-    def _hist(state, fld=75, qty=75, rej="--"):
+    def _hist(state, fld=75, qty=75, rej="--", avgprc="0"):
         # single_order_history returns a LIST of rows (newest first).
-        return [{"status": state, "fillshares": fld, "qty": qty, "rejreason": rej}]
+        return [{
+            "status": state,
+            "fillshares": fld,
+            "qty": qty,
+            "rejreason": rej,
+            "avgprc": avgprc,
+        }]
 
     def test_order_status_parses_latest_row(self):
-        c = self._client(self._hist("COMPLETE", fld=50, qty=75))
-        state, filled, qty, _reason = c._order_status("ORD1")
+        c = self._client(self._hist("COMPLETE", fld=50, qty=75, avgprc="125.25"))
+        state, filled, qty, _reason, average = c._order_status("ORD1")
         self.assertEqual((state, filled, qty), ("complete", 50, 75))
+        self.assertEqual(average, 125.25)
+
+    def test_get_order_status_exposes_documented_average_price(self):
+        c = self._client(self._hist("COMPLETE", avgprc="125.25"))
+
+        result = c.get_order_status("ORD1", requested_quantity=75)
+
+        self.assertEqual(result.average_fill_price, 125.25)
 
     def test_confirm_fill_returns_on_complete(self):
         c = self._client(self._hist("COMPLETE", fld=75, qty=75))
@@ -6449,6 +6974,85 @@ class TestShoonyaFillConfirmation(unittest.TestCase):
             result = c._confirm_fill("ORD1", 75)
         self.assertEqual(result.status, OrderStatus.UNKNOWN)
         self.assertIn("indeterminate", result.reason.lower())
+
+    def test_confirm_fill_timeout_preserves_last_known_average_price(self):
+        c = self._client(
+            self._hist("OPEN", fld=25, qty=75, avgprc="101.50")
+        )
+        mod = type(c).__module__
+        smod = sys.modules[mod]
+        with patch.object(smod, "_FILL_TIMEOUT_SECONDS", 0.05), \
+             patch.object(smod, "_FILL_POLL_INTERVAL", 0.01):
+            result = c._confirm_fill("ORD1", 75)
+
+        self.assertEqual(result.filled_quantity, 25)
+        self.assertEqual(result.average_fill_price, 101.50)
+
+
+class _StubKotak:
+    """Official v2 order-history row wrapper used without a broker session."""
+
+    def __init__(self, row):
+        self._row = row
+
+    def order_history(self, order_id=None):
+        return {"data": {"stat": "Ok", "data": [self._row]}}
+
+
+class TestKotakFillPrice(unittest.TestCase):
+    """Kotak v2 documents the traded average as ``avgPrc``."""
+
+    def setUp(self):
+        if master_file.kotak_execution_client is None:
+            self.skipTest("Kotak execution layer not importable in this environment.")
+        self.client = type(master_file.kotak_execution_client)()
+        self.client.client = _StubKotak({
+            "ordSt": "complete",
+            "fldQty": "75",
+            "qty": "75",
+            "rejRsn": "--",
+            "avgPrc": "125.25",
+        })
+        self.client.is_logged_in = True
+
+    def test_order_status_exposes_documented_average_price(self):
+        with patch.object(
+            self.client,
+            "_sdk_call",
+            side_effect=lambda _name, call, **_kwargs: call(),
+        ):
+            result = self.client.get_order_status(
+                "KOTAK-1",
+                requested_quantity=75,
+            )
+
+        self.assertEqual(result.average_fill_price, 125.25)
+
+    def test_confirm_fill_timeout_preserves_last_known_average_price(self):
+        partial = OrderResult(
+            order_id="KOTAK-1",
+            requested_quantity=75,
+            filled_quantity=25,
+            remaining_quantity=50,
+            status=OrderStatus.PARTIAL,
+            broker_state="OPEN",
+            reason="partial",
+            average_fill_price=101.5,
+        )
+        module = sys.modules[type(self.client).__module__]
+        with patch.object(
+            self.client,
+            "get_order_status",
+            return_value=partial,
+        ), patch.object(module, "_FILL_TIMEOUT_SECONDS", 0.05), patch.object(
+            module,
+            "_FILL_POLL_INTERVAL",
+            0.01,
+        ):
+            result = self.client._confirm_fill("KOTAK-1", 75)
+
+        self.assertEqual(result.filled_quantity, 25)
+        self.assertEqual(result.average_fill_price, 101.5)
 
 
 class TestShoonyaSymbolResolution(unittest.TestCase):
@@ -6813,35 +7417,45 @@ class TestFlattradeOrders(unittest.TestCase):
                 "fillshares": "65",
                 "qty": "65",
                 "rejreason": "",
+                "avgprc": "125.25",
             }
         ]
         with patch.object(self.client, "_post_api", return_value=history):
             self.assertEqual(
                 self.client._order_status("ORD1"),
-                ("complete", 65, 65, ""),
+                ("complete", 65, 65, "", 125.25),
             )
+            result = self.client.get_order_status("ORD1", requested_quantity=65)
+        self.assertEqual(result.average_fill_price, 125.25)
 
     def test_fill_confirmation_handles_complete_rejected_and_timeout(self):
         with patch.object(
-            self.client, "_order_status", return_value=("complete", 65, 65, "")
+            self.client,
+            "_order_status",
+            return_value=("complete", 65, 65, "", 125.25),
         ):
             complete = self.client._confirm_fill("ORD1", 65)
         self.assertEqual(complete.status, OrderStatus.FILLED)
+        self.assertEqual(complete.average_fill_price, 125.25)
 
         with patch.object(
             self.client,
             "_order_status",
-            return_value=("rejected", 0, 65, "RMS: margin"),
+            return_value=("rejected", 0, 65, "RMS: margin", 0.0),
         ):
             rejected = self.client._confirm_fill("ORD2", 65)
         self.assertEqual(rejected.status, OrderStatus.REJECTED)
 
         with patch.object(
-            self.client, "_order_status", return_value=("open", 0, 65, "")
+            self.client,
+            "_order_status",
+            return_value=("open", 25, 65, "", 101.5),
         ), patch.object(flattrade_module, "_FILL_TIMEOUT_SECONDS", 0.02), \
              patch.object(flattrade_module, "_FILL_POLL_INTERVAL", 0.005):
             unknown = self.client._confirm_fill("ORD3", 65)
-        self.assertEqual(unknown.status, OrderStatus.UNKNOWN)
+        self.assertEqual(unknown.status, OrderStatus.PARTIAL)
+        self.assertEqual(unknown.filled_quantity, 25)
+        self.assertEqual(unknown.average_fill_price, 101.5)
         self.assertIn("indeterminate", unknown.reason.lower())
 
     def test_recursive_order_id_extraction_and_local_logout(self):
@@ -7507,6 +8121,36 @@ class TestStartupLiveExposureWiring(unittest.TestCase):
             errors = master_file._live_config_errors(worker, "RENKO")
 
         self.assertIn("RENKO_TRADING_START_HOUR is not numeric", errors)
+
+    def test_option_ltp_freshness_bound_is_strictly_validated_for_live(self):
+        """A non-finite or non-positive global bound cannot disable stale-price safety."""
+        worker = self._Worker("Renko")
+        for raw in ("0", "-1", "nan", "inf", "not-a-number"):
+            with self.subTest(raw=raw), patch.dict(
+                os.environ,
+                {"MARKET_DATA_MAX_LTP_AGE_SECONDS": raw},
+            ):
+                errors = master_file._live_config_errors(worker, "RENKO")
+
+            self.assertTrue(
+                any("MARKET_DATA_MAX_LTP_AGE_SECONDS" in error for error in errors),
+                f"{raw!r} must block live trading, got {errors}",
+            )
+
+    def test_resolved_option_ltp_freshness_bound_fails_closed_for_live(self):
+        worker = self._Worker("Renko")
+        for value in (0.0, -1.0, float("nan"), float("inf")):
+            with self.subTest(value=value), patch.object(
+                master_file,
+                "MARKET_DATA_MAX_LTP_AGE_SECONDS",
+                value,
+            ):
+                errors = master_file._live_config_errors(worker, "RENKO")
+
+            self.assertIn(
+                "resolved MARKET_DATA_MAX_LTP_AGE_SECONDS must be finite and positive",
+                errors,
+            )
 
     def test_sl_hunting_entry_controls_are_strictly_validated_for_live(self):
         """Malformed cooldown/cutoff text cannot hide behind paper defaults."""

--- a/test_nifty_multi_strategy_master.py
+++ b/test_nifty_multi_strategy_master.py
@@ -12,6 +12,7 @@ import warnings
 from contextlib import ExitStack
 from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 from urllib.parse import parse_qs
 
@@ -3587,6 +3588,29 @@ class TestSLHuntingBnfMirror(unittest.TestCase):
             (master_file.OPTION_EXCHANGE_SEGMENT, 3003): 500.0,
         })
         return worker, store
+
+    def test_live_fill_price_beats_a_stale_ltp(self):
+        """MAT-112: a LIVE entry is recorded at the BROKER's price, not the LTP.
+
+        On 2026-07-30 a cached LTP recorded a NIFTY entry at 112.55 against a real
+        fill of 125.00, turning a Rs.760.50 loss into a Rs.4,095 "profit" in the
+        journal, the Sheet and the coach's training data.
+        """
+        worker, _store = self._make_worker()
+        filled = SimpleNamespace(average_fill_price=125.0)
+        self.assertEqual(worker._entry_fill_price(filled, 112.55), 125.0)
+
+    def test_paper_and_priceless_fills_keep_the_ltp(self):
+        """Fail-soft: no broker price (paper, or a broker that reports none) keeps
+        today's behaviour exactly, so this can never block or distort a trade."""
+        worker, _store = self._make_worker()
+        for result in (
+            SimpleNamespace(average_fill_price=0.0),      # broker reported none
+            SimpleNamespace(average_fill_price=float("nan")),
+            SimpleNamespace(),                            # paper: no attribute at all
+            None,
+        ):
+            self.assertEqual(worker._entry_fill_price(result, 112.55), 112.55)
 
     def test_slh008_nifty_leg_uses_current_week_expiry(self):
         """SLH-008: the NIFTY leg must resolve the CURRENT-WEEK contract.

--- a/test_nifty_multi_strategy_master.py
+++ b/test_nifty_multi_strategy_master.py
@@ -3589,6 +3589,73 @@ class TestSLHuntingBnfMirror(unittest.TestCase):
         })
         return worker, store
 
+    def test_stale_cached_ltp_is_not_dealable(self):
+        """MAT-112: a mark older than the bound must not be usable to book a trade.
+
+        The 2026-07-30 case exactly: a snapshot left behind by an earlier trade on
+        the SAME strike was handed out ~24 minutes later.
+        """
+        worker, store = self._make_worker()
+        key_segment, key_secid = master_file.OPTION_EXCHANGE_SEGMENT, 1001
+        store.update_ltp_map({(key_segment, key_secid): 112.55})
+        # Age the snapshot past the bound, exactly as an unsubscribed leg would.
+        snapshot = store._ltp_snapshots[(key_segment, key_secid)]
+        snapshot.fetched_at = snapshot.fetched_at - timedelta(
+            seconds=master_file.MARKET_DATA_MAX_LTP_AGE_SECONDS + 30
+        )
+        # Unbounded read still sees it; a bounded read must not.
+        self.assertEqual(store.get_ltp_by_secid(key_segment, key_secid, 0.0), 112.55)
+        self.assertEqual(
+            store.get_ltp_by_secid(
+                key_segment,
+                key_secid,
+                0.0,
+                max_age_seconds=master_file.MARKET_DATA_MAX_LTP_AGE_SECONDS,
+            ),
+            0.0,
+        )
+        # With the direct quote answering, the FRESH broker price wins.
+        worker.broker.fetch_ltp_map.return_value = {(key_segment, key_secid): 125.0}
+        price, fresh = worker._get_dealable_option_ltp(key_segment, key_secid)
+        self.assertEqual((price, fresh), (125.0, True))
+
+    def test_dealable_ltp_reports_stale_when_direct_quote_also_fails(self):
+        """Both sources failing surfaces the old price AND says it is not fresh."""
+        worker, store = self._make_worker()
+        key_segment, key_secid = master_file.OPTION_EXCHANGE_SEGMENT, 1001
+        store.update_ltp_map({(key_segment, key_secid): 112.55})
+        snapshot = store._ltp_snapshots[(key_segment, key_secid)]
+        snapshot.fetched_at = snapshot.fetched_at - timedelta(
+            seconds=master_file.MARKET_DATA_MAX_LTP_AGE_SECONDS + 30
+        )
+        worker.broker.fetch_ltp_map.side_effect = RuntimeError("feed down")
+        price, fresh = worker._get_dealable_option_ltp(key_segment, key_secid)
+        self.assertEqual(price, 112.55)
+        self.assertFalse(fresh)
+
+    def test_unsubscribing_a_leg_drops_its_cached_price(self):
+        """The residue that made a closed leg's last price look usable is gone."""
+        _worker, store = self._make_worker()
+        key_segment, key_secid = master_file.OPTION_EXCHANGE_SEGMENT, 1001
+        store.update_ltp_map({(key_segment, key_secid): 112.55})
+        self.assertEqual(store.get_ltp_by_secid(key_segment, key_secid, 0.0), 112.55)
+        store.unregister_option_subscription(key_segment, key_secid)
+        self.assertEqual(store.get_ltp_by_secid(key_segment, key_secid, 0.0), 0.0)
+
+    def test_register_option_subscription_reports_first_owner_only(self):
+        """Only the caller that ADDED a shared leg may later withdraw it."""
+        _worker, store = self._make_worker()
+        sub = master_file.OptionSubscription(
+            security_id=1001,
+            exchange_segment=master_file.OPTION_EXCHANGE_SEGMENT,
+            trading_symbol="NIFTY-24300-CE",
+            right="CE",
+            strike=24300.0,
+            expiry=date.today(),
+        )
+        self.assertTrue(store.register_option_subscription(sub))
+        self.assertFalse(store.register_option_subscription(sub))
+
     def test_live_fill_price_beats_a_stale_ltp(self):
         """MAT-112: a LIVE entry is recorded at the BROKER's price, not the LTP.
 


### PR DESCRIPTION
## Scope

This PR now combines the v3v Intraday Hunter knowledge update with the runtime hardening found during review of PR #97 and merged PRs #85-96.

The knowledge evidence remains the [30 Jul live session](https://www.youtube.com/watch?v=LvA_VPLdm6Q):

- **A SMALL GAP DOES NOT RESCUE A SEATED CROWD**: judge the opening gap against the multi-day move that recruited the crowd, not merely against zero.
- **YESTERDAY'S MOMENTUM CHARACTER CALIBRATES TODAY'S PATIENCE**: recent follow-through informs how aggressively a valid winner should be held.

The corrected 30 Jul agent journal remains excluded as method evidence because the session had unhealthy market data, manual intervention, and materially wrong local-price accounting.

## Runtime hardening

- Makes option subscriptions owner-aware, retains shared snapshots until the final owner releases, and releases orphan subscriptions only after broker-confirmed-flat recovery.
- Rejects invalid or future-dated freshness evidence and fails live entry closed when no bounded mark is available across ATM, spread, Delta-0.2, strangle, NIFTY, and BankNIFTY mirror paths.
- Extends the execution ledger with quantity-weighted entry/close notional across partial fills, retries, status refreshes, and reconciliation without double counting.
- Reads only documented broker price fields: Kotak `avgPrc`, Shoonya/Flattrade `avgprc`, and Dhan `averageTradedPrice`; timeout results preserve the latest price evidence.
- Uses ledger-derived broker prices for all live entry/exit P&L. Missing broker prices keep risk-reducing exits available through an explicitly approximate mark fallback.
- Propagates `BROKER_FILL`, `PAPER_FRESH_MARK`, `MARK_FALLBACK`, `STALE_MARK`, and `UNKNOWN` telemetry. Approximate rows remain visible operationally but are ineligible for reflection coaching.

## Input and prompt hardening

- Bounds order reasons to one printable 120-character line: entries reject invalid text; exits sanitize or use a sentinel and are never blocked.
- Bounds premarket and lessons files before JSON parsing.
- Enforces a 75,000-character system-prompt ceiling while preserving all v3r-v3v markers.

## Validation

- `411` master-runner tests passed.
- `21` market-data health tests passed.
- `927` Signal Generators / Dependencies / Data Extractors tests passed.
- Branch-enabled coverage: `69.0%` overall; every stricter safety and broker threshold passed.
- `compileall`, Ruff, mypy (`40` source files), Bandit, pre-commit, and `git diff --check` passed.
- Pinned audits for core, AI, and dev requirements found no known vulnerabilities.
- Diff-scoped security review found no reportable regression.

No real broker orders were placed. Live enablement remains blocked pending a full-session paper soak of subscription ownership, fill-price reconciliation, and exit telemetry.

Co-authored with Codex (`Co-Authored-By: Codex <codex@openai.com>`).