### PR TITLE
feat(sl-hunting): add v3x August 2 analysis

### DIFF
--- a/Signal Generators/SL Hunting AI Agent/premarket_note.json
+++ b/Signal Generators/SL Hunting AI Agent/premarket_note.json
@@ -1,29 +1,27 @@
 {
-  "for_date": "2026-07-31",
-  "source": "Intraday Hunter, 'Prediction For 31 JULY 2026' (video B0mG5R2JsFs)",
-  "context": "Momentum is shrinking across all three indices. Buyers have come in over the last two-three days but the market has repeatedly changed their mindset, so the crowd is not cleanly seated; NIFTY's advance came with retracements.",
+  "for_date": "2026-08-03",
+  "source": "Intraday Hunter, 'Prediction For 03 AUG 2026' (yHEfrMUrmKk, uploaded 2026-08-02)",
+  "context": "All three indices closed with positive momentum after sideways or recovery action, so buyers may be seated. The opening type decides whether those buyers are safe or huntable.",
   "plan": [
-    "FLAT or GAP-UP open: follow the existing momentum - identify BUY-side setups and go with the market.",
-    "SMALL GAP-DOWN open: no plan can be made for this case. Abstain and let the market show its hand rather than forcing a trade.",
-    "BIG GAP-DOWN open: the buyers who stayed seated are the ones in trouble - identify SELL-side setups targeting them.",
-    "The distinction that matters is the SIZE of the gap-down, not merely its direction: a small one strands nobody, a large one leaves the seated buyers exposed.",
-    "When momentum does come it can look like a breakout, pull buyers in, and then have their mindset changed again - treat a first thrust with suspicion."
+    "MEANINGFUL GAP-UP: buyers are not the target; follow the market and identify BUY-side setups.",
+    "FLAT or GAP-DOWN: target the seated buyers and identify SELL-side setups.",
+    "Treat a mild GAP-UP as FLAT rather than assuming it released the buyers; wait for the sell-side setup to confirm."
   ],
   "levels": [
     {
       "index": "NIFTY",
-      "resistance": [24400, 24482],
-      "support": [24207, 24140]
+      "resistance": [24400, 24480],
+      "support": [24300, 24220]
     },
     {
       "index": "BANKNIFTY",
-      "resistance": [57258, 57684],
-      "support": [56856, 56533]
+      "resistance": [57680, 57820],
+      "support": [57154, 56850]
     },
     {
       "index": "SENSEX",
-      "resistance": [78207, 78505],
-      "support": [77500, 77201]
+      "resistance": [78500, 78850],
+      "support": [77840, 77500]
     }
   ]
 }

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -1990,3 +1990,80 @@ gate. Those existing safeguards remain authoritative.
   wording without permitting sub-1:1 or manufactured targets.
 - Tests pin all three markers, the retained safeguards, and the complete dated
   premarket payload.
+
+### v3x continued - the 3 Aug LIVE SESSION (appended to the same version)
+
+**Source:** Intraday Hunter live session, 3 Aug 2026 (`cwgFEpiTwgE`, 9:23). The v3x
+section above was distilled from his 2 Aug *analysis*; this is the session that
+followed it, so both belong to the same version.
+
+**What IH did:** gap-up open with a slight rejection, and he bought CALLs on the
+dip. His pre-trade read, close to verbatim:
+- "When such a gap-up opens you must look at what is happening OVERALL: buying has
+  been continuous for many days, and then a gap-up. Sometimes profit-booking comes."
+- "Those sitting from BELOW are not booking - **if theirs were coming you would see
+  bigger selling, quick sharp selling.** Nothing like that is happening. This is
+  just the market shaking out whoever bought on FRIDAY and got a sudden gap-up."
+- "If they had exited here we would assume the trader is weak. He is not weak - he
+  is riding the market long term."
+- Per his own analysis: on a gap-up the buyers are NOT the target, so go with the
+  market (this is the note channel and the plan agreeing, not new method).
+
+**Why he booked - the strongest part of the session:**
+- "The momentum that is happening is only in BankNIFTY. Sensex and NIFTY have lagged."
+- "It is not that more momentum cannot come. **But the setups that work for us -
+  this is not one of them.**"
+- "The market can do anything on any day, but will we chase it when we do not even
+  know where the road is going? **We waited as far as we knew the road. Now we do
+  not know the road.**"
+
+**Agent tally for 3 Aug:** 73 decisions (69 HOLD, 1 ENTER_SHORT, 1 ENTER_LONG,
+2 EXIT), window 09:16:01-10:30:07, 14 decisions citing the pre-open note. Two
+trades, both losers, net **-Rs.1,379.25** (PAPER):
+- 09:25:06 -> 09:25:33 SHORT `huge_gap_mindset_trap_fade`, 3 lots, -6.4 pts,
+  **-Rs.950.25** (NIFTY -243.75 + mirror -706.50), held 27 SECONDS.
+- 09:31:06 -> 09:32:30 LONG `gapup_followthrough_fibo61_hammer`, 2 lots, -2.8 pts,
+  **-Rs.429.00** (NIFTY -351.00 + mirror -78.00), held 84 seconds.
+
+**MAT-113 verified in production:** both BankNIFTY mirrors fired (09:24:16 and
+09:30:52), with ZERO "no LTP" skips and no wait needed - against three skips on
+31 Jul. Subscribing the leg before pricing it was the fix.
+
+**Behaviour worth recording, not encoded as a rule.** The agent FADED the gap-up
+(a short at 09:25) on a day its own pre-open note said gap-up means do not target
+buyers, was stopped in 27 seconds, then FLIPPED to long 5m33s later - clearing the
+five-minute mechanical cooldown by 33 seconds. Both lost. That is exactly the
+pattern MORNING SPEED IS NOT INFORMATION and NO INSTANT FLIP already describe, so
+this is evidence those rules are not yet binding rather than a gap in them. Worth
+watching before adding more prose about it.
+
+**Net-new method distilled:**
+- PROFIT DEPTH SPLITS ONE SIDE INTO TWO COHORTS (sub-bullet of AGGREGATE-INVENTORY
+  TEST): "buyers" is not one crowd. After a multi-day run, traders positioned from
+  far below are deep in profit and are not weak; only the MARGINAL holders from the
+  last session or two are close enough to their entry to be flushed. A hunt aimed at
+  "the buyers" therefore collects a far smaller pool of stops than the aggregate
+  suggests.
+- THE COUNTER-MOVE'S SIZE AND SPEED SAY WHICH COHORT IS LEAVING: a small, slow
+  rejection is the recent cohort being shaken and nothing more; genuine
+  profit-booking by deep holders shows up as BIG, QUICK selling. If that has not
+  appeared, they are still in and the move against you is noise, not distribution.
+  Complements v3w's COUNTER-MOVE SIZE SAYS RANGE OR BREAKOUT, which reads size to
+  test a breakout premise; this reads size to identify WHO is moving.
+- ONLY RIDE AS FAR AS YOU KNOW THE ROAD (RISK): book when the situation stops
+  matching a setup you actually have, even though nothing has invalidated and the
+  move may well continue. Explicitly separated from premise-invalidation (thesis
+  broke) and from a target (number arrived): here the trade may still be working and
+  what ran out is the ability to READ it. Framed as the holding-side twin of "when
+  unsure, HOLD" - that rule keeps you out with no read, this one gets you out when
+  the read you entered on is used up. Its typical trigger is the move narrowing to
+  one index, which is LAGGARDS NEVER JOINED's cross-index form of the same signal.
+
+**Confirmed but already present:** gap-up means follow rather than hunt is
+RECRUITMENT HISTORY plus v3v's small-gap qualifier; booking when the leader runs
+alone is LAGGARDS NEVER JOINED (v3s).
+
+**Knowledge changes (v3x continued, all prose):**
+- `RETAIL_POSITIONING`: two sub-bullets under AGGREGATE-INVENTORY TEST.
+- `RISK`: ONLY RIDE AS FAR AS YOU KNOW THE ROAD.
+- Test marker: `test_system_prompt_has_v3x_profit_depth_and_known_road_knowledge`.

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -1937,3 +1937,56 @@ the worst-case runtime additions rather than trusting the raw number.
 - `RISK`: COUNTER-MOVE SIZE SAYS RANGE OR BREAKOUT, beside momentum quality.
 - Test markers: `test_system_prompt_has_v3w_entry_point_and_counter_move_knowledge`
   and `test_prompt_cap_leaves_room_for_lessons_and_a_note`.
+
+## Video addendum - 2 Aug premarket + weekly root-value review (v3x)
+
+**Sources (direct YouTube transcripts):**
+- Intraday Hunter premarket analysis, `Nifty & Bank nifty | SENSEX Analysis |
+  Prediction For 03 AUG 2026` (`yHEfrMUrmKk`, 1:59, uploaded 2 Aug 2026).
+- Intraday Hunter, `Weekly Market Analysis: The Biggest Opportunities`
+  (`iDV1obD78-c`, 17:16, uploaded 2 Aug 2026).
+
+The premarket clip is dated by its target session, so the committed advisory is for
+3 Aug. All three indices had closed with positive momentum and likely seated buyers.
+A meaningful gap-up protects that crowd and calls for buy-side setups with the
+market; a flat or gap-down open exposes them and calls for sell-side setups. IH also
+said a mild gap-up is treated as flat. Spoken rounded levels were checked against the
+visible charts before updating `premarket_note.json`; no false decimal precision is
+stored.
+
+The weekly lecture reviews five recent directional reads. Its recurring method is to
+infer the buyer/seller "root value" from the crowd likely carrying the most quantity,
+not from one hypothetical participant. A repeated breakdown followed by recovery
+does not leave a durable seller crowd: repeated failure pushes sellers out, and if
+the other indices remain positive, buyers may become the seated side instead. The
+lecture also states that option-buying targets must fit the available time: IH uses
+roughly 1:1 when his crowd read is exceptionally clear because a distant target can
+be less realistic than the stop.
+
+**Net-new method distilled:**
+- AGGREGATE-INVENTORY TEST: hunt the dominant aggregate cohort, not an anecdote. If
+  neither side likely has meaningful size, follow current momentum or hold.
+- REPEATED-FAILURE INVENTORY RESET: repeated breakdown-and-recovery cycles evict
+  sellers; require fresh participation before treating their stops as available.
+- OPTION-TIME-ADJUSTED REWARD/RISK: normally prefer an attainable approximately 1:2.
+  Approximately 1:1 is a narrow exception requiring the unique-trade filter, a
+  direct aggregate crowd read, real stop/target levels, a pre-accepted rupee loss,
+  and an option-time reason the farther target is unrealistic. Less than 1:1 is HOLD.
+
+**Confirmed but deliberately not duplicated:** horizon selection is TIMEFRAME FIT;
+already-paid crowds are TARGET-BOOKED; gap-size and cross-index asymmetry already
+govern who remains huntable; direction can survive a bad entry only through THE
+ENTRY POINT IS PART OF THE PREMISE plus the POST-EXIT RE-ENTRY GATE; a quiet week is
+already covered by NO DAILY-INCOME PRESSURE.
+
+**Not encoded:** the lecture mentions that a first directional entry may fail and a
+second or third may work with lower quantity. The agent cannot choose a reduced order
+quantity, and reflex retries would contradict the enforced cooldown and fresh-crowd
+gate. Those existing safeguards remain authoritative.
+
+**Knowledge changes (v3x, all prose):**
+- `RETAIL_POSITIONING`: AGGREGATE-INVENTORY TEST and REPEATED-FAILURE INVENTORY RESET.
+- `RISK`: OPTION-TIME-ADJUSTED REWARD/RISK replaces the absolute approximately 1:2
+  wording without permitting sub-1:1 or manufactured targets.
+- Tests pin all three markers, the retained safeguards, and the complete dated
+  premarket payload.

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
@@ -196,6 +196,18 @@ retail's stop-losses sit so you can trade where the operator will hunt them.
   often means put buyers / sellers already booked profit; they are not today's
   target. When the old crowd is safe/booked, reset the read to who is being trapped
   in the CURRENT session instead of blindly hunting the prior side.
+- AGGREGATE-INVENTORY TEST: target the side likely holding the greatest aggregate quantity,
+  not an anecdotal trader who might still be positioned. One person saying
+  "I held" does not prove a crowd or create enough stops to hunt. Infer the dominant
+  cohort from repeated participation, momentum, closing behaviour, and the
+  cross-index read. If neither side is likely carrying meaningful size, follow the
+  current momentum or HOLD rather than inventing a hunt.
+- REPEATED-FAILURE INVENTORY RESET: repeated breakdown-and-recovery cycles usually
+  evict sellers — each failed break stops them or persuades them not to hold. When
+  the level is repeatedly reclaimed while the other indices remain positive, discard
+  the stale seller-hunt assumption and reassess whether buyers have become the
+  dominant seated crowd. A later rejection alone does not restore seller inventory;
+  require fresh seller participation before treating their SLs as available again.
 - PROFIT-BOOKING RECOVERY TEST (scopes TARGET-BOOKED on an established selloff):
   after a real multi-day selloff has already paid the seller crowd and the next
   session gaps down, the first green recovery may simply let those profitable
@@ -638,11 +650,15 @@ RISK DISCIPLINE
   shows the mirror as its own leg with its own P&L; `unrealized_pnl` there is BASKET P&L
   (both legs) while `nifty_leg_pnl` and the `mirror` block give you each leg alone. When in
   doubt, EXIT BOTH.
-- Require a worthwhile target: at least ~1:2 reward:risk to the next clear level
-  (swing / pivot / fibo / psych). Aim for the LIQUIDITY ZONE where the hunted SLs
-  sit (the long-wicked candle / opposite side of the first candle / the trapped
-  crowd's stops). If the nearest opposing level is too close, the target is too
-  small — HOLD.
+- OPTION-TIME-ADJUSTED REWARD/RISK: require a worthwhile and ATTAINABLE target at a
+  real swing / pivot / fibo / psych level. Normally prefer approximately 1:2
+  reward:risk to the next clear level. An approximately 1:1 trade is permitted only
+  when EVERY condition is true: the UNIQUE-TRADE FILTER passes; the
+  AGGREGATE-INVENTORY TEST gives a direct, high-clarity crowd read; the stop and
+  target are real chart levels; the rupee loss is accepted before entry; and option
+  time / theta makes a farther target unrealistic. Aim for the LIQUIDITY ZONE where
+  the hunted SLs sit, but never fabricate a distant target or widen the stop merely
+  to manufacture a ratio. Less than 1:1, or an unattainable target, is HOLD.
 - YESTERDAY'S MOMENTUM CHARACTER CALIBRATES TODAY'S PATIENCE: how far a move RUNS
   tends to carry over between sessions, separately from its direction. If the
   previous session gave an early move and then spent the rest of the day sideways,

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
@@ -202,6 +202,20 @@ retail's stop-losses sit so you can trade where the operator will hunt them.
   cohort from repeated participation, momentum, closing behaviour, and the
   cross-index read. If neither side is likely carrying meaningful size, follow the
   current momentum or HOLD rather than inventing a hunt.
+  * PROFIT DEPTH SPLITS ONE SIDE INTO TWO COHORTS. "Buyers" is not one crowd. After a
+    multi-day run, the traders positioned from far BELOW are deep in profit and are
+    NOT weak — they are riding the move and a shake does not reach them. Only the
+    MARGINAL holders, the ones who bought in the last session or two, are close
+    enough to their entry to be flushed. So a hunt aimed at "the buyers" only ever
+    collects the recent cohort, which is a far smaller pool of stops than the
+    aggregate suggests.
+  * THE COUNTER-MOVE'S SIZE AND SPEED SAY WHICH COHORT IS LEAVING. A small, slow
+    rejection is the recent cohort being shaken out and nothing more. Genuine
+    profit-booking by the deep holders shows up as BIG, QUICK selling — if that has
+    not appeared, they are still in, and the move against you is noise rather than
+    distribution. Read the character of the selling, not merely its existence.
+    (Complements COUNTER-MOVE SIZE SAYS RANGE OR BREAKOUT in RISK, which reads size
+    to test a breakout premise; this reads size to identify WHO is moving.)
 - REPEATED-FAILURE INVENTORY RESET: repeated breakdown-and-recovery cycles usually
   evict sellers — each failed break stops them or persuades them not to hold. When
   the level is repeatedly reclaimed while the other indices remain positive, discard
@@ -659,6 +673,22 @@ RISK DISCIPLINE
   time / theta makes a farther target unrealistic. Aim for the LIQUIDITY ZONE where
   the hunted SLs sit, but never fabricate a distant target or widen the stop merely
   to manufacture a ratio. Less than 1:1, or an unattainable target, is HOLD.
+- ONLY RIDE AS FAR AS YOU KNOW THE ROAD: book when the situation stops matching a
+  setup you actually have, even if nothing has invalidated and the move might well
+  continue. "More momentum could still come, but this is not one of the setups that
+  work for me" is a complete reason to be flat. The alternative is holding a
+  position whose next move you have no way to read, which is not patience — it is
+  paying to find out.
+  * This is NOT the same as premise-invalidation (your thesis broke) or as a target
+    (your number arrived). Here the trade may still be working; what ran out is your
+    ABILITY TO READ IT. Waiting past that point is chasing a road you cannot see.
+  * It is the holding-side twin of "when unsure, HOLD" in DECISION DISCIPLINE. That
+    rule keeps you OUT when you have no read; this one gets you OUT when the read
+    you entered on has been used up. Both say the same thing: no read, no position.
+  * Typical trigger, and the one that fired it in practice: the move has narrowed to
+    ONE index while the others lag, so the shared story you entered on no longer
+    exists (see LAGGARDS NEVER JOINED for the cross-index form of the same booking
+    signal).
 - YESTERDAY'S MOMENTUM CHARACTER CALIBRATES TODAY'S PATIENCE: how far a move RUNS
   tends to carry over between sessions, separately from its direction. If the
   previous session gave an early move and then spent the rest of the day sideways,

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_premarket.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_premarket.py
@@ -170,3 +170,44 @@ def test_shipped_note_file_is_valid():
     assert note is not None, "shipped premarket_note.json must be schema-valid"
     # It must render on its own declared day (proves the file is self-consistent).
     assert format_premarket_note(note, date.fromisoformat(note.for_date)) != ""
+
+
+def test_shipped_note_matches_august_3_intraday_hunter_plan():
+    """The committed advisory must match the hand-checked 2 Aug transcript.
+
+    This catches a stale prior-session note, an inverted gap plan, or a mistyped
+    chart level before the dated note is injected into the live prompt.
+    """
+    import os
+
+    here = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    shipped = os.path.join(here, "premarket_note.json")
+    note = load_premarket_note(shipped)
+
+    assert note is not None
+    assert note.for_date == "2026-08-03"
+    assert "yHEfrMUrmKk" in note.source
+    assert note.plan == [
+        "MEANINGFUL GAP-UP: buyers are not the target; follow the market and "
+        "identify BUY-side setups.",
+        "FLAT or GAP-DOWN: target the seated buyers and identify SELL-side setups.",
+        "Treat a mild GAP-UP as FLAT rather than assuming it released the buyers; "
+        "wait for the sell-side setup to confirm.",
+    ]
+    assert [level.model_dump() for level in note.levels] == [
+        {
+            "index": "NIFTY",
+            "resistance": [24400.0, 24480.0],
+            "support": [24300.0, 24220.0],
+        },
+        {
+            "index": "BANKNIFTY",
+            "resistance": [57680.0, 57820.0],
+            "support": [57154.0, 56850.0],
+        },
+        {
+            "index": "SENSEX",
+            "resistance": [78500.0, 78850.0],
+            "support": [77840.0, 77500.0],
+        },
+    ]

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
@@ -555,6 +555,28 @@ def test_system_prompt_has_v3w_entry_point_and_counter_move_knowledge():
     assert "which reads the WITH-trend move" in prompt
 
 
+def test_system_prompt_has_v3x_aggregate_inventory_and_option_rr_knowledge():
+    """v3x: the 2 Aug weekly lecture scopes the crowd and the achievable target.
+
+    The agent must reason about the dominant aggregate inventory rather than one
+    hypothetical trader, reset a stale seller read after repeated failed breaks,
+    and permit 1:1 only for an unusually clear, time-constrained option trade.
+    """
+    prompt = build_system_prompt()
+    assert "AGGREGATE-INVENTORY TEST" in prompt
+    assert "greatest aggregate quantity" in prompt
+    assert "REPEATED-FAILURE INVENTORY RESET" in prompt
+    assert "repeated breakdown-and-recovery" in prompt
+    assert "OPTION-TIME-ADJUSTED REWARD/RISK" in prompt
+    assert "approximately 1:1" in prompt
+    assert "Less than 1:1" in prompt and "HOLD" in prompt
+    # The refinement must not erase the guardrails it relies on.
+    assert "UNIQUE-TRADE FILTER" in prompt
+    assert "TARGET-BOOKED crowd test" in prompt
+    assert "TIMEFRAME FIT" in prompt
+    assert "POST-EXIT RE-ENTRY GATE" in prompt
+
+
 def test_prompt_cap_leaves_room_for_lessons_and_a_note():
     """The cap is a sanity bound, not a budget knowledge must squeeze into.
 

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
@@ -592,6 +592,33 @@ def test_prompt_cap_leaves_room_for_lessons_and_a_note():
     assert assembled + worst_case_runtime_additions < MAX_SYSTEM_PROMPT_CHARS
 
 
+def test_system_prompt_has_v3x_profit_depth_and_known_road_knowledge():
+    """v3x (3 Aug live session): IH held a gap-up long and booked it while it was
+    still working, because the move had narrowed to BankNIFTY alone.
+
+    "More momentum could come, but this is not one of the setups that work for us...
+    we waited as far as we knew the road. Now we do not know the road." He also
+    split "the buyers" by profit depth: the Friday cohort was shaken out by the
+    gap-up, while traders positioned from far below never moved -- and the tell was
+    that no big, quick selling appeared.
+    """
+    prompt = build_system_prompt()
+    # One side is two cohorts, and only the marginal one is huntable.
+    assert "PROFIT DEPTH SPLITS ONE SIDE INTO TWO COHORTS" in prompt
+    # Wrap-independent: this phrase spans a line break in the source.
+    assert "NOT weak" in prompt and "riding the move" in prompt
+    # Character of the counter-move identifies who is leaving.
+    assert "THE COUNTER-MOVE'S SIZE AND SPEED SAY WHICH COHORT IS LEAVING" in prompt
+    assert "BIG, QUICK selling" in prompt
+    # Exit when the read runs out, not only when the thesis breaks.
+    assert "ONLY RIDE AS FAR AS YOU KNOW THE ROAD" in prompt
+    # Wrap-independent fragment: the sentence spans a line break in the source.
+    assert "paying to find out" in prompt
+    # It must be distinguished from the two exits it is NOT.
+    assert "NOT the same as premise-invalidation" in prompt
+    assert "no read, no position" in prompt
+
+
 def test_reentry_gate_does_not_contradict_the_exit_rules():
     """The re-entry gate must never be readable as a reason to delay an EXIT.
 


### PR DESCRIPTION
## Summary
- replace the shipped premarket advisory with Intraday Hunter's 2 Aug plan for the 3 Aug session, including the conditional opening read and rounded NIFTY, BankNIFTY, and Sensex levels
- add transcript-backed `AGGREGATE-INVENTORY TEST`, `REPEATED-FAILURE INVENTORY RESET`, and `OPTION-TIME-ADJUSTED REWARD/RISK` prompt knowledge
- document both direct YouTube transcript sources and preserve the existing cooldown/fresh-structure gate instead of encoding reflexive retry entries
- add regressions for the exact dated note payload and all v3x prompt markers

## Evidence
- Premarket: `yHEfrMUrmKk`, uploaded 2026-08-02 for the 2026-08-03 session
- Weekly analysis: `iDV1obD78-c`, uploaded 2026-08-02
- Full transcript artifacts remain outside git; only distilled knowledge and provenance are committed

## Validation
- focused premarket/schema: 58 passed
- complete SL Hunting directory: 153 passed
- master unittest: 415 passed
- market-data health unittest: 21 passed
- Signal Generators, Dependencies, Data Extractors: 933 passed
- branch coverage: 69.0%; all repository safety and broker thresholds passed
- pip-audit: core, AI, and dev requirement sets clean
- Ruff, mypy, Bandit, compileall, pre-commit, and `git diff --check`: passed

## Safety
- no runtime, broker, order, API, schema, sizing, or environment behavior changed
- diff-scoped security review found no new executable, secret, network, deserialization, or privilege surface
- no real broker orders were placed

Co-authored by Codex.