### PR TITLE
feat(sl-hunting): MAT-113 for every worker + SLH-009 note-consultation gate

### DIFF
--- a/Nifty Multi Strategy Front Test - Master File.py
+++ b/Nifty Multi Strategy Front Test - Master File.py
@@ -5643,6 +5643,52 @@ class BasePaperStrategyWorker(threading.Thread):
         self.paper_order_counter += 1
         return f"PAPER-{side}-{datetime.now():%Y%m%d%H%M%S}-{self.paper_order_counter:04d}"
 
+    def _subscribe_then_price(
+        self, contract: dict
+    ) -> tuple[float, bool, tuple[str, int] | None]:
+        """Join the feed FIRST, then price the leg. Returns (price, fresh, owned_key).
+
+        MAT-113, generalised to every worker. A tick feed cannot quote an instrument
+        it does not carry, so asking for a price before subscribing can only ever
+        succeed by accident -- via a REST fallback that has been observed returning a
+        map without the requested contract, or via a cached price left behind by an
+        earlier trade. Subscribing first makes the feed start work immediately; the
+        bounded wait then returns the moment the first tick lands, so an entry is
+        taken as soon as a price exists rather than after a fixed delay.
+
+        `owned_key` is the (segment, security_id) this call ADDED to the pool, or
+        None when the leg was already subscribed by someone else. Callers pass it to
+        `_release_feed_legs` so a fallen-through entry withdraws only what it opened
+        and never a leg shared with another worker.
+        """
+        segment = str(contract["exchange_segment"])
+        security_id = int(contract["security_id"])
+        owned = self.store.register_option_subscription(
+            OptionSubscription(
+                security_id=security_id,
+                exchange_segment=segment,
+                trading_symbol=str(contract["trading_symbol"]),
+                right=str(contract["option_type"]),
+                strike=float(contract["strike"]),
+                expiry=contract["expiry_date"],
+            ),
+            owner_id=self._execution_owner_id,
+        )
+        price, is_fresh = self._get_dealable_option_ltp(
+            segment, security_id, wait_seconds=MARKET_DATA_LTP_WAIT_SECONDS
+        )
+        return price, is_fresh, ((segment, security_id) if owned else None)
+
+    def _release_feed_legs(self, *owned_keys: tuple[str, int] | None) -> None:
+        """Withdraw feed legs this entry opened but never used."""
+        for key in owned_keys:
+            if key is None:
+                continue
+            segment, security_id = key
+            self.store.unregister_option_subscription(
+                segment, security_id, owner_id=self._execution_owner_id
+            )
+
     def _get_dealable_option_ltp(
         self, segment: str, security_id: int, *, wait_seconds: float = 0.0
     ) -> tuple[float, bool]:
@@ -8954,17 +9000,17 @@ class SupertrendBullishWorker(BasePaperStrategyWorker):
                 hedge_entry_price,
             )
             return False
-        main_entry_price, main_mark_is_fresh = self._get_dealable_option_ltp(
-            str(main["exchange_segment"]), int(main["security_id"])
-        )
-        hedge_entry_price, hedge_mark_is_fresh = self._get_dealable_option_ltp(
-            str(hedge["exchange_segment"]), int(hedge["security_id"])
-        )
+        # MAT-113: subscribe both legs before pricing them, then take the entry as
+        # soon as the feed quotes them rather than after a fixed delay.
+        main_entry_price, main_mark_is_fresh, main_feed_key = self._subscribe_then_price(main)
+        hedge_entry_price, hedge_mark_is_fresh, hedge_feed_key = self._subscribe_then_price(hedge)
         if main_entry_price <= 0 or hedge_entry_price <= 0:
             self.log.warning("Skipping bullish entry because a dealable leg price is unavailable.")
+            self._release_feed_legs(main_feed_key, hedge_feed_key)
             return False
         if self.live_trading and not (main_mark_is_fresh and hedge_mark_is_fresh):
             self.log.error("REFUSING LIVE bullish spread entry because a leg price is stale.")
+            self._release_feed_legs(main_feed_key, hedge_feed_key)
             return False
 
         main_live_order = {
@@ -9602,17 +9648,17 @@ class DonchianBearishWorker(BasePaperStrategyWorker):
                 hedge_entry_price,
             )
             return False
-        main_entry_price, main_mark_is_fresh = self._get_dealable_option_ltp(
-            str(main["exchange_segment"]), int(main["security_id"])
-        )
-        hedge_entry_price, hedge_mark_is_fresh = self._get_dealable_option_ltp(
-            str(hedge["exchange_segment"]), int(hedge["security_id"])
-        )
+        # MAT-113: subscribe both legs before pricing them, then take the entry as
+        # soon as the feed quotes them rather than after a fixed delay.
+        main_entry_price, main_mark_is_fresh, main_feed_key = self._subscribe_then_price(main)
+        hedge_entry_price, hedge_mark_is_fresh, hedge_feed_key = self._subscribe_then_price(hedge)
         if main_entry_price <= 0 or hedge_entry_price <= 0:
             self.log.warning("Skipping bearish entry because a dealable leg price is unavailable.")
+            self._release_feed_legs(main_feed_key, hedge_feed_key)
             return False
         if self.live_trading and not (main_mark_is_fresh and hedge_mark_is_fresh):
             self.log.error("REFUSING LIVE bearish spread entry because a leg price is stale.")
+            self._release_feed_legs(main_feed_key, hedge_feed_key)
             return False
 
         main_live_order = {
@@ -11838,20 +11884,21 @@ class LongStrangleWorker(BasePaperStrategyWorker):
             )
             return False
 
-        option_ltp, mark_is_fresh = self._get_dealable_option_ltp(
-            option_segment, option_sec_id
-        )
+        # MAT-113: join the feed before pricing, then enter as soon as it quotes.
+        option_ltp, mark_is_fresh, feed_key = self._subscribe_then_price(contract)
         if option_ltp <= 0:
             self.log.warning(
                 "Strangle %s entry skipped: option LTP unavailable for %s (security_id=%s).",
                 side, trading_symbol, option_sec_id,
             )
+            self._release_feed_legs(feed_key)
             return False
         if self.live_trading and not mark_is_fresh:
             self.log.error(
                 "REFUSING LIVE strangle %s entry because the option mark is stale.",
                 side,
             )
+            self._release_feed_legs(feed_key)
             return False
 
         quantity = lot_size * self.lots

--- a/Signal Generators/SL Hunting AI Agent/premarket_note.json
+++ b/Signal Generators/SL Hunting AI Agent/premarket_note.json
@@ -1,27 +1,29 @@
 {
-  "for_date": "2026-08-03",
-  "source": "Intraday Hunter, 'Prediction For 03 AUG 2026' (yHEfrMUrmKk, uploaded 2026-08-02)",
-  "context": "All three indices closed with positive momentum after sideways or recovery action, so buyers may be seated. The opening type decides whether those buyers are safe or huntable.",
+  "for_date": "2026-08-04",
+  "source": "Intraday Hunter, 'Prediction For 04 AUG 2026' (IHjbAmtdLro, uploaded 2026-08-03)",
+  "context": "All three indices closed higher, NIFTY continuing up and BANKNIFTY/SENSEX sitting on round-number support, so buyers are seated across the board. NIFTY expiry falls on this session.",
   "plan": [
-    "MEANINGFUL GAP-UP: buyers are not the target; follow the market and identify BUY-side setups.",
-    "FLAT or GAP-DOWN: target the seated buyers and identify SELL-side setups.",
-    "Treat a mild GAP-UP as FLAT rather than assuming it released the buyers; wait for the sell-side setup to confirm."
+    "Every opening type points the same way today: GAP-UP, FLAT and GAP-DOWN all mean identify SELL-side setups against the seated buyers.",
+    "BIG GAP-DOWN is the single exception -- he ignores it rather than hunting into it.",
+    "On a mild GAP-DOWN expect retracement chop first; the setup still has to confirm before entry.",
+    "His premise is explicitly conditional: he targets buyers only because this is NOT an all-time-high or runaway-momentum tape. Strong trend momentum would weaken it.",
+    "BANKNIFTY sits on round-number support with more round numbers nearby -- he flags retracement risk there specifically."
   ],
   "levels": [
     {
       "index": "NIFTY",
-      "resistance": [24400, 24480],
-      "support": [24300, 24220]
+      "resistance": [24610, 24700],
+      "support": [24500, 24400]
     },
     {
       "index": "BANKNIFTY",
-      "resistance": [57680, 57820],
-      "support": [57154, 56850]
+      "resistance": [57820, 58100],
+      "support": [57500, 57154]
     },
     {
       "index": "SENSEX",
-      "resistance": [78500, 78850],
-      "support": [77840, 77500]
+      "resistance": [78850, 79100],
+      "support": [78500, 78300]
     }
   ]
 }

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_agent.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_agent.py
@@ -345,6 +345,10 @@ class SLHuntingAgent:
             if premarket_block and premarket_block.strip()
             else ""
         )
+        # SLH-009: `premarket_block` is already date-gated by the caller (it renders
+        # empty unless the note is for today), so a non-empty block is exactly the
+        # condition under which the order tool demands a note_check on entries.
+        self._premarket_note_active = bool(premarket_block and premarket_block.strip())
         self._system_prompt = (
             build_system_prompt() + learned + premarket + FINAL_OUTPUT_INSTRUCTION
         )
@@ -642,6 +646,9 @@ class SLHuntingAgent:
             generation_is_current=generation_is_current,
             deadline_seconds=self._sdk_timeout_seconds,
             execution_lock=execution_lock,
+            # SLH-009: the note was already date-gated when the block was built, so a
+            # non-empty block means one applies TODAY.
+            premarket_note_active=bool(self._premarket_note_active),
         )
         position = executor.snapshot()
         prompt = self._build_user_prompt(prepared, position)

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_tools.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_tools.py
@@ -108,7 +108,7 @@ _PLACEHOLDER_REASONS = frozenset(
 NO_REASON_SENTINEL = "AI_EXIT (no reason supplied by the model)"
 
 
-def order_tool_description(venue: str) -> str:
+def order_tool_description(venue: str, *, note_active: bool = False) -> str:
     """The order tool's description, as a function so tests can assert on it.
 
     Kept out of `build_sl_hunting_mcp_server` because that call needs the Claude
@@ -136,6 +136,17 @@ def order_tool_description(venue: str) -> str:
         "and you may cut ONE leg on premise-invalidation while the other runs — but hard "
         "risk (stop/target/max-loss/square-off) always closes both. Returns whether "
         "the order was accepted or rejected."
+        + (
+            " note_check is REQUIRED on entries today because a pre-open analyst note "
+            "applies to this session. Start it with AGREES, CONTRADICTS or "
+            "NOT_APPLICABLE, then a colon and the branch of the note you are applying "
+            "-- for example 'CONTRADICTS: the note says a gap-up means follow the gap, "
+            "but I am fading it because the opening spike trapped fresh buyers'. The "
+            "note is ADVISORY and CONTRADICTS is a perfectly good answer: your own read "
+            "wins. What is not allowed is ignoring it silently."
+            if note_active
+            else ""
+        )
     )
 
 
@@ -262,6 +273,15 @@ class SLHuntingToolContext:
     broker: str | None = None
     last_price: float = field(default=0.0)
     bnf_candles: pd.DataFrame | None = None
+    # SLH-009: True when a pre-open note applies to TODAY. The note stays ADVISORY
+    # -- it can never veto a trade -- but when one exists the order tool refuses an
+    # ENTRY until the model says which branch of it applies and whether it is acting
+    # with or against it. On 2026-08-03 the agent faded a gap-up on a day its own
+    # note said gap-up means do NOT target buyers, never mentioned the note at all,
+    # and was stopped in 27 seconds. Code cannot check COMPLIANCE (which branch
+    # applies depends on the open, which only the model can read), but it can make
+    # silently ignoring the note impossible.
+    premarket_note_active: bool = False
     # Set via `expire()` when the agent abandons this bar's SDK call (SLH-001,
     # e.g. a timed-out CLI call). The abandoned agentic loop keeps running on
     # its daemon thread and could otherwise still call the order tool MINUTES
@@ -289,6 +309,7 @@ class SLHuntingToolContext:
         generation_is_current: Callable[[int], bool] | None = None,
         deadline_seconds: float | None = None,
         execution_lock: Any | None = None,
+        premarket_note_active: bool = False,
     ) -> SLHuntingToolContext:
         """Prepare the per-bar context: clean the candles, cache the last price, attach BNF.
 
@@ -313,6 +334,7 @@ class SLHuntingToolContext:
             broker=broker,
             last_price=last_price,
             bnf_candles=prepared_bnf,
+            premarket_note_active=bool(premarket_note_active),
             generation=int(generation),
             generation_is_current=generation_is_current,
             deadline_monotonic=(
@@ -387,8 +409,47 @@ class SLHuntingToolContext:
             return {"accepted": False, "reason": "decision deadline elapsed; order refused"}
         return None
 
+    # SLH-009. Accepted answers for an ENTRY while a pre-open note applies. The note
+    # is ADVISORY, so CONTRADICTS is a legitimate answer that lets the order through
+    # -- what is forbidden is not answering at all.
+    NOTE_ALIGNMENTS = ("AGREES", "CONTRADICTS", "NOT_APPLICABLE")
+
+    def _premarket_note_problem(self, note_check: str) -> str | None:
+        """Explain why this note acknowledgement is unusable, or None when fine."""
+
+        if not self.premarket_note_active:
+            return None
+        cleaned = _printable_one_line(note_check).strip()
+        if not cleaned:
+            return (
+                "a pre-open analyst note applies to TODAY and you have not addressed it. "
+                "Resend this entry with note_check set to AGREES, CONTRADICTS or "
+                "NOT_APPLICABLE, followed by the branch of the note you are applying "
+                "(e.g. 'CONTRADICTS: note says gap-up means follow the gap; I am fading "
+                "it because ...'). The note is ADVISORY -- CONTRADICTS is allowed and "
+                "your own read wins -- but it may not be passed over in silence."
+            )
+        verdict = cleaned.split(":", 1)[0].strip().upper().replace(" ", "_")
+        if verdict not in self.NOTE_ALIGNMENTS:
+            return (
+                f"note_check must START with one of {', '.join(self.NOTE_ALIGNMENTS)} "
+                f"(got {verdict!r}). Follow it with the branch you are applying."
+            )
+        if verdict != "NOT_APPLICABLE" and len(cleaned) <= len(verdict) + 1:
+            return (
+                f"note_check says {verdict} but does not say WHICH branch of the note "
+                "you are applying. Add it after a colon."
+            )
+        return None
+
     def do_order(
-        self, action: str, stop: float, target: float, reason: str, exit_leg: str = "BOTH"
+        self,
+        action: str,
+        stop: float,
+        target: float,
+        reason: str,
+        exit_leg: str = "BOTH",
+        note_check: str = "",
     ) -> dict[str, Any]:
         """Route an agent order through the injected executor (single source of truth).
 
@@ -426,6 +487,13 @@ class SLHuntingToolContext:
                         "with a one-line justification naming the setup and why you are acting."
                     ),
                 }
+            # SLH-009: when a pre-open note applies today, an ENTRY must say which
+            # branch of it applies and whether this trade agrees with it. The note
+            # remains ADVISORY -- "CONTRADICTS" is an accepted answer and the order
+            # goes through -- but it can no longer be passed over in silence.
+            note_problem = self._premarket_note_problem(note_check)
+            if note_problem:
+                return {"accepted": False, "reason": note_problem}
             entry_reason = bounded_reason(reason)
             def executor_call() -> dict[str, Any]:
                 return self.executor.enter(
@@ -545,8 +613,15 @@ def build_sl_hunting_mcp_server(context: SLHuntingToolContext):
 
     @tool(
         order_name,
-        order_tool_description(venue),
-        {"action": str, "stop": float, "target": float, "reason": str, "exit_leg": str},
+        order_tool_description(venue, note_active=context.premarket_note_active),
+        {
+            "action": str,
+            "stop": float,
+            "target": float,
+            "reason": str,
+            "exit_leg": str,
+            "note_check": str,
+        },
     )
     async def _order(args: dict[str, Any]) -> dict[str, Any]:
         result = context.do_order(
@@ -555,6 +630,7 @@ def build_sl_hunting_mcp_server(context: SLHuntingToolContext):
             args.get("target", 0.0),
             args.get("reason", ""),
             args.get("exit_leg", "BOTH"),
+            args.get("note_check", ""),
         )
         return _as_tool_text(result)
 

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_agent.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_agent.py
@@ -723,6 +723,77 @@ def test_do_order_sanitizes_and_truncates_exit_reason_without_blocking():
     assert len(recorded) == MAX_REASON_CHARS
 
 
+def test_slh009_entry_requires_a_note_check_when_a_note_applies():
+    """SLH-009: a pre-open note may not be passed over in silence.
+
+    On 2026-08-03 the agent faded a gap-up on a day its own note said gap-up means
+    do NOT target buyers, never mentioned the note at all, and was stopped in 27
+    seconds. Code cannot check COMPLIANCE -- which branch applies depends on the
+    open, which only the model can read -- but it can make silence impossible.
+    """
+    ex = StandaloneExecutor()
+    ctx = SLHuntingToolContext.build(_candles(), ex, premarket_note_active=True)
+    price = ctx.last_price
+
+    res = ctx.do_order(
+        "ENTER_LONG", stop=price - 30, target=price + 60,
+        reason="double bottom at the pivot with a confirmed hammer",
+    )
+    assert res["accepted"] is False
+    assert "note_check" in res["reason"]
+    assert ex.snapshot()["in_position"] is False
+
+
+def test_slh009_contradicting_the_note_is_allowed():
+    """The note stays ADVISORY: disagreeing is a valid answer, not a refusal."""
+    ex = StandaloneExecutor()
+    ctx = SLHuntingToolContext.build(_candles(), ex, premarket_note_active=True)
+    price = ctx.last_price
+
+    res = ctx.do_order(
+        "ENTER_SHORT", stop=price + 30, target=price - 60,
+        reason="opening spike trapped fresh buyers; shooting star confirmed",
+        note_check="CONTRADICTS: note says gap-up means follow the gap, but the "
+                   "spike trapped buyers so I am fading it",
+    )
+    assert res["accepted"] is True
+    assert ex.snapshot()["in_position"] is True
+
+
+def test_slh009_rejects_a_verdict_without_a_branch():
+    """AGREES on its own does not prove the note was read."""
+    ex = StandaloneExecutor()
+    price = SLHuntingToolContext.build(_candles(), ex).last_price
+    for bad in ("AGREES", "MAYBE: the note is unclear", "   "):
+        ctx = SLHuntingToolContext.build(_candles(), ex, premarket_note_active=True)
+        res = ctx.do_order(
+            "ENTER_LONG", stop=price - 30, target=price + 60,
+            reason="double bottom at the pivot with a confirmed hammer",
+            note_check=bad,
+        )
+        assert res["accepted"] is False, bad
+    assert ex.snapshot()["in_position"] is False
+
+
+def test_slh009_is_dormant_when_no_note_applies_and_never_blocks_an_exit():
+    """No note today -> nothing changes. And an EXIT is never gated on it."""
+    ex = StandaloneExecutor()
+    ctx = SLHuntingToolContext.build(_candles(), ex, premarket_note_active=False)
+    price = ctx.last_price
+    assert ctx.do_order(
+        "ENTER_LONG", stop=price - 30, target=price + 60,
+        reason="double bottom at the pivot with a confirmed hammer",
+    )["accepted"] is True
+
+    # Even with a note active, exits must never be refused for want of a note_check.
+    exit_ctx = SLHuntingToolContext.build(_candles(), ex, premarket_note_active=True)
+    out = exit_ctx.do_order(
+        "EXIT", stop=0.0, target=0.0, reason="premise invalidated; booking the loss"
+    )
+    assert out["accepted"] is True
+    assert ex.snapshot()["in_position"] is False
+
+
 def test_reason_bound_has_exactly_one_definition():
     """The tool and the executor must never disagree about what was recorded.
 

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_premarket.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_premarket.py
@@ -172,11 +172,17 @@ def test_shipped_note_file_is_valid():
     assert format_premarket_note(note, date.fromisoformat(note.for_date)) != ""
 
 
-def test_shipped_note_matches_august_3_intraday_hunter_plan():
-    """The committed advisory must match the hand-checked 2 Aug transcript.
+def test_shipped_note_matches_august_4_intraday_hunter_plan():
+    """The committed advisory must match the hand-checked 3 Aug transcript.
 
     This catches a stale prior-session note, an inverted gap plan, or a mistyped
     chart level before the dated note is injected into the live prompt.
+
+    Worth knowing when re-reading this: 4 Aug is NOT a repeat of 3 Aug. On 3 Aug
+    the plan forked on the opening type (gap-up -> buy side, flat/gap-down ->
+    sell side). Here every opening type points the SAME way -- sell side --
+    with a big gap-down as the only stand-aside. An assertion that still fork on
+    the gap direction would mean the note was copied, not re-transcribed.
     """
     import os
 
@@ -185,29 +191,35 @@ def test_shipped_note_matches_august_3_intraday_hunter_plan():
     note = load_premarket_note(shipped)
 
     assert note is not None
-    assert note.for_date == "2026-08-03"
-    assert "yHEfrMUrmKk" in note.source
+    assert note.for_date == "2026-08-04"
+    assert "IHjbAmtdLro" in note.source
     assert note.plan == [
-        "MEANINGFUL GAP-UP: buyers are not the target; follow the market and "
-        "identify BUY-side setups.",
-        "FLAT or GAP-DOWN: target the seated buyers and identify SELL-side setups.",
-        "Treat a mild GAP-UP as FLAT rather than assuming it released the buyers; "
-        "wait for the sell-side setup to confirm.",
+        "Every opening type points the same way today: GAP-UP, FLAT and GAP-DOWN "
+        "all mean identify SELL-side setups against the seated buyers.",
+        "BIG GAP-DOWN is the single exception -- he ignores it rather than "
+        "hunting into it.",
+        "On a mild GAP-DOWN expect retracement chop first; the setup still has to "
+        "confirm before entry.",
+        "His premise is explicitly conditional: he targets buyers only because "
+        "this is NOT an all-time-high or runaway-momentum tape. Strong trend "
+        "momentum would weaken it.",
+        "BANKNIFTY sits on round-number support with more round numbers nearby -- "
+        "he flags retracement risk there specifically.",
     ]
     assert [level.model_dump() for level in note.levels] == [
         {
             "index": "NIFTY",
-            "resistance": [24400.0, 24480.0],
-            "support": [24300.0, 24220.0],
+            "resistance": [24610.0, 24700.0],
+            "support": [24500.0, 24400.0],
         },
         {
             "index": "BANKNIFTY",
-            "resistance": [57680.0, 57820.0],
-            "support": [57154.0, 56850.0],
+            "resistance": [57820.0, 58100.0],
+            "support": [57500.0, 57154.0],
         },
         {
             "index": "SENSEX",
-            "resistance": [78500.0, 78850.0],
-            "support": [77840.0, 77500.0],
+            "resistance": [78850.0, 79100.0],
+            "support": [78500.0, 78300.0],
         },
     ]

--- a/test_nifty_multi_strategy_master.py
+++ b/test_nifty_multi_strategy_master.py
@@ -49,6 +49,30 @@ with (
         print(f"Failed to load master_file for testing: {e}")
 
 
+_LTP_WAIT_PATCHER = None
+
+
+def setUpModule():
+    """Collapse the first-tick wait for the whole suite.
+
+    MAT-113 makes every worker subscribe a leg and then wait up to
+    MARKET_DATA_LTP_WAIT_SECONDS for the feed's first tick. Tests drive fake
+    brokers that never tick, so each entry that legitimately fails to find a price
+    would sit through that wait for real -- it took the suite from 7s to 54s. The
+    wait's own behaviour is covered directly by
+    TestSLHuntingBnfMirror.test_mirror_waits_for_a_late_first_tick, which passes
+    an explicit wait_seconds and is therefore unaffected by this patch.
+    """
+    global _LTP_WAIT_PATCHER
+    _LTP_WAIT_PATCHER = patch.object(master_file, "MARKET_DATA_LTP_WAIT_SECONDS", 0.0)
+    _LTP_WAIT_PATCHER.start()
+
+
+def tearDownModule():
+    if _LTP_WAIT_PATCHER is not None:
+        _LTP_WAIT_PATCHER.stop()
+
+
 # The Flattrade helper is loaded separately so its low-level REST behaviour can
 # be tested without starting the master runner or making any network requests.
 flattrade_file_path = Path(__file__).parent / "Dependencies" / "Flattrade API" / "flattrade_execution.py"
@@ -3836,18 +3860,6 @@ class TestSLHuntingBnfMirror(unittest.TestCase):
     basket). The mirror is fail-soft and must never disturb the NIFTY leg.
     """
 
-    def setUp(self):
-        """Collapse the first-tick wait so a no-LTP path costs microseconds.
-
-        In production the mirror waits MARKET_DATA_LTP_WAIT_SECONDS for a
-        just-subscribed leg's first tick. Tests that exercise the give-up branch
-        would otherwise sit through that wait for real; the wait's own behaviour
-        is covered explicitly by test_mirror_waits_for_a_late_first_tick.
-        """
-        patcher = patch.object(master_file, "MARKET_DATA_LTP_WAIT_SECONDS", 0.0)
-        patcher.start()
-        self.addCleanup(patcher.stop)
-
     NIFTY_CONTRACT = {
         "security_id": 1001, "exchange_segment": None,  # segment filled in setUp
         "trading_symbol": "NIFTY-24300-CE", "custom_symbol": "NIFTY CE",
@@ -3895,6 +3907,49 @@ class TestSLHuntingBnfMirror(unittest.TestCase):
             (master_file.OPTION_EXCHANGE_SEGMENT, 3003): 500.0,
         })
         return worker, store
+
+    def test_subscribe_then_price_joins_the_feed_first(self):
+        """MAT-113 generalised: the shared helper every worker now uses.
+
+        The leg must be in the subscription pool at the moment it is priced, and
+        the caller must learn whether IT added the leg so a fallen-through entry
+        withdraws only what it opened.
+        """
+        worker, store = self._make_worker()
+        contract = dict(
+            self.BNF_CONTRACT,
+            exchange_segment=master_file.OPTION_EXCHANGE_SEGMENT,
+            expiry_date=date.today() + timedelta(days=20),
+        )
+        subscribed_at_pricing = {}
+        real_getter = worker._get_dealable_option_ltp
+
+        def _spy(segment, security_id, **kwargs):
+            subscribed_at_pricing["seen"] = any(
+                sub.security_id == int(security_id)
+                for sub in store.snapshot_option_subscriptions()
+            )
+            return real_getter(segment, security_id, **kwargs)
+
+        worker._get_dealable_option_ltp = _spy
+        price, _fresh, owned = worker._subscribe_then_price(contract)
+        self.assertTrue(subscribed_at_pricing["seen"], "must subscribe before pricing")
+        self.assertEqual(price, 500.0)
+        self.assertEqual(owned, (master_file.OPTION_EXCHANGE_SEGMENT, 3003))
+
+        # A second call by the SAME owner is not a new acquisition, so an abort
+        # there must not tear down the leg the first call is still using.
+        _p2, _f2, owned_again = worker._subscribe_then_price(contract)
+        self.assertIsNone(owned_again)
+        worker._release_feed_legs(owned_again)
+        self.assertTrue(
+            any(s.security_id == 3003 for s in store.snapshot_option_subscriptions())
+        )
+        # Releasing the key this worker really owns does remove it.
+        worker._release_feed_legs(owned)
+        self.assertFalse(
+            any(s.security_id == 3003 for s in store.snapshot_option_subscriptions())
+        )
 
     def test_mirror_subscribes_before_it_prices_the_leg(self):
         """MAT-113: the mirror used to ask for a price before joining the feed.


### PR DESCRIPTION
Two changes requested after the 3 Aug session. **PR #100 merged while this was being written**, so
these landed on the branch after the merge and needed their own PR.

## 1. MAT-113 generalised to every worker

Only the ATM family and the BankNIFTY mirror joined the feed before pricing a leg. The hedged-puts
pair (Supertrend Bullish, Donchian Bearish) and the Long Strangle still **priced first and
subscribed afterwards** — so they could only ever get a price by accident: via the REST fallback
that has been observed returning a map *without* the requested contract, or via a snapshot left
behind by an earlier trade.

A shared helper replaces the pattern in all of them:

- `_subscribe_then_price(contract)` — registers the leg, prices it with the bounded first-tick
  wait, and reports whether **this** call acquired the subscription.
- `_release_feed_legs(*keys)` — withdraws only what an entry opened, never a leg shared with
  another worker.

The wait polls and **returns the instant a price lands**, so an entry is taken as soon as one
exists rather than after a fixed delay — which is the "then take entry ASAP" part of the request.

## 2. SLH-009 — a pre-open note can no longer be ignored in silence

On 3 Aug the agent faded a gap-up on a day its own note said gap-up means **do not** target buyers,
never mentioned the note at all, and was stopped in 27 seconds. Six minutes later it cited the note
correctly while reversing into agreement.

**Code cannot check compliance.** Which branch of the note applies depends on the open, which only
the model can read. So this enforces **consultation** instead: when a note applies today, an ENTRY
is refused until `note_check` starts with `AGREES` / `CONTRADICTS` / `NOT_APPLICABLE` and names the
branch being applied.

`CONTRADICTS` is accepted and the order proceeds. That is deliberate — the note stays **advisory**,
which is the operator's recorded scope, and `sl_hunting_premarket.py`'s promise that it "can never
justify an entry on its own" and never overrides the agent's read is preserved. What is no longer
possible is passing over it without a word.

**Exits are never gated on it**, and with no note for the day the gate is dormant.

> **Numbering:** SLH-006 is already the pre-open note channel itself, so this mechanism is
> **SLH-009**.

## Test-suite runtime

MAT-113 made every fake-broker entry sit through the real five-second wait — the suite went from
~7s to **54s**. `setUpModule` collapses the wait for the whole module; the wait's own behaviour
keeps its dedicated test, which passes `wait_seconds` explicitly and is unaffected. Back to ~9s.

## Gates

416 master tests, 938 pytest, 21 market-data-health, ruff, mypy (CI scope), compileall — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)