### PR TITLE
fix(strategy): stop the fade taking a trade its own bar already completed

### DIFF
--- a/Nifty Multi Strategy Front Test - Master File.py
+++ b/Nifty Multi Strategy Front Test - Master File.py
@@ -12941,6 +12941,25 @@ def _build_signal_gen_worker_class(
                 return
 
             # Flat -> a LONG buys an ATM CE, a SHORT buys an ATM PE (see enter_position).
+            if decision.action in ("ENTER_LONG", "ENTER_SHORT"):
+                # Log WHY before acting. For most ports `reason` is a short rule
+                # name, but for the Regime Adaptive router it also names the
+                # branch that fired ("BREAKOUT_long" / "MEANREV_short"), which is
+                # otherwise invisible: the entry line below records the option and
+                # the levels, never which rule chose them. Without this you cannot
+                # confirm from a session log that the router actually switched
+                # branch as ADX crossed -- the one thing its porting notes ask you
+                # to verify in paper.
+                self.log.info(
+                    "SIGNAL %s | %s | reason=%s | entry=%.2f stop=%.2f target=%.2f%s",
+                    decision.action,
+                    self.strategy_name,
+                    getattr(decision, "reason", "") or "-",
+                    _safe_float(decision.entry_underlying, 0.0),
+                    _safe_float(decision.stop_underlying, 0.0),
+                    _safe_float(getattr(decision, "target_underlying", 0.0), 0.0),
+                    f" | {decision.debug}" if getattr(decision, "debug", None) else "",
+                )
             if decision.action == "ENTER_LONG":
                 self.enter_position(
                     "LONG",

--- a/Signal Generators/Regime Adaptive Strategy/REGIME_PORTING_NOTES.md
+++ b/Signal Generators/Regime Adaptive Strategy/REGIME_PORTING_NOTES.md
@@ -155,6 +155,40 @@ every strategy except Regime Adaptive (`_DEFAULT_MAX_SPREAD_PCT`), so no existin
 worker's behaviour changed. The default lives in code, not only in `env.example`,
 so deleting the `.env` line cannot silently disarm it.
 
+### First session's numbers, and why the refusal rule stays (2026-08-04)
+
+Paper session, 4 entries. Every gate reading:
+
+| Time | Spread | Liquidity | Strikes |
+|---|---|---|---|
+| 09:54 | 0.27% | 89.9 | 462 |
+| 10:24 | 0.23% | 89.9 | 462 |
+| 10:25 | 0.31% | 90.1 | 462 |
+| 11:55 | **unscoreable** | **unscoreable** | — |
+
+Two things to take from that:
+
+1. **Both caps are loose by roughly an order of magnitude.** The worst spread seen
+   was 0.31% against a 2.00% cap, and liquidity sat at ~90 against a floor of 30 —
+   over 462 strikes. The worry recorded above, that a far-OTM tail would drag the
+   median down and veto everything, **did not happen.** Neither gate has yet
+   refused anything, so neither is proven in anger.
+2. **1 entry in 4 could not be scored at all.** At 11:55:18 `/optionchain` returned
+   a success-shaped but EMPTY payload — Dhan's rate-limit response; no fetch
+   exception was logged, so transport was fine. Paper proceeded (by design) and
+   that trade was the day's best, +Rs.1,423.50. On LIVE both gates would have
+   refused it.
+
+**Operator decision (2026-08-04): the live refusal stays.** The reasoning is that
+the +Rs.1,423.50 outcome was chance — the same unscoreable entry could equally
+have been the day's worst trade, and a rule that lets an unverifiable entry
+through because it *might* be the winner is not a risk rule. Regime Adaptive
+continues VIRTUAL for about a month before this is revisited with a real sample of
+how often the chain is unscoreable and what those entries actually do.
+
+Do NOT "fix" the refusal by relaxing it because a blocked trade would have won;
+that reasoning is only ever available after the fact.
+
 ---
 
 ## The liquidity gate (implemented)

--- a/Signal Generators/Regime Adaptive Strategy/regime_candidates.py
+++ b/Signal Generators/Regime Adaptive Strategy/regime_candidates.py
@@ -106,6 +106,9 @@ def attach_mean_reversion_columns(
     adx = result["adx"].astype(float)
     vwap = result["vwap"].astype(float)
 
+    high = result["high"].astype(float)
+    low = result["low"].astype(float)
+
     distance = close - vwap
     threshold = np.maximum(atr * float(atr_mult), float(min_points))
     # ADX must be PRESENT and below the ceiling. `adx.notna()` is what makes a
@@ -113,15 +116,30 @@ def attach_mean_reversion_columns(
     range_regime = adx.notna() & (adx < float(adx_ceiling))
     usable = range_regime & atr.notna() & vwap.notna()
 
-    result["mr_long_setup"] = (usable & (distance <= -threshold)).fillna(False)
-    result["mr_short_setup"] = (usable & (distance >= threshold)).fillna(False)
-
     result["mr_long_entry_price"] = close
     result["mr_short_entry_price"] = close
     result["mr_long_stop_from_setup"] = close * (1.0 - float(stop_loss_pct))
     # A fade targets the mean it is fading back towards, capped by the ordinary
     # percentage target so a VWAP sitting far away cannot invent a huge target.
-    result["mr_long_target_from_setup"] = np.minimum(vwap, close * (1.0 + float(target_pct)))
+    long_target = np.minimum(vwap, close * (1.0 + float(target_pct)))
+    short_target = np.maximum(vwap, close * (1.0 - float(target_pct)))
+    result["mr_long_target_from_setup"] = long_target
     result["mr_short_stop_from_setup"] = close * (1.0 + float(stop_loss_pct))
-    result["mr_short_target_from_setup"] = np.maximum(vwap, close * (1.0 - float(target_pct)))
+    result["mr_short_target_from_setup"] = short_target
+
+    # ALREADY-REVERTED GUARD. The fade fires on a bar that CLOSES beyond the
+    # threshold, but that same bar's HIGH/LOW usually reaches back past VWAP --
+    # a bar that dipped below VWAP to close there generally traded above it on
+    # the way. Because the engine tests stop/target against the CURRENT bar's
+    # full range, such a setup exits on TARGET at the very next evaluation,
+    # booking a fill-to-fill round trip that never moved. Observed live on
+    # 2026-08-04: entered 10:24:11, "TARGET" at 10:24:20, +0.05 option points.
+    #
+    # If the bar has already traded to the mean, the reversion this rule exists
+    # to capture has happened INSIDE it -- so there is nothing left to trade.
+    long_room = high < long_target
+    short_room = low > short_target
+
+    result["mr_long_setup"] = (usable & (distance <= -threshold) & long_room).fillna(False)
+    result["mr_short_setup"] = (usable & (distance >= threshold) & short_room).fillna(False)
     return result

--- a/Signal Generators/Regime Adaptive Strategy/test_regime_adaptive.py
+++ b/Signal Generators/Regime Adaptive Strategy/test_regime_adaptive.py
@@ -10,6 +10,7 @@ the router refuses to guess a regime it cannot measure.
 from __future__ import annotations
 
 import importlib.util
+import math
 import sys
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -227,6 +228,115 @@ def test_fade_threshold_matches_the_source_formula():
         frame, atr_mult=0.6, min_points=15.0, adx_ceiling=25.0,
         stop_loss_pct=0.015, target_pct=0.03,
     )["mr_long_setup"].any()
+
+
+def test_fade_stands_down_when_the_bar_already_reached_the_mean():
+    """Regression, observed live 2026-08-04: entered 10:24:11, "TARGET" 10:24:20,
+    +0.05 option points.
+
+    The fade fires on a bar that CLOSES below VWAP, but such a bar's HIGH is
+    usually back above VWAP -- it dipped to close there. Since the engine tests
+    stop/target against the CURRENT bar's full range, the VWAP target was already
+    inside the entry bar, so the position exited on TARGET at the next evaluation
+    having never moved. If the bar already traded to the mean, the reversion this
+    rule exists to capture happened inside it and there is no trade left.
+    """
+    frame = regime_common.prepare_session_frame(_session("2026-08-03", 40), 15)
+    frame["adx"] = 10.0
+    frame["atr"] = 10.0
+    # Extended 30 below VWAP (threshold is max(10*0.6, 15) = 15), so distance
+    # alone would fire the long fade.
+    frame["vwap"] = frame["close"] + 30.0
+
+    reached = frame.copy()
+    reached["high"] = reached["vwap"] + 1.0          # bar already traded past VWAP
+    assert not attach_mean_reversion_columns(
+        reached, atr_mult=0.6, min_points=15.0, adx_ceiling=25.0,
+        stop_loss_pct=0.015, target_pct=0.03,
+    )["mr_long_setup"].any(), "took a fade whose target was inside the entry bar"
+
+    room = frame.copy()
+    room["high"] = room["close"] + 1.0               # still well short of VWAP
+    assert attach_mean_reversion_columns(
+        room, atr_mult=0.6, min_points=15.0, adx_ceiling=25.0,
+        stop_loss_pct=0.015, target_pct=0.03,
+    )["mr_long_setup"].any(), "guard also blocked a fade that had real room"
+
+
+def test_short_fade_stands_down_when_the_bar_already_reached_the_mean():
+    """Same guard, mirrored -- the short side has the identical exposure."""
+    frame = regime_common.prepare_session_frame(_session("2026-08-03", 40), 15)
+    frame["adx"] = 10.0
+    frame["atr"] = 10.0
+    frame["vwap"] = frame["close"] - 30.0            # extended ABOVE VWAP
+
+    reached = frame.copy()
+    reached["low"] = reached["vwap"] - 1.0
+    assert not attach_mean_reversion_columns(
+        reached, atr_mult=0.6, min_points=15.0, adx_ceiling=25.0,
+        stop_loss_pct=0.015, target_pct=0.03,
+    )["mr_short_setup"].any()
+
+    room = frame.copy()
+    room["low"] = room["close"] - 1.0
+    assert attach_mean_reversion_columns(
+        room, atr_mult=0.6, min_points=15.0, adx_ceiling=25.0,
+        stop_loss_pct=0.015, target_pct=0.03,
+    )["mr_short_setup"].any()
+
+
+def _ranging_session(day: str, bars: int, *, base: float = 25000.0, amp: float = 40.0,
+                     period: float = 9.0, seed: int = 7) -> pd.DataFrame:
+    """A choppy session that actually produces MEAN-REVERSION bars.
+
+    The plain ramp in `_session` trends hard enough that ADX never drops under
+    the 20 threshold, so the router picks BREAKOUT on every bar and any test
+    filtering for fades silently matches nothing. Sine + noise keeps ADX low
+    enough for the range regime and swings price through its own VWAP.
+    """
+    rng = np.random.default_rng(seed)
+    start = datetime.fromisoformat(f"{day} 09:15:00")
+    rows: list[dict] = []
+    previous = base
+    for i in range(bars):
+        close = base + amp * math.sin(i / period) + rng.normal(0.0, 12.0)
+        rows.append({
+            "timestamp": start + timedelta(minutes=i),
+            "open": previous,
+            "high": max(previous, close) + 10.0,
+            "low": min(previous, close) - 10.0,
+            "close": close,
+        })
+        previous = close
+    return pd.DataFrame(rows)
+
+
+def test_a_published_fade_cannot_exit_on_target_from_its_own_entry_bar():
+    """End-to-end version of the guard: take whatever the builder publishes and
+    prove the engine will not immediately close it on TARGET."""
+    config = ROUTER.RegimeAdaptiveConfig()
+    frame = ROUTER.build_regime_adaptive_with_indicators(_ranging_session("2026-08-03", 250), config)
+    engine = ROUTER.RegimeAdaptiveSignalEngine(config)
+
+    fades = frame[(frame["regime"] == ROUTER.MEAN_REVERSION_BRANCH)
+                  & (frame["long_setup"] | frame["short_setup"])]
+    # Without this the test passes by matching nothing -- which is exactly what it
+    # did on the trending fixture before the live bug made the gap obvious.
+    assert len(fades) > 0, "fixture produced no fade setups; the assertion below would be vacuous"
+    for _index, row in fades.iterrows():
+        is_long = bool(row["long_setup"])
+        side = "long" if is_long else "short"
+        one_bar = frame.loc[[_index]]
+        position = ROUTER.RegimeAdaptivePositionContext(
+            direction="LONG" if is_long else "SHORT",
+            entry_underlying=float(row[f"{side}_entry_price"]),
+            stop_underlying=float(row[f"{side}_stop_from_setup"]),
+            target_underlying=float(row[f"{side}_target_from_setup"]),
+        )
+        decision = engine.evaluate_candle(one_bar, position=position)
+        assert decision.exit_reason != "TARGET", (
+            f"{side} fade at {row.get('timestamp')} exits on TARGET using its own entry bar"
+        )
 
 
 def test_config_defaults_match_the_source_fade_distance():


### PR DESCRIPTION
Two defects from the first Regime Adaptive paper session (2026-08-04), plus the session's gate numbers.

## 1. Instant TARGET on the fade

Observed live: **entered 10:24:11, exited "TARGET" at 10:24:20** — 9 seconds, +0.05 option points (₹3.25). Reproduced in a clean harness.

The fade targets VWAP. It fires on a bar that **closes** beyond the threshold — but such a bar's **high** is usually back past VWAP, because it dipped below to close there. The engine tests stop/target against the current bar's *full range*, so the target was already inside the entry bar and the position closed on TARGET at the very next evaluation, having never moved.

Fixed in the **candidate, not the engine**: a setup whose target already lies inside the triggering bar is no longer published. The engine's exit logic is deliberately untouched — it must still honour a genuine target. If the bar already traded to the mean, the reversion this rule exists to capture happened inside it and there's nothing left to trade.

The cost wasn't only the ₹3.25 — the phantom exit freed a re-entry a minute later at a worse price, which became the day's **−₹1,482** loser.

## 2. The branch was invisible

Nothing logged *which rule* fired, so a session log couldn't answer the one question the porting notes ask you to verify in paper: does the router actually switch branch as ADX crosses? The entry line records the option and the levels, never the reason.

Added a `SIGNAL` line for every signal-gen port logging `decision.reason` — for this router that's `BREAKOUT_long` / `MEANREV_short` — plus levels and debug.

## A test that was passing by matching nothing

While fixing #1 I found the end-to-end assertion I first wrote was **vacuous**. Its fixture is a monotonic ramp, so ADX never drops under 20, the router picks BREAKOUT on every bar, and the filter for fade setups matched nothing — the loop asserted over an empty set and passed.

Replaced with a sine+noise ranging fixture that yields **32 mean-reversion bars and 16 real fades**, plus an explicit non-vacuity assertion. Verified by mutation: disabling the guard fails 3 tests, including that one.

## Session numbers, recorded in the porting notes

| Time | Spread | Liquidity | Strikes |
|---|---|---|---|
| 09:54 | 0.27% | 89.9 | 462 |
| 10:24 | 0.23% | 89.9 | 462 |
| 10:25 | 0.31% | 90.1 | 462 |
| 11:55 | **unscoreable** | **unscoreable** | — |

Both caps are loose by roughly an order of magnitude, and the feared far-OTM-tail veto **did not happen** — so neither gate has yet refused anything.

**Operator decision recorded: the LIVE refusal on an unscoreable chain stays.** The blocked entry being the day's best trade (+₹1,423.50) was chance; the same entry could equally have been the worst, and a rule that admits unverifiable entries because they *might* win is not a risk rule. Regime Adaptive stays virtual for ~1 month before this is revisited. The note says explicitly not to relax it on the basis that a blocked trade would have won.

## Gates

452 unittest ✅ · 1007 pytest ✅ · ruff ✅ · mypy 42 files ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
