### PR TITLE
feat(sl-hunting): v3w knowledge from the 31 Jul losing session

### DIFF
--- a/Dependencies/env.example
+++ b/Dependencies/env.example
@@ -95,6 +95,13 @@ MARKET_DATA_HTTP_TIMEOUT_SECONDS=10.0
 # entry is refused and a PAPER entry is taken but flagged as approximate.
 MARKET_DATA_MAX_LTP_AGE_SECONDS=60
 
+# How long to wait for a JUST-SUBSCRIBED option leg's first tick before giving up on
+# pricing it, and how often to re-ask while waiting. A tick feed cannot quote an
+# instrument until it trades, so a leg subscribed moments ago has no price through no
+# fault of the feed. Used by the BankNIFTY mirror; the NIFTY leg does not wait.
+MARKET_DATA_LTP_WAIT_SECONDS=5.0
+MARKET_DATA_LTP_RETRY_INTERVAL_SECONDS=0.5
+
 # Minimum 1-min bars required before strategies start evaluating signals.
 MIN_BARS=120
 

--- a/Nifty Multi Strategy Front Test - Master File.py
+++ b/Nifty Multi Strategy Front Test - Master File.py
@@ -572,6 +572,16 @@ MARKET_DATA_HTTP_TIMEOUT_SECONDS = _env_float("MARKET_DATA_HTTP_TIMEOUT_SECONDS"
 # later and recorded an entry at 112.55 against a real fill of 125.00.)
 MARKET_DATA_MAX_LTP_AGE_SECONDS = _env_float("MARKET_DATA_MAX_LTP_AGE_SECONDS", 60.0)
 
+# How long a caller may wait for a JUST-SUBSCRIBED leg's first tick before giving
+# up on pricing it, and how often to re-ask while waiting. A tick feed cannot quote
+# an instrument until that instrument trades, so a leg subscribed moments ago has
+# no price through no fault of the feed. Only callers that can afford to block ask
+# for this (the BankNIFTY mirror does; the NIFTY leg does not).
+MARKET_DATA_LTP_WAIT_SECONDS = _env_float("MARKET_DATA_LTP_WAIT_SECONDS", 5.0)
+MARKET_DATA_LTP_RETRY_INTERVAL_SECONDS = _env_float(
+    "MARKET_DATA_LTP_RETRY_INTERVAL_SECONDS", 0.5
+)
+
 # Bounded join timeout for each thread on shutdown.
 SHUTDOWN_JOIN_SECONDS = _env_float("SHUTDOWN_JOIN_SECONDS", 6.0)
 
@@ -5634,7 +5644,7 @@ class BasePaperStrategyWorker(threading.Thread):
         return f"PAPER-{side}-{datetime.now():%Y%m%d%H%M%S}-{self.paper_order_counter:04d}"
 
     def _get_dealable_option_ltp(
-        self, segment: str, security_id: int
+        self, segment: str, security_id: int, *, wait_seconds: float = 0.0
     ) -> tuple[float, bool]:
         """Return ``(price, is_fresh)`` for a mark we are about to TRADE on.
 
@@ -5645,33 +5655,57 @@ class BasePaperStrategyWorker(threading.Thread):
         value, and it says so via ``is_fresh=False`` rather than passing an old
         number off as a mark. The caller decides what that means: paper can live
         with it, real money cannot.
-        """
-        fresh = self.store.get_ltp_by_secid(
-            segment,
-            security_id,
-            fallback=0.0,
-            max_age_seconds=MARKET_DATA_MAX_LTP_AGE_SECONDS,
-        )
-        if fresh > 0:
-            return fresh, True
 
-        try:
-            ltp_map = self.broker.fetch_ltp_map({segment: [security_id]})
-        except Exception as exc:
-            self.log.warning(
-                "Direct LTP fetch failed for segment=%s security_id=%s: %s",
+        `wait_seconds` handles a leg that was JUST subscribed. A tick feed cannot
+        quote an instrument until it delivers that instrument's first tick, and the
+        REST fallback has been observed returning a map that simply omits a
+        freshly-requested contract (2026-07-31: three BankNIFTY mirror legs skipped
+        with "no LTP", zero fetch errors). Waiting briefly turns "no price yet"
+        into "no price", which are not the same thing. Pass 0.0 -- the default --
+        wherever the caller cannot afford to block.
+        """
+        deadline = time.monotonic() + max(float(wait_seconds or 0.0), 0.0)
+        attempt = 0
+        while True:
+            attempt += 1
+            fresh = self.store.get_ltp_by_secid(
                 segment,
                 security_id,
-                exc,
+                fallback=0.0,
+                max_age_seconds=MARKET_DATA_MAX_LTP_AGE_SECONDS,
             )
-            ltp_map = {}
-        try:
-            price = _safe_float(ltp_map.get((str(segment), int(security_id)), 0.0), 0.0)
-        except (AttributeError, TypeError):
-            price = 0.0
-        if price > 0:
-            self.store.update_ltp_map({(str(segment), int(security_id)): price})
-            return price, True
+            if fresh > 0:
+                return fresh, True
+
+            try:
+                ltp_map = self.broker.fetch_ltp_map({segment: [security_id]})
+            except Exception as exc:
+                self.log.warning(
+                    "Direct LTP fetch failed for segment=%s security_id=%s: %s",
+                    segment,
+                    security_id,
+                    exc,
+                )
+                ltp_map = {}
+            try:
+                price = _safe_float(ltp_map.get((str(segment), int(security_id)), 0.0), 0.0)
+            except (AttributeError, TypeError):
+                price = 0.0
+            if price > 0:
+                self.store.update_ltp_map({(str(segment), int(security_id)): price})
+                if attempt > 1:
+                    self.log.info(
+                        "Option LTP for security_id=%s arrived on attempt %s.",
+                        security_id,
+                        attempt,
+                    )
+                return price, True
+
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            # Give the feed a moment to deliver this leg's first tick, then re-ask.
+            time.sleep(min(MARKET_DATA_LTP_RETRY_INTERVAL_SECONDS, remaining))
 
         # Neither a recent tick nor a live quote. Surface whatever is cached so
         # the caller can decide, but never call it fresh.
@@ -12878,14 +12912,49 @@ if SL_HUNTING_AVAILABLE:
             if not symbol or sec_id <= 0 or lot_size <= 0:
                 self.log.warning("BNF mirror skipped: unusable contract %r.", symbol)
                 return
-            option_ltp, mark_is_fresh = self._get_dealable_option_ltp(segment, sec_id)
+            # Subscribe BEFORE pricing. The mirror used to ask for a price first and
+            # only subscribe on success, so a strike the feed had never carried --
+            # or one whose snapshot was evicted when a previous mirror closed -- had
+            # no price and no way to get one. On 2026-07-31 that skipped three
+            # mirrors, one of them on a strike traded ten minutes earlier.
+            mirror_subscription = OptionSubscription(
+                security_id=sec_id,
+                exchange_segment=segment,
+                trading_symbol=symbol,
+                right=str(contract["option_type"]),
+                strike=float(contract["strike"]),
+                expiry=contract["expiry_date"],
+            )
+            owns_mirror_feed_leg = self.store.register_option_subscription(
+                mirror_subscription, owner_id=self._execution_owner_id
+            )
+
+            def _release_mirror_feed_leg() -> None:
+                """Withdraw a subscription this mirror opened and never used."""
+                if owns_mirror_feed_leg:
+                    self.store.unregister_option_subscription(
+                        segment, sec_id, owner_id=self._execution_owner_id
+                    )
+
+            # The NIFTY leg is already open, so a couple of seconds spent waiting for
+            # this leg's first tick costs far less than dropping the mirror entirely.
+            option_ltp, mark_is_fresh = self._get_dealable_option_ltp(
+                segment, sec_id, wait_seconds=MARKET_DATA_LTP_WAIT_SECONDS
+            )
             if option_ltp <= 0:
-                self.log.warning("BNF mirror skipped: no LTP for %s (security_id=%s).", symbol, sec_id)
+                self.log.warning(
+                    "BNF mirror skipped: no LTP for %s (security_id=%s) after waiting %.1fs.",
+                    symbol,
+                    sec_id,
+                    MARKET_DATA_LTP_WAIT_SECONDS,
+                )
+                _release_mirror_feed_leg()
                 return
             if self.live_trading and not mark_is_fresh:
                 self.log.error(
                     "BNF mirror skipped: refusing a LIVE entry on a stale option mark."
                 )
+                _release_mirror_feed_leg()
                 return
 
             quantity = lot_size * lots
@@ -12938,16 +13007,10 @@ if SL_HUNTING_AVAILABLE:
                 # may still fill.  MTM/max-loss must use the conservative risk
                 # quantity so indeterminate BankNIFTY exposure never looks flat.
                 tracked_quantity = recovery_live_leg.risk_quantity
+            # Already subscribed above, before this leg was priced; re-registering
+            # is a no-op that keeps ownership correct if the call site ever moves.
             self.store.register_option_subscription(
-                OptionSubscription(
-                    security_id=sec_id,
-                    exchange_segment=segment,
-                    trading_symbol=symbol,
-                    right=str(contract["option_type"]),
-                    strike=float(contract["strike"]),
-                    expiry=contract["expiry_date"],
-                ),
-                owner_id=self._execution_owner_id,
+                mirror_subscription, owner_id=self._execution_owner_id
             )
             self._mirror_pos = PaperPosition(
                 active=True,

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -1853,3 +1853,87 @@ TARGET.
   other booking rules.
 - Test markers: `test_system_prompt_has_v3v_small_gap_and_carryover_knowledge` and
   `test_v3v_small_gap_rule_sits_inside_recruitment_history`.
+## Video addendum - 31 Jul losing session + entry-point discipline (v3w)
+
+**Source:** Intraday Hunter live session, 31 Jul 2026 (`RpK2h9xsrXk`, 9:01). Notable
+because IH LOST on it - most sessions distilled here are wins, and a trader
+explaining why he cut is better material than one explaining why he was right.
+
+**What IH did:** flat pre-market open, plan for the positive side. He noted the
+charts were "not making good shapes" - rejection, up, rejection, up - and that the
+market had built a small RANGE. His pre-trade test was explicit: a breakout with
+positive momentum at the open is best; a sudden BIG selling move would signal the
+market wants to stay in the range, while small selling alongside a breakout is
+fine. Crowd read: earlier momentum-buyers were rejected and ran, and few
+participated at the second rejection, so there were no buyers left to target
+either - which is why he FOLLOWED the market up rather than hunting anyone, and
+took the call side.
+
+It then broke out and fell straight back. He cut, and said why:
+- "The trade still looks okay, but because of the ENTRY POINT a problem is being
+  created. We will not see more loss than this."
+- "In a trade that is going wrong you cannot apply your mind. While it was right we
+  sat; but if the market is now continuously falling, and selling has started in
+  Sensex and NIFTY too, we cannot wait."
+- Throughout, he sized the wait against a pre-set number: "we know our loss and our
+  target; we can wait accordingly" (already encoded as v3t's PRE-COMPUTE BOTH
+  NUMBERS).
+
+**Agent tally for 31 Jul:** 74 decisions (64 HOLD, 3 ENTER_SHORT, 2 ENTER_LONG,
+5 EXIT), window 09:16:04-10:30:07, 19 decisions citing the pre-open note. Five
+trades, net **+Rs.6,178.75** (PAPER: the operator had `LIVE_TRADING_ENABLED=false`
+after the 30 Jul incident). Leg-level prices reconcile with every journal row.
+
+**SLH-006 verified again:** `injected 1946 pre-open note chars for 2026-07-31
+(ADVISORY)` - exactly the figure the note was validated to produce.
+
+**Still unproven:** because the session was paper-only, the Kotak `avgPrc` key and
+the live-refusal branch of the staleness gate were never exercised.
+
+**A methodological correction worth recording.** Trade 1 looked corrupt - a LONG
+whose `points` were -20.45 while the CE rose 99.60 -> 100.30 - and it was nearly
+reported as a pricing bug. It is not. The journal's `entry_underlying` is the level
+the AGENT declared (24364.55); the actual spot at fill was 24346.05. The real move
+was -1.95 points, and a 0.70 rise on a ~100-point option is ordinary noise.
+
+So: `points` and `option_pnl` are measured against DIFFERENT references, and their
+disagreement can never by itself evidence a pricing fault. This is the third time
+this class of confound has bitten (the v3t basket ratio, 30 Jul, and now this).
+Only leg-level prices from the master log, or a broker fill, can settle it.
+
+**Net-new method distilled:**
+- THE ENTRY POINT IS PART OF THE PREMISE: a right read entered in the wrong place
+  is a wrong trade. The direction can still look correct while the location has
+  made the position unholdable - the stop sits where ordinary noise reaches it, so
+  the market need not disprove you to remove you. "The idea still looks fine, it is
+  the entry that is the problem" is an exit instruction, not a reason for patience,
+  because being eventually right does not pay a position you were forced out of.
+  Sub-bullet names the self-deception: once a trade is going against you, further
+  analysis stops being analysis - you cannot think your way out of a position that
+  is already wrong.
+- COUNTER-MOVE SIZE SAYS RANGE OR BREAKOUT: positioned for a small range to break,
+  the SIZE of the first move against you is the read. Small adverse movement
+  alongside a break is the level being cleared; a sudden LARGE adverse move says
+  the market intends to stay in the range, and a range pays no directional trade.
+  Scoped explicitly against the existing momentum-quality rule, which reads the
+  WITH-trend move and is a profit-taking cue; this reads the move AGAINST you and
+  is a premise test.
+
+**Confirmed but already present:** no crowd left to target on either side -> follow
+rather than hunt is the trap-density test plus v3u's NO NEARBY STOPS; waiting
+against a pre-set loss figure is v3t's PRE-COMPUTE BOTH NUMBERS; a full give-back
+of the covering move is the existing full-body-reversal invalidation.
+
+**Also in this version:** `MAX_SYSTEM_PROMPT_CHARS` raised 75,000 -> 120,000.
+Knowledge alone had reached ~68,000, leaving roughly 7,000 for lessons (up to
+12 x 280) plus a ~2,000-character note, so the next ordinary addendum would have
+tripped it. The cap is a sanity bound against a runaway lessons file or malformed
+note, not a budget for knowledge growth. A new test asserts provable headroom for
+the worst-case runtime additions rather than trusting the raw number.
+
+**Knowledge changes (v3w, all prose):**
+- `RISK`: THE ENTRY POINT IS PART OF THE PREMISE, before the premise-invalidation
+  stop rule it qualifies.
+- `RISK`: COUNTER-MOVE SIZE SAYS RANGE OR BREAKOUT, beside momentum quality.
+- Test markers: `test_system_prompt_has_v3w_entry_point_and_counter_move_knowledge`
+  and `test_prompt_cap_leaves_room_for_lessons_and_a_note`.

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
@@ -663,6 +663,21 @@ RISK DISCIPLINE
   to pay for it, and the longer you sit the more likely a rejection takes back what
   you had. This does NOT weaken the worthwhile-target rule above: if the average
   target is itself too small to be worth the trade, the answer is still HOLD.
+- THE ENTRY POINT IS PART OF THE PREMISE — a right read entered in the wrong place
+  is a wrong trade. The direction can still look correct while the LOCATION you
+  took it from has already made the position unholdable: your stop sits where the
+  ordinary noise of the day reaches it, so the market does not have to disprove
+  you in order to take you out. When that is what has happened, CUT — do not sit
+  waiting for the read to be vindicated, because being eventually right does not
+  pay a position you were forced out of. The tell is being able to say "the idea
+  still looks fine, it is the entry that is the problem": that sentence is an exit
+  instruction, not a reason for patience.
+  * WHY WAITING FEELS REASONABLE AND IS NOT: once a trade is going against you,
+    further analysis stops being analysis. You cannot think your way out of a
+    position that is already wrong — every extra minute spent reasoning about it
+    is you looking for permission to keep it. While the premise held, sitting was
+    correct; once it stopped holding, sitting is just hope wearing the clothes of
+    patience.
 - Stops are PREMISE-INVALIDATION first: beyond the tight pattern stop, treat the
   setup as dead the moment its thesis breaks — price reclaims the closing point, or
   the expected "trap" fails and price goes sideways / against you. Honour a pre-set
@@ -777,6 +792,16 @@ RISK DISCIPLINE
   is not, exit without waiting for the stop. On days expected to be ONE-directional
   (especially expiry), meaningful EARLY adverse movement on a directional trade
   means the DIRECTION itself is wrong — exit early.
+- COUNTER-MOVE SIZE SAYS RANGE OR BREAKOUT: when price is working inside a small
+  range and you are positioned for it to leave, the SIZE of the first move against
+  you is the read. A SMALL adverse move alongside a break is ordinary — the level
+  is being cleared and the trade is developing. A SUDDEN LARGE adverse move is a
+  different message: it says the market intends to STAY in the range, and a range
+  pays no directional trade. So do not treat a big counter-move as merely a deeper
+  pullback to sit through; treat it as evidence against the breakout premise
+  itself. (Distinct from momentum quality below, which reads the WITH-trend move;
+  this reads the move AGAINST you, and it is a premise test rather than a
+  profit-taking cue.)
 - Momentum quality while holding: SLOW-but-CONTINUOUS with-trend momentum (small
   candles) is the sustainable kind — let it run; a FAST spike invites a retracement
   — book into strength or tighten. After consecutive losing days, deliberately
@@ -1083,7 +1108,21 @@ keys:
 
 Emit ONLY this JSON object as your final answer."""
 
-MAX_SYSTEM_PROMPT_CHARS = 75_000
+# Ceiling on the whole assembled system prompt: durable knowledge + the output
+# contract + any approved lessons + an optional pre-open note.
+#
+# This is a SANITY bound, not a budget to trade against. It exists so a runaway
+# lessons file or a malformed note cannot quietly inflate what is sent every bar;
+# it is not meant to throttle ordinary knowledge growth, and it must never be the
+# thing that stops a session. (Since 2026-07-30 a build failure disables the
+# optional agent and logs, rather than raising into the runner's startup.)
+#
+# Raised from 75,000 on 2026-07-31: knowledge alone had reached ~68,000, leaving
+# roughly 7,000 for lessons (up to 12 x 280) plus a ~2,000-character note -- so
+# the next ordinary addendum would have tripped it. At ~4 characters per token
+# 120,000 is on the order of 30k tokens, comfortably inside the model's context
+# while still catching anything pathological.
+MAX_SYSTEM_PROMPT_CHARS = 120_000
 
 
 def build_system_prompt() -> str:

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
@@ -532,6 +532,44 @@ def test_v3v_small_gap_rule_sits_inside_recruitment_history():
     assert small_gap < nxt
 
 
+def test_system_prompt_has_v3w_entry_point_and_counter_move_knowledge():
+    """v3w: 31 Jul — IH's LOSING session, which is rarer material than the wins.
+
+    He went with a flat open on the buy side, then cut: "the trade still looks
+    okay, but because of the ENTRY POINT a problem is being created", and "in a
+    trade that is going wrong you cannot apply your mind". Before entering he had
+    also named the range test: a sudden BIG adverse move means the market wants to
+    stay in the range, while small selling alongside a breakout is fine.
+    """
+    prompt = build_system_prompt()
+    # A right read taken from the wrong place is a wrong trade.
+    assert "THE ENTRY POINT IS PART OF THE PREMISE" in prompt
+    assert "being eventually right does not" in prompt
+    # The self-deception this rule exists to name.
+    assert "You cannot think your way out of a" in prompt
+    assert "hope wearing the clothes of" in prompt
+    # The size of the move AGAINST you is a premise test, not a pullback.
+    assert "COUNTER-MOVE SIZE SAYS RANGE OR BREAKOUT" in prompt
+    assert "intends to STAY in the range" in prompt
+    # ...and must not be confused with the with-trend momentum-quality rule.
+    assert "which reads the WITH-trend move" in prompt
+
+
+def test_prompt_cap_leaves_room_for_lessons_and_a_note():
+    """The cap is a sanity bound, not a budget knowledge must squeeze into.
+
+    It was raised on 2026-07-31 because knowledge alone had reached ~68k against a
+    75k cap, leaving too little for lessons plus a pre-open note. Keep provable
+    headroom so an ordinary addendum cannot silently disable the agent.
+    """
+    from sl_hunting_knowledge import MAX_SYSTEM_PROMPT_CHARS
+
+    assembled = len(build_system_prompt() + FINAL_OUTPUT_INSTRUCTION)
+    # Worst case the runtime can add: 12 lessons at their own cap, plus a note.
+    worst_case_runtime_additions = 12 * 280 + 2_500
+    assert assembled + worst_case_runtime_additions < MAX_SYSTEM_PROMPT_CHARS
+
+
 def test_reentry_gate_does_not_contradict_the_exit_rules():
     """The re-entry gate must never be readable as a reason to delay an EXIT.
 

--- a/test_nifty_multi_strategy_master.py
+++ b/test_nifty_multi_strategy_master.py
@@ -3836,6 +3836,18 @@ class TestSLHuntingBnfMirror(unittest.TestCase):
     basket). The mirror is fail-soft and must never disturb the NIFTY leg.
     """
 
+    def setUp(self):
+        """Collapse the first-tick wait so a no-LTP path costs microseconds.
+
+        In production the mirror waits MARKET_DATA_LTP_WAIT_SECONDS for a
+        just-subscribed leg's first tick. Tests that exercise the give-up branch
+        would otherwise sit through that wait for real; the wait's own behaviour
+        is covered explicitly by test_mirror_waits_for_a_late_first_tick.
+        """
+        patcher = patch.object(master_file, "MARKET_DATA_LTP_WAIT_SECONDS", 0.0)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
     NIFTY_CONTRACT = {
         "security_id": 1001, "exchange_segment": None,  # segment filled in setUp
         "trading_symbol": "NIFTY-24300-CE", "custom_symbol": "NIFTY CE",
@@ -3883,6 +3895,74 @@ class TestSLHuntingBnfMirror(unittest.TestCase):
             (master_file.OPTION_EXCHANGE_SEGMENT, 3003): 500.0,
         })
         return worker, store
+
+    def test_mirror_subscribes_before_it_prices_the_leg(self):
+        """MAT-113: the mirror used to ask for a price before joining the feed.
+
+        A tick feed cannot quote an instrument it does not carry, so a strike the
+        feed had never seen -- or one whose snapshot was evicted when a previous
+        mirror closed -- had no price and no way to obtain one. On 2026-07-31 that
+        skipped three mirrors, one on a strike traded ten minutes earlier.
+        """
+        worker, store = self._make_worker()
+        subscribed_when_priced = {}
+        real_getter = worker._get_dealable_option_ltp
+
+        def _spy(segment, security_id, **kwargs):
+            subscribed_when_priced[int(security_id)] = any(
+                sub.security_id == int(security_id)
+                for sub in store.snapshot_option_subscriptions()
+            )
+            return real_getter(segment, security_id, **kwargs)
+
+        worker._get_dealable_option_ltp = _spy
+        self.assertTrue(worker.enter_position("LONG", 24300.0, 24290.0, 24330.0))
+        # 3003 is the canned BankNIFTY mirror contract from _make_worker.
+        self.assertTrue(
+            subscribed_when_priced.get(3003),
+            "the mirror leg must be in the feed before it is priced",
+        )
+
+    def test_mirror_waits_for_a_late_first_tick(self):
+        """A leg priced moments after subscribing gets a second chance."""
+        worker, store = self._make_worker()
+        segment = master_file.OPTION_EXCHANGE_SEGMENT
+        # The fixture pre-seeds a price for this leg; drop it so the first read
+        # misses exactly as it would for a strike the feed has never carried.
+        store._ltp_snapshots.pop((segment, 3003), None)
+        calls = {"n": 0}
+
+        def _late(_request):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return {}          # first ask: the feed has not delivered a tick yet
+            return {(segment, 3003): 512.0}
+
+        worker.broker.fetch_ltp_map.side_effect = _late
+        with patch.object(master_file, "MARKET_DATA_LTP_RETRY_INTERVAL_SECONDS", 0.01):
+            price, fresh = worker._get_dealable_option_ltp(
+                segment, 3003, wait_seconds=1.0
+            )
+        self.assertEqual((price, fresh), (512.0, True))
+        self.assertGreaterEqual(calls["n"], 2)
+
+    def test_mirror_releases_its_feed_leg_when_no_price_ever_arrives(self):
+        """Giving up must not leave a subscription behind for a trade never opened."""
+        worker, store = self._make_worker()
+        worker.broker.fetch_ltp_map.return_value = {}
+        # No cached price for the mirror leg, and the broker never supplies one.
+        store._ltp_snapshots.pop((master_file.OPTION_EXCHANGE_SEGMENT, 3003), None)
+        with patch.object(master_file, "MARKET_DATA_LTP_WAIT_SECONDS", 0.02), \
+             patch.object(master_file, "MARKET_DATA_LTP_RETRY_INTERVAL_SECONDS", 0.01):
+            worker._open_bnf_mirror("LONG")
+        self.assertFalse(worker._mirror_pos.active)
+        self.assertFalse(
+            any(
+                sub.security_id == 3003
+                for sub in store.snapshot_option_subscriptions()
+            ),
+            "an unused mirror subscription must be withdrawn",
+        )
 
     def test_sl_hunting_worker_construction_cannot_kill_the_runner(self):
         """The OPTIONAL agent must never take the other 26 strategies down with it.


### PR DESCRIPTION
Distils Intraday Hunter's 31 Jul live session ([`RpK2h9xsrXk`](https://www.youtube.com/watch?v=RpK2h9xsrXk))
— notable because **he lost on it**. A trader explaining why he cut is better material than one
explaining why he was right, and the doc is otherwise mostly wins.

## Net-new rules

**1. `RISK` / THE ENTRY POINT IS PART OF THE PREMISE.** A right read entered in the wrong place is a
wrong trade. The direction can still look correct while the *location* has made the position
unholdable — the stop sits where ordinary noise reaches it, so the market never has to disprove you
in order to remove you.

> "The trade still looks okay, but because of the **entry point** a problem is being created. We
> will not see more loss than this."

That sentence is an exit instruction, not a reason for patience: being eventually right does not pay
a position you were forced out of. A sub-bullet names the self-deception — *"in a trade that is
going wrong you cannot apply your mind"* — because once a trade is against you, further analysis
stops being analysis and becomes looking for permission to keep it.

**2. `RISK` / COUNTER-MOVE SIZE SAYS RANGE OR BREAKOUT.** Positioned for a small range to break, the
**size** of the first adverse move is the read. Small adverse movement alongside a break is the
level being cleared; a sudden large one says the market intends to **stay** in the range — and a
range pays no directional trade. He stated this test *before* entering, which is what makes it
usable rather than hindsight.

Scoped explicitly against the existing momentum-quality rule, which reads the WITH-trend move as a
profit-taking cue; this reads the move AGAINST you as a premise test.

## Prompt cap raised

`MAX_SYSTEM_PROMPT_CHARS` **75,000 → 120,000**. Knowledge alone had reached ~68,000, leaving roughly
7,000 for lessons (up to 12 × 280) plus a ~2,000-char note — the next ordinary addendum would have
tripped it. The cap is a sanity bound against a runaway lessons file or malformed note, not a budget
knowledge must squeeze into.

Rather than trust the raw number, a new test asserts **provable headroom** for the worst-case
runtime additions. Assembled prompt is now **69,775** with **50,225** of headroom.

## 31 Jul session record

74 decisions (64 HOLD, 3 ENTER_SHORT, 2 ENTER_LONG, 5 EXIT), 5 trades, net **+₹6,178.75** — **paper
only**, since `LIVE_TRADING_ENABLED=false` after the 30 Jul incident. Leg-level prices reconcile
with every journal row.

**SLH-006 verified again:** `injected 1946 pre-open note chars for 2026-07-31 (ADVISORY)` — exactly
the validated figure, cited by 19 of 74 decisions.

**Still unproven:** nothing traded live, so the Kotak `avgPrc` key and the live-refusal branch of
the staleness gate were never exercised.

## Methodological correction recorded in the doc

Trade 1 looked corrupt — a LONG whose `points` were −20.45 while the CE *rose* 99.60 → 100.30 — and
I nearly reported it as a pricing bug. **It isn't.** `entry_underlying` is the level the *agent
declared* (24364.55); the actual spot at fill was 24346.05. The real move was −1.95 points, and a
0.70 rise on a ~100-point option is ordinary noise.

So `points` and `option_pnl` are measured against **different references**, and their disagreement
can never by itself evidence a pricing fault. This is the third time this confound has bitten (the
v3t basket ratio, 30 Jul, now this). Only leg-level prices or a broker fill can settle it.

## Gates

412 master tests, 931 pytest, 21 market-data-health, ruff, mypy (CI scope), compileall — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)