### PR TITLE
feat(sl-hunting): v3z knowledge from the 5 Aug live session

### DIFF
--- a/Signal Generators/SL Hunting AI Agent/premarket_note.json
+++ b/Signal Generators/SL Hunting AI Agent/premarket_note.json
@@ -1,29 +1,27 @@
 {
-  "for_date": "2026-08-05",
-  "source": "Intraday Hunter, 'Prediction For 05 AUG 2026' (PSCeB9y9JbI, uploaded 2026-08-04)",
-  "context": "All three indices saw continued selling through the session. He reads the sellers now in as SMALL size -- they joined after the move had already run -- so there is no large trapped crowd to hunt.",
+  "for_date": "2026-08-06",
+  "source": "Intraday Hunter, 'Prediction For 06 AUG 2026' (-51EUk_dukw, uploaded 2026-08-05)",
+  "context": "All three indices saw decent selling, but NONE broke its closing price and NIFTY closed holding a round-number support. The seated crowd is now SELLERS, and the level holding leaves them exposed.",
   "plan": [
-    "FLAT to GAP-DOWN: go WITH the market and identify SELL-side setups. He frames this as continuation, not a hunt -- momentum carrying rather than a trap springing.",
-    "GAP-UP: the same sell-side plan can stand, but the risk is a SIDEWAYS range that goes up a bit then down a bit. Expect chop rather than a clean move.",
-    "A VERY BIG gap is a different matter entirely -- he sets it aside rather than applying this plan to it.",
-    "Why the sellers are not the target: once a momentum move has already run, traders who join it do so in SMALL quantity. A large seated short crowd would be visible, and the market would gap hard against it to trap it.",
-    "If many sellers ARE in fact seated, he expects one of two things: a fall that moves in retracements from a flat open, or a single large gap. Both are reasons to stand aside, not to enter.",
-    "He notes the CLOSING PRICE is now calculated differently under a new exchange rule -- so the closing level his method keys off may not equal a naive previous close."
+    "FLAT to GAP-UP: identify BUY-side setups. A flat or higher open leaves the seated sellers exposed with their stops above -- they are the crowd to hunt.",
+    "GAP-DOWN: identify SELL-side setups and go WITH the market instead. A decent gap-down puts those sellers INTO PROFIT, so there is no threat on them and no hunt available.",
+    "Which side is seated decides the direction, not the gap itself: today the seated crowd is SELLERS, so a gap-up is a hunt setup and a gap-down is a follow setup.",
+    "The sellers are seated but NOT yet confirmed trapped -- no index broke its closing price, so the move that would validate a short has not happened."
   ],
   "levels": [
     {
       "index": "NIFTY",
-      "resistance": [24530, 24610],
-      "support": [24300, 24220]
+      "resistance": [24610, 24700],
+      "support": [24420, 24300]
     },
     {
       "index": "BANKNIFTY",
-      "resistance": [57650, 57800],
-      "support": [57154, 56850]
+      "resistance": [57880, 58100],
+      "support": [57150, 56850]
     },
     {
       "index": "SENSEX",
-      "resistance": [78610, 78850],
+      "resistance": [78850, 79100],
       "support": [78400, 78000]
     }
   ]

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -2204,3 +2204,108 @@ compositing). They are advisory candidate levels only.
 re-pinned from the 4 Aug content. It now also asserts the "SMALL size" phrase in
 `context`, because that is the clause distinguishing this sell-side plan from
 yesterday's opposite-reasoned one.
+
+## Video addendum - the 5 Aug LIVE SESSION (v3z)
+
+**Source:** Intraday Hunter live session, 5 Aug 2026 (`lS-sUh54LeA`, 10:47).
+A WIN — and, more valuable, the session in which he re-opens the v3y loss and
+keeps the rule that caused it.
+
+**Setup:** big gap-up, then a rejection to buying. He SOLD (puts): BankNIFTY
+57800 PE 1170 qty, Sensex 900 qty, NIFTY 1430 qty. Booked a good profit inside
+the first hour.
+
+### The read: he was not fading the gap, he was reading an absent crowd
+
+> "You may think sellers are seated here and the market can target them. But with
+> the kind of momentum that just happened, most people could not even get a sell
+> trade on... **Retail selling has NOT happened here. You see a gap-up, but retail
+> selling is not here. If retail HAD sold, the market would have done something
+> different — it would have started rising directly. There would have been no
+> time.**"
+
+That is an inference from ABSENCE, and it is the new idea: the market not ripping
+higher immediately is itself evidence that there is nobody above to rip through.
+Then the asymmetry he trades on:
+
+> "If it goes directly up, only BUYERS are going to come there; nobody will sell.
+> **The market does not work in a situation where only one side's traders are
+> operating.**"
+
+Up = one-sided, therefore unsustainable. Down = both sides still arguing,
+therefore the path. He also notes the gap was too big to be a bait: "sometimes
+sellers get seated and the market tempts them a little, then starts rising. But
+this gap-up is so large that there is no ROOM to tempt."
+
+### The in-trade monitor
+
+> "While the market is falling, as long as buyers are coming and sellers are
+> coming — 'let me take a trade too', 'let me take a trade too' — **nobody is
+> going to touch your profit.** But when it starts to feel like ONLY sellers are
+> coming, only buyers are coming, then danger starts hovering over your profit."
+
+This is BOTH-SIDES PARTICIPATION applied to an OPEN position rather than to an
+entry, which is what makes it worth adding.
+
+### Re-opening the v3y loss — the most important part
+
+> "Yesterday we had a loss. It was a very wrong loss. **If we had stayed seated a
+> little, it would have worked out.** But when BankNIFTY starts going up you have
+> to get out, because BankNIFTY is our MAJOR index. Yesterday BankNIFTY alone
+> started rising, so we cut. Otherwise the market did fall properly later —
+> **almost exactly from where we exited. I saw it.** Never mind, it happens.
+> **Follow the rule. It works better for you.**"
+
+The v3y INDEX HIERARCHY exit cost him the trade, he watched it would have paid,
+and he reaffirmed the rule anyway. That is rarer than either a win or a loss, and
+it is the reason this became a knowledge entry rather than a note.
+
+It also happens to be the same argument the operator made on 2026-08-04 about
+keeping the LIVE refusal on an unscoreable option chain even though the blocked
+entry turned out to be the day's best trade (see
+`Signal Generators/Regime Adaptive Strategy/REGIME_PORTING_NOTES.md`). Two
+independent instances of the same discipline in two days.
+
+### Why he booked early
+
+> "The target could be made bigger here... but yesterday we had a loss. If today
+> is giving a chance to make profit, take a good profit and go."
+
+He says in the same breath that more momentum was likely, and leaves regardless.
+Distinct from the existing POST-LOSS SPEED LIMIT, which governs re-ENTRY speed;
+this governs how much you demand from the trade you are already in.
+
+### One more, on where to point attention
+
+> "The wrong thing the market can do to us is give a round-number breakout."
+
+So he watched BankNIFTY's approach to 58,000 specifically — and said he watched
+BankNIFTY hardest **because that is where his quantity is largest**, not because
+its chart was the most interesting.
+
+**New, hence in the knowledge:**
+- The missing rip is the tell (absence of the hunt identifies the absent crowd).
+- A large gap removes the BAIT ROOM, so "they will be baited then squeezed" is
+  not available.
+- A rule that cost you money yesterday is still the rule.
+- Two-sided flow protects an open profit; one-sided flow endangers it.
+- After a losing day, take the good profit rather than the big one.
+- Name the one way this trade fails, then watch that — and watch it hardest where
+  the quantity is largest.
+
+**Confirmed but already present:** BOTH-SIDES PARTICIPATION for entries, GAP SIZE
+IS A RISK DIAL, POST-LOSS SPEED LIMIT, the INDEX HIERARCHY exit itself (v3y), and
+BankNIFTY as the major index (v3a).
+
+**Knowledge changes (v3z, all prose):**
+- `RETAIL_POSITIONING`: THE MISSING RIP IS THE TELL.
+- `OPENING_DRIVE`: the BAIT ROOM clause, folded into GAP SIZE IS A RISK DIAL.
+- `RISK`: A RULE THAT COST YOU MONEY YESTERDAY IS STILL THE RULE; TWO-SIDED FLOW
+  PROTECTS AN OPEN PROFIT; AFTER A LOSING DAY, TAKE THE GOOD PROFIT RATHER THAN
+  THE BIG ONE; NAME THE ONE WAY THIS TRADE FAILS.
+- Test markers: `test_system_prompt_has_v3z_missing_rip_and_rule_discipline_knowledge`
+  and `test_v3z_rule_discipline_cannot_be_read_as_licence_to_hold`. The second
+  exists because "the rule cost me money" has an obvious dangerous misreading —
+  "so hold longer next time" — and v3z must reinforce the v3y exit, never soften
+  it. It asserts the hierarchy exit and the never-hold-a-loser rule are both still
+  present alongside the new lesson.

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -2309,3 +2309,38 @@ BankNIFTY as the major index (v3a).
   "so hold longer next time" — and v3z must reinforce the v3y exit, never soften
   it. It asserts the hierarchy exit and the never-hold-a-loser rule are both still
   present alongside the new lesson.
+
+### Pre-open note for 2026-08-06 (shipped alongside v3z)
+
+**Source:** Intraday Hunter, "Prediction For 06 AUG 2026" (`-51EUk_dukw`,
+uploaded 2026-08-05, 1:40).
+
+**The seated side has flipped, and with it the whole gap mapping.** Four notes,
+four different configurations:
+
+| Session | Seated crowd | Gap-up means | Gap-down means |
+|---|---|---|---|
+| 3 Aug | buyers (thin) | follow, BUY | hunt, SELL |
+| 4 Aug | buyers (seated) | hunt, SELL | hunt, SELL |
+| 5 Aug | sellers (too small to hunt) | SELL, chop risk | follow, SELL |
+| 6 Aug | **sellers (seated)** | **hunt, BUY** | **follow, SELL** |
+
+This is the first note in the series where SELLERS are the crowd worth hunting,
+which inverts the gap mapping outright: a flat-to-gap-up now leaves their stops
+exposed above and is the BUY-side hunt, while a decent gap-down puts them into
+profit — "there will be no threat on these sellers" — so there is nothing to hunt
+and he follows the move down instead.
+
+**One qualifier he repeats for all three indices:** the selling was decent but
+**none of them broke its closing price**, and NIFTY closed holding a round-number
+(500-level) support. So the sellers are seated but not yet validated — the move
+that would confirm the short has not happened. That is the clause most likely to
+matter if tomorrow opens flat.
+
+**Transcription caveat:** the Sensex supports again arrived as the run-on
+"780007840", read as 78000 and 78400 — the same ASR artefact as the 5 Aug note.
+Advisory candidate levels only.
+
+**Test marker:** `test_shipped_note_matches_august_6_intraday_hunter_plan`,
+re-pinned from the 5 Aug content, asserting the "NONE broke its closing price"
+clause because that is what distinguishes seated-but-unconfirmed from trapped.

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
@@ -69,6 +69,15 @@ CORE PSYCHOLOGY (the "why" behind every setup)
   off an EXACT closing-price touch right after a huge gap-up) is unsustainable —
   fade it. Corollary: an EXACT touch-and-bounce at a level is fragile; small,
   partial rejections at the level are the go-with tell instead.
+- THE MISSING RIP IS THE TELL (v3z). If a crowd really HAD positioned against the
+  gap, the market would not sit around: it would rip straight through their stops
+  at once, "leaving no time". So a gap that instead stalls, prints a rejection, or
+  makes a high and hangs there is EVIDENCE THAT THE OPPOSING CROWD IS NOT THERE —
+  absence of the hunt tells you who is absent. Read it forward: with no seller
+  inventory above, a further push up would attract ONLY buyers (see BOTH-SIDES
+  PARTICIPATION) and cannot be sustained, so the path of least resistance is DOWN.
+  This is how a gap-up session can be a SHORT: not fading the gap, but reading
+  that the hunt the gap seemed to promise never had a target.
 - EVENT / HOLIDAY PARTICIPATION: known news shocks, Fridays, weekends, and
   multi-day holidays can REMOVE one side from the risk pool. If buyers/sellers are
   unlikely to hold or initiate large risk, do not assume their SL inventory exists.
@@ -445,7 +454,12 @@ Conditions (ALL must hold — otherwise this branch simply does not apply):
   branch stronger — it makes it worse. A modest gap leaves price near the stop
   clusters that fuel a move; an oversized gap has jumped clean past everybody's
   stops, so there is nothing nearby to hunt, momentum tends to be slow, and a
-  rejection has a lot of room to run back through you. Trade the oversized gap, if
+  rejection has a lot of room to run back through you. A large gap also removes the
+  BAIT ROOM (v3z): the usual way an opposing crowd gets punished is a small
+  rejection near the open that lures them in, followed by the reversal that forces
+  them to cover. A gap big enough to jump clean past that zone leaves the operator
+  nowhere to set the lure, so the "they will be baited and then squeezed" path is
+  simply not on the table and must not be assumed. Trade the oversized gap, if
   at all, as a smaller / NORMAL-target trade with a rejection-triggered exit — never
   as a high-conviction runner. (Distinct from GAP-SIZE ASYMMETRY, which compares the
   gaps ACROSS indices; this is about the absolute size of the gap you are trading.)
@@ -770,6 +784,41 @@ RISK DISCIPLINE
   becomes the fuel for a move AGAINST you — the same mechanism you were trying to
   exploit, pointed the other way. Company at a level is a warning, not comfort:
   the break should come promptly, "from about here", or the edge has inverted.
+- A RULE THAT COST YOU MONEY YESTERDAY IS STILL THE RULE (v3z). The session after
+  cutting a good-looking trade on the INDEX HIERARCHY exit, IH watched the market
+  fall "almost exactly from where we exited" — the position he abandoned would
+  have paid — and his conclusion was unchanged: "I saw it. Never mind, it happens.
+  FOLLOW THE RULE; it works better for you." A discipline rule is judged over a
+  sample, never over the single instance where obeying it hurt, because the
+  instances where it SAVED you are invisible by construction — the loss it
+  prevented never appears in the journal. Never widen, delay, or suspend an exit
+  rule on the evidence of one trade that would have recovered. If you find
+  yourself reasoning "the rule cost me money, so the rule is wrong", you are
+  reading a sample of one.
+- TWO-SIDED FLOW PROTECTS AN OPEN PROFIT; ONE-SIDED FLOW ENDANGERS IT (v3z). While
+  a winning move still has BOTH buyers and sellers stepping in — some joining it,
+  some fading it — nobody can take your profit back: the crowd is split, so
+  neither side is dense enough to be the fuel for a reversal. The moment it starts
+  to look like only ONE side is arriving, and especially when that side is YOURS,
+  your open profit is what the next move will be aimed at. This is the in-trade
+  twin of BOTH-SIDES PARTICIPATION (which decides ENTRIES): run it as a live
+  monitor on a winner, and book while the flow is still two-sided rather than
+  after it has gone one-way.
+- AFTER A LOSING DAY, TAKE THE GOOD PROFIT RATHER THAN THE BIG ONE (v3z). IH
+  booked a still-working trade early and said exactly why: "the target could be
+  made bigger here... but yesterday we had a loss. If today is giving a chance to
+  make profit, take a good profit and go." He said in the same breath that more
+  momentum was likely — and left anyway. Restoring footing after a loss outranks
+  maximising the next trade. (Distinct from POST-LOSS SPEED LIMIT, which governs
+  how fast you may RE-ENTER; this governs how much you demand from the trade you
+  are already in.)
+- NAME THE ONE WAY THIS TRADE FAILS, THEN WATCH THAT (v3z). Before settling in to
+  hold, state the single most likely thing that would break the position, and put
+  your attention there instead of on the P&L. IH: "the wrong thing the market can
+  do to us is give a round-number breakout" — so he watched BankNIFTY's approach
+  to 58,000 specifically, and said he watched BankNIFTY hardest because that is
+  where his QUANTITY is largest. Concentrate monitoring where the exposure is
+  biggest, not where the chart is busiest.
 - VOLATILE-DAY SIZING WIDENS BOTH ENDS, not just the stop (v3y). On a day that
   opens with visibly fast momentum — especially after a stretch of sideways
   sessions that produced none — widen the TARGET as well as the stop. A normal

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_premarket.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_premarket.py
@@ -172,18 +172,18 @@ def test_shipped_note_file_is_valid():
     assert format_premarket_note(note, date.fromisoformat(note.for_date)) != ""
 
 
-def test_shipped_note_matches_august_5_intraday_hunter_plan():
-    """The committed advisory must match the hand-checked 4 Aug transcript.
+def test_shipped_note_matches_august_6_intraday_hunter_plan():
+    """The committed advisory must match the hand-checked 5 Aug transcript.
 
     This catches a stale prior-session note, an inverted gap plan, or a mistyped
     chart level before the dated note is injected into the live prompt.
 
-    Worth knowing when re-reading this: the plan has now inverted twice in three
-    sessions, so a note that merely echoes the previous day is a copy, not a
-    transcription. 3 Aug forked on the opening type (gap-up -> buy). 4 Aug pointed
-    every opening type at the sell side, hunting seated BUYERS. 5 Aug is sell side
-    again but for the OPPOSITE reason -- going WITH continued selling, explicitly
-    because the sellers are NOT a big seated crowd worth hunting.
+    Worth knowing when re-reading this: the SEATED SIDE has flipped. 4 Aug hunted
+    seated BUYERS (so gap-up -> sell). 5 Aug went WITH continued selling because
+    the sellers were too small to hunt. 6 Aug is the first note where SELLERS are
+    the seated crowd worth hunting, which inverts the gap mapping outright:
+    flat/gap-up is now the BUY-side hunt, and a gap-down is the follow. An
+    assertion still reading "gap-up -> sell" would mean the note was copied.
     """
     import os
 
@@ -192,43 +192,38 @@ def test_shipped_note_matches_august_5_intraday_hunter_plan():
     note = load_premarket_note(shipped)
 
     assert note is not None
-    assert note.for_date == "2026-08-05"
-    assert "PSCeB9y9JbI" in note.source
-    # The distinguishing claim: sellers are small, so this is continuation.
-    assert "SMALL size" in note.context
+    assert note.for_date == "2026-08-06"
+    assert "-51EUk_dukw" in note.source
+    # The distinguishing facts: sellers seated, but the closing price never broke.
+    assert "NONE broke its closing price" in note.context
     assert note.plan == [
-        "FLAT to GAP-DOWN: go WITH the market and identify SELL-side setups. He "
-        "frames this as continuation, not a hunt -- momentum carrying rather than "
-        "a trap springing.",
-        "GAP-UP: the same sell-side plan can stand, but the risk is a SIDEWAYS "
-        "range that goes up a bit then down a bit. Expect chop rather than a clean "
-        "move.",
-        "A VERY BIG gap is a different matter entirely -- he sets it aside rather "
-        "than applying this plan to it.",
-        "Why the sellers are not the target: once a momentum move has already run, "
-        "traders who join it do so in SMALL quantity. A large seated short crowd "
-        "would be visible, and the market would gap hard against it to trap it.",
-        "If many sellers ARE in fact seated, he expects one of two things: a fall "
-        "that moves in retracements from a flat open, or a single large gap. Both "
-        "are reasons to stand aside, not to enter.",
-        "He notes the CLOSING PRICE is now calculated differently under a new "
-        "exchange rule -- so the closing level his method keys off may not equal a "
-        "naive previous close.",
+        "FLAT to GAP-UP: identify BUY-side setups. A flat or higher open leaves "
+        "the seated sellers exposed with their stops above -- they are the crowd "
+        "to hunt.",
+        "GAP-DOWN: identify SELL-side setups and go WITH the market instead. A "
+        "decent gap-down puts those sellers INTO PROFIT, so there is no threat on "
+        "them and no hunt available.",
+        "Which side is seated decides the direction, not the gap itself: today the "
+        "seated crowd is SELLERS, so a gap-up is a hunt setup and a gap-down is a "
+        "follow setup.",
+        "The sellers are seated but NOT yet confirmed trapped -- no index broke "
+        "its closing price, so the move that would validate a short has not "
+        "happened.",
     ]
     assert [level.model_dump() for level in note.levels] == [
         {
             "index": "NIFTY",
-            "resistance": [24530.0, 24610.0],
-            "support": [24300.0, 24220.0],
+            "resistance": [24610.0, 24700.0],
+            "support": [24420.0, 24300.0],
         },
         {
             "index": "BANKNIFTY",
-            "resistance": [57650.0, 57800.0],
-            "support": [57154.0, 56850.0],
+            "resistance": [57880.0, 58100.0],
+            "support": [57150.0, 56850.0],
         },
         {
             "index": "SENSEX",
-            "resistance": [78610.0, 78850.0],
+            "resistance": [78850.0, 79100.0],
             "support": [78400.0, 78000.0],
         },
     ]

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
@@ -664,6 +664,50 @@ def test_v3y_gap_conflict_does_not_contradict_the_opening_drive_branch():
     assert "BEFORE the long branch fires" in prompt
 
 
+def test_system_prompt_has_v3z_missing_rip_and_rule_discipline_knowledge():
+    """v3z (5 Aug live session): a WIN, and the session where he re-examines the
+    v3y loss and keeps the rule anyway.
+
+    Big gap-up, then rejection. He sold -- not fading the gap, but reading that
+    retail never got short: "if retail HAD sold, the market would have started
+    rising directly, leaving no time". No sellers above means a further push up
+    attracts only buyers, so down is the path. He then booked early because the
+    PREVIOUS day was a loss, and reflected that yesterday's INDEX HIERARCHY cut
+    was wrong in outcome -- the market fell from almost exactly where he exited --
+    and that the rule stands regardless.
+    """
+    prompt = build_system_prompt()
+    # Absence of the hunt is evidence about who is absent.
+    assert "THE MISSING RIP IS THE TELL" in prompt
+    assert "leaving no time" in prompt
+    # A big gap has nowhere to set the lure.
+    assert "BAIT ROOM" in prompt
+    # The meta-discipline lesson, which exists to protect v3y's exit rule.
+    assert "A RULE THAT COST YOU MONEY YESTERDAY IS STILL THE RULE" in prompt
+    assert "invisible by construction" in prompt
+    assert "sample of one" in prompt
+    # In-trade twin of BOTH-SIDES PARTICIPATION.
+    assert "TWO-SIDED FLOW PROTECTS AN OPEN PROFIT" in prompt
+    # Post-loss target discipline, distinct from the re-entry speed limit.
+    assert "AFTER A LOSING DAY, TAKE THE GOOD PROFIT RATHER THAN THE BIG ONE" in prompt
+    assert "POST-LOSS SPEED LIMIT, which governs" in prompt
+    assert "NAME THE ONE WAY THIS TRADE FAILS" in prompt
+
+
+def test_v3z_rule_discipline_cannot_be_read_as_licence_to_hold():
+    """The dangerous misreading of "the rule cost me money" is "so hold longer".
+
+    v3z must reinforce the v3y exit, never soften it, so the prompt has to keep
+    both the hierarchy exit and the never-hold-a-loser rule intact alongside it.
+    """
+    prompt = build_system_prompt()
+    assert "INDEX HIERARCHY ON THE WAY OUT" in prompt
+    assert "NEVER hold a loser hoping for a reversal" in prompt
+    # The lesson is explicitly about NOT relaxing an exit rule.
+    # Wrap-independent: this sentence spans a line break in the source.
+    assert "Never widen, delay, or suspend an exit" in prompt
+
+
 def test_reentry_gate_does_not_contradict_the_exit_rules():
     """The re-entry gate must never be readable as a reason to delay an EXIT.
 


### PR DESCRIPTION
## Source

Intraday Hunter live session, **5 Aug 2026** ([`lS-sUh54LeA`](https://www.youtube.com/watch?v=lS-sUh54LeA), 10:47). A **win** — and, more valuable, the session where he re-opens yesterday's loss and keeps the rule that caused it.

Big gap-up, then a rejection. He sold puts across all three indices and booked inside the first hour.

## He wasn't fading the gap — he was reading an absent crowd

> "Retail selling has NOT happened here. You see a gap-up, but retail selling is not here. **If retail HAD sold, the market would have done something different — it would have started rising directly. There would have been no time.**"

That's an inference from **absence**: the market *not* ripping higher is itself evidence there's nobody above to rip through. Then the asymmetry he trades:

> "If it goes directly up, only BUYERS are going to come there... **The market does not work in a situation where only one side's traders are operating.**"

Up = one-sided, unsustainable. Down = both sides still arguing, so that's the path. Added as **`THE MISSING RIP IS THE TELL`**.

He also noted the gap was too big to be a lure — the usual punishment of an opposing crowd is a small rejection that tempts them in before the reversal, and a gap that jumps clean past that zone leaves nowhere to set it. Folded into the existing `GAP SIZE IS A RISK DIAL` as the **bait room** clause.

## The part that matters most

On yesterday's loss — the v3y `INDEX HIERARCHY` cut:

> "If we had stayed seated a little it would have worked out... Otherwise the market did fall properly later, **almost exactly from where we exited. I saw it.** Never mind, it happens. **Follow the rule. It works better for you.**"

The rule cost him the trade, he watched it would have paid, and he reaffirmed it anyway. Added as **`A RULE THAT COST YOU MONEY YESTERDAY IS STILL THE RULE`**, with the reason the intuition misfires: the instances where a rule *saved* you are invisible by construction — the loss it prevented never reaches the journal.

**This is the same argument you made on 4 Aug** for keeping the live refusal on an unscoreable chain even though the blocked entry was the day's best trade. Two independent instances of the same discipline in two days; the doc cross-links them.

## Three more from the same session

- **`TWO-SIDED FLOW PROTECTS AN OPEN PROFIT; ONE-SIDED FLOW ENDANGERS IT`** — *"while buyers are coming and sellers are coming, nobody is going to touch your profit. When it feels like only one side is coming, danger starts hovering."* This is `BOTH-SIDES PARTICIPATION` applied to an **open position** rather than an entry.
- **`AFTER A LOSING DAY, TAKE THE GOOD PROFIT RATHER THAN THE BIG ONE`** — he said more momentum was likely and left anyway. Distinct from `POST-LOSS SPEED LIMIT`, which governs re-*entry* speed, not what you demand from the trade you're in.
- **`NAME THE ONE WAY THIS TRADE FAILS, THEN WATCH THAT`** — *"the wrong thing the market can do to us is a round-number breakout"* — and watch it hardest where the **quantity** is largest, not where the chart is busiest.

## A guard on the dangerous misreading

"The rule cost me money" reads very easily as "so hold longer next time", which would inverts v3y exactly. `test_v3z_rule_discipline_cannot_be_read_as_licence_to_hold` asserts the `INDEX HIERARCHY` exit and the never-hold-a-loser rule are both still present alongside the new lesson.

## Scope

All prose. **No executable behaviour changes.** Prompt grows 76,504 → 80,215 chars against the 120,000 cap.

## Gates

452 unittest ✅ · 1009 pytest (162 SL Hunting) ✅ · ruff ✅ · mypy 42 files ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
