### PR TITLE
feat(sl-hunting): v4a knowledge from the 6 Aug live session

### DIFF
--- a/Signal Generators/SL Hunting AI Agent/premarket_note.json
+++ b/Signal Generators/SL Hunting AI Agent/premarket_note.json
@@ -1,28 +1,28 @@
 {
-  "for_date": "2026-08-06",
-  "source": "Intraday Hunter, 'Prediction For 06 AUG 2026' (-51EUk_dukw, uploaded 2026-08-05)",
-  "context": "All three indices saw decent selling, but NONE broke its closing price and NIFTY closed holding a round-number support. The seated crowd is now SELLERS, and the level holding leaves them exposed.",
+  "for_date": "2026-08-07",
+  "source": "Intraday Hunter, 'Prediction For 07 AUG 2026' (Lq7JGlZj6PY, uploaded 2026-08-06)",
+  "context": "Mild positive momentum -- not big, but enough that people took CALL trades -- while Sensex barely moved yet held itself up. BUYERS are the seated crowd, with their stops at the lower points already formed.",
   "plan": [
-    "FLAT to GAP-UP: identify BUY-side setups. A flat or higher open leaves the seated sellers exposed with their stops above -- they are the crowd to hunt.",
-    "GAP-DOWN: identify SELL-side setups and go WITH the market instead. A decent gap-down puts those sellers INTO PROFIT, so there is no threat on them and no hunt available.",
-    "Which side is seated decides the direction, not the gap itself: today the seated crowd is SELLERS, so a gap-up is a hunt setup and a gap-down is a follow setup.",
-    "The sellers are seated but NOT yet confirmed trapped -- no index broke its closing price, so the move that would validate a short has not happened."
+    "GAP-DOWN: identify SELL-side setups and hunt the seated buyers. Their stops sit at the lower points already formed on the chart.",
+    "The BIGGER the gap-down the better the hunt -- he wants the open as far below BankNIFTY 58,000 as it can be, because that distance is what puts the buyers underwater.",
+    "FLAT to GAP-UP: identify BUY-side setups and go WITH the market instead. It has been grinding slowly upward, so a flat or higher open offers no hunt.",
+    "The momentum that recruited those call buyers was SMALL, not a big move -- so treat this as a modest, lightly committed crowd rather than a heavily loaded one."
   ],
   "levels": [
     {
       "index": "NIFTY",
-      "resistance": [24610, 24700],
-      "support": [24420, 24300]
+      "resistance": [24720, 24800],
+      "support": [24610, 24500]
     },
     {
       "index": "BANKNIFTY",
-      "resistance": [57880, 58100],
-      "support": [57150, 56850]
+      "resistance": [58100, 58400],
+      "support": [57500, 57100]
     },
     {
       "index": "SENSEX",
-      "resistance": [78850, 79100],
-      "support": [78400, 78000]
+      "resistance": [79200, 79500],
+      "support": [78650, 78300]
     }
   ]
 }

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -2344,3 +2344,116 @@ Advisory candidate levels only.
 **Test marker:** `test_shipped_note_matches_august_6_intraday_hunter_plan`,
 re-pinned from the 5 Aug content, asserting the "NONE broke its closing price"
 clause because that is what distinguishes seated-but-unconfirmed from trapped.
+
+## Video addendum - the 6 Aug LIVE SESSION (v4a)
+
+**Source:** Intraday Hunter live session, 6 Aug 2026 (`9pZtVvUBDq4`, 9:45). A WIN,
+and he BOUGHT — the first buy-side session in this run.
+
+**Setup:** slight gap-up, plan already positive from his own analysis. He wanted
+price a little LOWER before entering, got a small rejection, and bought calls
+(BankNIFTY 57700 CE + 57800 CE, NIFTY 1430 qty). Booked a good profit.
+
+### The dating rule — why the sellers existed today but not yesterday
+
+This is the core new idea, and it completes v3z rather than repeating it:
+
+> "When selling comes on ONE day, not many people can participate — before that
+> the market was decently positive, there were gap-ups, so people cannot
+> participate. **But when the NEXT day also falls the same way, traders start
+> paying attention — 'the market is going down, why not make a put trade here'.
+> So sellers WILL have come in.** We are making those sellers our target."
+
+v3z said "retail did not get to sell" about a single day. v4a says **when they
+DO** — on the second consecutive adverse day. Together they date the inventory,
+which is what turns "is a crowd seated?" from a feeling into a count.
+
+### What a freshly recruited crowd implies
+
+> "Whoever is sitting in a trade here will not give the market a very big SL."
+
+Two consequences that pull opposite ways on purpose: do NOT plan a large target
+(the move exists to take a shallow stop cluster, not to trend), but DO expect the
+move to be FAST —
+
+> "The momentum should be fast, because these sellers will not give the market
+> much opportunity... if it is going to hit their SL, the market will pause a
+> little and then suddenly produce fast momentum and eat as many SLs as it can."
+
+So speed is the SIGNATURE of the flush, and a slow grind means the cluster you
+assumed is probably not there: "if the momentum is slow then maybe we will not get
+that much target — we will have to take an average target."
+
+### Entry preference
+
+He wanted a dip BEFORE buying, not the first push up: "if we get the market a bit
+lower it is better; if it starts rising directly we would have to work with a
+retracement." He also checked no big sudden selling was underway first — a small
+orderly move against you is a cheap fill, a large one says the premise is wrong.
+
+### The two-phase handling of a wobble
+
+Mid-trade his profit collapsed on a rejection:
+
+> "There is no need to be afraid of such a rejection. Nothing will happen. There
+> will be up and down moves, but **you will definitely get one opportunity in
+> which your profit is made.**"
+
+...and then, once the sharp move came: "a good profit has been made, so we will
+not be greedy" — and he booked. The discriminator between the two phases is
+factual: **has the fast one-way move through the stop cluster happened yet?**
+
+### The asymmetry
+
+> "When profit is increasing, if you wait a bit, enlarge the target, even make a
+> few mistakes — in profit those pass. **But never make a mistake in a loss.**"
+
+Also, on humility: "SL hunting does not mean what you thought is what will happen…
+I make mistakes too. When a mistake happens, accept it and take the loss." And
+practically: "do not work thinking at 100% that your trade must go right — better
+to wait, REDUCE QUANTITY."
+
+### How the agent compared on the same session
+
+The agent traded the same premise FIRST and then abandoned it:
+
+| # | Agent | Result |
+|---|---|---|
+| 1 | 09:23 LONG `hammer_confirmation_gapup_seller_hunt` | **+Rs.712.75**, booked in 3.5 min ("momentum stalled") |
+| 2 | 10:06 SHORT `double_top_neckline_break_continuation` | -Rs.1,767.75 (cut on BankNIFTY confirming against) |
+| 3 | 10:16 SHORT `shooting_star_fib50_rejection` | -Rs.1,547.25 (premise stalled) |
+| | | **-Rs.2,602.25** |
+
+Trade 1 IS IH's trade — same direction, same premise, even the same name for it
+("gapup_seller_hunt"), and it was the only winner. The agent then closed it after
+3.5 minutes on a stall, and traded AGAINST that read twice.
+
+IH sat through the same stall, said explicitly it was not to be feared, and took
+the move. That is exactly what A REJECTION BEFORE THE FLUSH IS NOISE is for — and
+the two losses that followed are what ERRORS IN PROFIT ARE CHEAP; ERRORS IN A LOSS
+ARE NOT is for. The pre-open note was injected (1909 chars) and cited in 4
+decisions, and its plan — gap-up means hunt the seated sellers, BUY side — was
+correct.
+
+**New, hence in the knowledge:**
+- SECOND-DAY RECRUITMENT (one adverse day seats nobody; the second does).
+- A freshly recruited crowd has tight stops: sharp but SMALL, and FAST or not real.
+- A rejection BEFORE the flush is noise; after it, book.
+- Errors in profit are cheap; errors in a loss are not.
+- When the stops are above you, prefer a dip to a chase.
+
+**Confirmed but already present:** THE MISSING RIP IS THE TELL (v3z) is the
+one-day half of the recruitment rule; recruit-then-turn after the flush is
+RECRUITMENT HISTORY; "reduce quantity when unsure" overlaps existing sizing
+discipline.
+
+**Knowledge changes (v4a, all prose):**
+- `RETAIL_POSITIONING`: SECOND-DAY RECRUITMENT; A FRESHLY RECRUITED CROWD HAS
+  TIGHT STOPS.
+- `RISK`: A REJECTION BEFORE THE FLUSH IS NOISE; ERRORS IN PROFIT ARE CHEAP;
+  WHEN THE STOPS ARE ABOVE YOU, PREFER A DIP TO A CHASE.
+- Test markers: `test_system_prompt_has_v4a_second_day_recruitment_knowledge` and
+  `test_v4a_rejection_rule_cannot_be_read_as_licence_to_hold_a_loser`. The second
+  matters more than usual: this is the first lesson that argues for NOT closing,
+  so it carries an explicit scope clause and the test asserts every exit rule it
+  must not weaken is still present beside it.

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -2457,3 +2457,50 @@ discipline.
   matters more than usual: this is the first lesson that argues for NOT closing,
   so it carries an explicit scope clause and the test asserts every exit rule it
   must not weaken is still present beside it.
+
+### Pre-open note for 2026-08-07 (shipped alongside v4a)
+
+**Source:** Intraday Hunter, "Prediction For 07 AUG 2026" (`Lq7JGlZj6PY`,
+uploaded 2026-08-06, 2:00).
+
+**The seated side has flipped back to BUYERS.** Five notes, five configurations:
+
+| Session | Seated crowd | The hunt is | The follow is |
+|---|---|---|---|
+| 3 Aug | buyers (thin) | gap-down -> SELL | gap-up -> BUY |
+| 4 Aug | buyers (seated) | any open -> SELL | — |
+| 5 Aug | sellers (too small) | — | any open -> SELL |
+| 6 Aug | sellers (seated) | gap-up -> BUY | gap-down -> SELL |
+| 7 Aug | **buyers (seated)** | **gap-down -> SELL** | **flat/gap-up -> BUY** |
+
+> "There is some positive momentum. Not big momentum, but **enough that people
+> would go and make CALL trades**. So buyers will be seated here... To target the
+> buyers, what do we need? At minimum a GAP-DOWN."
+
+He also names where their stops are — "somewhere at these lower points that have
+formed" — which is a concrete claim rather than a vague direction.
+
+**A first for this channel: a MAGNITUDE-scaled condition.**
+
+> "If we get a decent gap-down — that is, **the farther the opening is from
+> 58,000, the better for us** — so we can target these buyers."
+
+Every prior note treated gap direction as categorical. This one says the SIZE of
+the adverse gap improves the hunt, because distance is what puts the crowd
+underwater. Worth noting it does NOT contradict `GAP SIZE IS A RISK DIAL` in the
+knowledge, which says a bigger gap makes the CONTINUATION branch worse: that rule
+is about trading WITH a gap past everyone's stops, this is about trading AGAINST a
+crowd the gap has just buried. Different branches, opposite signs, both correct.
+
+**A link to v4a:** he stresses the recruiting move was small — "not big momentum,
+but enough that people would make call trades" — which is exactly the
+lightly-committed crowd v4a's A FRESHLY RECRUITED CROWD HAS TIGHT STOPS describes.
+Expect a sharp but small flush if the gap-down arrives.
+
+**Transcription caveat:** one BankNIFTY support arrived as "5710" where every
+other level is five digits; read as 57100 alongside 57500. Same dropped-digit ASR
+artefact seen on 4 and 5 Aug. Advisory candidate levels only.
+
+**Test marker:** `test_shipped_note_matches_august_7_intraday_hunter_plan`,
+re-pinned from the 6 Aug content, asserting the "BUYERS are the seated crowd"
+clause because that is the single fact the whole gap mapping hangs on.

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
@@ -69,6 +69,29 @@ CORE PSYCHOLOGY (the "why" behind every setup)
   off an EXACT closing-price touch right after a huge gap-up) is unsustainable —
   fade it. Corollary: an EXACT touch-and-bounce at a level is fragile; small,
   partial rejections at the level are the go-with tell instead.
+- SECOND-DAY RECRUITMENT — one adverse day does NOT seat a crowd, the SECOND one
+  does (v4a). This is the counterpart to THE MISSING RIP IS THE TELL, and together
+  they date the inventory. Day one of a fall after a positive stretch recruits
+  almost nobody: traders are still mentally in the uptrend, they cannot believe
+  the turn, and the ones who do act take small size. When the NEXT day falls the
+  same way, confidence arrives — "the market is going down, why not buy a put" —
+  and only THEN is there a short crowd worth hunting. So:
+    * ONE down day + a gap-up = no seller inventory; the gap-up is not a hunt.
+    * TWO consecutive down days + a gap-up = sellers ARE seated with their stops
+      above; the gap-up IS the hunt, and the trade is LONG against them.
+  Mirror the same test for buyers after two up days. Count the days before
+  deciding whether a crowd exists — a single session's move is not a crowd.
+- A FRESHLY RECRUITED CROWD HAS TIGHT STOPS, so expect a SHARP but SMALL move
+  (v4a). Traders who joined only on the second day have no conviction and "will
+  not give the market a very big SL". Two consequences, and they pull in opposite
+  directions on purpose:
+    * Do NOT plan a large target. The move exists to take a shallow stop cluster,
+      not to trend. A normal or average target is the honest one.
+    * DO expect the move itself to be FAST. The operator pauses, then produces
+      sudden speed to eat as many stops as it can reach. Speed is the SIGNATURE
+      of the flush.
+  If the expected move arrives SLOW and grinding instead, the stop cluster you
+  assumed is probably not there — reduce the target, do not extend the hold.
 - THE MISSING RIP IS THE TELL (v3z). If a crowd really HAD positioned against the
   gap, the market would not sit around: it would rip straight through their stops
   at once, "leaving no time". So a gap that instead stalls, prints a rejection, or
@@ -784,6 +807,43 @@ RISK DISCIPLINE
   becomes the fuel for a move AGAINST you — the same mechanism you were trying to
   exploit, pointed the other way. Company at a level is a warning, not comfort:
   the break should come promptly, "from about here", or the edge has inverted.
+- A REJECTION BEFORE THE FLUSH IS NOISE; A REJECTION AFTER IT IS THE EXIT (v4a).
+  When you are positioned against a seated crowd, the trade has TWO phases and
+  they take opposite handling:
+    * BEFORE the flush — the stops you are trading toward have NOT been taken yet.
+      Price will wobble both ways and can hand back most of an early paper profit.
+      That is not the read failing; it is the setup still waiting. "There is no
+      need to be afraid of such a rejection. There will be up and down moves, but
+      you will definitely get one opportunity in which your profit is made."
+    * AFTER the flush — the sharp move has run and the stops are gone. Now book.
+      "A good profit has been made, so we will not be greedy."
+  THE DISCRIMINATOR IS FACTUAL, NOT A FEELING: has the fast, one-way move through
+  the stop cluster actually happened? If no, a wobble is not information. If yes,
+  the fuel is spent and further holding is greed.
+  SCOPE — THIS IS NOT LICENCE TO HOLD A LOSER. It applies only while the PREMISE
+  is intact: the crowd still seated, your level still untaken, and price still on
+  the correct side of your stop. Your stop, the max loss, premise-invalidation,
+  the INDEX HIERARCHY exit and the post-exit cooldown all continue to govern
+  unchanged. This narrows ONE thing only: a profit giving back part of itself
+  before the flush is not by itself a reason to close.
+- ERRORS IN PROFIT ARE CHEAP; ERRORS IN A LOSS ARE NOT (v4a). "When profit is
+  increasing, if you wait a bit, enlarge the target, even make a few mistakes —
+  in profit those pass. But NEVER make a mistake in a loss." The asymmetry is
+  structural: a misjudgement while ahead costs some of a gain you did not have
+  before, while the same misjudgement while behind compounds a real loss and is
+  the one that ends days. So spend your carefulness where it is expensive — on
+  the losing side. And when you are wrong, "accept the mistake and take the loss";
+  do not spend more of the day's risk defending the entry (see BEING
+  DIRECTIONALLY RIGHT DOES NOT EARN THE HOLD).
+- WHEN THE STOPS ARE ABOVE YOU, PREFER A DIP TO A CHASE (v4a). Hunting a crowd
+  whose stops sit above means you want to be LONG — but the cheap entry is a small
+  move DOWN, not the first push up. "If we get the market a bit lower it is better
+  for us; if it starts rising directly we would have to work with a retracement
+  instead." A dip against your intended direction, with no big sudden opposite
+  flow, is the low-risk fill; chasing the first move up means paying for it and
+  then waiting for a pullback anyway. One check before taking the dip: confirm the
+  move against you is SMALL and orderly — a large sudden flow the other way says
+  the premise is wrong, not that the entry is cheap. Mirror it for shorts.
 - A RULE THAT COST YOU MONEY YESTERDAY IS STILL THE RULE (v3z). The session after
   cutting a good-looking trade on the INDEX HIERARCHY exit, IH watched the market
   fall "almost exactly from where we exited" — the position he abandoned would

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_premarket.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_premarket.py
@@ -172,18 +172,22 @@ def test_shipped_note_file_is_valid():
     assert format_premarket_note(note, date.fromisoformat(note.for_date)) != ""
 
 
-def test_shipped_note_matches_august_6_intraday_hunter_plan():
-    """The committed advisory must match the hand-checked 5 Aug transcript.
+def test_shipped_note_matches_august_7_intraday_hunter_plan():
+    """The committed advisory must match the hand-checked 6 Aug transcript.
 
     This catches a stale prior-session note, an inverted gap plan, or a mistyped
     chart level before the dated note is injected into the live prompt.
 
-    Worth knowing when re-reading this: the SEATED SIDE has flipped. 4 Aug hunted
-    seated BUYERS (so gap-up -> sell). 5 Aug went WITH continued selling because
-    the sellers were too small to hunt. 6 Aug is the first note where SELLERS are
-    the seated crowd worth hunting, which inverts the gap mapping outright:
-    flat/gap-up is now the BUY-side hunt, and a gap-down is the follow. An
-    assertion still reading "gap-up -> sell" would mean the note was copied.
+    Worth knowing when re-reading this: the SEATED SIDE flips constantly, so a
+    note echoing the previous day is a copy rather than a transcription. 5 Aug:
+    sellers, too small to hunt. 6 Aug: sellers seated, so gap-up was the BUY-side
+    hunt. 7 Aug: BUYERS are seated, which inverts it back -- gap-DOWN is now the
+    SELL-side hunt and flat/gap-up is the follow.
+
+    It also carries the first MAGNITUDE-scaled condition in the series: a bigger
+    gap-down makes the hunt better, not worse, because distance is what puts the
+    buyers underwater. That is specific to hunting a crowd and does not contradict
+    GAP SIZE IS A RISK DIAL, which governs the continuation branch.
     """
     import os
 
@@ -192,38 +196,37 @@ def test_shipped_note_matches_august_6_intraday_hunter_plan():
     note = load_premarket_note(shipped)
 
     assert note is not None
-    assert note.for_date == "2026-08-06"
-    assert "-51EUk_dukw" in note.source
-    # The distinguishing facts: sellers seated, but the closing price never broke.
-    assert "NONE broke its closing price" in note.context
+    assert note.for_date == "2026-08-07"
+    assert "Lq7JGlZj6PY" in note.source
+    # The distinguishing facts: buyers seated, recruited by only a small move.
+    assert "BUYERS are the seated crowd" in note.context
     assert note.plan == [
-        "FLAT to GAP-UP: identify BUY-side setups. A flat or higher open leaves "
-        "the seated sellers exposed with their stops above -- they are the crowd "
-        "to hunt.",
-        "GAP-DOWN: identify SELL-side setups and go WITH the market instead. A "
-        "decent gap-down puts those sellers INTO PROFIT, so there is no threat on "
-        "them and no hunt available.",
-        "Which side is seated decides the direction, not the gap itself: today the "
-        "seated crowd is SELLERS, so a gap-up is a hunt setup and a gap-down is a "
-        "follow setup.",
-        "The sellers are seated but NOT yet confirmed trapped -- no index broke "
-        "its closing price, so the move that would validate a short has not "
-        "happened.",
+        "GAP-DOWN: identify SELL-side setups and hunt the seated buyers. Their "
+        "stops sit at the lower points already formed on the chart.",
+        "The BIGGER the gap-down the better the hunt -- he wants the open as far "
+        "below BankNIFTY 58,000 as it can be, because that distance is what puts "
+        "the buyers underwater.",
+        "FLAT to GAP-UP: identify BUY-side setups and go WITH the market instead. "
+        "It has been grinding slowly upward, so a flat or higher open offers no "
+        "hunt.",
+        "The momentum that recruited those call buyers was SMALL, not a big move "
+        "-- so treat this as a modest, lightly committed crowd rather than a "
+        "heavily loaded one.",
     ]
     assert [level.model_dump() for level in note.levels] == [
         {
             "index": "NIFTY",
-            "resistance": [24610.0, 24700.0],
-            "support": [24420.0, 24300.0],
+            "resistance": [24720.0, 24800.0],
+            "support": [24610.0, 24500.0],
         },
         {
             "index": "BANKNIFTY",
-            "resistance": [57880.0, 58100.0],
-            "support": [57150.0, 56850.0],
+            "resistance": [58100.0, 58400.0],
+            "support": [57500.0, 57100.0],
         },
         {
             "index": "SENSEX",
-            "resistance": [78850.0, 79100.0],
-            "support": [78400.0, 78000.0],
+            "resistance": [79200.0, 79500.0],
+            "support": [78650.0, 78300.0],
         },
     ]

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
@@ -708,6 +708,50 @@ def test_v3z_rule_discipline_cannot_be_read_as_licence_to_hold():
     assert "Never widen, delay, or suspend an exit" in prompt
 
 
+def test_system_prompt_has_v4a_second_day_recruitment_knowledge():
+    """v4a (6 Aug live session): IH bought a gap-up to hunt SELLERS, and the
+    reasoning dates the inventory.
+
+    One down day after a positive stretch recruits almost nobody -- traders cannot
+    believe the turn. The SECOND consecutive down day is when confidence arrives
+    and shorts actually get seated. So two down days plus a gap-up is a long
+    against them, and the move should be sharp but small because a freshly
+    recruited crowd holds tight stops.
+    """
+    prompt = build_system_prompt()
+    assert "SECOND-DAY RECRUITMENT" in prompt
+    # Wrap-independent fragments: these sentences span line breaks in the source.
+    assert "confidence arrives" in prompt
+    assert "a single session's move is not a crowd" in prompt
+    # Tight stops -> sharp but small, and slow means the cluster is not there.
+    assert "A FRESHLY RECRUITED CROWD HAS TIGHT STOPS" in prompt
+    assert "SIGNATURE" in prompt
+    assert "reduce the target, do not extend the hold" in prompt
+    # The two-phase handling of a wobble, and the other two lessons.
+    assert "A REJECTION BEFORE THE FLUSH IS NOISE" in prompt
+    assert "ERRORS IN PROFIT ARE CHEAP" in prompt
+    assert "PREFER A DIP TO A CHASE" in prompt
+
+
+def test_v4a_rejection_rule_cannot_be_read_as_licence_to_hold_a_loser():
+    """The dangerous misreading of "a rejection is noise" is "so sit through it".
+
+    This is the same failure mode v3z's rule-discipline lesson had, and it matters
+    more here because this one is explicitly about NOT closing. The prompt must
+    keep every exit rule intact beside it and scope the narrowing precisely.
+    """
+    prompt = build_system_prompt()
+    # It must state its own scope.
+    assert "THIS IS NOT LICENCE TO HOLD A LOSER" in prompt
+    assert "premise-invalidation" in prompt
+    # ...and the exits it must not weaken must still be present.
+    assert "NEVER hold a loser hoping for a reversal" in prompt
+    assert "INDEX HIERARCHY ON THE WAY OUT" in prompt
+    assert "A TRIGGER THAT NEVER FIRED IS AN EXIT REASON" in prompt
+    # The discriminator has to be an observable, not a feeling.
+    assert "THE DISCRIMINATOR IS FACTUAL, NOT A FEELING" in prompt
+
+
 def test_reentry_gate_does_not_contradict_the_exit_rules():
     """The re-entry gate must never be readable as a reason to delay an EXIT.
 


### PR DESCRIPTION
## Source

Intraday Hunter live session, **6 Aug 2026** ([`9pZtVvUBDq4`](https://www.youtube.com/watch?v=9pZtVvUBDq4), 9:45). A **win**, and he **bought** — the first buy-side session in this run. First entry in the v4 letter series; v3 is exhausted at v3z.

## The dating rule — the core new idea

> "When selling comes on ONE day, not many people can participate — before that the market was decently positive... **But when the NEXT day also falls the same way, traders start paying attention** — 'the market is going down, why not make a put trade here'. So sellers WILL have come in."

v3z said *"retail did not get to sell"* about a single day. **v4a says when they do** — on the second consecutive adverse day. Together they **date the inventory**, which turns "is a crowd seated?" from a feeling into a count:

- One down day + gap-up → no seller inventory, the gap-up is **not** a hunt
- Two down days + gap-up → sellers seated with stops above, the gap-up **is** the hunt, trade is **long**

## What a freshly recruited crowd implies

> "Whoever is sitting in a trade here will not give the market a very big SL."

So plan a **small** target — but expect a **fast** move: *"the market will pause a little and then suddenly produce fast momentum and eat as many SLs as it can."* Speed is the signature of the flush. A slow grind means the cluster isn't there → reduce the target, don't extend the hold.

## The one that needed careful scoping

**`A REJECTION BEFORE THE FLUSH IS NOISE; A REJECTION AFTER IT IS THE EXIT`** — this is the first lesson in the entire series that argues for *not* closing, so it carries an explicit scope clause. It applies only while the premise is intact and price is on the correct side of the stop, and it narrows exactly one thing: *a profit giving back part of itself before the flush is not by itself a reason to close.* Stop, max loss, premise-invalidation, the `INDEX HIERARCHY` exit and the cooldown all continue unchanged.

The discriminator is **factual, not a feeling**: has the fast one-way move through the stop cluster actually happened?

## Why that scoping matters — the agent's own session makes the case

| # | Agent | Result |
|---|---|---|
| 1 | 09:23 LONG `hammer_confirmation_gapup_seller_hunt` | **+₹712.75**, booked in **3.5 min** ("momentum stalled") |
| 2 | 10:06 SHORT `double_top_neckline_break_continuation` | −₹1,767.75 |
| 3 | 10:16 SHORT `shooting_star_fib50_rejection` | −₹1,547.25 |
| | | **−₹2,602.25** |

**Trade 1 IS IH's trade** — same direction, same premise, even the same name for it — and the only winner. The agent closed it after 3.5 minutes on a stall, then traded *against* that read twice. IH sat through the same stall, said explicitly it wasn't to be feared, and took the move.

The pre-open note was injected (1,909 chars) and cited in 4 decisions, and its plan — gap-up means hunt the seated sellers, buy side — was correct.

## Also added

- **`ERRORS IN PROFIT ARE CHEAP; ERRORS IN A LOSS ARE NOT`** — *"in profit those pass. But never make a mistake in a loss."*
- **`WHEN THE STOPS ARE ABOVE YOU, PREFER A DIP TO A CHASE`** — he wanted price lower before buying, having first checked no large sudden opposite flow.

## Guard

`test_v4a_rejection_rule_cannot_be_read_as_licence_to_hold_a_loser` asserts the scope clause is present and that never-hold-a-loser, the `INDEX HIERARCHY` exit and the never-fired-trigger exit all still stand beside it.

## Scope

All prose. **No executable behaviour changes.** Prompt grows 80,215 → 84,693 chars against the 120,000 cap.

## Gates

452 unittest ✅ · 1011 pytest (164 SL Hunting) ✅ · ruff ✅ · mypy 42 files ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
