### PR TITLE
chore(deps): take the safe subset of the python-runtime group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,6 +41,22 @@ updates:
       - dependency-name: "pandas-stubs"
         update-types:
           - "version-update:semver-major"
+      # claude-agent-sdk caps this at mcp<2.0.0, so an mcp MAJOR can never
+      # resolve alongside the pinned SDK -- pip fails with ResolutionImpossible
+      # before a single test runs. This is what made PR #99 un-mergeable. Take
+      # mcp majors only together with an SDK release that raises the ceiling.
+      - dependency-name: "mcp"
+        update-types:
+          - "version-update:semver-major"
+      # The async transport under dhanhq.marketfeed, i.e. the LIVE market feed.
+      # dhanhq only declares websockets>=12.0.1, so this pin is the sole thing
+      # holding a major back, and a breaking change surfaces as a dead feed at
+      # 09:15 rather than as a failing gate -- nothing in CI opens a real
+      # socket. Bump majors deliberately, after a paper session on the new
+      # version.
+      - dependency-name: "websockets"
+        update-types:
+          - "version-update:semver-major"
 
   - package-ecosystem: github-actions
     directory: "/"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,10 +1,10 @@
 # Development / CI quality-gate tools (runtime deps live in requirements.txt).
 # Versions mirror the Streamlit Scanner App's verified set where shared.
 pytest==9.1.1
-ruff==0.15.22
+ruff==0.16.1
 mypy==1.20.2
 bandit==1.9.4
-pre-commit==4.6.0
+pre-commit==4.6.1
 coverage==7.15.2
 pytest-cov==7.1.0
 pip-audit==2.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,10 +8,13 @@
 dhanhq==2.2.0
 pandas==3.0.3
 numpy==2.4.6
-backtesting==0.6.5
+backtesting==0.6.6
 python-dotenv==1.2.2
 gspread==6.2.1
-pytz==2026.2
+# Timezone data. Bumping this is desirable in its own right: every trading-day
+# boundary, the 15:15 square-off and the pre-open note's date gate are computed
+# in Asia/Kolkata, so stale tz data is a correctness risk rather than a chore.
+pytz==2026.3.post1
 # The broker, symbol-master and Telegram HTTP paths all use requests. Keep this
 # at the newest release that clears the repository audit (2.33.0 was the first
 # past PYSEC-2026-2275; 2.34.2 is the current audited pin).


### PR DESCRIPTION
Dependabot's #99 grouped eight bumps and **could not install** — `claude-agent-sdk` declares
`mcp<2.0.0`, so the `mcp` 2.0.0 bump made the group internally inconsistent and pip failed with
`ResolutionImpossible` before a single test ran. #99 is closed. This takes the four bumps whose only
failure mode is a loud, visible gate failure.

| Package | From | To | Scope |
|---|---|---|---|
| `backtesting` | 0.6.5 | 0.6.6 | backtest-only |
| `pytz` | 2026.2 | 2026.3.post1 | runtime (tz data) |
| `ruff` | 0.15.22 | 0.16.1 | dev |
| `pre-commit` | 4.6.0 | 4.6.1 | dev |

`pytz` is worth taking on its own merits rather than as housekeeping: every trading-day boundary,
the 15:15 square-off and the pre-open note's date gate are computed in `Asia/Kolkata`, so stale tz
data is a correctness risk.

## Deliberately not taken

- **`mcp` 2.0.0** — blocked by the SDK's ceiling.
- **`claude-agent-sdk` 0.2.128** — `requirements-ai.txt` pins the SDK trio precisely to stop a fresh
  install silently changing the agent transport. Worth having, but on its own so any behaviour
  change is attributable.
- **`websockets` 17.0** — a **major** on the library carrying the live market feed.
- **`pandas` 3.0.5** — `pandas-stubs` is pinned separately and wasn't bumped in step; mypy is a
  required gate, so those two move together.

## Dependabot config

`.github/dependabot.yml` already exists to stop Dependabot proposing bumps that are un-mergeable by
policy, and records the same lesson from PR #76. Two additions:

- **`mcp` majors** — they can *never* resolve against the pinned SDK. This is exactly what made #99
  red.
- **`websockets` majors** — `dhanhq` only declares `websockets>=12.0.1`, so the pin is the sole
  guard, and a breaking change surfaces as a **dead feed at 09:15** rather than a failing gate.
  Nothing in CI opens a real socket.

## Verification

Editing a pin file does **not** exercise the new versions locally — none of them are installed on
this machine. **CI is the real test here**: it installs from these files and runs the full gate
suite against the pinned set. Watch the `ruff` bump in particular, since a minor can introduce new
lint findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)