### PR TITLE
chore(sl-hunting): prose pruning pass — two merges, and why the rest stays

### DIFF
--- a/Signal Generators/SL Hunting AI Agent/premarket_note.json
+++ b/Signal Generators/SL Hunting AI Agent/premarket_note.json
@@ -1,28 +1,28 @@
 {
-  "for_date": "2026-08-18",
-  "source": "Intraday Hunter, 'Prediction For 18 AUG 2026' (UAHKZbgRaJA, uploaded 2026-08-17)",
-  "context": "NIFTY EXPIRY DAY. The breakdown trapped sellers and the market recovered, so the seated crowd is short, not long. Buyers who are already well in profit are NOT a target. Plan is BUY side, with the market.",
+  "for_date": "2026-08-19",
+  "source": "Intraday Hunter, 'Prediction For 19 AUG 2026' (_WvVlwJ6NqY, uploaded 2026-08-18)",
+  "context": "NO trend and NO momentum: a trader can enter but cannot hold. So there is no directional thesis today - follow the market, and do not fight a good opening. Yesterday closed slightly negative, so a few sellers may be seated.",
   "plan": [
-    "SMALL GAP-UP, FLAT, or SLIGHT GAP-DOWN: identify confirmed BUY-side setups and go with the market.",
-    "LARGE GAP-UP: NO PLAN, stand aside. A big gap makes others focus on buying too, or at least stop selling, which removes the crowd the trade needs.",
-    "A LARGE GAP-UP means an opening ABOVE the FIRST RESISTANCE; for BANKNIFTY, an opening above the round number also cancels the plan.",
-    "The trapped crowd is the SELLERS from the breakdown; do not build the trade around targeting buyers, who are already in profit and should not hold big size."
+    "FLAT or GAP-UP: identify confirmed BUY-side setups. The thin seller crowd left by yesterday's negative close is the target; do not fight an opening that goes up.",
+    "GAP-DOWN: identify confirmed SELL-side setups and go WITH the market. Sellers are already into profit on a gap-down, so they cannot be the target.",
+    "This is a REACTIVE day, not a thesis day: the side is decided by the open, not before it. Neither branch is a reason to enter without the usual pattern and confirmation.",
+    "With no trend and no momentum, expect entries that cannot be held. Size the expectation down and book what the move actually gives."
   ],
   "levels": [
     {
       "index": "NIFTY",
-      "resistance": [24440, 24540],
-      "support": [24210, 24270]
+      "resistance": [24230, 24360],
+      "support": [24000, 24100]
     },
     {
       "index": "BANKNIFTY",
-      "resistance": [57800, 58000],
-      "support": [57120, 57400]
+      "resistance": [57460, 57800],
+      "support": [56960, 57120]
     },
     {
       "index": "SENSEX",
-      "resistance": [78000, 78200],
-      "support": [77460, 77650]
+      "resistance": [77550, 77800],
+      "support": [76800, 77000]
     }
   ]
 }

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -3864,3 +3864,64 @@ entry pays the round-trip cost for no exposure to the move".
   delete `exit_leg`, and the time rule must not become "cut anything slow".
 - Prompt size 118,049 -> 121,817 chars. Assembled 123,108 against a 154,140
   budget: **31,032 chars of headroom.**
+
+---
+
+## The prose pruning pass (2026-08-18)
+
+Promised when `MAX_SYSTEM_PROMPT_CHARS` was raised: pruning superseded prose is
+worth doing on its own merits, judged on whether the result reads better, never
+to buy space. This is that pass, done with 31,000 characters of headroom in hand
+so nothing was under pressure to go.
+
+**The headline finding is that there is very little to prune.** 115 bulleted
+rules across 12 sections, and the clusters that look redundant from a list of
+headings turn out to be deliberately paired. Two changes were made. Several
+obvious-looking candidates were examined and deliberately kept, which is the more
+useful result to record.
+
+### Examined and KEPT
+
+| Pair | Why it stays |
+|---|---|
+| `PRE-COMMIT THE ADVERSE MOVE` (v4d) vs `NAME THE LAST POINT` (v4e) | One is a MAGNITUDE, the other a LOCATION plus a deadline. v4e already says so in its own text. |
+| `A FORECAST OF WHO WILL ARRIVE` (v4e) vs `AN EMPTY BOOK MEANS A TRAP IS COMING` (v4f) | A deliberate dialectic from two real sessions — 11 Aug (predicted, lost) against 12 Aug (waited for confirmation, won). v4f is framed as the reconciliation of v4e. Deleting either destroys the lesson. |
+| `REPEATED-FAILURE INVENTORY RESET` vs `DIRECT-MOMENTUM / CURRENT-SESSION TRAP RESET` | Both "resets", different triggers: one is level-based (repeated reclaims evict sellers), one is time-based (the opening thrust supersedes yesterday's crowd). |
+| `NO INSTANT FLIP` / `MOVE-EXHAUSTION` / `POST-EXIT RE-ENTRY GATE` | Opposite-direction, same-direction, and the mechanical check. Each names the others; the gate's "a different pattern name on the same structure is not a new premise" is an anti-rationalisation guard worth its length on its own. |
+| `YOUR ENTRY PRICE IS THE FOURTH TARGET INPUT` / `CROWD SIZE IS THE THIRD` | A numbered series of distinct inputs, not restatements. |
+
+The reason for this is structural, and worth knowing before the next pass: **this
+series has reconciled every new rule against its neighbours as it landed.** The
+prose is full of "Distinct from X, which is...", "scopes the rule above", "this is
+the TEST that Y implies", "NOT the fear rule above in disguise". Those sentences
+are the redundancy check, already run, one version at a time. A future pass should
+expect to find little, and should treat a rule that does NOT reconcile itself
+against a neighbour as the suspicious one.
+
+### Changed
+
+**1. `POST-LOSS SPEED LIMIT` absorbed `Loss recovery discipline`.** These were one
+protocol split across two bullets 16 lines apart, and the shared half — do not
+take the next trade immediately after a loss — was stated in both. Merged, keeping
+the `POST-LOSS SPEED LIMIT` name because `NO INSTANT FLIP` defers to it by name.
+The recovery half (spread a big loss over several ordinary trades; distrust the
+day's "one last trade") survives intact.
+
+**2. `BOOK WHEN THE PROFIT STOPS GROWING` (v4f) gave up its first support bullet.**
+Both v4f and v4g's `NEVER EXIT AT ZERO` told the agent that a profit it merely SAW
+counts. The two rules themselves are distinct and both stay — v4f is the exit
+TRIGGER (the rate of gain), v4g is the FLOOR (what an acceptable exit looks like
+once profit has printed) — but the idea was written twice and owned by neither.
+v4f now states the trigger and points at v4g.
+
+Net effect on size: **-206 characters.** That is the correct order of magnitude for
+this pass and is not the point; the point is that two ideas now have one home each.
+
+### Also fixed: a test helper that could assert against the wrong rule
+
+`_flat_rule` located a rule with a bare `prompt.index(heading)`. Because rules cite
+each other by name, that could land on another rule's CROSS-REFERENCE and silently
+assert against the wrong prose — the new `POST-LOSS SPEED LIMIT` test failed this
+way and exposed it. It now anchors on the bullet (`"\n- " + heading`) and falls
+back to the bare heading. This is the same class of bug as the v4i locator
+collision, which suggests the pattern rather than the instance was the problem.

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
@@ -1169,14 +1169,11 @@ RISK DISCIPLINE
   stop easily, so the target may be BIG... we are not exiting now" — and closed
   the moment that changed: "now see, the profit has started REDUCING. So let us
   book. The more smoothly the profit comes, the better."
-  Two supports he gives for it, both worth keeping:
-    * "Especially if we have ALREADY SEEN a good target, after that we should not
-      be greedy." A target that has been printed on the screen counts as reached,
-      even if you did not take it there.
-    * "We had already captured one momentum... if any retracement becomes a bit
-      too big it becomes a problem for us." One captured leg is a complete trade;
-      the second leg is a new trade needing its own premise, not a continuation
-      of this one's entitlement.
+  His support for it: "we had already captured one momentum... if any retracement
+  becomes a bit too big it becomes a problem for us." One captured leg is a
+  complete trade; the second leg is a new trade needing its own premise, not a
+  continuation of this one's entitlement. What a PRINTED but untaken profit then
+  obliges you to accept is NEVER EXIT AT ZERO's job, not this rule's.
   This is the general form of BOOK BEFORE THE ROUND NUMBER (v4d): that rule names
   WHERE the late crowd's targets sit, this one names WHEN your own edge has been
   spent regardless of where price is.
@@ -1498,7 +1495,9 @@ RISK DISCIPLINE
 - POST-LOSS SPEED LIMIT: after a loss, quick-decision mode is disabled. Wait for
   a fresh, deliberate, high-quality setup with a named target crowd and clear
   invalidation before trading again; never use the next candle as a recovery
-  attempt.
+  attempt. Recover a BIG loss across MULTIPLE ordinary trades, never in one, and
+  distrust the "one last trade" of the day — taking the next trade immediately is
+  where revenge trading starts, and that last trade is where over-trading does.
 - MORNING SPEED IS NOT INFORMATION: in the opening window momentum resolves within
   a couple of bars in EITHER direction, so a morning trade stopped out within
   minutes is ORDINARY morning behaviour. The SPEED of that stop-out tells you
@@ -1511,10 +1510,6 @@ RISK DISCIPLINE
   second trade of the morning — a genuinely fresh premise after a stop-out is
   allowed and has paid. What is banned is the reflex retry whose only new evidence
   is that the last one ended fast.
-- Loss recovery discipline: after a losing trade, do NOT take the next trade
-  immediately (that reflex is where revenge trading starts); recover a BIG loss
-  across MULTIPLE ordinary trades, never in one; and beware the "one last trade"
-  of the day — it is the classic start of over-trading.
 """
 
 

--- a/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_premarket.py
+++ b/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_premarket.py
@@ -201,21 +201,18 @@ def test_shipped_note_targets_the_next_TRADING_day_not_the_next_calendar_day():
     )
 
 
-def test_shipped_note_matches_august_18_intraday_hunter_plan():
-    """The committed advisory must match the hand-checked 17 Aug transcript.
+def test_shipped_note_matches_august_19_intraday_hunter_plan():
+    """The committed advisory must match the hand-checked 18 Aug transcript.
 
-    This catches a stale prior-session note, an inverted gap plan, or a mistyped
-    chart level before the dated note is injected into the live prompt.
+    This one is structurally different from every prior note and the difference
+    is the point: there is NO directional thesis. IH opens with "the market must
+    have either a trend or momentum... right now there is neither, so a trader
+    builds a trade but cannot hold it", and concludes "we will ONLY follow the
+    market". Both branches are therefore live, and a summarising edit that picked
+    a side would invert half the plan.
 
-    Two things distinguish this session and are asserted rather than summarised:
-
-    1. The direction INVERTS from 17 Aug. The breakdown trapped SELLERS and the
-       market recovered, so the plan is BUY side. A note that still reads
-       "sell-side" is the exact stale-note failure this test exists to catch.
-    2. The stand-aside branch is a LARGE GAP-UP -- and it is DEFINED (an open
-       above the first resistance), which is what makes it checkable at 09:15
-       instead of a judgement call. Losing that definition would quietly turn a
-       hard veto into an opinion.
+    The SENSEX supports came through the auto-caption merged into one token
+    and were read off the chart by hand; see the assertion below.
     """
     import os
 
@@ -224,40 +221,38 @@ def test_shipped_note_matches_august_18_intraday_hunter_plan():
     note = load_premarket_note(shipped)
 
     assert note is not None
-    assert note.for_date == "2026-08-18"
-    assert "UAHKZbgRaJA" in note.source
-    # Expiry is session context the RISK rules already act on; it must survive.
-    assert "NIFTY EXPIRY DAY" in note.context
-    assert "seated crowd is short, not long" in note.context
-    assert note.plan == [
-        "SMALL GAP-UP, FLAT, or SLIGHT GAP-DOWN: identify confirmed BUY-side "
-        "setups and go with the market.",
-        "LARGE GAP-UP: NO PLAN, stand aside. A big gap makes others focus on "
-        "buying too, or at least stop selling, which removes the crowd the "
-        "trade needs.",
-        "A LARGE GAP-UP means an opening ABOVE the FIRST RESISTANCE; for "
-        "BANKNIFTY, an opening above the round number also cancels the plan.",
-        "The trapped crowd is the SELLERS from the breakdown; do not build the "
-        "trade around targeting buyers, who are already in profit and should "
-        "not hold big size.",
-    ]
+    assert note.for_date == "2026-08-19"
+    assert "_WvVlwJ6NqY" in note.source
+    assert "NO trend and NO momentum" in note.context
+    assert "no directional thesis" in note.context
+
+    # Both branches must survive, and in opposite directions.
+    buy_side = next(line for line in note.plan if line.startswith("FLAT or GAP-UP"))
+    sell_side = next(line for line in note.plan if line.startswith("GAP-DOWN"))
+    assert "BUY-side" in buy_side and "SELL-side" not in buy_side
+    assert "SELL-side" in sell_side and "BUY-side" not in sell_side
+    # The reason the gap-down branch cannot hunt sellers.
+    assert "already into profit" in sell_side
+
     assert [level.model_dump() for level in note.levels] == [
         {
             "index": "NIFTY",
-            # Caption garbles the second resistance as "2440"; it is 24440,
-            # unchanged from the 17 Aug note and consistent with the pair he
-            # reads out ("24540, 24440").
-            "resistance": [24440.0, 24540.0],
-            "support": [24210.0, 24270.0],
+            "resistance": [24230.0, 24360.0],
+            "support": [24000.0, 24100.0],
         },
         {
             "index": "BANKNIFTY",
-            "resistance": [57800.0, 58000.0],
-            "support": [57120.0, 57400.0],
+            "resistance": [57460.0, 57800.0],
+            "support": [56960.0, 57120.0],
         },
         {
+            # The auto-caption ran BOTH Sensex supports together into one token,
+            # "776,800" -- which is 77,000 and 76,800 with the boundary lost.
+            # Read off the chart by the operator rather than inferred: the token
+            # is consistent with several splits and a guessed level in
+            # live-money knowledge is worse than no level at all.
             "index": "SENSEX",
-            "resistance": [78000.0, 78200.0],
-            "support": [77460.0, 77650.0],
+            "resistance": [77550.0, 77800.0],
+            "support": [76800.0, 77000.0],
         },
     ]

--- a/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_schema.py
+++ b/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_schema.py
@@ -940,8 +940,15 @@ def _flat_rule(prompt: str, heading: str) -> str:
 
     Rule prose is hard-wrapped, so asserting on wording against the raw prompt
     breaks whenever a paragraph is re-flowed -- a change the agent never sees.
+
+    Anchors on the BULLET ("\n- HEADING") in preference to a bare match, because
+    rules cite each other by name: a plain `.index(heading)` can land on another
+    rule's cross-reference and silently assert against the wrong prose. Falls
+    back to the bare heading so a non-bullet heading still resolves.
     """
-    body = prompt[prompt.index(heading):]
+    bullet = "\n- " + heading
+    start = prompt.find(bullet)
+    body = prompt[start + 1:] if start != -1 else prompt[prompt.index(heading):]
     if "\n- " in body:
         body = body[: body.index("\n- ")]
     return " ".join(body.split())
@@ -1238,3 +1245,48 @@ def test_v4j_time_to_profit_rule_bounds_v4h_without_becoming_cut_everything():
     assert "not the stop and not fear" in rule
     # And the concrete test that replaces them.
     assert "in the time you have" in rule
+
+
+def test_post_loss_speed_limit_keeps_both_halves_and_the_name_others_cite():
+    """The post-loss protocol was two overlapping rules; it is now one.
+
+    Two things could regress silently. NO INSTANT FLIP defers to this rule BY
+    NAME, so a rename leaves a dangling pointer that no import or type check
+    would catch. And the merge folded in the recovery half -- spread a big loss
+    over several trades, distrust the day's "one last trade" -- which is the
+    part a future tightening pass would drop first, because it reads like a
+    restatement of the cooldown when it is actually about position sizing of
+    the recovery.
+    """
+    prompt = build_system_prompt()
+    rule = _flat_rule(prompt, "POST-LOSS SPEED LIMIT")
+
+    # The name other rules cite.
+    assert "POST-LOSS SPEED LIMIT then governs" in " ".join(prompt.split())
+
+    # Half one: no fast re-entry.
+    assert "quick-decision mode is disabled" in rule
+    assert "never use the next candle as a recovery attempt" in rule
+    # Half two: how a big loss is recovered, and the end-of-day trap.
+    assert "MULTIPLE ordinary trades, never in one" in rule
+    assert "one last trade" in rule
+
+
+def test_printed_profit_obligation_is_owned_by_exactly_one_rule():
+    """v4f states the exit TRIGGER; v4g owns what a printed profit obliges.
+
+    Both rules stay -- they are a trigger and a floor -- but the "a target you
+    saw counts as reached" idea was written into both, so a reader met it twice
+    and neither rule owned it. v4f now points at v4g instead.
+    """
+    prompt = build_system_prompt()
+    book = _flat_rule(prompt, "BOOK WHEN THE PROFIT STOPS GROWING")
+    floor = _flat_rule(prompt, "NEVER EXIT AT ZERO AFTER A GOOD PROFIT HAS PRINTED")
+
+    # v4f keeps the trigger and defers the floor.
+    assert "the RATE at which the position is still gaining" in book
+    assert "NEVER EXIT AT ZERO's job, not this rule's" in book
+    assert "ALREADY SEEN a good target" not in book
+
+    # v4g still owns it.
+    assert "the floor for that trade stops being breakeven" in floor


### PR DESCRIPTION
> **Stacked on [#128](https://github.com/DoRmAmMu1997/My-Algo-Trading-Code/pull/128) (v4j)**, not `main` — the pass had to
> cover v4j's rules too. Merge #128 first; GitHub will retarget this to `main`.

## What

The pruning pass I promised when the sanity bound was raised: *"pruning genuinely
superseded prose is still worth doing on its own merits; it is just never a way to buy
space under this number."*

Done with **31,000 characters of headroom in hand**, so nothing was under pressure to go.

## The finding: there is very little to prune

115 bulleted rules across 12 sections. The clusters that look redundant from a list of
headings turn out to be **deliberately paired**. Two changes were made; several
obvious-looking candidates were examined and kept — which is the more useful result.

| Pair | Why it stays |
|---|---|
| `PRE-COMMIT THE ADVERSE MOVE` vs `NAME THE LAST POINT` | One is a MAGNITUDE, the other a LOCATION plus a deadline. v4e already says so in its own text. |
| `A FORECAST OF WHO WILL ARRIVE` vs `AN EMPTY BOOK MEANS A TRAP IS COMING` | A deliberate dialectic from two real sessions — 11 Aug (predicted, lost) vs 12 Aug (waited for confirmation, won). Deleting either destroys the lesson. |
| the two `RESET` rules | Both "resets", different triggers: level-based vs time-based. |
| `NO INSTANT FLIP` / `MOVE-EXHAUSTION` / `POST-EXIT RE-ENTRY GATE` | Opposite-direction, same-direction, mechanical check. The gate's "a different pattern name on the same structure is not a new premise" is an anti-rationalisation guard worth its length alone. |
| the numbered target-input series | Distinct inputs, not restatements. |

**Why**: this series has reconciled every new rule against its neighbours *as it landed*.
The prose is full of *"Distinct from X, which is…"*, *"scopes the rule above"*, *"NOT the
fear rule above in disguise"*. Those sentences **are** the redundancy check, already run,
one version at a time.

That's worth recording for the next pass: expect to find little, and treat a rule that
does **not** reconcile itself against a neighbour as the suspicious one.

## Changed

**`POST-LOSS SPEED LIMIT` absorbed `Loss recovery discipline`** — one protocol split
across two bullets 16 lines apart, with the shared half (*don't take the next trade
immediately after a loss*) stated in both. Keeps the `POST-LOSS SPEED LIMIT` name,
because `NO INSTANT FLIP` defers to it **by name**. The recovery half survives intact.

**`BOOK WHEN THE PROFIT STOPS GROWING` (v4f) gave up its first support bullet** — both it
and v4g's `NEVER EXIT AT ZERO` told the agent that a profit it merely *saw* counts. Both
rules stay (v4f is the exit **trigger**, v4g is the **floor**), but the idea was written
twice and owned by neither. v4f now states the trigger and points at v4g.

Net: **−206 characters.** That's the right order of magnitude and not the point — two
ideas now have one home each.

## A test helper that could assert against the wrong rule

`_flat_rule` located a rule with a bare `prompt.index(heading)`. Because rules cite each
other by name, that could land on another rule's **cross-reference** and silently assert
against the wrong prose:

```
AssertionError: assert 'quick-decision mode is disabled' in
'POST-LOSS SPEED LIMIT, which governs how fast you may RE-ENTER; this governs
how much you demand from the trade you are already in.)'
```

My new test failed exactly that way and exposed it. It now anchors on the bullet
(`"\n- " + heading`), falling back to the bare heading. Same class as the v4i locator
collision, so this fixes the pattern rather than the instance — and the two earlier
rules that hit it are now protected by construction.

## Gates

| Gate | Result |
|---|---|
| `Tests.test_nifty_multi_strategy_master` | 528 passed |
| `Tests.test_market_data_health` | 28 passed |
| `pytest "Tests/Signal Generators" "Tests/Dependencies" "Tests/Data Extractors"` | 1206 passed |
| Ruff / mypy / compileall | clean |

Knowledge-only — no runtime behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
