### PR TITLE
fix(sheet): widen the P&L window to the close and stop a restart erasing the day

### DIFF
--- a/Nifty Multi Strategy Front Test - Master File.py
+++ b/Nifty Multi Strategy Front Test - Master File.py
@@ -14146,11 +14146,25 @@ _PNL_SHEET_ROW_LABELS = {
 
 _PNL_LOG_LINE_RE = re.compile(r"RealizedPnL=(-?\d+(?:\.\d+)?)")
 _PNL_MODE_RE = re.compile(r"\bMode=(PAPER|LIVE|MIXED)\b")
+# Trade count from the same summary line. Used to stop a RESTARTED runner erasing
+# a finished session: on 2026-08-03 the process was restarted at ~15:29 and every
+# worker immediately logged "Trades=0 | RealizedPnL=0.00" at square-off, seven
+# minutes after the real figures. Under plain last-write-wins those zeros would
+# overwrite a full trading day.
+_PNL_TRADES_RE = re.compile(r"\bTrades=(\d+)\b")
 # Only result-summary lines inside this window are used for the sheet. Covers
-# max-loss during the session (from 9:15) through the last square-off (15:20)
-# while ignoring after-market test runs that log fresh summaries at 17:00+.
+# max-loss during the session (from 9:15) through shutdown, while ignoring
+# after-market test runs that log fresh summaries at 17:00+.
+#
+# The end is the market close. It was 15:21 until 2026-08-03, which left only
+# ONE MINUTE of margin after the 15:20 the summaries normally land at -- and that
+# day shutdown ran a little late, so 53 of the 54 summary lines fell outside the
+# window and were silently discarded. Exactly one cell reached the Sheet (SL
+# Hunting AI's, whose summary happened to be logged at 11:00). The guard itself
+# is worth keeping: without it an evening test run would overwrite a real
+# session's P&L. What was wrong was the margin, not the idea.
 _PNL_LOG_WINDOW_START = (9, 15)
-_PNL_LOG_WINDOW_END = (15, 21)
+_PNL_LOG_WINDOW_END = (15, 30)
 
 
 def _normalize_pnl_strategy_name(name: str) -> str:
@@ -14180,7 +14194,7 @@ def _asctime_in_pnl_window(asctime: str) -> bool:
     return start_minutes <= current_minutes <= end_minutes
 
 
-def _parse_eod_pnl_by_day(log_path) -> dict:
+def _parse_eod_pnl_by_day(log_path, today_str: str | None = None) -> dict:
     """
     Parse the runner's log for each strategy's end-of-day realised P&L per day.
 
@@ -14198,6 +14212,12 @@ def _parse_eod_pnl_by_day(log_path) -> dict:
     "Misc " are normalized before lookup in _PNL_SHEET_ROW_LABELS.
     """
     result: dict[str, dict[str, float]] = {}
+    # Summary lines for TODAY that the window threw away. Counted so the drop can
+    # announce itself: on 2026-08-03 a late shutdown put 53 of 54 summaries past
+    # the cutoff and the only symptom was a Google Sheet that quietly stayed blank.
+    skipped_today = 0
+    if today_str is None:
+        today_str = datetime.now().date().isoformat()
     try:
         # A missing log (e.g. a brand-new machine) just means "no figures yet".
         if not Path(log_path).exists():
@@ -14220,6 +14240,8 @@ def _parse_eod_pnl_by_day(log_path) -> dict:
                 # Ignore lines logged outside trading hours (e.g. an after-market
                 # test run) so they can't overwrite the real session's figures.
                 if not _asctime_in_pnl_window(asctime):
+                    if asctime.strip()[:10] == today_str:
+                        skipped_today += 1
                     continue
                 # The date is the first 10 chars of asctime: "YYYY-MM-DD".
                 date_str = asctime.strip()[:10]
@@ -14243,17 +14265,44 @@ def _parse_eod_pnl_by_day(log_path) -> dict:
                     if not mode_match:
                         continue
                     mode = mode_match.group(1)
+                trades_match = _PNL_TRADES_RE.search(message)
+                trades = int(trades_match.group(1)) if trades_match else 0
                 try:
                     # Last write wins: a later summary for the same strategy/day
-                    # (e.g. a re-entry's final line) overwrites the earlier one.
-                    result.setdefault(date_str, {})[strategy] = {
+                    # (e.g. a re-entry's final line) overwrites the earlier one --
+                    # EXCEPT when the later line reports FEWER trades. A restarted
+                    # runner logs "Trades=0" for every worker as soon as it reaches
+                    # square-off, and those empty summaries must never erase the
+                    # session that already happened. Equal counts still overwrite,
+                    # so a genuine final line for the same run wins as before, and
+                    # a strategy that really did nothing still records 0.00.
+                    previous = result.setdefault(date_str, {}).get(strategy)
+                    if previous is not None and trades < previous.get("trades", 0):
+                        continue
+                    result[date_str][strategy] = {
                         "pnl": float(match.group(1)),
                         "mode": mode,
+                        "trades": trades,
                     }
                 except ValueError:
                     continue
     except Exception as exc:  # pragma: no cover - defensive
         logger.warning("Could not parse P&L from the log file: %s", exc)
+    if skipped_today:
+        # Loud on purpose. The failure mode this replaces was invisible: the run
+        # looked clean and the Sheet simply did not fill in.
+        logger.warning(
+            "P&L SHEET: %d of today's result-summary lines fell OUTSIDE the "
+            "%02d:%02d-%02d:%02d window and were IGNORED, so those strategies will "
+            "not reach the Google Sheet. The figures are still in the log. This "
+            "usually means shutdown ran late; re-running the summary writer inside "
+            "the window will backfill them.",
+            skipped_today,
+            _PNL_LOG_WINDOW_START[0],
+            _PNL_LOG_WINDOW_START[1],
+            _PNL_LOG_WINDOW_END[0],
+            _PNL_LOG_WINDOW_END[1],
+        )
     return result
 
 

--- a/test_nifty_multi_strategy_master.py
+++ b/test_nifty_multi_strategy_master.py
@@ -3088,9 +3088,115 @@ class TestExecutionModeResults(unittest.TestCase):
 
             parsed = master_file._parse_eod_pnl_by_day(path)
 
-        self.assertEqual(parsed["2026-07-16"]["Renko"], {"pnl": 100.0, "mode": "LIVE"})
-        self.assertEqual(parsed["2026-07-16"]["EMA"], {"pnl": -25.0, "mode": "MIXED"})
-        self.assertEqual(parsed["2026-07-15"]["Renko"], {"pnl": 50.0, "mode": "PAPER"})
+        # `trades` rides along so a restarted runner's empty summary cannot erase
+        # a finished session; only pnl/mode reach the sheet.
+        self.assertEqual(
+            parsed["2026-07-16"]["Renko"], {"pnl": 100.0, "mode": "LIVE", "trades": 1}
+        )
+        self.assertEqual(
+            parsed["2026-07-16"]["EMA"], {"pnl": -25.0, "mode": "MIXED", "trades": 2}
+        )
+        self.assertEqual(
+            parsed["2026-07-15"]["Renko"], {"pnl": 50.0, "mode": "PAPER", "trades": 1}
+        )
+
+    def test_pnl_window_reaches_the_market_close(self):
+        """2026-08-03: the window ended at 15:21 and shutdown ran late.
+
+        Summaries normally land at 15:20, so the old cutoff left ONE MINUTE of
+        margin. That day 53 of 54 lines fell outside it and were discarded; the
+        only cell that reached the Sheet was the one strategy whose summary
+        happened to be logged at 11:00. The end is now the market close.
+        """
+        self.assertEqual(master_file._PNL_LOG_WINDOW_END, (15, 30))
+        # The exact times seen on 2026-08-03 must now be accepted...
+        for stamp in ("2026-08-03 15:28:04,444", "2026-08-03 15:30:59,000"):
+            self.assertTrue(master_file._asctime_in_pnl_window(stamp), stamp)
+        # ...while an after-market run still cannot overwrite a real session.
+        for stamp in ("2026-08-03 15:31:00,000", "2026-08-03 17:02:11,000",
+                      "2026-08-03 09:14:59,000"):
+            self.assertFalse(master_file._asctime_in_pnl_window(stamp), stamp)
+
+    def test_discarded_summaries_for_today_are_reported(self):
+        """The old failure was SILENT: a clean-looking run and a blank Sheet."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "runner.log"
+            path.write_text(
+                # Inside the window -> parsed.
+                "2026-08-03 15:20:00,000 | INFO | RenkoThread | "
+                "Result summary | Mode=PAPER | Trades=1 | RealizedPnL=100.00\n"
+                # Today but too late -> dropped, and must be announced.
+                "2026-08-03 15:44:00,000 | INFO | EMAThread | "
+                "Result summary | Mode=PAPER | Trades=1 | RealizedPnL=-25.00\n"
+                # A different day outside the window must NOT be reported today.
+                "2026-07-16 18:00:00,000 | INFO | GoldmineThread | "
+                "Result summary | Mode=PAPER | Trades=1 | RealizedPnL=5.00\n",
+                encoding="utf-8",
+            )
+            with self.assertLogs(master_file.logger, level="WARNING") as captured:
+                parsed = master_file._parse_eod_pnl_by_day(path, today_str="2026-08-03")
+
+        self.assertEqual(parsed["2026-08-03"]["Renko"]["pnl"], 100.0)
+        self.assertNotIn("EMA", parsed.get("2026-08-03", {}))
+        warning = "\n".join(captured.output)
+        self.assertIn("P&L SHEET", warning)
+        self.assertIn("1 of today", warning)          # only today's line counted
+        self.assertNotIn("2 of today", warning)
+
+    def test_a_restarted_runner_cannot_erase_a_finished_session(self):
+        """2026-08-03: the runner was restarted at ~15:29.
+
+        Every worker in the fresh process logged "Trades=0 | RealizedPnL=0.00" as
+        soon as it reached square-off -- seven minutes after the real figures.
+        Under plain last-write-wins, widening the window to catch the real 15:28
+        lines would have let those zeros overwrite a whole trading day, writing 27
+        cells of 0.00. A later summary may only win if it saw at least as many
+        trades.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "runner.log"
+            path.write_text(
+                "2026-08-03 15:28:05,033 | INFO | RenkoThread | "
+                "Result summary | Mode=PAPER | Trades=2 | RealizedPnL=3165.50\n"
+                "2026-08-03 15:30:22,528 | INFO | RenkoThread | "
+                "Result summary | Mode=PAPER | Trades=0 | RealizedPnL=0.00\n"
+                # A strategy that genuinely did nothing all day still records 0.00.
+                "2026-08-03 15:30:22,530 | INFO | MoneyMachineThread | "
+                "Result summary | Mode=PAPER | Trades=0 | RealizedPnL=0.00\n",
+                encoding="utf-8",
+            )
+            parsed = master_file._parse_eod_pnl_by_day(path, today_str="2026-08-03")
+
+        self.assertEqual(parsed["2026-08-03"]["Renko"]["pnl"], 3165.50)
+        self.assertEqual(parsed["2026-08-03"]["MoneyMachine"]["pnl"], 0.00)
+
+    def test_a_later_summary_with_more_trades_still_wins(self):
+        """Last-write-wins must survive for the ordinary re-entry case."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "runner.log"
+            path.write_text(
+                "2026-08-03 11:00:00,000 | INFO | LongStrangleThread | "
+                "Result summary | Mode=PAPER | Trades=4 | RealizedPnL=100.00\n"
+                "2026-08-03 15:20:00,000 | INFO | LongStrangleThread | "
+                "Result summary | Mode=PAPER | Trades=12 | RealizedPnL=-760.50\n",
+                encoding="utf-8",
+            )
+            parsed = master_file._parse_eod_pnl_by_day(path, today_str="2026-08-03")
+
+        self.assertEqual(parsed["2026-08-03"]["LongStrangle"]["pnl"], -760.50)
+
+    def test_no_warning_when_every_summary_is_inside_the_window(self):
+        """A normal day must stay quiet -- this warning has to mean something."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "runner.log"
+            path.write_text(
+                "2026-08-03 15:20:00,000 | INFO | RenkoThread | "
+                "Result summary | Mode=PAPER | Trades=1 | RealizedPnL=100.00\n",
+                encoding="utf-8",
+            )
+            with patch.object(master_file.logger, "warning") as warn:
+                master_file._parse_eod_pnl_by_day(path, today_str="2026-08-03")
+        warn.assert_not_called()
 
     def test_sheet_uses_mode_specific_labels_without_turning_pnl_into_text(self):
         values = [


### PR DESCRIPTION
Only **one cell** reached the Google Sheet on 3 Aug despite all 25 strategies running. Two
independent defects, both silent.

## 1. The window ended one minute after the summaries

`_parse_eod_pnl_by_day` ignores result-summary lines outside **09:15–15:21**. Every prior session in
the log finished its summaries at **15:20** — sixty seconds of margin:

| Date | last summary |
|---|---|
| 17 Jul – 31 Jul (11 sessions) | 15:20 |
| **3 Aug** | **15:28 / 15:30** |

Shutdown ran late, so **53 of 54 lines were discarded**. The single survivor was SL Hunting AI's,
logged at **11:00** — exactly the one cell that updated.

The end is now the **market close (15:30)**. The guard is worth keeping — without it an evening test
run would overwrite a real session — so what changed is the margin, not the idea.

## 2. Widening alone would have been WORSE than the bug

I verified the fix against the real log rather than trusting it, and the day turns out to have **two
rounds** of summaries:

```
15:28:05  RenkoThread | Trades=2 | RealizedPnL=3165.50     <- the real session
15:30:22  RenkoThread | Trades=0 | RealizedPnL=0.00        <- a RESTARTED runner
```

The runner was restarted around 15:29, and each worker logged `Trades=0` on reaching square-off.
Under plain last-write-wins, the wider window let those zeros **overwrite everything** — 27 cells of
`0.00`, worse than one correct cell.

A later summary may now only replace an earlier one **if it saw at least as many trades**. Equal
counts still overwrite, so the ordinary re-entry final line wins as before, and a strategy that
genuinely did nothing still records `0.00`.

## 3. The failure was invisible; now it announces itself

Summary lines for *today* that fall outside the window are counted and logged as a warning naming
the count and the window. The only symptom before was a Sheet that quietly stayed blank — which is
why this went unnoticed until you spotted it.

## Verified against the real 3 Aug log

**27 strategies now parse (was 1)**, with their true figures:

```
Renko             3,165.50 (trades=2)     LongStrangle      -760.50 (trades=12)
EMA               1,027.00 (trades=1)     SL Hunting AI   -1,379.25 (trades=2)
HeikinAshi        1,309.75 (trades=9)     DonchianBearish -1,725.75 (trades=1)
MoneyMachine          0.00 (trades=0)     ... 27 total, summing to -368.50
```

**Today's figures are recoverable** — today's column is always rewritten, so running the writer
inside the window will backfill them.

## Gates

420 master tests (5 new), 934 pytest, 21 market-data-health, ruff, mypy (CI scope), compileall —
all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)