### PR TITLE
feat(sl-hunting): v4j knowledge from the 18 Aug IH live session

### DIFF
--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -3747,3 +3747,120 @@ hour into a move he had been riding since 9:15. The agent's no-new-entry cutoff
 then fired at 11:00 (`LIFECYCLE RUNNING -> ENTRY_BLOCKED | reason=TIME_CUTOFF`).
 On a day whose whole character was set in the first fifteen minutes, most of the
 move was already gone by the time the agent was willing to act.
+
+---
+
+## Video addendum - the 18 Aug LIVE SESSION (v4j)
+
+**Source:** Intraday Hunter live session `sSgO_Jole74` (18 Aug 2026, 9:23).
+
+**A LOSING session, and the most useful one in the series so far** - because he
+diagnoses the loss mid-trade, names the mechanism, and cuts. Every prior version
+learned from a win or from a loss reviewed afterwards; this is the first where
+the post-mortem happens live and identifies a market participant the prompt had
+never modelled.
+
+### The session
+
+NIFTY expiry, large gap-down on all three indices. He deliberately suspended the
+plan until the open resolved - "if it stays a bit in buying we plan the positive
+side; if it stays in selling we can sell" - then read yesterday's breakdown plus
+the recovery as good traders seated LONG, making the gap-down "just a trap". He
+bought calls across BankNIFTY (57600 CE, 1170), Sensex (900) and NIFTY (1430).
+
+It did not recover. And the reason he gives is new to this document.
+
+### The three rules
+
+**A SHARP SPIKE THAT IMMEDIATELY STALLS IS WHERE THE CALLS GOT WRITTEN.** The
+crowd is not only directional traders. Option WRITERS position against you, and
+they do it into a fast move because that is when the premium is richest. IH at
+7:01: "they suddenly produced positive momentum and WROTE the calls... so call
+writers are seated here. The market will not go much lower - but it will STAY
+negative. If they had written PUTS you would have seen a gradual recovery."
+
+What makes it actionable is the signature, which is **not a reversal**: momentum
+dies in BOTH directions - "one sell, one buy, one sell, one buy" - and price
+holds below the level it spiked through. For an option buyer that is the worst
+regime that exists: neither direction pays and theta runs throughout. So it is an
+EXIT read, and explicitly **not** a licence to flip short: the writers' interest
+is a range, not a collapse. `test_v4j_call_writer_rule_stays_an_exit_read_and_not_a_reversal_trade`
+guards that, because "writers are seated above" reads like a short signal and
+is not one.
+
+**THE PERMISSION TO WAIT ENDS WHEN THE TIME TO PROFIT BECOMES THE COST.** The
+third bound on v4h's loss-limit rule, and the one that makes it safe. You can be
+RIGHT that no large adverse move is coming and still have to leave, because "not
+falling" is not "rising". IH, cutting while still arguing the market would not
+break down much: "the market can definitely make our loss bigger. It will take a
+LOT of time to bring it back into profit. We CAN give time - but this trade does
+not look like it is going right." The test is neither the stop nor fear; it is
+whether the move that would pay you can still happen in the time you have.
+
+**CUTTING THE MIRROR ON A BANKNIFTY REVERSAL IS A VERDICT ON THE WHOLE BASKET.**
+This one comes from our own book rather than the video - see below.
+
+### How our agent traded the same session
+
+**Provisional - the runner was still live at 14:11.** Basket **-3,498.75** across
+59 legs. SL Hunting: **+60.00** over 3 trades, cross-checked against its own
+`Result summary` (Trades=3, RealizedPnL=60.00).
+
+| Time | Leg | P&L |
+|---|---|---|
+| 09:33 | NIFTY short / BNF mirror | +182.00 / +15.00 |
+| 09:56 | NIFTY long / BNF mirror | +58.50 / -63.00 |
+| 10:34 | **BNF mirror cut ALONE** | **+303.00** |
+| 10:40 | **NIFTY leg** | **-435.50** |
+
+Three things worth recording.
+
+**1. The pre-open note worked exactly as its own framing says it should.** The
+note is injected as "a VOTE... if your own live read disagrees with it, your read
+wins". At 09:31 the agent went SHORT and said so explicitly: *"this contradicts
+the pre-open note's buy-side plan but the live confirmed rejection overrides
+it."* That was the day's best trade (+197.00). Both trades that FOLLOWED the
+note's buy-side plan lost. First hard evidence the advisory is being weighed
+rather than obeyed.
+
+**2. `exit_leg` was used for the first time - and it is the source of the third
+rule.** v4i merged the night before; today the agent cut the BankNIFTY mirror
+alone at 10:34 on a confirmed BNF shooting star and bearish engulfing, booking
+**+303.00**, and held NIFTY because "its own read is unaffected", explicitly
+noting an opposing `cross_index` verdict and overriding it as "a caution".
+
+Six minutes later it closed NIFTY for **-435.50**, giving as its reason the very
+same fact: *"BankNIFTY turning down first is disqualifying regardless of NIFTY's
+own noise."* The information that ended the trade was already in hand when the
+mirror was cut; only the conclusion was late. Hence the rule: the per-leg escape
+is for an IDIOSYNCRATIC problem in the mirror, not for the leading index simply
+TURNING - because the index hierarchy says BankNIFTY leads. Its corollary closes
+the other half of the gap: an opposing `cross_index` verdict on an OPEN position
+does not force an exit by itself, but it removes the benefit of the doubt.
+
+**3. Agent and IH were wrong the same way.** Both read "breakdown then recovery =
+good traders seated long" and bought; both lost on the long side; both were
+rescued only by cutting. The market did what IH diagnosed at 7:01 - the spike was
+where the calls got written, and momentum died in both directions rather than
+reversing. Our agent had no concept for that participant, which is why the rule
+is worth its characters.
+
+One smaller flaw, already covered by existing knowledge rather than needing a new
+rule: the 09:55 long was a **51-second round trip** (09:55:38 -> 09:56:29, net
+-4.50). Its own exit reasoning says a bearish engulfing "has kept grinding lower
+for 5 bars" - a structure already visible when it entered. v4a's PREMIUM
+NON-CONFIRMATION already warns that "a trade you abandon within a bar or two of
+entry pays the round-trip cost for no exposure to the move".
+
+### Knowledge changes (v4j, all prose)
+
+- `RETAIL_POSITIONING`: A SHARP SPIKE THAT IMMEDIATELY STALLS IS WHERE THE CALLS
+  GOT WRITTEN.
+- `RISK`: THE PERMISSION TO WAIT ENDS WHEN THE TIME TO PROFIT BECOMES THE COST
+  (beside v4h's loss limit); CUTTING THE MIRROR ON A BANKNIFTY REVERSAL IS A
+  VERDICT ON THE WHOLE BASKET (beside v4i's lagging-index rule).
+- Three drift guards, each protecting the reading that would decay first: the
+  call-writer rule must not become a short signal, the basket rule must not
+  delete `exit_leg`, and the time rule must not become "cut anything slow".
+- Prompt size 118,049 -> 121,817 chars. Assembled 123,108 against a 154,140
+  budget: **31,032 chars of headroom.**

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
@@ -203,6 +203,23 @@ Don't gauge retail from indicators or raw S/R alone — read the OPENING GAP, wh
 retail is trapped, and the context of momentum. The whole edge is knowing where
 retail's stop-losses sit so you can trade where the operator will hunt them.
 
+- A SHARP SPIKE THAT IMMEDIATELY STALLS IS WHERE THE CALLS GOT WRITTEN (v4j). The
+  crowd you are reading is not only directional traders; option WRITERS position
+  against you, and they do it into a fast move because that is when the premium they
+  sell is richest. IH, watching a bought-call basket go wrong on expiry day: "they
+  suddenly produced positive momentum and WROTE the calls... so call writers are
+  seated here. The market will not go much lower — but it will STAY negative. If
+  they had written PUTS you would have seen a gradual recovery instead."
+  The signature is what makes this actionable, because it is NOT a reversal:
+  * Momentum dies in BOTH directions. "One sell, one buy, one sell, one buy" — the
+    market stops trending either way rather than turning against you.
+  * Price holds BELOW the level it spiked through and simply refuses to leave.
+  * The spike was fast and its failure was immediate; a move that is bought rather
+    than written keeps going, or retraces and resumes.
+  For an option BUYER this is the worst regime that exists: neither direction pays,
+  and theta runs the whole time. It is therefore an EXIT read, not a reversal read —
+  do not flip short expecting the crash, because the writers' interest is a RANGE,
+  not a collapse. Treat it as a hard stand-down for new entries at that level too.
 - GAP-UP open → retail is largely UN-positioned (caught off guard, few active
   shorts). With little trapped on the wrong side there's less to hunt, so a gap-up
   is more likely to FOLLOW its momentum than to reverse — don't reflexively fade it;
@@ -978,6 +995,26 @@ RISK DISCIPLINE
   This is a cross-index refinement of v4f's book-when-the-profit-stops-growing rule:
   that one watches the rate on your own P&L, this one names the leg that will stop it
   first, usually before the basket total shows it.
+- CUTTING THE MIRROR ON A BANKNIFTY REVERSAL IS A VERDICT ON THE WHOLE BASKET (v4j).
+  The per-leg escape above is for an IDIOSYNCRATIC problem in the mirror — a level
+  only BankNIFTY is at, a pattern only it printed. It is NOT for the case where
+  BankNIFTY has simply TURNED, because the index hierarchy says BankNIFTY leads: if
+  its reversal is real enough to close the mirror, it is real enough to disqualify
+  the NIFTY leg standing beside it. Before an `exit_leg` of "BNF", answer one
+  question out loud: is this BankNIFTY-only, or is BankNIFTY telling me the move is
+  over? If it is the second, the honest action is EXIT BOTH.
+  Measured on this book (2026-08-18): the mirror was cut alone at 10:34 on a
+  confirmed BankNIFTY shooting star and bearish engulfing, booking +303.00, with the
+  NIFTY leg held because "its own read is unaffected" and an opposing cross-index
+  verdict explicitly noted but overridden as "a caution". Six minutes later the same
+  BankNIFTY reversal was the stated reason to close NIFTY — "BankNIFTY turning down
+  first is disqualifying regardless of NIFTY's own noise" — for -435.50. The
+  information that ended the trade was already in hand when the mirror was cut; only
+  the conclusion was late.
+  Corollary for an OPEN position: an opposing `cross_index` verdict is a real vote
+  here too, not only at entry. It does not by itself force an exit while the premise
+  is intact, but it REMOVES the benefit of the doubt — pair it with any second
+  adverse fact and close, rather than requiring the stop to be tagged.
 - OPTION-TIME-ADJUSTED REWARD/RISK: require a worthwhile and ATTAINABLE target at a
   real swing / pivot / fibo / psych level. Normally prefer approximately 1:2
   reward:risk to the next clear level. An approximately 1:1 trade is permitted only
@@ -1179,6 +1216,17 @@ RISK DISCIPLINE
   It does NOT license entering merely because a move is fast and scary — you still
   need a named crowd, a level and a pattern. It tells you the edge is perishable
   once you have one.
+- THE PERMISSION TO WAIT ENDS WHEN THE TIME TO PROFIT BECOMES THE COST (v4j). The
+  third bound on the loss-limit rule below, and the one that makes it safe. You can
+  be RIGHT that no large adverse move is coming and still have to leave, because
+  "not falling" is not "rising". IH, cutting a losing expiry-day trade while still
+  arguing the market would not break down much: "the market can definitely make our
+  loss bigger. It will take a LOT of time to bring it back into profit. We CAN give
+  time — but this trade does not look like it is going right." So the test is not
+  the stop and not fear: it is whether the move that would pay you can still happen
+  in the time you have. When the answer needs the rest of the session, the wait has
+  already failed. On an expiry day this arrives fastest, because the premium is
+  draining while the range holds.
 - THE LOSS LIMIT IS A PERMISSION TO WAIT, NOT ONLY A PLACE TO STOP (v4h). Read
   this WITH v4e's DISCIPLINE IS ASYMMETRIC, not against it: that rule says cut a
   loser mechanically, this one says cut it AT the limit and not before, because

--- a/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_schema.py
+++ b/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_schema.py
@@ -1163,3 +1163,78 @@ def test_runaway_trend_section_is_composed_into_the_prompt():
     assert RUNAWAY_TREND.strip() in prompt
     # It belongs with the other continuation exception, before the levels rules.
     assert prompt.index("RUNAWAY TREND —") > prompt.index("OPENING DRIVE —")
+
+
+def test_v4j_call_writer_rule_stays_an_exit_read_and_not_a_reversal_trade():
+    """v4j (18 Aug live session): IH's losing expiry-day trade, diagnosed.
+
+    The dangerous misreading is obvious and expensive: "writers are seated
+    above" sounds like a short signal. It is not -- their interest is a RANGE,
+    so flipping short expects a collapse the mechanism argues against. The
+    stand-down and the both-directions signature are what make it usable.
+    """
+    prompt = build_system_prompt()
+    rule = _flat_rule(prompt, "A SHARP SPIKE THAT IMMEDIATELY STALLS")
+
+    # The signature is dead momentum BOTH ways, not a turn against you.
+    assert "Momentum dies in BOTH directions" in rule
+    assert "NOT a reversal" in rule
+    # The trap this rule must never become.
+    assert "do not flip short" in rule
+    assert "RANGE, not a collapse" in rule
+    # Why an option BUYER specifically must leave rather than sit.
+    assert "theta runs" in rule
+    assert "EXIT read" in rule
+
+
+def test_v4j_per_leg_cut_rule_does_not_cancel_the_v4i_per_leg_escape():
+    """A BankNIFTY reversal is a basket verdict; a BankNIFTY-only problem is not.
+
+    Read carelessly this rule deletes `exit_leg` entirely, which would undo
+    v4i and throw away a real host capability. The idiosyncratic-vs-turned
+    distinction is the whole rule, so it is asserted directly -- along with the
+    measured evidence, since the numbers are what make it more than an opinion.
+    """
+    prompt = build_system_prompt()
+    rule = _flat_rule(prompt, "CUTTING THE MIRROR ON A BANKNIFTY REVERSAL")
+
+    # The distinction that keeps v4i's escape hatch alive.
+    assert "IDIOSYNCRATIC" in rule
+    assert "is this BankNIFTY-only" in rule
+    assert "EXIT BOTH" in rule
+    # v4i's rule must still be present and still offer the per-leg cut.
+    lagging = _flat_rule(prompt, "THE LAGGING INDEX DECIDES THE BASKET'S EXIT")
+    assert "exit_leg" in lagging
+
+    # The measured 2026-08-18 sequence: +303.00 saved on the mirror, -435.50
+    # lost on the leg held six minutes longer on information already in hand.
+    assert "+303.00" in rule and "-435.50" in rule
+    assert "only the conclusion was late" in rule
+
+    # An opposing cross-index verdict on an OPEN position removes benefit of the
+    # doubt without becoming an automatic exit -- both halves must survive.
+    assert "It does not by itself force an exit while the premise" in rule
+    assert "REMOVES the benefit of the doubt" in rule
+
+
+def test_v4j_time_to_profit_rule_bounds_v4h_without_becoming_cut_everything():
+    """The third bound on THE LOSS LIMIT IS A PERMISSION TO WAIT.
+
+    Without it v4h reads as "sit until the stop"; with it read carelessly it
+    reads as "cut anything slow". The rule survives only if it keeps naming
+    what the test is NOT (the stop, and fear) alongside what it is.
+    """
+    prompt = build_system_prompt()
+    flat = " ".join(prompt.split())
+    rule = _flat_rule(prompt, "THE PERMISSION TO WAIT ENDS WHEN THE TIME TO PROFIT")
+
+    # It must sit with, and name, the rule it bounds.
+    assert "THE LOSS LIMIT IS A PERMISSION TO WAIT" in flat
+    assert "loss-limit rule below" in rule
+
+    # The counter-intuitive half: being right about direction is not enough.
+    assert '"not falling" is not "rising"' in rule
+    # It is neither the stop nor fear -- both exclusions must stay.
+    assert "not the stop and not fear" in rule
+    # And the concrete test that replaces them.
+    assert "in the time you have" in rule


### PR DESCRIPTION
## What

v4j, from IH's 18 Aug live session (`sSgO_Jole74`) — **a losing session, and the
most useful one in the series so far.** He diagnoses the loss mid-trade, names the
mechanism, and cuts. Every prior version learned from a win, or from a loss reviewed
afterwards; this is the first live post-mortem, and it identifies a market
participant the prompt had never modelled.

Knowledge-only. No runtime behaviour changes.

## The three rules

**A SHARP SPIKE THAT IMMEDIATELY STALLS IS WHERE THE CALLS GOT WRITTEN.** The crowd
isn't only directional traders — option **writers** position against you, and they do
it into a fast move because that's when the premium they sell is richest. IH at 7:01:
*"they suddenly produced positive momentum and WROTE the calls… so call writers are
seated here. The market will not go much lower — but it will STAY negative. If they
had written PUTS you would have seen a gradual recovery."*

The signature is what makes it usable, and it is **not a reversal**: momentum dies in
**both** directions — *"one sell, one buy, one sell, one buy"* — and price holds below
the level it spiked through. For an option buyer that's the worst regime that exists:
neither direction pays and theta runs throughout. So it's an **exit** read, explicitly
not a licence to flip short — the writers' interest is a range, not a collapse. That
misreading is the one the guard exists for.

**THE PERMISSION TO WAIT ENDS WHEN THE TIME TO PROFIT BECOMES THE COST.** The third
bound on v4h's loss-limit rule, and the one that makes it safe. You can be *right*
that no large adverse move is coming and still have to leave, because **"not falling"
is not "rising"**. IH, cutting while still arguing the market wouldn't break down
much: *"it will take a LOT of time to bring it back into profit. We CAN give time —
but this trade does not look like it is going right."* Neither the stop nor fear:
whether the move that pays you can still happen in the time you have.

**CUTTING THE MIRROR ON A BANKNIFTY REVERSAL IS A VERDICT ON THE WHOLE BASKET.** This
one comes from our own book — see below.

## v4i shipped last night, and `exit_leg` fired for the first time today

| Time | Leg | P&L |
|---|---|---|
| 09:33 | NIFTY short / BNF mirror | +182.00 / +15.00 |
| 09:56 | NIFTY long / BNF mirror | +58.50 / −63.00 |
| **10:34** | **BNF mirror cut ALONE** | **+303.00** |
| **10:40** | **NIFTY leg** | **−435.50** |

At 10:34 the agent cut the mirror alone on a confirmed BankNIFTY shooting star and
bearish engulfing (+303.00), holding NIFTY because *"its own read is unaffected"* —
explicitly noting an opposing `cross_index` verdict and overriding it as *"a caution"*.

Six minutes later it closed NIFTY for −435.50, giving as its reason the very same
fact: *"BankNIFTY turning down first is disqualifying regardless of NIFTY's own
noise."*

**The information that ended the trade was already in hand when the mirror was cut;
only the conclusion was late.** Hence the rule: the per-leg escape is for an
*idiosyncratic* problem in the mirror, never for the leading index simply **turning**
— the index hierarchy says BankNIFTY leads. Its corollary closes the other half: an
opposing `cross_index` verdict on an **open** position doesn't force an exit by
itself, but it removes the benefit of the doubt.

## Agent vs IH

SL Hunting: **+60.00** over 3 trades in a **−3,498.75** basket across 59 legs
(provisional — runner still live at 14:11). Cross-checked against its own
`Result summary`.

**Both were wrong the same way.** Both read "breakdown then recovery = good traders
seated long", both bought, both were rescued only by cutting. The market did what IH
diagnosed at 7:01 — the spike was where the calls got written, and momentum died in
both directions rather than reversing. Our agent had no concept for that participant,
which is what earns the rule its characters.

**The pre-open note is being weighed, not obeyed.** At 09:31 the agent went short and
said so: *"this contradicts the pre-open note's buy-side plan but the live confirmed
rejection overrides it."* That was the day's best trade (+197.00), and both trades
that *followed* the note's buy-side plan lost. First hard evidence the advisory works
as its own framing intends.

One smaller flaw recorded but **not** given a new rule, because existing knowledge
already covers it: the 09:55 long was a **51-second round trip** (net −4.50) whose own
exit reasoning cites a bearish engulfing that "has kept grinding lower for 5 bars" — a
structure already visible at entry. v4a's PREMIUM NON-CONFIRMATION already warns that
a trade abandoned within a bar or two pays the round trip for no exposure.

## Budget

```
assembled            : 123,108
budget for assembled : 154,140
headroom             :  31,032
```

## Gates

| Gate | Result |
|---|---|
| `Tests.test_nifty_multi_strategy_master` | 528 passed |
| `Tests.test_market_data_health` | 28 passed |
| `pytest "Tests/Signal Generators" "Tests/Dependencies" "Tests/Data Extractors"` | 1204 passed |
| Ruff | clean |
| mypy | 54 files, clean |
| compileall | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
