### PR TITLE
feat(sl-hunting): v4b knowledge from the 7 Aug live session

### DIFF
--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -2504,3 +2504,120 @@ artefact seen on 4 and 5 Aug. Advisory candidate levels only.
 **Test marker:** `test_shipped_note_matches_august_7_intraday_hunter_plan`,
 re-pinned from the 6 Aug content, asserting the "BUYERS are the seated crowd"
 clause because that is the single fact the whole gap mapping hangs on.
+
+## Video addendum - the 7 Aug LIVE SESSION (v4b)
+
+**Source:** Intraday Hunter live session, 7 Aug 2026 (`SupzF0JT_vE`, 9:10). A WIN
+on the put side, and the first session where he ENLARGED the target mid-trade and
+explained the reasoning for it.
+
+**Setup:** slight gap-down, then a recovery. He waited through the bounce, sold
+puts into it (BankNIFTY 57900 + 57800 PE, Sensex 900, NIFTY 1430), and booked a
+large profit. The 2026-08-07 pre-open note called exactly this: buyers seated,
+gap-down means hunt them, sell side.
+
+### The central idea: the bounce is the trap, not its failure
+
+> "If the market had opened gap-down and started falling directly, the buyers
+> might have got out **in two or three minutes**. But once it comes up, the trader
+> gets a little hope that yes, the market can go up too — and he may even try to
+> AVERAGE."
+
+> "Those sitting in buys should feel the market can go up, **so that when it goes
+> down again they take a bigger loss.**"
+
+This inverts the naive read. A post-gap bounce toward a trapped crowd's entry is
+the most commonly misread event on a chart: it looks like the short failing, and
+it is actually the mechanism that converts a small trapped loss into a large one.
+A direct fall is the operator's WORST outcome, because the crowd escapes cheaply.
+
+Recorded with the invalidation attached, so it cannot read as "ignore adverse
+movement": what would genuinely break the trade is price RECLAIMING the level, not
+approaching and failing at it. IH named his in advance — "if it crosses the
+closing price, understand we have made the trade wrong."
+
+### Why the resistance did not recruit fresh sellers
+
+A viewer objection he answers directly, and the answer is a general rule:
+
+> "They will not be able to sell here. Most traders who sold did it earlier in
+> this chart and had to suffer losses again and again. **Now everyone's focus is
+> on where to BUY**, because their mindset has formed that the market keeps going
+> up. Nobody is even paying attention to the resistance."
+
+A level does not attract participants by geometry — it attracts whoever the recent
+past has left willing to act there. Added as REGIME MEMORY DECIDES WHO SHOWS UP AT
+A LEVEL, with the practical test: ask who has been PAID and who PUNISHED lately.
+
+### Target sizing from crowd behaviour — completing the v4a pair
+
+> "Why could we make the target bigger here? Because those who average get a
+> little courage from the market — 'go on, wait' — and then it targets them. So
+> their SLs would have been hit."
+
+v4a: freshly recruited crowd, shallow stops, SMALL target, fast move.
+v4b: crowd baited into AVERAGING, more size at a worse average, pain threshold
+further away, so the flush runs further and a LARGER target is justified.
+
+Together they give a way to size a target from what the crowd has DONE rather than
+from a fixed percentage. He also cites all three indices moving together as a
+second reason to enlarge.
+
+### The stall is the last bait
+
+> "Now what will the market do? Give them a little hope that the breakdown is not
+> going to happen... with that hope they will take an even bigger loss. **You will
+> get one more momentum move. Then book the target.**"
+
+Added as EXPECT A SECOND LEG AFTER THE PAUSE, THEN BOOK — scoped explicitly to a
+position that is working, never to one that is offside.
+
+### The hierarchy is asymmetric
+
+> "Looking at BankNIFTY it seems the trade should be taken right now. **But let us
+> wait a little, according to Sensex and NIFTY.**" ... "BankNIFTY's chart is
+> completely right; it is Sensex and NIFTY where we could have trouble."
+
+He had a textbook major-index setup and did NOT take it until the laggards agreed.
+That qualifies v3y's INDEX HIERARCHY, which is an EXIT rule: the leader alone is
+enough to CLOSE on, not enough to OPEN on. Entering on the leader alone buys a
+move the other two may never join; exiting on it alone only costs a trade.
+
+### How the agent compared
+
+| # | Agent (all SHORT) | Result |
+|---|---|---|
+| 1 | 09:32 -> 09:34 `pivot_resistance_shooting_star_reject` | -Rs.62.00 (cut in 2.5 min, "price round-tripped") |
+| 2 | 09:43 -> 09:44 `averaging_trap_bearish_inside_bar_breakdown` | -Rs.1,089.75 (cut in 1.4 min, "spot pinned") |
+| 3 | 10:03 -> 10:09 BNF / 10:12 NIFTY | -Rs.128.00 (**per-leg**: BNF -1,038.00, NIFTY +910.00) |
+| 4 | 10:18 -> 10:28 | **+Rs.2,400.75** ("Booking profit on seated-buyer short hunt") |
+| | | **+Rs.1,121.00** |
+
+Three points worth recording:
+
+1. **The note's plan was followed and it worked.** All four entries were shorts,
+   the gap-down condition was met (NIFTY -97, BankNIFTY -182, "well below 58000" —
+   the note's own magnitude clause appears in entry 2's reasoning), and the day
+   was profitable.
+2. **v4a was live today and did not prevent the early cuts.** Trades 1 and 2 were
+   closed after 2.5 and 1.4 minutes on a round-trip and a stall — precisely the
+   post-gap bounce this session explains. A REJECTION BEFORE THE FLUSH IS NOISE
+   merged the previous evening and was in the prompt. Stated plainly because it is
+   evidence about what prose can and cannot change: the agent still cut. v4b
+   attacks the same behaviour from the mechanism side rather than the discipline
+   side, which may or may not do better.
+3. **The per-leg exit earned its keep.** On trade 3 the agent cut BankNIFTY alone
+   (-Rs.1,038.00) and let NIFTY run to target (+Rs.910.00), turning what would
+   have been a full-basket loss into -Rs.128.00. First clear instance of the
+   `exit_leg` selector paying for itself.
+
+**Knowledge changes (v4b, all prose):**
+- `RETAIL_POSITIONING`: THE POST-GAP BOUNCE IS THE TRAP DEEPENING; REGIME MEMORY
+  DECIDES WHO SHOWS UP AT A LEVEL.
+- `RISK`: A CROWD THAT HAS AVERAGED DOWN EARNS A BIGGER TARGET; EXPECT A SECOND
+  LEG AFTER THE PAUSE, THEN BOOK.
+- `BNF_SPECIFIC`: THE HIERARCHY IS ASYMMETRIC (entry vs exit).
+- Test markers: `test_system_prompt_has_v4b_post_gap_bounce_and_averaging_target_knowledge`
+  and `test_v4b_bounce_rule_names_what_would_actually_invalidate`. The second
+  exists because a rule that says "do not exit on a bounce" must also say what a
+  real invalidation looks like, or it degrades into "ignore adverse movement".

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
@@ -69,6 +69,33 @@ CORE PSYCHOLOGY (the "why" behind every setup)
   off an EXACT closing-price touch right after a huge gap-up) is unsustainable —
   fade it. Corollary: an EXACT touch-and-bounce at a level is fragile; small,
   partial rejections at the level are the go-with tell instead.
+- THE POST-GAP BOUNCE IS THE TRAP DEEPENING, NOT THE SETUP FAILING (v4b). After a
+  gap that puts a seated crowd underwater, the bounce back toward their entry is
+  the most commonly MISREAD event on the chart. It is not your thesis breaking:
+    * A gap that fell straight down would let the trapped crowd out "in two or
+      three minutes" at a small loss. That is the operator's worst outcome, not
+      yours only.
+    * The bounce exists so they feel the market "can go up again". That hope is
+      what makes them HOLD, and often AVERAGE DOWN, instead of cutting — which is
+      what converts a small trapped loss into a large one.
+  So the sequence adverse-gap -> bounce -> stall near the old level is the trap
+  working as designed. Expect it, and do not read it as invalidation. What WOULD
+  invalidate is price actually RECLAIMING the level (previous close / round
+  number) rather than approaching and failing at it — name that level in advance
+  and let it, not the bounce, be your evidence (see NAME THE ONE WAY THIS TRADE
+  FAILS and A REJECTION BEFORE THE FLUSH IS NOISE).
+- REGIME MEMORY DECIDES WHO SHOWS UP AT A LEVEL (v4b). A level does not attract
+  participants by geometry; it attracts whoever the recent past has left willing
+  to act there. After a stretch where one side was repeatedly punished, that side
+  stops arriving even at the price where textbook logic says it should:
+    "They will not be able to sell here. Most traders who sold did it earlier in
+    this chart and had to suffer losses again and again. Now everyone's focus is
+    on where to BUY, because their mindset has formed that the market keeps going
+    up. Nobody is even paying attention to the resistance."
+  Practical use: before assuming a resistance will recruit fresh sellers (or a
+  support fresh buyers), ask who has been PAID and who has been PUNISHED over the
+  last several sessions. A level in front of a beaten side is thin, which is
+  exactly why price can lean on it and still fall.
 - SECOND-DAY RECRUITMENT — one adverse day does NOT seat a crowd, the SECOND one
   does (v4a). This is the counterpart to THE MISSING RIP IS THE TELL, and together
   they date the inventory. Day one of a fall after a positive stretch recruits
@@ -807,6 +834,30 @@ RISK DISCIPLINE
   becomes the fuel for a move AGAINST you — the same mechanism you were trying to
   exploit, pointed the other way. Company at a level is a warning, not comfort:
   the break should come promptly, "from about here", or the edge has inverted.
+- A CROWD THAT HAS AVERAGED DOWN EARNS A BIGGER TARGET (v4b). This is the
+  counterpart to A FRESHLY RECRUITED CROWD HAS TIGHT STOPS, and the two together
+  are how you SIZE a target from crowd behaviour rather than from a fixed
+  percentage:
+    * Freshly recruited, no averaging -> shallow stop cluster -> SMALL target,
+      fast move.
+    * Baited into averaging down -> the same traders now hold MORE size at a WORSE
+      average, and their pain threshold sits FURTHER away -> the flush runs
+      further -> a LARGER target is justified.
+  IH's own reasoning for enlarging the target mid-trade: "Why could we make the
+  target bigger here? Because those who average get a little courage from the
+  market — 'go on, wait' — and then it targets them. So their SLs would have been
+  hit." Two supporting reads for enlarging: all THREE indices moving together
+  ("achieving the target will be easy"), and a visible averaging/hope phase
+  earlier in the move.
+- EXPECT A SECOND LEG AFTER THE PAUSE, THEN BOOK (v4b). When a flush stalls
+  mid-move, the stall is usually the LAST bait rather than the end: the market
+  gives the trapped side "a little hope that the breakdown is not going to
+  happen", they hold rather than cut, and one further leg takes them out. So a
+  pause after a working flush predicts ONE more move, and that move is where the
+  target gets booked — not where a new position gets added. This is a refinement
+  of A REJECTION BEFORE THE FLUSH IS NOISE for the phase AFTER a flush has begun;
+  it does not extend to a position that is offside, and it never overrides the
+  stop, the max loss, or premise-invalidation.
 - A REJECTION BEFORE THE FLUSH IS NOISE; A REJECTION AFTER IT IS THE EXIT (v4a).
   When you are positioned against a seated crowd, the trade has TWO phases and
   they take opposite handling:
@@ -1121,6 +1172,17 @@ you size or place the NIFTY trade. Advisory, not a hard gate.
   about the LEADER failing to lead, not about momentum speed in general — a genuine
   leader-led move that grinds on in small candles is still the sustainable kind
   described in RISK.)
+- THE HIERARCHY IS ASYMMETRIC: BankNIFTY DECIDES EXITS, THE LAGGARDS GATE ENTRIES
+  (v4b). The major index leading is enough to CLOSE on (see the next bullet), but
+  it is NOT enough to OPEN on. IH, with a textbook BankNIFTY setup in front of
+  him: "Looking at BankNIFTY it seems the trade should be taken right now. But
+  let us wait a little, according to Sensex and NIFTY." He entered only once the
+  other two agreed, and said plainly which one was the risk: "BankNIFTY's chart is
+  completely right; it is Sensex and NIFTY where we could have trouble."
+  The asymmetry is deliberate and matches the risk: entering on the leader alone
+  buys a move the other two may never join (that is LAGGARDS NEVER JOINED, seen
+  from the front), while exiting on the leader alone only costs you a trade.
+  Be slow to enter on BankNIFTY alone; be fast to leave on it.
 - INDEX HIERARCHY ON THE WAY OUT — the indices are NOT equal when a position is
   going against you (v3y). NIFTY and Sensex drifting against the trade is
   TOLERABLE; that is handleable noise and does not by itself end the trade.

--- a/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
+++ b/Signal Generators/SL Hunting AI Agent/tests/test_sl_hunting_schema.py
@@ -752,6 +752,46 @@ def test_v4a_rejection_rule_cannot_be_read_as_licence_to_hold_a_loser():
     assert "THE DISCRIMINATOR IS FACTUAL, NOT A FEELING" in prompt
 
 
+def test_system_prompt_has_v4b_post_gap_bounce_and_averaging_target_knowledge():
+    """v4b (7 Aug live session): a WIN on the put side where he ENLARGED the
+    target mid-trade.
+
+    The central idea inverts the naive read of a post-gap bounce: a gap that fell
+    straight down would let the trapped crowd out in two or three minutes, so the
+    bounce exists to give them hope, make them hold or average, and deepen the
+    loss. A crowd that has averaged then justifies a BIGGER target, and a stall
+    mid-flush predicts one more leg rather than the end.
+    """
+    prompt = build_system_prompt()
+    assert "THE POST-GAP BOUNCE IS THE TRAP DEEPENING" in prompt
+    # Wrap-independent fragments: these sentences span line breaks in the source.
+    assert "three minutes" in prompt
+    assert "REGIME MEMORY DECIDES WHO SHOWS UP AT A LEVEL" in prompt
+    assert "who has been PAID and who has been PUNISHED" in prompt
+    # Target sizing from crowd behaviour, and the pair it completes.
+    assert "A CROWD THAT HAS AVERAGED DOWN EARNS A BIGGER TARGET" in prompt
+    assert "A FRESHLY RECRUITED CROWD HAS TIGHT STOPS" in prompt
+    assert "EXPECT A SECOND LEG AFTER THE PAUSE" in prompt
+    # The entry/exit asymmetry of the major index.
+    assert "THE HIERARCHY IS ASYMMETRIC" in prompt
+    assert "Be slow to enter on BankNIFTY alone" in prompt
+
+
+def test_v4b_bounce_rule_names_what_would_actually_invalidate():
+    """The bounce rule tells the agent NOT to exit on a bounce, so it must also
+    say what a real invalidation looks like -- otherwise it reads as "ignore
+    adverse movement", which is the failure mode every one of these lessons has.
+    """
+    prompt = build_system_prompt()
+    # It must point at a concrete, checkable invalidation.
+    assert "RECLAIMING the level" in prompt
+    # ...and the second-leg rule must scope itself off an offside position.
+    assert "does not extend to a position that is offside" in prompt
+    # The exits it must not weaken are still present.
+    assert "NEVER hold a loser hoping for a reversal" in prompt
+    assert "INDEX HIERARCHY ON THE WAY OUT" in prompt
+
+
 def test_reentry_gate_does_not_contradict_the_exit_rules():
     """The re-entry gate must never be readable as a reason to delay an EXIT.
 


### PR DESCRIPTION
## Source

Intraday Hunter live session, **7 Aug 2026** ([`SupzF0JT_vE`](https://www.youtube.com/watch?v=SupzF0JT_vE), 9:10). A win on the put side, and the first session where he **enlarged** the target mid-trade and explained why.

## The central idea inverts the naive read of a post-gap bounce

> "If the market had opened gap-down and started falling directly, the buyers might have got out **in two or three minutes**. But once it comes up, the trader gets a little hope that yes, the market can go up too — and he may even try to AVERAGE."

> "Those sitting in buys should feel the market can go up, **so that when it goes down again they take a bigger loss.**"

The bounce toward a trapped crowd's entry *looks* like the short failing. It's actually the mechanism that turns a small trapped loss into a large one — a direct fall is the operator's **worst** outcome, because the crowd escapes cheaply.

Recorded **with its invalidation attached**, so it can't degrade into "ignore adverse movement": what breaks the trade is price **reclaiming** the level, not approaching and failing at it. A dedicated test asserts that clause is present.

## Also from this session

- **`REGIME MEMORY DECIDES WHO SHOWS UP AT A LEVEL`** — answering why the resistance didn't recruit fresh sellers: *"Most traders who sold did it earlier in this chart and had to suffer losses again and again. Now everyone's focus is on where to BUY... nobody is even paying attention to the resistance."* A level attracts whoever the recent past left willing to act there, not whoever geometry says.
- **`A CROWD THAT HAS AVERAGED DOWN EARNS A BIGGER TARGET`** — completes v4a's pair. Freshly recruited → shallow stops → **small** target. Baited into averaging → more size at a worse average → **larger** target. Target sizing from what the crowd has *done*, not a fixed percentage.
- **`EXPECT A SECOND LEG AFTER THE PAUSE, THEN BOOK`** — the mid-flush stall is the last bait. Scoped to a working position, never an offside one.
- **`THE HIERARCHY IS ASYMMETRIC`** — he had a textbook BankNIFTY setup and refused it: *"Looking at BankNIFTY it seems the trade should be taken right now. But let us wait, according to Sensex and NIFTY."* That qualifies v3y's `INDEX HIERARCHY`, which is an **exit** rule: the leader alone is enough to close on, not to open on.

## Agent comparison — 4 trades, all short, **+₹1,121.00**

| # | | Result |
|---|---|---|
| 1 | 09:32 → 09:34 | −₹62.00 (cut in **2.5 min**, "price round-tripped") |
| 2 | 09:43 → 09:44 | −₹1,089.75 (cut in **1.4 min**, "spot pinned") |
| 3 | 10:03 → 10:12 | −₹128.00 (**per-leg**: BNF −1,038.00, NIFTY +910.00) |
| 4 | 10:18 → 10:28 | **+₹2,400.75** ("seated-buyer short hunt") |

**1. The note's plan was followed and it worked.** All shorts, gap-down condition met, and the note's own magnitude clause ("well below 58000") appears verbatim in entry 2's reasoning.

**2. v4a was live today and did not prevent the early cuts.** Trades 1 and 2 closed after 2.5 and 1.4 minutes on exactly the post-gap bounce this session explains — with `A REJECTION BEFORE THE FLUSH IS NOISE` already in the prompt from last night. Recorded plainly, because it's evidence about what prose can and cannot change. v4b attacks the same behaviour from the *mechanism* side rather than the discipline side; whether that does better is an open question.

**3. The per-leg exit earned its keep.** Cutting BankNIFTY alone and letting NIFTY run to target turned a full-basket loss into −₹128.00. First clear instance of `exit_leg` paying for itself.

## Scope

All prose. **No executable behaviour changes.** Prompt grows 84,693 → 89,193 chars against the 120,000 cap.

## Gates

452 unittest ✅ · 1013 pytest (166 SL Hunting) ✅ · ruff ✅ · mypy 42 files ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
