### PR TITLE
fix(cpr-ai): align authenticated Codex turn contract

### DIFF
--- a/Signal Generators/CPR AI Agent/cpr_ai_agent.py
+++ b/Signal Generators/CPR AI Agent/cpr_ai_agent.py
@@ -448,7 +448,10 @@ class CPRAgent:
         from cpr_ai_schema import CPRAgentDecision
 
         return self.runner(
-            prompt=build_system_prompt(),
+            # Tell the prompt builder which configured model identifier must be
+            # echoed in the strict response.  This remains advisory metadata;
+            # the host independently verifies it before accepting a decision.
+            prompt=build_system_prompt(model_used=self.model),
             context=context,
             bar_signature=bar_signature,
             model=self.model,

--- a/Signal Generators/CPR AI Agent/cpr_ai_codex_subprocess.py
+++ b/Signal Generators/CPR AI Agent/cpr_ai_codex_subprocess.py
@@ -21,6 +21,21 @@ from typing import Any
 
 _REQUEST_KEYS = {"snapshot_path", "model", "reasoning_effort", "prompt", "output_schema"}
 _EXPECTED_TOOLS = ("session_levels", "momentum_vwap", "market_structure", "position_state")
+# ``build_system_prompt()`` contains durable role, tool, and safety policy.  The
+# actual turn request stays short so those rules are stated once at the SDK's
+# stronger developer-instruction layer instead of being repeated as user text.
+_TURN_REQUEST = "Evaluate the current frozen CPR context and return one decision."
+_ALLOWED_TURN_ITEM_TYPES = frozenset(
+    {
+        # The SDK records the prompt submitted through ``Thread.run`` as a
+        # completed user-message item.  This is input bookkeeping, not a tool or
+        # capability used by Codex, so it is safe to ignore during action checks.
+        "userMessage",
+        "agentMessage",
+        "reasoning",
+        "mcpToolCall",
+    }
+)
 
 
 def build_isolated_thread_config(snapshot_path: str, python_executable: str = sys.executable) -> dict[str, Any]:
@@ -154,12 +169,16 @@ def _run_request(request: Mapping[str, Any]) -> dict[str, Any]:
             model=str(request["model"]),
             config=config,
             cwd=runtime_directory,
+            # The modular CPR prompt is policy for every turn, not merely the
+            # user's one-off task.  Passing it through the SDK's dedicated
+            # field makes the intended instruction hierarchy explicit.
+            developer_instructions=str(request["prompt"]),
             ephemeral=True,
             sandbox=Sandbox.read_only,
             approval_mode=ApprovalMode.deny_all,
         )
         result = thread.run(
-            str(request["prompt"]),
+            _TURN_REQUEST,
             approval_mode=ApprovalMode.deny_all,
             output_schema=request["output_schema"],
             effort=request["reasoning_effort"],
@@ -174,7 +193,7 @@ def _run_request(request: Mapping[str, Any]) -> dict[str, Any]:
         "unexpected_actions": [
             str(_item_value(_root_item(item), "type", "unknown"))
             for item in _item_value(result, "items", ())
-            if _item_value(_root_item(item), "type", "") not in {"agentMessage", "reasoning", "mcpToolCall"}
+            if _item_value(_root_item(item), "type", "") not in _ALLOWED_TURN_ITEM_TYPES
         ],
     }
 

--- a/Signal Generators/CPR AI Agent/cpr_ai_prompt.py
+++ b/Signal Generators/CPR AI Agent/cpr_ai_prompt.py
@@ -8,7 +8,7 @@ without burying safety instructions inside runtime orchestration code.
 
 from __future__ import annotations
 
-CPR_AI_PROMPT_VERSION = "cpr-srsi-vwap-context-v1"
+CPR_AI_PROMPT_VERSION = "cpr-srsi-vwap-context-v2"
 
 _ROLE = """ROLE AND BOUNDARY
 You are an advisory CPR context analyst. Assess only complete five-minute bars.
@@ -32,15 +32,30 @@ premise, use EXIT with PREMISE_EXIT. Use the long-only R1_SCALE_IN at most once,
 only when market_structure reports its eligible R1 candidate. Prefer HOLD/NONE
 whenever evidence conflicts or is incomplete."""
 
-_OUTPUT = f"""STRICT STRUCTURED OUTPUT
+def _output_rules(model_used: str) -> str:
+    """Build output rules that echo the host's configured model exactly.
+
+    ``model_used`` is dynamic configuration, so it cannot live in a fixed
+    module-level paragraph.  Including it here keeps all prompt prose inside
+    the prompt builder instead of scattering instructions through SDK runtime
+    code.
+    """
+
+    return f"""STRICT STRUCTURED OUTPUT
 Return only CPRAgentDecision with exactly action, regime, setup, confidence,
 reasoning, model_used, and prompt_version. Valid actions are HOLD, ENTER_LONG,
-ENTER_SHORT, EXIT, SCALE_IN. prompt_version must be {CPR_AI_PROMPT_VERSION}.
-Never include entry, stop, target, trail, lots, quantity, symbol, expiry, broker,
-venue, order, or any execution field."""
+ENTER_SHORT, EXIT, SCALE_IN. confidence must be an integer from 0 through 10.
+model_used must exactly equal {model_used}. prompt_version must be
+{CPR_AI_PROMPT_VERSION}. Never include entry, stop, target, trail, lots,
+quantity, symbol, expiry, broker, venue, order, or any execution field."""
 
 
-def build_system_prompt(*, operator_approved_knowledge: str = "", discretionary_context: str = "") -> str:
+def build_system_prompt(
+    *,
+    model_used: str = "gpt-5.6-terra",
+    operator_approved_knowledge: str = "",
+    discretionary_context: str = "",
+) -> str:
     """Return one prompt while keeping future knowledge visibly separated.
 
     ``discretionary_context`` is a harmless compatibility alias while later
@@ -57,7 +72,7 @@ def build_system_prompt(*, operator_approved_knowledge: str = "", discretionary_
     # show exactly what changed without mixing it into permanent safety text.
     if knowledge:
         sections.append("FUTURE OPERATOR-APPROVED KNOWLEDGE\n" + knowledge)
-    sections.append(_OUTPUT)
+    sections.append(_output_rules(model_used))
     return "\n".join(section.strip() for section in sections) + "\n"
 
 

--- a/Signal Generators/CPR AI Agent/cpr_ai_schema.py
+++ b/Signal Generators/CPR AI Agent/cpr_ai_schema.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 CPRAction = Literal["HOLD", "ENTER_LONG", "ENTER_SHORT", "EXIT", "SCALE_IN"]
 CPRRegime = Literal["SIDEWAYS", "TRENDING", "UNDECIDED"]
@@ -44,7 +44,9 @@ class CPRAgentDecision(BaseModel):
     action: CPRAction
     regime: CPRRegime
     setup: CPRSetup
-    confidence: int
+    # Field bounds become JSON-Schema minimum/maximum values.  Codex therefore
+    # sees the same 0-10 contract that Pydantic enforces after the turn returns.
+    confidence: int = Field(ge=0, le=10)
     reasoning: str
     model_used: str
     prompt_version: str

--- a/Tests/Signal Generators/CPR AI Agent/test_cpr_ai_context.py
+++ b/Tests/Signal Generators/CPR AI Agent/test_cpr_ai_context.py
@@ -496,12 +496,17 @@ def test_mcp_server_exposes_exactly_four_no_argument_frozen_context_tools(tmp_pa
 def test_prompt_requires_tools_judgment_risk_boundary_and_future_knowledge_seam():
     """The prompt must guide judgment while reserving execution for the host."""
 
-    prompt = build_system_prompt(operator_approved_knowledge="Only after human approval.")
+    prompt = build_system_prompt(
+        model_used="configured-test-model",
+        operator_approved_knowledge="Only after human approval.",
+    )
 
     assert all(name in prompt for name in EXPECTED_TOOL_NAMES)
     assert "SIDEWAYS" in prompt and "TRENDING" in prompt and "UNDECIDED" in prompt
     assert "breakout" in prompt.lower() and "breakdown" in prompt.lower()
     assert "SRSI" in prompt and "VWAP" in prompt and "PREMISE_EXIT" in prompt
     assert "host-owned" in prompt.lower()
+    assert "confidence" in prompt and "0 through 10" in prompt
+    assert "model_used" in prompt and "configured-test-model" in prompt
     assert "FUTURE OPERATOR-APPROVED KNOWLEDGE" in prompt
     assert CPR_AI_PROMPT_VERSION in prompt

--- a/Tests/Signal Generators/CPR AI Agent/test_cpr_ai_runtime.py
+++ b/Tests/Signal Generators/CPR AI Agent/test_cpr_ai_runtime.py
@@ -496,6 +496,10 @@ def test_agent_validates_positive_timeout_and_passes_it_to_the_runtime():
 
     assert outcome.validation_code == "accepted_hold"
     assert observed["timeout_seconds"] == 17.5
+    assert "model_used must exactly equal gpt-5.6-terra" in observed["prompt"]
+    confidence_schema = observed["output_schema"]["properties"]["confidence"]
+    assert confidence_schema["minimum"] == 0
+    assert confidence_schema["maximum"] == 10
 
 
 def test_timeout_returns_before_a_late_sdk_thread_finishes():
@@ -712,6 +716,10 @@ def test_child_uses_one_authoritative_config_and_public_sdk_item_contract(monkey
                 {"approval_mode": approval_mode, "output_schema": output_schema, "effort": effort},
             )
             items = [
+                # The real SDK includes the submitted turn input in
+                # ``TurnResult.items``.  It is bookkeeping, not a capability
+                # used by Codex, so the host must not classify it as an action.
+                SimpleNamespace(root=SimpleNamespace(type="userMessage")),
                 SimpleNamespace(root=SimpleNamespace(type="agentMessage")),
                 SimpleNamespace(root=SimpleNamespace(type="reasoning")),
                 *[
@@ -754,6 +762,8 @@ def test_child_uses_one_authoritative_config_and_public_sdk_item_contract(monkey
 
     assert observed["start"]["config"] == codex_child.build_isolated_thread_config(str(tmp_path / "snapshot.json"))
     assert observed["start"]["approval_mode"] == "deny"
+    assert observed["start"]["developer_instructions"] == "prompt"
+    assert observed["run"][0] == "Evaluate the current frozen CPR context and return one decision."
     assert observed["run"][1] == {"approval_mode": "deny", "output_schema": {"type": "object"}, "effort": "medium"}
     assert [call["tool"] for call in response["tool_calls"]] == list(EXPECTED_TOOL_NAMES)
     assert [call["status"] for call in response["tool_calls"]] == ["completed"] * 4
@@ -763,6 +773,7 @@ def test_child_uses_one_authoritative_config_and_public_sdk_item_contract(monkey
         "total_tokens": 5,
         "model_context_window": 128000,
     }
+    assert response["unexpected_actions"] == []
     assert all(value is False for value in observed["start"]["config"]["features"].values())
     assert set(observed["start"]["config"]["features"]) >= {
         "shell_tool",


### PR DESCRIPTION
## What changed

- accept the Codex SDK's passive userMessage result item without classifying it as an agent action
- place the CPR strategy policy in developer_instructions and keep the user turn deliberately short
- require the exact configured model and prompt version in the structured response
- constrain confidence to the documented 0-10 scale in both the schema and prompt
- add regression coverage under PR #116's consolidated Tests/ layout

## Why

The authenticated synthetic smoke completed the required four read-only MCP calls, but the host then rejected the SDK's echoed user message as unexpected_agent_action. The same integration also sent the long-lived strategy policy as ordinary user content, which weakened the intended instruction boundary.

## Impact and safety

- authenticated synthetic smoke now returns: HOLD validation=accepted_hold NO ORDER
- the agent still has exactly four frozen, no-argument MCP tools
- shell, web, workspace mutation, and trading credentials remain unavailable to the child
- malformed output, missing tools, unexpected capabilities, and runtime errors still fail closed to HOLD
- no entry, exit, broker, or order capability was added

## Verification

- CPR AI suite: 68 passed
- master suite: 487 passed, 52 skipped
- market-health suite: 26 passed
- Signal Generators, Dependencies, and Data Extractors: 1089 passed
- Ruff, mypy (53 files), compileall, Bandit, and pre-commit passed
- one authenticated synthetic smoke passed before publication; it made a model call but no broker/order call

## Stack

This PR is intentionally based on #116 (chore/docs-and-tests-restructure). Merge #116 first, then retarget this PR to main before merging it.

Co-authored-by: Codex <codex@openai.com>
