### PR TITLE
feat(sl-hunting): v4i knowledge, and raise the prompt sanity bound instead of deleting knowledge

### DIFF
--- a/Signal Generators/SL Hunting AI Agent/premarket_note.json
+++ b/Signal Generators/SL Hunting AI Agent/premarket_note.json
@@ -1,27 +1,28 @@
 {
-  "for_date": "2026-08-17",
-  "source": "Intraday Hunter, 'Prediction For 17 AUG 2026' (4xfMmQW6x5I, uploaded 2026-08-16)",
-  "context": "All three indices recovered after sellers were removed or stopped out, leaving buyers as the likely seated crowd. The sell-side plan targets those buyers, but a gap-down can recruit fresh sellers and increase risk.",
+  "for_date": "2026-08-18",
+  "source": "Intraday Hunter, 'Prediction For 18 AUG 2026' (UAHKZbgRaJA, uploaded 2026-08-17)",
+  "context": "NIFTY EXPIRY DAY. The breakdown trapped sellers and the market recovered, so the seated crowd is short, not long. Buyers who are already well in profit are NOT a target. Plan is BUY side, with the market.",
   "plan": [
-    "GAP-UP or FLAT: identify confirmed SELL-side setups targeting the buyers left seated after the prior recovery.",
-    "GAP-DOWN: retain the SELL-side search, but risk is higher because fresh sellers may participate; the gap alone is not confirmation.",
-    "GAP-DOWN WITH POSITIVE MOMENTUM: a large recovery weakens the short plan. Retain it only if the recovery stays limited and the normal setup confirms."
+    "SMALL GAP-UP, FLAT, or SLIGHT GAP-DOWN: identify confirmed BUY-side setups and go with the market.",
+    "LARGE GAP-UP: NO PLAN, stand aside. A big gap makes others focus on buying too, or at least stop selling, which removes the crowd the trade needs.",
+    "A LARGE GAP-UP means an opening ABOVE the FIRST RESISTANCE; for BANKNIFTY, an opening above the round number also cancels the plan.",
+    "The trapped crowd is the SELLERS from the breakdown; do not build the trade around targeting buyers, who are already in profit and should not hold big size."
   ],
   "levels": [
     {
       "index": "NIFTY",
       "resistance": [24440, 24540],
-      "support": [24300, 24210]
+      "support": [24210, 24270]
     },
     {
       "index": "BANKNIFTY",
-      "resistance": [57720, 57890],
-      "support": [57280, 57154]
+      "resistance": [57800, 58000],
+      "support": [57120, 57400]
     },
     {
       "index": "SENSEX",
-      "resistance": [78300, 78500],
-      "support": [77700, 77400]
+      "resistance": [78000, 78200],
+      "support": [77460, 77650]
     }
   ]
 }

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -3607,3 +3607,143 @@ The supervisor heartbeat shipped in the session-state work is confirmed working
 in production: **65 heartbeat lines** in the 14 Aug log. The 2026-08-12 failure
 mode - snapshot writes stopping silently at 12:30 while trading continued to
 15:10 - would now be visible within five minutes.
+
+---
+
+## Video addendum - the 17 Aug LIVE SESSION (v4i)
+
+**Source:** Intraday Hunter live session `nozGFwXsdQg` (17 Aug 2026, 8:33).
+
+A three-index PUT basket, entered at the open and **booked while still
+profitable** because one index stopped confirming. That exit is the reason this
+version exists: it is the first session in the series that acts on cross-index
+divergence from the HOLDING side, and it lands directly on our BankNIFTY mirror.
+
+### The session
+
+He entered puts immediately on the open drive, across all three indices --
+BankNIFTY 57300 PE (1170 qty) and 57200 PE, Sensex 840 qty, NIFTY 1365 qty --
+with Sensex deliberately sized DOWN because its weekly-expiry timing made it the
+likely slow mover. Entry rationale was the familiar empty-book read: the market
+had been selling for days, had already given a retracement and closed, so
+"sellers are not seated here" and a direct upside retracement was unlikely.
+
+He then sat through an immediate drawdown, and booked into profit at the end.
+
+### The three rules
+
+**THE LAGGING INDEX DECIDES THE BASKET'S EXIT, NOT THE LEADING ONE.** He needed
+a breakdown in both indices and got it -- "Sensex needed the 500 level breakdown.
+It happened in both" -- but no fast momentum followed, and BankNIFTY held back
+while Sensex and NIFTY ran. That was the exit: "Sensex and NIFTY have momentum,
+BankNIFTY is trying to hold itself back. So this can create a problem for us. So
+we will have to book this profit and go... if BankNIFTY starts turning, our
+quantity there is larger, so the problem becomes bigger for us." His closing
+generalisation is the rule itself: "when two indices run far ahead, one index
+lags a little behind, or sometimes tries to retrace a bit. So we had to book."
+
+**A DOUBLE BOTTOM INSIDE AN ESTABLISHED DOWNTREND SHAKES SHORTS OUT; IT DOES NOT
+INVITE BUYERS IN.** Stated twice, once while holding through the pattern and once
+in review: "it is not made to attract BUYERS, it is made so that people do not
+SELL here", and "there is no need to fear the double bottom... it is only to
+chase away those who are selling. Then the market keeps falling slowly." Read the
+pattern by who it removes, not by its textbook name.
+
+**THE CROWD'S FEAR IS YOUR WINDOW, AND IT CLOSES WHEN THEY JOIN.** The twin of
+v4g's FEAR IS NOT A SIGNAL -- that rule governs the agent's own fear, this one
+reads the crowd's. "You think anyone can sell here - nobody will. Right now
+everyone is afraid it might turn around, and while they stay afraid our work gets
+done." Plus the entry corollary: "before the other person applies their mind, we
+should build our position."
+
+This last one is also the **mechanism under v4h's TIME EXPIRES THE PREMISE**: time
+retires a premise because the frightened crowd eventually stops being frightened
+and participates. The prose says so explicitly, so the two read as one idea rather
+than two pieces of timing advice.
+
+### Why the mapping to our basket needed spelling out
+
+IH was size-weighted INTO BankNIFTY on purpose. Our mirror is **equal-lot**, which
+is not equal-rupee -- BankNIFTY travels further per unit of time, so the mirror leg
+still carries the larger rupee swing. The laggard is the dangerous leg for us too,
+for a different reason than it was for him. The rule states that mapping rather
+than leaving the agent to assume his basket shape, and
+`test_v4i_lagging_index_rule_governs_the_basket_and_keeps_its_per_leg_escape`
+asserts both halves.
+
+It also keeps pointing at `exit_leg`: we have a finer instrument than he did and
+can cut the stalling mirror alone when the NIFTY premise is genuinely intact. A
+rule that always took the whole basket down would be strictly worse than the
+capability the host already exposes.
+
+### Knowledge changes (v4i, all prose)
+
+- `PATTERNS_AND_CONFIRMATION`: A DOUBLE BOTTOM INSIDE AN ESTABLISHED DOWNTREND
+  SHAKES SHORTS OUT.
+- `RISK`: THE LAGGING INDEX DECIDES THE BASKET'S EXIT (beside the BASKET NOTE);
+  THE CROWD'S FEAR IS YOUR WINDOW (beside v4g's FEAR IS NOT A SIGNAL).
+- Three new drift guards, each protecting the reading that would decay first: the
+  double-bottom rule must not generalise into "ignore reversal patterns" or become
+  a counter-trend entry licence; the lagging-index rule must keep its per-leg
+  escape; the crowd-fear rule must not read as an entry licence.
+- Adds a `_flat_rule` helper to the test module. Rule prose is hard-wrapped, so
+  asserting wording against the raw prompt breaks on a re-flow the agent never
+  sees -- the same brittleness that failed a v4h assertion.
+- Prompt size 113,461 -> 118,049 chars. Assembled 119,340 against a 154,140
+  budget: **34,800 chars of headroom.**
+
+Worth noting: at the old 120,000 cap this version would not have fitted at all
+(119,340 assembled against a 114,140 budget). The cap was raised earlier the same
+day -- see "The budget was never the design constraint" in the v4h addendum.
+
+### How our agent traded the same session
+
+**Provisional - the runner was still live at 12:12.** Realized so far: **+7,004.50**
+across 26 legs, a positive basket for a change.
+
+| Strategy | Legs | Realized |
+|---|---|---|
+| Renko | 5 | +3,016.00 |
+| **SL Hunting AI** | **2** | **+1,580.25** |
+| CPR Algo 3 | 2 | +1,560.00 |
+| EMA | 1 | +851.50 |
+| Heikin Ashi | 5 | +386.75 |
+| Long Strangle | 10 | -74.75 |
+| RSI Reversal | 1 | -315.25 |
+| **Total** | **26** | **+7,004.50** |
+
+One trade, cross-checked against its own `Result summary` (Trades=1,
+RealizedPnL=1580.25):
+
+| Time | Decision | Reason |
+|---|---|---|
+| 10:23 | ENTER_SHORT (conf=7) | `runaway_trend_continuation_short`, stop 24270, target 24200 |
+| 10:46 | EXIT (conf=8) | `book_before_round_number` - +2,565 unrealized, ~30pts from target, last several candles stalled |
+
+**Agent vs IH.** Same side, same structural read: both were short/put-side on a
+continuation of the existing selling rather than a reversal, and both booked on
+momentum stalling rather than at a target. The agent's stated exit reason -
+booking before the round number while the profit stopped growing - is v4g and v4d
+firing together, and it is a nameable reason, which now holds for four consecutive
+sessions.
+
+**The finding that matters is in the leg split:**
+
+| Leg | Realized |
+|---|---|
+| NIFTY | +2,115.75 |
+| BankNIFTY mirror | **-535.50** |
+| Net | +1,580.25 |
+
+The mirror LOST money while the NIFTY leg earned. That is precisely the divergence
+IH exited on, occurring in our own book on the same tape -- BankNIFTY lagging while
+NIFTY ran. The agent booked the whole basket at 10:46 and so closed the losing
+mirror too, but it got there for a NIFTY-side reason and never named the
+divergence. v4i is written so that next time the lag itself is a readable signal,
+and so that `exit_leg` is the considered response rather than an unused capability.
+
+One difference worth recording: IH entered at the open, the agent at 10:23 -- an
+hour into a move he had been riding since 9:15. The agent's no-new-entry cutoff
+then fired at 11:00 (`LIFECYCLE RUNNING -> ENTRY_BLOCKED | reason=TIME_CUTOFF`).
+On a day whose whole character was set in the first fifteen minutes, most of the
+move was already gone by the time the agent was willing to act.

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -3502,7 +3502,7 @@ time can retire the premise before price ever reaches the limit.
 `test_v4h_entry_and_direction_and_the_loss_limit_pair_with_their_neighbours`
 asserts the reconciliation in both directions.
 
-### One rule was cut for budget, not for merit
+### One rule was cut for budget, then restored the same week
 
 A third rule - **A SEATED CROWD IS WARNED BEFORE IT IS HUNTED, SO NO WARNING
 MEANS NO CROWD** - was written, tested, and then removed to fit the cap. IH:
@@ -3510,8 +3510,10 @@ MEANS NO CROWD** - was written, tested, and then removed to fit the cap. IH:
 give a WARNING... because the market kept making no momentum, sellers will not
 be seated, so it will not go up to warn." The mechanism is that an early adverse
 spike is the market shaking a seated crowd, so its *absence* confirms an empty
-book. It is the sharpest new idea in the session and it should be the first
-thing restored once a pruning pass frees room.
+book.
+
+**It was restored on 2026-08-17 when the cap was raised to 160,000.** Cutting it
+was the wrong call: see "The budget was never the design constraint" below.
 
 ### Knowledge changes (v4h, all prose)
 
@@ -3520,19 +3522,53 @@ thing restored once a pruning pass frees room.
 - `RISK` (extended): TIME SPENT IN THE TRADE ... now also EXPIRES THE PREMISE.
 - **Pruned:** v4e's `A SHARP FIRST SLIDE BAITS; A SLOW ONE MEANS IT` - superseded
   by v4f's confirmation rule, which covers the same tell with a checkable trigger.
-- Prompt size 111,283 -> 112,730 chars. **Assembled 114,021 against a 114,140
-  budget - 119 chars of headroom.** The cap is now the binding constraint on this
-  series: v4i cannot ship anything without pruning first. See below.
+- Prompt size 111,283 -> 113,461 chars (after the 2026-08-17 restore).
+  **Assembled 114,752 against a 154,140 budget - 39,388 chars of headroom.**
 
-### The budget is now the design constraint
+### The budget was never the design constraint
 
-Worst-case runtime additions (12 lessons x 280 + a 2,500-char note) are already
-reserved, so the true ceiling for static prose is 114,140 assembled. At 119 chars
-of slack, the append-only rhythm this series has used since v3 is finished.
-Before v4i, someone should do a dedicated pruning pass over `OPENING_DRIVE` and
-`RISK` - both have accumulated rules that later versions restated with better
-triggers - and re-measure. That is a knowledge-quality task and deserves its own
-change, not a rushed trim at the end of a version.
+v4h originally shipped at 119 characters under the cap, having dropped one of its
+own rules to get there, and this document claimed the append-only rhythm was
+finished and v4i could not ship without a pruning pass first.
+
+**That was wrong, and the guard's own comment says so.** `MAX_SYSTEM_PROMPT_CHARS`
+is documented in `sl_hunting_knowledge.py` as:
+
+> a SANITY bound, not a budget to trade against. It exists so a runaway lessons
+> file or a malformed note cannot quietly inflate what is sent every bar; it is
+> not meant to throttle ordinary knowledge growth
+
+It had already been raised once for exactly this situation (75,000 -> 120,000 on
+2026-07-31, because "the next ordinary addendum would have tripped it"). Reading
+it as a fixed budget and deleting hard-won knowledge to fit inverted its purpose.
+
+On 2026-08-17 it was raised to **160,000** and the cut rule was restored. The
+cost of the extra room was measured, not guessed:
+
+| Session | Decisions | Mean cost | Session total |
+|---|---|---|---|
+| 2026-08-13 | 72 | $0.2278 | $16.40 |
+| 2026-08-14 | 73 | $0.2362 | $17.24 |
+| 2026-08-17 | 91 | $0.2333 | $21.23 |
+
+~70-90 decisions a session at ~$0.23. The prompt growth this permits moves the
+input portion by single-digit rupees a day, against a strategy that booked
++2,866.50 on 14 Aug and +1,580.25 on 17 Aug. That is not a trade worth deleting
+knowledge for.
+
+**The rule for next time:** when the cap is hit, ask whether the growth is
+ordinary knowledge (raise the bound) or something pathological - a runaway
+lessons file, a malformed note (fix the cause). Pruning genuinely superseded
+prose is still worth doing on its own merits; it is just never a way to buy space
+under this number.
+
+One real redundancy was found while looking, and is recorded here rather than
+acted on under time pressure: `NEVER EXIT AT ZERO AFTER A GOOD PROFIT HAS
+PRINTED` (v4g) overlaps `BOOK WHEN THE PROFIT STOPS GROWING` (v4f), whose first
+support bullet already says a printed target "counts as reached, even if you did
+not take it there". The two could merge into one rule. That is a knowledge-quality
+change and belongs in its own commit, judged on whether the merged rule reads
+better - not on the character count.
 
 ### How our agent traded the same session
 

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
@@ -861,6 +861,21 @@ confirmation must have ALREADY printed.
 - Invalidation: if the confirmation candle's wick pokes back through the pattern,
   it is a trap — no trade. A pattern formed "in between" (not AT the level) is not
   tradeable; the pattern must form at the very top/bottom of the level.
+- A DOUBLE BOTTOM INSIDE AN ESTABLISHED DOWNTREND SHAKES SHORTS OUT; IT DOES NOT
+  INVITE BUYERS IN (v4i). Read the pattern by WHO it is built to remove, not by the
+  shape's textbook name. IH, twice in one session while holding puts through it:
+  "this double bottom the market has made — it is not made to attract BUYERS. It is
+  made so that people do not SELL here", and later "there is no need to fear the
+  double bottom, because this double bottom is not built to attract buyers, it is
+  only to chase away those who are selling. Then the market keeps falling slowly."
+  So inside a trend that is already running, a textbook REVERSAL pattern against
+  that trend is more often a shake-out of the crowd riding it than a turn. This does
+  NOT license ignoring reversal patterns generally — it is scoped to a pattern that
+  forms AGAINST an established, already-moving trend, and the tell is that the
+  pattern produces no real momentum in its own direction. A double bottom that
+  actually recruits buyers goes UP; one built to scare sellers just stops falling
+  for a while. If you are already positioned WITH the trend, this is a reason to sit
+  rather than to cut; if you are flat, it is not an entry against the trend.
 - Behavioural confirmation COMPLEMENTS the candle rule (it does NOT replace it):
   at a level, how price behaves corroborates the setup — holding WITHOUT aggressive
   selling backs a long; failing to break out and STALLING backs a short. Use it to
@@ -937,6 +952,32 @@ RISK DISCIPLINE
   shows the mirror as its own leg with its own P&L; `unrealized_pnl` there is BASKET P&L
   (both legs) while `nifty_leg_pnl` and the `mirror` block give you each leg alone. When in
   doubt, EXIT BOTH.
+- THE LAGGING INDEX DECIDES THE BASKET'S EXIT, NOT THE LEADING ONE (v4i). When the
+  indices are moving together and one falls BEHIND, the laggard is where the
+  retracement starts and it caps what the basket can actually collect — so a trade
+  can be working on the leg you are watching and still be finished. IH, booking a
+  profitable three-index put basket for exactly this reason: "Sensex and NIFTY have
+  momentum, BankNIFTY is trying to hold itself back. So this can create a problem
+  for us. So we will have to book this profit and go... if BankNIFTY starts turning,
+  our quantity there is larger, so the problem becomes bigger for us." His closing
+  generalisation is the rule: "when two indices run far ahead, one index lags a
+  little behind, or sometimes tries to retrace a bit. So we had to book our profit."
+  How this maps onto YOUR basket, which is not shaped like his:
+  * He was size-weighted INTO BankNIFTY deliberately. Your mirror is EQUAL-LOT, which
+    is NOT equal-rupee: BankNIFTY travels further per unit of time than NIFTY, so the
+    mirror leg still carries the larger rupee swing. The laggard is structurally the
+    dangerous leg for you too, for a different reason than it was for him.
+  * Therefore: while holding, check whether BOTH indices are still confirming the
+    move, not just NIFTY. NIFTY running while BankNIFTY stalls is a BOOK signal for
+    the basket even when `nifty_leg_pnl` looks healthy — the mirror is quietly giving
+    back what the NIFTY leg is earning.
+  * You have a finer instrument than he did: `exit_leg` lets you cut the stalling
+    mirror alone and let the NIFTY leg run. Prefer that to a whole-basket exit WHEN
+    the NIFTY premise is genuinely intact and only the mirror has stopped confirming.
+    If the divergence instead says the MOVE is tiring, exit BOTH.
+  This is a cross-index refinement of v4f's book-when-the-profit-stops-growing rule:
+  that one watches the rate on your own P&L, this one names the leg that will stop it
+  first, usually before the basket total shows it.
 - OPTION-TIME-ADJUSTED REWARD/RISK: require a worthwhile and ATTAINABLE target at a
   real swing / pivot / fibo / psych level. Normally prefer approximately 1:2
   reward:risk to the next clear level. An approximately 1:1 trade is permitted only
@@ -1120,6 +1161,24 @@ RISK DISCIPLINE
   Operationally: an exit needs a NAMED, checkable reason — stop, target, the
   profit rate falling, the premise invalidated, the round number crossed, the
   time cutoff. "It might turn" is not on that list.
+- THE CROWD'S FEAR IS YOUR WINDOW, AND IT CLOSES WHEN THEY JOIN (v4i). The twin of
+  FEAR IS NOT A SIGNAL above: that rule governs YOUR fear, this one reads THEIRS.
+  When a move is fast, the people who would fade it are frightened of being caught,
+  and their hesitation is the reason the move keeps paying. IH, entering into an
+  immediate drawdown: "you think anyone can sell here — nobody will. Right now
+  everyone is afraid it might turn around, and while they stay afraid our work gets
+  done." He acts on it at the entry too: "before the other person applies their
+  mind, we should build our position." Two consequences:
+  * An empty book is a TEMPORARY state, and the clock on it is the crowd's nerve, not
+    the chart. "Slowly others may also participate, because the momentum is good" —
+    once they do, retracement and chop start.
+  * This is the MECHANISM under v4h's TIME EXPIRES THE PREMISE. Time retires a premise
+    because the frightened crowd eventually stops being frightened and joins; that is
+    the structural change, and it is why elapsed time can end a trade that price has
+    not yet ended.
+  It does NOT license entering merely because a move is fast and scary — you still
+  need a named crowd, a level and a pattern. It tells you the edge is perishable
+  once you have one.
 - THE LOSS LIMIT IS A PERMISSION TO WAIT, NOT ONLY A PLACE TO STOP (v4h). Read
   this WITH v4e's DISCIPLINE IS ASYMMETRIC, not against it: that rule says cut a
   loser mechanically, this one says cut it AT the limit and not before, because

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
@@ -565,6 +565,15 @@ Conditions (ALL must hold — otherwise this branch simply does not apply):
   v4c's WHEN THE TRAPPED INVENTORY IS SPENT, THE MARKET MANUFACTURES MORE:
   manufacturing is what the market does over time, but it may not complete inside
   your holding period, and you cannot bank on being early to it.
+- A SEATED CROWD IS WARNED BEFORE IT IS HUNTED, SO NO WARNING MEANS NO CROWD (v4h).
+  Rather than asking who is seated, watch for the move that would shake them. IH:
+  "if sellers WERE seated, the market would go up to target them — especially to
+  give a WARNING. That is why your entry has chances of being wrong. But because
+  the market kept making no momentum and holding above the 500 level, sellers will
+  not be seated, so it will not go up to warn." So an early adverse spike is the
+  market shaking a seated crowd, and its ABSENCE confirms an empty book; a drift
+  straight in your favour is the confirmation, an immediate sharp move against you
+  says somebody was there and the ENTRY was wrong, not only the direction.
 - ENTRY QUALITY AND DIRECTION ARE SEPARATE JUDGEMENTS (v4h). IH, entering a fall
   he knew might reverse: "if the market turns it could go much higher — then we
   would be wrong ACCORDING TO DIRECTION. We would NOT be wrong according to
@@ -1708,7 +1717,23 @@ Emit ONLY this JSON object as your final answer."""
 # the next ordinary addendum would have tripped it. At ~4 characters per token
 # 120,000 is on the order of 30k tokens, comfortably inside the model's context
 # while still catching anything pathological.
-MAX_SYSTEM_PROMPT_CHARS = 120_000
+#
+# Raised again from 120,000 on 2026-08-17, for the same reason and by the same
+# reasoning. v4h landed with 119 characters to spare and was only made to fit by
+# dropping one of its own rules, which is precisely the "throttle ordinary
+# knowledge growth" outcome the paragraph above says this bound is NOT for. The
+# cost of the extra room was measured rather than guessed: the agent makes ~70-90
+# decisions a session at ~$0.23 each (2026-08-10..17 logs), so the prompt growth
+# this permits moves the input portion by single-digit rupees a day against a
+# strategy booking thousands. 160,000 is ~40k tokens -- still far inside context,
+# still small enough to catch a runaway lessons file or a malformed note, which
+# is the failure this guard actually exists to catch.
+#
+# The rule when this is next hit is the same: check whether the growth is
+# ordinary knowledge (raise the bound) or something pathological (fix the cause).
+# Pruning genuinely superseded prose is worth doing on its own merits, but it is
+# a knowledge-quality task -- never a way to buy space under this number.
+MAX_SYSTEM_PROMPT_CHARS = 160_000
 
 
 def build_system_prompt() -> str:

--- a/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_premarket.py
+++ b/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_premarket.py
@@ -201,15 +201,21 @@ def test_shipped_note_targets_the_next_TRADING_day_not_the_next_calendar_day():
     )
 
 
-def test_shipped_note_matches_august_17_intraday_hunter_plan():
-    """The committed advisory must match the hand-checked 16 Aug transcript.
+def test_shipped_note_matches_august_18_intraday_hunter_plan():
+    """The committed advisory must match the hand-checked 17 Aug transcript.
 
     This catches a stale prior-session note, an inverted gap plan, or a mistyped
     chart level before the dated note is injected into the live prompt.
 
-    What distinguishes this session is the same sell-side search across gap-up,
-    flat, and gap-down opens, with an explicit extra-risk test for a gap-down:
-    fresh sellers or a large positive recovery can make the buyer hunt unsafe.
+    Two things distinguish this session and are asserted rather than summarised:
+
+    1. The direction INVERTS from 17 Aug. The breakdown trapped SELLERS and the
+       market recovered, so the plan is BUY side. A note that still reads
+       "sell-side" is the exact stale-note failure this test exists to catch.
+    2. The stand-aside branch is a LARGE GAP-UP -- and it is DEFINED (an open
+       above the first resistance), which is what makes it checkable at 09:15
+       instead of a judgement call. Losing that definition would quietly turn a
+       hard veto into an opinion.
     """
     import os
 
@@ -218,33 +224,40 @@ def test_shipped_note_matches_august_17_intraday_hunter_plan():
     note = load_premarket_note(shipped)
 
     assert note is not None
-    assert note.for_date == "2026-08-17"
-    assert "4xfMmQW6x5I" in note.source
-    assert "buyers as the likely seated crowd" in note.context
+    assert note.for_date == "2026-08-18"
+    assert "UAHKZbgRaJA" in note.source
+    # Expiry is session context the RISK rules already act on; it must survive.
+    assert "NIFTY EXPIRY DAY" in note.context
+    assert "seated crowd is short, not long" in note.context
     assert note.plan == [
-        "GAP-UP or FLAT: identify confirmed SELL-side setups targeting the "
-        "buyers left seated after the prior recovery.",
-        "GAP-DOWN: retain the SELL-side search, but risk is higher because fresh "
-        "sellers may participate; the gap alone is not confirmation.",
-        "GAP-DOWN WITH POSITIVE MOMENTUM: a large recovery weakens the short plan. "
-        "Retain it only if the recovery stays limited and the normal setup confirms.",
+        "SMALL GAP-UP, FLAT, or SLIGHT GAP-DOWN: identify confirmed BUY-side "
+        "setups and go with the market.",
+        "LARGE GAP-UP: NO PLAN, stand aside. A big gap makes others focus on "
+        "buying too, or at least stop selling, which removes the crowd the "
+        "trade needs.",
+        "A LARGE GAP-UP means an opening ABOVE the FIRST RESISTANCE; for "
+        "BANKNIFTY, an opening above the round number also cancels the plan.",
+        "The trapped crowd is the SELLERS from the breakdown; do not build the "
+        "trade around targeting buyers, who are already in profit and should "
+        "not hold big size.",
     ]
     assert [level.model_dump() for level in note.levels] == [
         {
             "index": "NIFTY",
+            # Caption garbles the second resistance as "2440"; it is 24440,
+            # unchanged from the 17 Aug note and consistent with the pair he
+            # reads out ("24540, 24440").
             "resistance": [24440.0, 24540.0],
-            "support": [24300.0, 24210.0],
+            "support": [24210.0, 24270.0],
         },
         {
             "index": "BANKNIFTY",
-            # The auto-caption garbles the second support. The chart frame at
-            # 0:44 labels the two selected teal levels 57,280 and 57,154.
-            "resistance": [57720.0, 57890.0],
-            "support": [57280.0, 57154.0],
+            "resistance": [57800.0, 58000.0],
+            "support": [57120.0, 57400.0],
         },
         {
             "index": "SENSEX",
-            "resistance": [78300.0, 78500.0],
-            "support": [77700.0, 77400.0],
+            "resistance": [78000.0, 78200.0],
+            "support": [77460.0, 77650.0],
         },
     ]

--- a/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_schema.py
+++ b/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_schema.py
@@ -916,6 +916,7 @@ def test_v4h_entry_and_direction_and_the_loss_limit_pair_with_their_neighbours()
     # line break. Collapse whitespace before asserting on wording -- otherwise the
     # test breaks on a re-wrap that changed nothing about what the agent reads.
     flat = " ".join(prompt.split())
+    assert "A SEATED CROWD IS WARNED BEFORE IT IS HUNTED" in flat
     assert "ENTRY QUALITY AND DIRECTION ARE SEPARATE JUDGEMENTS" in flat
     assert "THE LOSS LIMIT IS A PERMISSION TO WAIT" in flat
 

--- a/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_schema.py
+++ b/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_schema.py
@@ -935,6 +935,78 @@ def test_v4h_entry_and_direction_and_the_loss_limit_pair_with_their_neighbours()
     assert "retire the premise before price ever reaches the limit" in flat
 
 
+def _flat_rule(prompt: str, heading: str) -> str:
+    """Return one '- HEADING ...' bullet, whitespace-collapsed.
+
+    Rule prose is hard-wrapped, so asserting on wording against the raw prompt
+    breaks whenever a paragraph is re-flowed -- a change the agent never sees.
+    """
+    body = prompt[prompt.index(heading):]
+    if "\n- " in body:
+        body = body[: body.index("\n- ")]
+    return " ".join(body.split())
+
+
+def test_v4i_lagging_index_rule_governs_the_basket_and_keeps_its_per_leg_escape():
+    """v4i (17 Aug live session): a WORKING three-index basket booked on divergence.
+
+    This is the first rule that acts on the BankNIFTY mirror from the HOLDING
+    side, so two things have to survive edits: it must not collapse into "exit
+    whenever the indices disagree", and it must keep pointing at `exit_leg`
+    rather than always taking the whole basket down.
+    """
+    prompt = build_system_prompt()
+    rule = _flat_rule(prompt, "THE LAGGING INDEX DECIDES THE BASKET'S EXIT")
+
+    # The mechanism: the laggard caps the basket, so a healthy NIFTY leg alone is
+    # not proof the trade is still working.
+    assert "nifty_leg_pnl" in rule
+    assert "BOOK signal" in rule
+
+    # The equal-lot mapping is the reason this transfers to our basket at all --
+    # IH was deliberately size-weighted into BankNIFTY and we are not.
+    assert "EQUAL-LOT" in rule
+    assert "NOT equal-rupee" in rule
+
+    # The per-leg escape hatch must stay, or the rule becomes strictly worse than
+    # the capability the host already exposes.
+    assert "exit_leg" in rule
+    assert "exit BOTH" in rule
+
+
+def test_v4i_double_bottom_rule_stays_scoped_to_countertrend_patterns():
+    """The shake-out reading must not generalise into "ignore reversal patterns".
+
+    Read carelessly this rule would cancel PATTERNS_AND_CONFIRMATION wholesale,
+    so the scope qualifier and the falsifier are asserted explicitly.
+    """
+    prompt = build_system_prompt()
+    rule = _flat_rule(prompt, "A DOUBLE BOTTOM INSIDE AN ESTABLISHED DOWNTREND")
+
+    assert "does NOT license ignoring reversal patterns generally" in rule
+    assert "AGAINST an established, already-moving trend" in rule
+    # The falsifier: a real reversal produces its own momentum.
+    assert "actually recruits buyers goes UP" in rule
+    # And it must not become a licence to enter counter-trend.
+    assert "it is not an entry against the trend" in rule
+
+
+def test_v4i_crowd_fear_rule_pairs_with_the_agent_fear_rule_and_the_time_rule():
+    """THEIR fear vs YOUR fear -- the two must not read as one contradictory rule."""
+    prompt = build_system_prompt()
+    flat = " ".join(prompt.split())
+    rule = _flat_rule(prompt, "THE CROWD'S FEAR IS YOUR WINDOW")
+
+    assert "FEAR IS NOT A SIGNAL" in flat
+    assert "FEAR IS NOT A SIGNAL above" in rule  # names the rule it sits beside
+    assert "governs YOUR fear" in rule and "reads THEIRS" in rule
+
+    # It explains v4h's time rule rather than competing with it.
+    assert "TIME EXPIRES THE PREMISE" in rule
+    # And it is not an entry licence.
+    assert "does NOT license entering merely because a move is fast" in rule
+
+
 def test_system_prompt_has_v4f_repeat_chart_and_confirmation_knowledge():
     """v4f (12 Aug live session): a WIN taken from the same empty book that lost.
 


### PR DESCRIPTION
Two commits. The first fixes a mistake I made in v4h; the second is v4i, which
could not have shipped without it.

---

# 1. `fix`: raise the sanity bound instead of deleting knowledge

You asked about the pruning pass I flagged in v4h. I went to do it, read the
guard's own comment, and concluded the premise was wrong.

v4h shipped **119 characters** under `MAX_SYSTEM_PROMPT_CHARS`, and only fitted
because I dropped one of its own three rules. I then wrote in the doc that the cap
had become the binding constraint and v4i couldn't ship without pruning first.

The guard is documented as:

> a **SANITY bound, not a budget to trade against**. It exists so a runaway lessons
> file or a malformed note cannot quietly inflate what is sent every bar; **it is
> not meant to throttle ordinary knowledge growth**

It had already been raised once for exactly this situation — 75,000 → 120,000 on
2026-07-31, because *"the next ordinary addendum would have tripped it."* Reading it
as a fixed budget and deleting hard-won prose to fit is the outcome it warns against.

- **`MAX_SYSTEM_PROMPT_CHARS` 120,000 → 160,000**, with the reasoning and the
  next-time rule recorded in the comment.
- **Restores `A SEATED CROWD IS WARNED BEFORE IT IS HUNTED`** — the v4h rule cut for
  space, and the sharpest mechanism in that session.
- Corrects the v4h doc section, which currently tells a future reader the opposite.

**The cost was measured, not assumed:**

| Session | Decisions | Mean cost | Session total |
|---|---|---|---|
| 2026-08-13 | 72 | $0.2278 | $16.40 |
| 2026-08-14 | 73 | $0.2362 | $17.24 |
| 2026-08-17 | 91 | $0.2333 | $21.23 |

~70–90 decisions a session at ~$0.23. The growth this permits moves the input
portion by single-digit rupees a day, against a strategy that booked +2,866.50 on
14 Aug and +1,580.25 on 17 Aug.

**Vindicated immediately:** v4i below assembles to 119,340 — it would not have fitted
under the old cap **at all**.

**The rule for next time:** when the cap is hit, ask whether the growth is ordinary
knowledge (raise the bound) or pathological — runaway lessons file, malformed note
(fix the cause). Pruning superseded prose is still worth doing on its own merits; it
is just never a way to buy space under this number. One genuine redundancy found
while looking is recorded in the doc rather than acted on here (v4g's `NEVER EXIT AT
ZERO` overlaps v4f's `BOOK WHEN THE PROFIT STOPS GROWING`).

---

# 2. `feat`: v4i from the 17 Aug live session

Source: `nozGFwXsdQg` (8:33). A three-index PUT basket entered on the open drive and
**booked while still profitable**, because one index stopped confirming. First
session in the series to act on cross-index divergence from the *holding* side — and
it lands directly on our BankNIFTY mirror.

### The three rules

**THE LAGGING INDEX DECIDES THE BASKET'S EXIT, NOT THE LEADING ONE.** He got the
breakdown he needed in both indices, then BankNIFTY held back while Sensex and NIFTY
ran: *"BankNIFTY is trying to hold itself back. So this can create a problem for us.
So we will have to book this profit and go."* A trade can be working on the leg you
are watching and still be finished.

**A DOUBLE BOTTOM INSIDE AN ESTABLISHED DOWNTREND SHAKES SHORTS OUT; IT DOES NOT
INVITE BUYERS IN.** Stated twice — *"it is not made to attract BUYERS, it is made so
that people do not SELL here."* Read the pattern by who it removes, not by its
textbook name.

**THE CROWD'S FEAR IS YOUR WINDOW, AND IT CLOSES WHEN THEY JOIN.** The twin of v4g's
FEAR IS NOT A SIGNAL — that governs the agent's own fear, this reads the crowd's. It
is also the **mechanism under v4h's TIME EXPIRES THE PREMISE**, and says so, so the
two read as one idea rather than two pieces of timing advice.

### The basket mapping is stated, not assumed

IH was size-weighted into BankNIFTY deliberately. Our mirror is **equal-lot**, which
is not equal-rupee — BankNIFTY travels further per unit time, so the mirror still
carries the larger rupee swing. The laggard is our dangerous leg too, for a different
reason than it was his. The rule keeps pointing at `exit_leg`, since one that always
took the whole basket down would be strictly worse than the capability the host
already exposes.

### Agent vs IH — the finding is in the leg split

Same side, same structural read (continuation, not reversal), both booked on
momentum stalling rather than at a target. SL Hunting: **+1,580.25** over 1 trade,
in a **+7,004.50** basket across 26 legs (provisional — runner still live at 12:12).

| Leg | Realized |
|---|---|
| NIFTY | +2,115.75 |
| BankNIFTY mirror | **−535.50** |
| Net | +1,580.25 |

**The mirror lost money while the NIFTY leg earned** — precisely the divergence IH
exited on, occurring in our own book on the same tape. The agent closed the losing
mirror only incidentally, via a whole-basket exit taken for a NIFTY-side reason
(`book_before_round_number`); it never named the lag. v4i makes that lag readable and
makes `exit_leg` the considered response rather than an unused capability.

Also recorded: IH entered at the open, the agent at 10:23 — an hour into a move he'd
been riding since 9:15, with the no-new-entry cutoff then firing at 11:00. On a day
whose character was set in the first fifteen minutes, most of the move was gone
before the agent would act.

### Tests

Three drift guards, each protecting the reading that would decay first: the
double-bottom rule must not generalise into "ignore reversal patterns" or become a
counter-trend entry licence; the lagging-index rule must keep its per-leg escape and
its equal-lot mapping; the crowd-fear rule must not read as an entry licence.

Adds a `_flat_rule` test helper — rule prose is hard-wrapped, so asserting wording
against the raw prompt breaks on a re-flow the agent never sees (the brittleness that
failed a v4h assertion). Writing v4i also surfaced a locator collision: a cross-
reference to another rule's heading shadowed that rule's own test anchor, so the
reference is now phrased so it cannot.

---

## Gates

| Gate | Result |
|---|---|
| `Tests.test_nifty_multi_strategy_master` | 528 passed |
| `Tests.test_market_data_health` | 28 passed |
| `pytest "Tests/Signal Generators" "Tests/Dependencies" "Tests/Data Extractors"` | 1198 passed |
| Ruff | clean |
| mypy | 54 files, clean |
| compileall | clean |

```
assembled            : 119,340
budget for assembled : 154,140
headroom             :  34,800
```

Knowledge-only — no runtime behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
