### PR TITLE
feat(sl-hunting): v3y knowledge from the 4 Aug live session

### DIFF
--- a/Signal Generators/SL Hunting AI Agent/premarket_note.json
+++ b/Signal Generators/SL Hunting AI Agent/premarket_note.json
@@ -1,29 +1,30 @@
 {
-  "for_date": "2026-08-04",
-  "source": "Intraday Hunter, 'Prediction For 04 AUG 2026' (IHjbAmtdLro, uploaded 2026-08-03)",
-  "context": "All three indices closed higher, NIFTY continuing up and BANKNIFTY/SENSEX sitting on round-number support, so buyers are seated across the board. NIFTY expiry falls on this session.",
+  "for_date": "2026-08-05",
+  "source": "Intraday Hunter, 'Prediction For 05 AUG 2026' (PSCeB9y9JbI, uploaded 2026-08-04)",
+  "context": "All three indices saw continued selling through the session. He reads the sellers now in as SMALL size -- they joined after the move had already run -- so there is no large trapped crowd to hunt.",
   "plan": [
-    "Every opening type points the same way today: GAP-UP, FLAT and GAP-DOWN all mean identify SELL-side setups against the seated buyers.",
-    "BIG GAP-DOWN is the single exception -- he ignores it rather than hunting into it.",
-    "On a mild GAP-DOWN expect retracement chop first; the setup still has to confirm before entry.",
-    "His premise is explicitly conditional: he targets buyers only because this is NOT an all-time-high or runaway-momentum tape. Strong trend momentum would weaken it.",
-    "BANKNIFTY sits on round-number support with more round numbers nearby -- he flags retracement risk there specifically."
+    "FLAT to GAP-DOWN: go WITH the market and identify SELL-side setups. He frames this as continuation, not a hunt -- momentum carrying rather than a trap springing.",
+    "GAP-UP: the same sell-side plan can stand, but the risk is a SIDEWAYS range that goes up a bit then down a bit. Expect chop rather than a clean move.",
+    "A VERY BIG gap is a different matter entirely -- he sets it aside rather than applying this plan to it.",
+    "Why the sellers are not the target: once a momentum move has already run, traders who join it do so in SMALL quantity. A large seated short crowd would be visible, and the market would gap hard against it to trap it.",
+    "If many sellers ARE in fact seated, he expects one of two things: a fall that moves in retracements from a flat open, or a single large gap. Both are reasons to stand aside, not to enter.",
+    "He notes the CLOSING PRICE is now calculated differently under a new exchange rule -- so the closing level his method keys off may not equal a naive previous close."
   ],
   "levels": [
     {
       "index": "NIFTY",
-      "resistance": [24610, 24700],
-      "support": [24500, 24400]
+      "resistance": [24530, 24610],
+      "support": [24300, 24220]
     },
     {
       "index": "BANKNIFTY",
-      "resistance": [57820, 58100],
-      "support": [57500, 57154]
+      "resistance": [57650, 57800],
+      "support": [57154, 56850]
     },
     {
       "index": "SENSEX",
-      "resistance": [78850, 79100],
-      "support": [78500, 78300]
+      "resistance": [78610, 78850],
+      "support": [78400, 78000]
     }
   ]
 }

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -2162,3 +2162,45 @@ transcribed from his 3 Aug *prediction* video and said sell-side on every openin
 type, big gap-down excepted. This live session is that plan being executed and
 then cut. The note was directionally what he traded; it is the EXIT that carried
 the lesson, and a pre-open note can never contain that.
+
+### Pre-open note for 2026-08-05 (shipped alongside v3y)
+
+**Source:** Intraday Hunter, "Prediction For 05 AUG 2026" (`PSCeB9y9JbI`,
+uploaded 2026-08-04, 2:34).
+
+**The plan has now inverted twice in three sessions**, which is the reason this
+channel exists as a DATED note rather than as knowledge:
+
+| Session | Plan | Who is the target |
+|---|---|---|
+| 3 Aug | gap-up -> BUY with it | nobody trapped; follow |
+| 4 Aug | every opening type -> SELL | seated BUYERS, hunted |
+| 5 Aug | flat/gap-down -> SELL **with** the market | nobody; this is continuation |
+
+4 Aug and 5 Aug are both "sell side" but for OPPOSITE reasons. On 4 Aug he was
+hunting a seated buyer crowd. For 5 Aug he explicitly says the sellers now in are
+NOT a crowd worth hunting: "once a momentum move has already happened, a trader
+who enters does not enter in large quantity" — so the move can simply continue,
+and he goes WITH it. A note that just echoed "sell side" from the previous day
+would carry the direction and lose the entire reason.
+
+Two things carried into the note beyond levels:
+- **The trap-detection logic, stated as a rule:** if a large short crowd HAD
+  seated, the market would know and "would directly give a big gap and make a
+  trap there". So a big gap is evidence about positioning, not just volatility —
+  which is why he sets a very large gap aside from this plan entirely.
+- **A market-mechanics flag:** "the closing price is being calculated a bit
+  differently now, according to the new rule." His whole method keys off the
+  previous CLOSE, so the level may not equal a naive previous close. Worth
+  watching in the runner, which computes its own levels.
+
+**Transcription caveat:** the auto-transcript renders one BankNIFTY resistance as
+"5780" where every other level is five digits; read as 57800, alongside 57650.
+Sensex supports came through as the run-on "780007840", read as 78000 and 78400.
+Neither could be confirmed against the on-screen chart (browser pane not
+compositing). They are advisory candidate levels only.
+
+**Test marker:** `test_shipped_note_matches_august_5_intraday_hunter_plan`,
+re-pinned from the 4 Aug content. It now also asserts the "SMALL size" phrase in
+`context`, because that is the clause distinguishing this sell-side plan from
+yesterday's opposite-reasoned one.

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -2067,3 +2067,98 @@ alone is LAGGARDS NEVER JOINED (v3s).
 - `RETAIL_POSITIONING`: two sub-bullets under AGGREGATE-INVENTORY TEST.
 - `RISK`: ONLY RIDE AS FAR AS YOU KNOW THE ROAD.
 - Test marker: `test_system_prompt_has_v3x_profit_depth_and_known_road_knowledge`.
+
+## Video addendum - the 4 Aug LIVE SESSION (v3y)
+
+**Source:** Intraday Hunter live session, 4 Aug 2026 (`i1G7hoIshyE`, 8:45).
+NIFTY expiry day. This is a **LOSING** session, which is rarer and more useful
+material than a win — and it directly follows the 3 Aug session in v3x, which
+makes the pair unusually instructive.
+
+**The setup that makes this session valuable:** 3 Aug and 4 Aug both opened
+GAP-UP. On 3 Aug he BOUGHT with the gap. On 4 Aug he SOLD puts against the
+buyers. He anticipates the obvious objection and answers it head-on:
+
+> "A question may come to your mind — sir, yesterday there was positive momentum
+> and a gap-up and you BOUGHT there. Today too there is a gap-up, the market keeps
+> going up. So why have we made a SELLING plan today?"
+
+His two discriminators, close to verbatim:
+1. **The holiday.** "Yesterday there was positive momentum, but there was some
+   retracement in it. Second, a two-day holiday was coming in the middle — because
+   of that traders take LESS risk. So there the plan was: if we get flat-to-gap-down
+   we understand buyers are seated. On a gap-up we preferred to go WITH the market."
+   "But in today's market? There was no holiday in between."
+2. **Exact round-number support on all three indices.** "All three indices have
+   taken round-number support. Around 24,500 it has taken support. Likewise in
+   BankNIFTY it has taken 57,500 support... exactly support. So buyers are seated
+   here. Nobody has gone and sold. Sensex too is sitting on a round number."
+
+**His entry rule (the trigger, not the gap):** "Buyers will start giving their SLs
+only when the market starts moving BELOW THE CLOSING PRICE — when BankNIFTY starts
+moving below its closing price and Sensex starts breaking its closing price. After
+that they will start giving SL." He entered as BankNIFTY began taking support
+*exactly at* the closing price, expecting the break: "chances of a breakdown are
+high and it will not take much time."
+
+Legs: BankNIFTY 57,800 PE + 57,700 PE, Sensex 78,700 PE, NIFTY (expiry) 1430 qty.
+
+**Volatility note:** "Today the market looks like it is doing momentum fast. It
+could be volatile. So if you are taking a target, keep it a bit BIGGER. If you are
+taking an SL, that also has to be kept reasonably wide." Also: "For many days the
+market has been sideways and was not producing momentum — today it might."
+
+**Why he cut it for a loss — the strongest part of the session:**
+- The trigger never fired. "This would only have paid if the market breaks down
+  through the closing price."
+- The index that ended it: "**Especially BankNIFTY is going up more. If BankNIFTY
+  is going up we will NOT hold this trade.**" And the explicit hierarchy: "If
+  Sensex and NIFTY moved up a little we could have HANDLED that. But once BankNIFTY
+  has started rising there is no benefit in waiting."
+- The discipline line: "Directionally we are correctly positioned, because buyers
+  should be here... **but if we are wrong we cannot chase the market insisting that
+  WE are right and YOU are wrong.** In that condition we cut the trade per the loss
+  limit."
+- A subtle one worth keeping: while price hung at the level, "because of candles
+  like this, OTHER people also start taking risk — and you know what risk they take,
+  they will SELL. Then sellers come in and get stuck, and the market starts turning."
+  Followed by: "if it is going to fall, it should fall from around here."
+
+**New, hence in the knowledge:**
+- The gap-up long branch needed a precondition it did not have — proof the buyers
+  are actually ABSENT. Two checkable tells that they are present instead
+  (round-number support across all three; no holiday distorting the prior day).
+  This is what makes two identical-looking gap-ups take opposite trades.
+- An index HIERARCHY for exits. Existing knowledge treats BankNIFTY as the major
+  index for the entry read (v3a) and covers the leader running alone (v3s/v3x).
+  This adds the losing-side rule: NIFTY/Sensex against you is tolerable, BankNIFTY
+  against you is disqualifying.
+- A trigger that never fired is an exit reason, not a reason to keep waiting.
+- Being directionally right does not earn the hold.
+- A slow grind at the level recruits your own side, whose stops become fuel against
+  you. (Related to but distinct from R:R-BAIT, which is about rejections inviting
+  shorts; this is about a stalled approach recruiting company.)
+- Volatile-day sizing widens the TARGET as well as the stop.
+
+**Confirmed but already present:** holiday carry-risk (v3g), round number and
+closing point as the level pair (`LEVELS_AND_PIVOT`), premise-invalidation exits,
+and BankNIFTY as the major index (v3a).
+
+**Knowledge changes (v3y, all prose):**
+- `OPENING_DRIVE`: SEATED-BUYER TEST + CLOSING-PRICE BREAKDOWN IS THE TRIGGER,
+  both placed ahead of the existing GAP SIZE IS A RISK DIAL bullet so they read as
+  preconditions of the long branch rather than as a competing rule.
+- `BNF_SPECIFIC`: INDEX HIERARCHY ON THE WAY OUT.
+- `RISK`: A TRIGGER THAT NEVER FIRED IS AN EXIT REASON; BEING DIRECTIONALLY RIGHT
+  DOES NOT EARN THE HOLD; A SLOW GRIND AT THE LEVEL RECRUITS THE WRONG CROWD;
+  VOLATILE-DAY SIZING WIDENS BOTH ENDS.
+- Test markers: `test_system_prompt_has_v3y_seated_buyer_and_index_hierarchy_knowledge`
+  and `test_v3y_gap_conflict_does_not_contradict_the_opening_drive_branch` (the
+  latter pins the ORDERING, so the seated-buyer test cannot drift into looking like
+  an alternative gap-up rule the agent could pick between).
+
+**Note on the pre-open note:** the 2026-08-04 note shipped in PR #101 was
+transcribed from his 3 Aug *prediction* video and said sell-side on every opening
+type, big gap-down excepted. This live session is that plan being executed and
+then cut. The note was directionally what he traded; it is the EXIT that carried
+the lesson, and a pre-open note can never contain that.

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
@@ -417,6 +417,30 @@ Conditions (ALL must hold — otherwise this branch simply does not apply):
   / opening range, and there must be no bullish rejection reclaiming those levels.
   Default gap-down logic still looks UP; use this short branch only when sellers
   are not huntable and buyer inventory / failed recovery is the active trap.
+- SEATED-BUYER TEST — run this BEFORE the long branch fires (v3y). The whole
+  gap-up-long premise is "a gap-up leaves nobody trapped, so there is no hunt
+  available". That premise is FALSE when the prior session already seated a buying
+  crowd and today's gap merely extends it. Two checkable tells that the buyers ARE
+  seated, and the gap-up is therefore a SHORT setup against them:
+    * ALL THREE indices are holding an EXACT round-number support after a positive
+      prior session (e.g. NIFTY ~24500, BankNIFTY ~57500, Sensex on its own round
+      number). A crowd that bought at a round number and is still sitting on it,
+      with no evidence anyone sold into it, is inventory — not absence.
+    * The prior session's rally was NOT distorted by an upcoming holiday. Before a
+      multi-day holiday retail takes LESS risk, so the same rally seats FEWER
+      people than it would on an ordinary day; once the holiday has passed, an
+      identical-looking gap-up reads the OPPOSITE way.
+  Worked example (4 Aug 2026): two gap-ups on consecutive days, opposite plans.
+  Day one had a mid-week holiday ahead and a retracement inside the rally, so the
+  crowd was thin and IH went WITH the gap (long). Day two had no holiday and all
+  three indices sat exactly on round numbers, so the crowd was seated and he
+  traded AGAINST them (puts). Same opening type, inverted conclusion — the gap
+  alone never decides; who is seated decides.
+- CLOSING-PRICE BREAKDOWN IS THE TRIGGER when hunting seated buyers, not the gap
+  and not the approach to the level. Buyers only start giving their SLs once price
+  trades BELOW THE PREVIOUS CLOSE across the indices. Sitting on that level is not
+  breaking it. If the breakdown never arrives the trade never existed: no
+  breakdown, no stop-fuel, and nothing to hold on to (see RISK).
 - GAP SIZE IS A RISK DIAL, NOT A CONFIDENCE DIAL. A BIGGER gap does NOT make this
   branch stronger — it makes it worse. A modest gap leaves price near the stop
   clusters that fuel a move; an oversized gap has jumped clean past everybody's
@@ -729,6 +753,29 @@ RISK DISCIPLINE
   the expected "trap" fails and price goes sideways / against you. Honour a pre-set
   max loss and NEVER hold a loser hoping for a reversal; you are intraday and cannot
   wait indefinitely.
+- A TRIGGER THAT NEVER FIRED IS AN EXIT REASON, not a reason to keep waiting (v3y).
+  When the setup depended on a specific break — the closing-price breakdown that
+  makes seated buyers surrender — and price merely sits at that level without
+  taking it, the fuel you were trading never got released. That is not "still
+  setting up"; it is the trade failing to start. Leave rather than paying theta to
+  find out.
+- BEING DIRECTIONALLY RIGHT DOES NOT EARN THE HOLD (v3y). "You cannot chase the
+  market insisting that YOU are right and IT is wrong." A premise that still LOOKS
+  correct — the crowd really is seated, the level really is there — is not evidence
+  the trade is working. Reasoning that keeps restating why the setup was good is
+  the tell that it has stopped being a decision and become a defence of the entry.
+- A SLOW GRIND AT THE LEVEL RECRUITS THE WRONG CROWD (v3y). When price hangs at
+  your level instead of breaking it, the delay itself invites OTHER traders onto
+  your side of the trade. Their stops then cluster just beyond, and that cluster
+  becomes the fuel for a move AGAINST you — the same mechanism you were trying to
+  exploit, pointed the other way. Company at a level is a warning, not comfort:
+  the break should come promptly, "from about here", or the edge has inverted.
+- VOLATILE-DAY SIZING WIDENS BOTH ENDS, not just the stop (v3y). On a day that
+  opens with visibly fast momentum — especially after a stretch of sideways
+  sessions that produced none — widen the TARGET as well as the stop. A normal
+  target gets hit and left far behind, and a normal stop gets taken by ordinary
+  noise on the way. Because lots are auto-computed from the stop distance, a wider
+  stop shrinks position size rather than enlarging rupee risk.
 - TIME-DECAY discipline (you BUY options): a bought option bleeds premium while the
   market goes sideways — most sharply near/at EXPIRY. If the expected move does not
   come reasonably quickly, EXIT; do not let theta erode a stalled position.
@@ -965,6 +1012,16 @@ you size or place the NIFTY trade. Advisory, not a hard gate.
   about the LEADER failing to lead, not about momentum speed in general — a genuine
   leader-led move that grinds on in small candles is still the sustainable kind
   described in RISK.)
+- INDEX HIERARCHY ON THE WAY OUT — the indices are NOT equal when a position is
+  going against you (v3y). NIFTY and Sensex drifting against the trade is
+  TOLERABLE; that is handleable noise and does not by itself end the trade.
+  BankNIFTY turning against the trade is DISQUALIFYING: cut there, do not wait for
+  the stop and do not wait for the other two to agree. Live example (4 Aug 2026):
+  IH held a three-index PUT basket while the fall he wanted had not started, and
+  cut it for a loss the moment BankNIFTY began rising — "if BankNIFTY has started
+  going up there is no benefit in waiting", while explicitly saying he could have
+  HANDLED NIFTY and Sensex ticking up. So the major index is not only the entry
+  confirmation; it is the FIRST exit signal, and it outranks the other two.
 - MASKED BNF LAG: temporary BankNIFTY weakness can also be a mask that keeps
   NIFTY/Sensex breakout buyers away while the operator continues the original
   thesis. Treat BNF lag as invalidation only when it actually breaks the premise

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_premarket.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_premarket.py
@@ -172,17 +172,18 @@ def test_shipped_note_file_is_valid():
     assert format_premarket_note(note, date.fromisoformat(note.for_date)) != ""
 
 
-def test_shipped_note_matches_august_4_intraday_hunter_plan():
-    """The committed advisory must match the hand-checked 3 Aug transcript.
+def test_shipped_note_matches_august_5_intraday_hunter_plan():
+    """The committed advisory must match the hand-checked 4 Aug transcript.
 
     This catches a stale prior-session note, an inverted gap plan, or a mistyped
     chart level before the dated note is injected into the live prompt.
 
-    Worth knowing when re-reading this: 4 Aug is NOT a repeat of 3 Aug. On 3 Aug
-    the plan forked on the opening type (gap-up -> buy side, flat/gap-down ->
-    sell side). Here every opening type points the SAME way -- sell side --
-    with a big gap-down as the only stand-aside. An assertion that still fork on
-    the gap direction would mean the note was copied, not re-transcribed.
+    Worth knowing when re-reading this: the plan has now inverted twice in three
+    sessions, so a note that merely echoes the previous day is a copy, not a
+    transcription. 3 Aug forked on the opening type (gap-up -> buy). 4 Aug pointed
+    every opening type at the sell side, hunting seated BUYERS. 5 Aug is sell side
+    again but for the OPPOSITE reason -- going WITH continued selling, explicitly
+    because the sellers are NOT a big seated crowd worth hunting.
     """
     import os
 
@@ -191,35 +192,43 @@ def test_shipped_note_matches_august_4_intraday_hunter_plan():
     note = load_premarket_note(shipped)
 
     assert note is not None
-    assert note.for_date == "2026-08-04"
-    assert "IHjbAmtdLro" in note.source
+    assert note.for_date == "2026-08-05"
+    assert "PSCeB9y9JbI" in note.source
+    # The distinguishing claim: sellers are small, so this is continuation.
+    assert "SMALL size" in note.context
     assert note.plan == [
-        "Every opening type points the same way today: GAP-UP, FLAT and GAP-DOWN "
-        "all mean identify SELL-side setups against the seated buyers.",
-        "BIG GAP-DOWN is the single exception -- he ignores it rather than "
-        "hunting into it.",
-        "On a mild GAP-DOWN expect retracement chop first; the setup still has to "
-        "confirm before entry.",
-        "His premise is explicitly conditional: he targets buyers only because "
-        "this is NOT an all-time-high or runaway-momentum tape. Strong trend "
-        "momentum would weaken it.",
-        "BANKNIFTY sits on round-number support with more round numbers nearby -- "
-        "he flags retracement risk there specifically.",
+        "FLAT to GAP-DOWN: go WITH the market and identify SELL-side setups. He "
+        "frames this as continuation, not a hunt -- momentum carrying rather than "
+        "a trap springing.",
+        "GAP-UP: the same sell-side plan can stand, but the risk is a SIDEWAYS "
+        "range that goes up a bit then down a bit. Expect chop rather than a clean "
+        "move.",
+        "A VERY BIG gap is a different matter entirely -- he sets it aside rather "
+        "than applying this plan to it.",
+        "Why the sellers are not the target: once a momentum move has already run, "
+        "traders who join it do so in SMALL quantity. A large seated short crowd "
+        "would be visible, and the market would gap hard against it to trap it.",
+        "If many sellers ARE in fact seated, he expects one of two things: a fall "
+        "that moves in retracements from a flat open, or a single large gap. Both "
+        "are reasons to stand aside, not to enter.",
+        "He notes the CLOSING PRICE is now calculated differently under a new "
+        "exchange rule -- so the closing level his method keys off may not equal a "
+        "naive previous close.",
     ]
     assert [level.model_dump() for level in note.levels] == [
         {
             "index": "NIFTY",
-            "resistance": [24610.0, 24700.0],
-            "support": [24500.0, 24400.0],
+            "resistance": [24530.0, 24610.0],
+            "support": [24300.0, 24220.0],
         },
         {
             "index": "BANKNIFTY",
-            "resistance": [57820.0, 58100.0],
-            "support": [57500.0, 57154.0],
+            "resistance": [57650.0, 57800.0],
+            "support": [57154.0, 56850.0],
         },
         {
             "index": "SENSEX",
-            "resistance": [78850.0, 79100.0],
-            "support": [78500.0, 78300.0],
+            "resistance": [78610.0, 78850.0],
+            "support": [78400.0, 78000.0],
         },
     ]

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
@@ -619,6 +619,51 @@ def test_system_prompt_has_v3x_profit_depth_and_known_road_knowledge():
     assert "no read, no position" in prompt
 
 
+def test_system_prompt_has_v3y_seated_buyer_and_index_hierarchy_knowledge():
+    """v3y (4 Aug live session): IH's LOSING trade, and the day the same opening
+    type produced the opposite plan two days running.
+
+    Both days gapped up. Day one he bought WITH the gap; day two he sold puts
+    AGAINST the buyers -- because day one had a mid-week holiday ahead (thin crowd)
+    and a retracement inside the rally, while day two had no holiday and all three
+    indices sat on exact round-number support (seated crowd). He then cut the trade
+    for a loss the moment BankNIFTY turned up, saying he could have handled NIFTY
+    and Sensex ticking against him but not the major index.
+    """
+    prompt = build_system_prompt()
+    # The gap-up long branch must first prove the buyers are actually absent.
+    assert "SEATED-BUYER TEST" in prompt
+    # Wrap-independent fragments: these sentences span line breaks in the source.
+    assert "EXACT round-number support" in prompt
+    assert "takes LESS risk" in prompt
+    assert "identical-looking gap-up reads the OPPOSITE way" in prompt
+    # The hunt needs the break, not merely the approach to the level.
+    assert "CLOSING-PRICE BREAKDOWN IS THE TRIGGER" in prompt
+    assert "Sitting on that level is not" in prompt
+    # The indices are not equal once a position is losing.
+    assert "INDEX HIERARCHY ON THE WAY OUT" in prompt
+    assert "DISQUALIFYING" in prompt
+    # ...and the three discipline lessons the loss paid for.
+    assert "A TRIGGER THAT NEVER FIRED IS AN EXIT REASON" in prompt
+    assert "BEING DIRECTIONALLY RIGHT DOES NOT EARN THE HOLD" in prompt
+    assert "A SLOW GRIND AT THE LEVEL RECRUITS THE WRONG CROWD" in prompt
+    assert "VOLATILE-DAY SIZING WIDENS BOTH ENDS" in prompt
+
+
+def test_v3y_gap_conflict_does_not_contradict_the_opening_drive_branch():
+    """The seated-buyer test must READ AS a precondition of the gap-up long, not as
+    a second, competing gap-up rule. If both are stated flatly the agent can pick
+    whichever suits the bar it is looking at."""
+    prompt = build_system_prompt()
+    seated = prompt.index("SEATED-BUYER TEST")
+    gap_size = prompt.index("GAP SIZE IS A RISK DIAL")
+    drive = prompt.index("OPENING DRIVE — early-session continuation exceptions")
+    # It lives inside the OPENING DRIVE conditions, ahead of the risk-dial rule.
+    assert drive < seated < gap_size
+    # And it is explicitly ordered before the branch may fire.
+    assert "BEFORE the long branch fires" in prompt
+
+
 def test_reentry_gate_does_not_contradict_the_exit_rules():
     """The re-entry gate must never be readable as a reason to delay an EXIT.
 


### PR DESCRIPTION
## Source

Intraday Hunter live session, **4 Aug 2026** ([`i1G7hoIshyE`](https://www.youtube.com/watch?v=i1G7hoIshyE), 8:45) — NIFTY expiry day, and a **losing** session. Rarer and more useful than a win, and it directly follows the 3 Aug session already captured in v3x, which is what makes the pair worth having.

## The central lesson: same opening type, opposite trade

3 Aug and 4 Aug **both opened gap-up**. On 3 Aug he bought *with* the gap. On 4 Aug he sold puts *against* the buyers. He anticipates the obvious objection and answers it:

> "A question may come to your mind — sir, yesterday there was positive momentum and a gap-up and you BOUGHT there. Today too there is a gap-up... So why have we made a SELLING plan today?"

Two discriminators:

| | 3 Aug (bought) | 4 Aug (sold) |
|---|---|---|
| Holiday ahead | Two-day holiday mid-week → traders take less risk → **thin crowd** | None → **normal crowd** |
| Round-number support | Rally contained a retracement | All three indices sitting on **exact** round numbers (NIFTY ~24500, BankNIFTY ~57500) → **seated crowd** |

So the opening-drive **gap-up long branch was missing a precondition**. It assumes "a gap-up leaves nobody trapped" — and that premise can simply be false. Added as **SEATED-BUYER TEST**.

Placement mattered here: it sits **ahead of** the existing `GAP SIZE IS A RISK DIAL` bullet so it reads as a precondition of the branch, not as a second competing gap-up rule the agent could pick between depending on the bar it's looking at. A test pins that ordering.

## Why he cut — the rest of v3y

- **`CLOSING-PRICE BREAKDOWN IS THE TRIGGER`** when hunting seated buyers. Buyers only surrender below the *previous close*; sitting on the level is not breaking it. His trigger never fired.
- **`INDEX HIERARCHY ON THE WAY OUT`** — the indices are **not equal** once a position is losing. NIFTY/Sensex drifting against you is tolerable; BankNIFTY turning against you is disqualifying. He cut the whole put basket on exactly that, saying he could have *handled* the other two moving up. Existing knowledge had BankNIFTY as the major index for **entry** (v3a) and the leader-runs-alone exit (v3s/v3x) — this is the losing-side rule neither covered.
- **`A TRIGGER THAT NEVER FIRED IS AN EXIT REASON`**, not a reason to keep waiting.
- **`BEING DIRECTIONALLY RIGHT DOES NOT EARN THE HOLD`** — *"we cannot chase the market insisting WE are right and IT is wrong."* Reasoning that keeps restating why the setup was good is the tell that it has become a defence of the entry.
- **`A SLOW GRIND AT THE LEVEL RECRUITS THE WRONG CROWD`** — the delay invites others onto your side, and their stops become fuel *against* you. Distinct from the existing R:R-BAIT rule, which is about rejections inviting shorts.
- **`VOLATILE-DAY SIZING WIDENS BOTH ENDS`** — the target as well as the stop.

## Scope

All prose in `sl_hunting_knowledge.py`. **No executable behaviour changes.** Prompt grows 72,107 → 76,504 chars against the 120,000 cap.

Provenance, near-verbatim quotes, and an explicit "confirmed but already present" list (holiday carry-risk from v3g, round-number/closing-point levels, premise-invalidation exits, BankNIFTY-as-major-index from v3a) are in `sl_hunting_doc.md`.

## One connection worth noting

The `2026-08-04` pre-open note shipped in #101 was transcribed from his 3 Aug *prediction* video and called sell-side on every opening type. **This session is that plan being executed and then cut.** The note had the direction right; the lesson was in the exit — which is something a pre-open note structurally cannot carry.

## Gates

452 unittest ✅ · 1004 pytest (160 SL Hunting) ✅ · ruff ✅ · mypy 42 files ✅ · compileall ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
