### PR TITLE
feat(sl-hunting): v4m knowledge from the 21 Aug IH live session

### DIFF
--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -4266,3 +4266,121 @@ and out three times in 26 minutes, its best trade lasting two.
   becoming "waiting is safer".
 - Prompt size 125,054 -> 128,303 chars. Assembled 129,594 against a 154,140
   budget: **24,546 chars of headroom.**
+
+---
+
+## Video addendum - the 21 Aug LIVE SESSION (v4m)
+
+**Source:** Intraday Hunter live session `yacw-NpZq30` (21 Aug 2026, 10:11).
+
+**Both IH and our agent lost, on the same side, for the same reason.** That
+alignment is rare and makes this the most directly comparable session in the
+series: the pre-open note said sell-side, IH bought puts across all three indices
+inside two minutes of the open, our agent shorted four times in 51 minutes, and
+neither got the move.
+
+### One precondition, named before the trade and missing all day
+
+The whole session turns on a single checkable gate. IH, mid-trade: "if momentum
+comes, we need the CLOSING PRICE breakdown - especially BankNIFTY's. If it breaks
+that, we get a good move." And then the property that makes it cheap to check:
+
+> All three indices have held it. It is not the case that it breaks in one and
+> stays in another: either the market falls in all three, or it stops. **If it
+> breaks in even ONE index it will break in all three; if it does not break in
+> even one, all three will sit and hold.**
+
+His post-mortem is the same sentence inverted: "no index broke the closing price,
+and until that level breaks no rejection could come." He also names his own error
+- "the gap-up was not large, rejection started right at the open, so we made our
+entry EARLY too."
+
+The existing `CLOSING-PRICE BREAKDOWN IS THE TRIGGER` rule already said the
+breakdown is the trigger and that sitting on the level is not breaking it, so this
+is recorded as an EXTENSION rather than a new bullet. What is new is the
+all-or-nothing property, the fact that the failure mode while it holds is CHOP
+rather than a clean loss - "the fear of a sideways market is there every day now"
+- and that a rejection at the open is a reason to WATCH the level, never a
+substitute for it breaking.
+
+### The loss limit is regime-conditional
+
+v4h says the limit is a permission to WAIT, bounded by elapsed time (v4j). Today
+adds a third bound: "when it is a momentum market we do sit, and we do let the
+loss grow a bit, because the next day gives a chance to cover it. But these days
+there is not much momentum, so there is no benefit in making the loss bigger
+here."
+
+So what buys the right to sit toward the limit is a market that still MOVES. The
+reconciliation matters more than the rule: read carelessly this becomes "cut early
+when it feels slow", which is precisely the error v4h exists to prevent. The prose
+keeps all three bounds naming an OBSERVABLE - the limit, the clock, the regime -
+and none of them licenses cutting on feel.
+
+### How our agent traded the same session
+
+**Complete session.** Basket **-12,912.00** across 68 legs, a bad day everywhere.
+SL Hunting: **-2,300.75** over 4 trades, its worst of the series and the worst
+single strategy on the board.
+
+| Time | Leg | P&L | Held |
+|---|---|---|---|
+| 09:28 | NIFTY short / BNF mirror | +419.25 / **-1,539.00** | 7 min |
+| 09:36 | NIFTY short / BNF mirror | -312.00 / -768.00 | 1m47s |
+| 10:00 | NIFTY short / BNF mirror | -240.50 / +48.00 | 1m51s |
+| 10:12 | NIFTY short / BNF mirror | +312.00 / -220.50 | 7 min |
+
+**1. Four shorts, and the leading index killed every one.** Each exit names it
+correctly - "per index hierarchy, BankNIFTY turning against the trade is
+disqualifying for the whole basket, not just the mirror leg" - and then the next
+entry is justified fresh on NIFTY patterns as though BankNIFTY had not just
+refused. The disqualifying fact was true of the SESSION, not of one position, and
+it never carried forward. That is the new rule, and this is the clearest example
+the journal has.
+
+**2. The stale hatch was used selectively, for the second session running.** At
+10:05 `cross_index` was dismissed - "'both at resistance/bias up' looks stale
+given the live rollover" - to justify an ENTRY. At 10:12, seven minutes later, the
+SAME verdict was cited as a reason to EXIT. The 20 Aug session did it at 09:18 and
+09:27. In every instance the re-rating favoured the action already chosen.
+
+v4l recorded the first occurrence with "noted so the next occurrence is the second
+data point rather than the first". It arrived the next day, so v4m legislates: the
+hatch stays open, but staleness must be judged from the verdict's age and
+anchoring, never from whether it agrees. The test the agent can actually run is
+"would I still call it stale if it AGREED with me right now?"
+
+**3. v4l's cut-every-leg rule was applied correctly and immediately.** Every one of
+the four exits closed BOTH legs, and two say why in v4l's own language - "exiting
+both legs since BankNIFTY structure confirms the same uptrend, not an idiosyncratic
+mirror-only issue". No per-leg cut was attempted. On the evidence the rule is being
+read and applied; it did not save the day, because the entries were the problem.
+
+**4. The 09:28 exit still described the trade by its healthy leg.** The reasoning
+reads "Booked the healthy NIFTY leg (+585) and closed the mirror together" while
+the mirror was **-1,539.00** and the basket about **-1,120**. The ACTION was right
+and cited the basket-exit rule; the characterisation was not. v4k already demands
+the basket number when justifying a HOLD - this was an EXIT, so no rule was broken,
+but the same habit of narrating by the favourable leg is visible and worth watching.
+
+**5. The note was followed four times and lost every time.** It said sell-side; all
+four entries were shorts citing it. It also carried an explicit warning - "EVIDENCE
+IS WEAKER ON NIFTY AND SENSEX... demand a cleaner confirmation" - which the entries
+cite as satisfied without engaging with the weakness. Across five sessions the
+note-versus-override record now points both ways with no pattern; the honest reading
+is that it is one vote, exactly as its own header says.
+
+### Knowledge changes (v4m)
+
+- `OPENING_DRIVE`: `CLOSING-PRICE BREAKDOWN IS THE TRIGGER` extended with the
+  all-or-nothing cross-index property, the sideways failure mode, and the
+  early-entry trap.
+- `RISK`: v4h's loss-limit permission extended with the regime condition; two new
+  rules - THE FACT THAT DISQUALIFIED YOUR LAST TRADE STILL HOLDS, and YOU MAY NOT
+  RE-RATE A SIGNAL TO SUIT THE DECISION YOU WANT.
+- Four drift guards: the closing-price rule must keep the binary property and the
+  early-entry trap, the regime bound must not license cutting on feel, the
+  session-fact rule must stay specific to the LEADING index, and the re-rating rule
+  must not read as closing the stale hatch.
+- Prompt size 128,303 -> 132,468 chars. Assembled 133,759 against a 154,140
+  budget: **20,381 chars of headroom.**

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
@@ -723,6 +723,23 @@ Conditions (ALL must hold — otherwise this branch simply does not apply):
   trades BELOW THE PREVIOUS CLOSE across the indices. Sitting on that level is not
   breaking it. If the breakdown never arrives the trade never existed: no
   breakdown, no stop-fuel, and nothing to hold on to (see RISK).
+  IT IS ALL-OR-NOTHING ACROSS THE INDICES, AND UNTIL IT BREAKS EXPECT SIDEWAYS
+  (v4m). IH, mid-trade, on a short that needed it and never got it: "if momentum
+  comes, we need the CLOSING PRICE breakdown -- especially BankNIFTY's. If it
+  breaks that, we get a good move... all three indices have held it. It is not
+  the case that it breaks in one and stays in another: either the market falls in
+  all three, or it stops. If it breaks in even ONE index it will break in all
+  three; if it does not break in even one, all three will sit and hold."
+  So the check is cheap and binary — look at ONE index's closing price and you
+  have read all of them. Two consequences:
+  * The failure mode when it has not broken is not a clean loss, it is CHOP.
+    "The fear of a sideways market is there every day now" — and sideways is the
+    regime that pays an option BUYER nothing in either direction.
+  * An early entry on the rejection ALONE is the trap. He took one and said so:
+    "the gap-up was not large, rejection started right at the open, so we made
+    our entry EARLY too. But no index broke the closing price, and until that
+    level breaks no rejection could come." Rejection at the open is a reason to
+    WATCH the level, not a substitute for it breaking.
 - GAP SIZE IS A RISK DIAL, NOT A CONFIDENCE DIAL. A BIGGER gap does NOT make this
   branch stronger — it makes it worse. A modest gap leaves price near the stop
   clusters that fuel a move; an oversized gap has jumped clean past everybody's
@@ -1291,6 +1308,17 @@ RISK DISCIPLINE
   holding the first adverse leg but running on the SECOND. Same error, different
   depths. So the limit is two-sided — it forbids holding past it, AND forbids
   cutting inside it on feel. Only the rule below legitimately overrides it.
+  THE PERMISSION IS REGIME-CONDITIONAL (v4m). What buys the right to sit toward
+  the limit is a market that still MOVES. IH, cutting early on a low-momentum
+  day: "when it is a momentum market we do sit, and we do let the loss grow a
+  bit, because the next day gives a chance to cover it. But these days there is
+  not much momentum, so there is no benefit in making the loss bigger here."
+  So in a market that is trending or moving, the patience above stands as
+  written; in one that keeps stalling into sideways, the limit stops being a
+  place worth waiting for, because neither this session nor the next offers the
+  move that would pay it back. This is a third bound alongside elapsed time —
+  the limit, the clock, and the regime — and none of them licenses cutting on
+  feel: each names an observable that has changed.
 - TIME SPENT IN THE TRADE SHRINKS THE ACHIEVABLE TARGET (v4g). Elapsed time is a
   cost in its own right, separate from price. A trade that stalls and round-trips
   does not merely return to where it started — it returns with less of the
@@ -1496,6 +1524,33 @@ RISK DISCIPLINE
     have an independent reason the market can move — expiry only adds fuel to a premise
     you already hold. (This TEMPERS the "expiry = extra FUEL" note in BANK NIFTY —
     SPECIFIC BEHAVIOUR: fuel for an existing thesis, never a thesis of its own.)
+- THE FACT THAT DISQUALIFIED YOUR LAST TRADE STILL HOLDS (v4m). A reason to exit
+  is usually a fact about the SESSION, not about that one position, and it does not
+  expire when the position closes. Carry it into the next entry as a raised bar on
+  that DIRECTION, or you will take the same trade again with a new pattern name.
+  Measured on this book (2026-08-21), which is the clearest example the journal has:
+  FOUR shorts were opened in 51 minutes and every one was closed because BankNIFTY —
+  the leading index — turned UP against it. The exits name it explicitly and
+  correctly ("per index hierarchy, BankNIFTY turning against the trade is
+  disqualifying for the whole basket"), then the next entry is justified fresh on
+  NIFTY patterns as though the leading index had not just refused four times. Net
+  -2,300.75, the worst session of the series.
+  So: after an exit caused by the LEADING index opposing you, that direction needs
+  more than a fresh NIFTY pattern — it needs BankNIFTY itself to stop opposing.
+  Until that changes, the honest output is HOLD, however good the NIFTY setup looks.
+- YOU MAY NOT RE-RATE A SIGNAL TO SUIT THE DECISION YOU WANT (v4m). The companion
+  failure, from the same session and the one before it. `cross_index` may be
+  discounted as stale inside the opening hour — that hatch is real and its scope is
+  written above — but the choice must be made from the signal's age and anchoring,
+  never from whether it agrees with you. Measured: at 10:05 it was dismissed
+  ("cross_index's mechanical 'both at resistance/bias up' read looks stale given the
+  live rollover") to justify an entry, and at 10:12, seven minutes later, the SAME
+  verdict was cited as a reason to exit. The previous session did the same thing at
+  09:18 and 09:27. In every instance the re-rating favoured the action already
+  chosen.
+  The test to apply before using the word "stale": would I still call it stale if it
+  AGREED with me right now? If not, it is not stale, it is inconvenient — and an
+  inconvenient signal is the one worth reading.
 - POST-EXIT RE-ENTRY GATE (the MECHANICAL check for the two rules above — they are
   judgement, and judgement alone has proven too easy to talk past): after ANY exit,
   before you may open the NEXT position in EITHER direction, ALL of these must hold.

--- a/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_schema.py
+++ b/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_schema.py
@@ -1424,3 +1424,83 @@ def test_v4l_entry_time_rule_is_a_tradeoff_not_a_preference_for_waiting():
     assert "size the EXPECTATION as well as the" in rule
     # Kept distinct from the rule it sits beside.
     assert "MORNING SPEED IS NOT INFORMATION" in rule
+
+
+def test_v4m_closing_price_rule_gains_the_all_or_nothing_cross_index_property():
+    """v4m (21 Aug live session): IH lost on the same side our agent did.
+
+    The existing rule already said the breakdown is the trigger. What today
+    adds is that it is BINARY ACROSS INDICES -- so the check is cheap -- and
+    that the failure mode while it holds is CHOP rather than a clean loss. The
+    early-entry trap is asserted too, because it is the error IH made and the
+    one an opening rejection most invites.
+    """
+    prompt = build_system_prompt()
+    rule = _flat_rule(prompt, "CLOSING-PRICE BREAKDOWN IS THE TRIGGER")
+
+    assert "ALL-OR-NOTHING ACROSS THE INDICES" in rule
+    assert "it will break in all three" in rule
+    assert "all three will sit and hold" in rule
+    # The regime it leaves you in, which is the part that costs an option buyer.
+    assert "it is CHOP" in rule
+    # And the trap: a rejection at the open is not the breakdown.
+    assert "not a substitute for it breaking" in rule
+
+
+def test_v4m_loss_limit_permission_is_regime_conditional_without_licensing_feel():
+    """The third bound on v4h, alongside the clock.
+
+    Read carelessly this becomes "cut early when it feels slow", which is the
+    exact error v4h exists to prevent. The prose has to keep naming an
+    OBSERVABLE, so the assertion checks the reconciliation survives.
+    """
+    prompt = build_system_prompt()
+    rule = _flat_rule(prompt, "THE LOSS LIMIT IS A PERMISSION TO WAIT")
+
+    assert "THE PERMISSION IS REGIME-CONDITIONAL" in rule
+    assert "a market that still MOVES" in rule
+    # Both regimes must stay, or it collapses into a bias one way.
+    assert "the patience above stands as" in rule
+    assert "stalling into sideways" in rule
+    # It must not license cutting on feel -- the whole point of v4h.
+    assert "none of them licenses cutting on" in rule
+    assert "names an observable that has changed" in rule
+
+
+def test_v4m_disqualifying_fact_carries_into_the_next_entry():
+    """Four shorts, each killed by the leading index, each re-entered fresh.
+
+    The rule must stay about the LEADING index specifically -- a generic "do
+    not re-enter" duplicates the post-exit gate below it -- and must keep the
+    measured evidence, which is what makes it more than an opinion.
+    """
+    prompt = build_system_prompt()
+    rule = _flat_rule(prompt, "THE FACT THAT DISQUALIFIED YOUR LAST TRADE")
+
+    assert "FOUR shorts" in rule and "51 minutes" in rule
+    assert "-2,300.75" in rule
+    # The specific bar it raises, and on what.
+    assert "it needs BankNIFTY itself to stop opposing" in rule
+    assert "the honest output is HOLD" in rule
+
+
+def test_v4m_stale_hatch_may_not_be_used_selectively():
+    """The companion failure: re-rating a signal to fit the chosen action.
+
+    This must NOT read as "the stale hatch is closed" -- v3 scoped it
+    deliberately and it is still valid inside the opening hour. What is banned
+    is choosing staleness by whether the verdict agrees.
+    """
+    prompt = build_system_prompt()
+    rule = _flat_rule(prompt, "YOU MAY NOT RE-RATE A SIGNAL")
+
+    # The hatch survives...
+    assert "that hatch is real" in rule
+    # ...but the basis for using it is fixed.
+    assert "never from whether it agrees with you" in rule
+    # Both measured occurrences, so a later edit cannot reduce it to one anecdote.
+    assert "at 10:05" in rule and "at 10:12" in rule
+    assert "09:18 and 09:27" in rule
+    # The check the agent can actually run.
+    assert "would I still call it stale if it" in rule
+    assert "it is inconvenient" in rule


### PR DESCRIPTION
## What

v4m, from IH's 21 Aug live session (`yacw-NpZq30`). **Both IH and our agent lost, on
the same side, for the same reason** — the most directly comparable session in the
series. The note said sell-side; IH bought puts across all three indices within two
minutes of the open; our agent shorted four times in 51 minutes; neither got the move.

Two extensions and two new rules. Knowledge-only; no runtime behaviour changes.

## EXTENDED — the closing-price breakdown is binary across indices

The whole session turns on one checkable gate that was named before the trade and
never arrived:

> We need the CLOSING PRICE breakdown — especially BankNIFTY's… It is not the case that
> it breaks in one and stays in another. **If it breaks in even ONE index it will break
> in all three; if it does not break in even one, all three will sit and hold.**

So the check is cheap and binary: read one index's closing price and you have read all
three. Two consequences recorded with it — the failure mode while it holds is **chop**,
not a clean loss (*"the fear of a sideways market is there every day now"*), which is
the regime that pays an option buyer nothing either way; and a rejection at the open is
a reason to **watch** the level, never a substitute for it breaking. That last is IH's
own diagnosed error: *"we made our entry EARLY too."*

The existing rule already said the breakdown is the trigger and that sitting on the
level is not breaking it, so this is an **extension**, not a new bullet.

## EXTENDED — the loss-limit permission is regime-conditional

> When it is a momentum market we do sit, and we do let the loss grow a bit, because the
> next day gives a chance to cover it. But these days there is not much momentum, so
> there is no benefit in making the loss bigger here.

A third bound alongside elapsed time. **The reconciliation matters more than the rule**:
read carelessly this becomes "cut early when it feels slow", which is exactly the error
v4h exists to prevent. All three bounds — the limit, the clock, the regime — name an
**observable**, and the test asserts that none of them licenses cutting on feel.

## NEW — the fact that disqualified your last trade still holds

**Four shorts in 51 minutes; the leading index killed every one.** Each exit names it
correctly — *"per index hierarchy, BankNIFTY turning against the trade is disqualifying
for the whole basket"* — and then the next entry is justified fresh on NIFTY patterns as
though BankNIFTY had not just refused. The disqualifying fact was true of the **session**,
not of one position, and never carried forward. Net **−2,300.75**, the worst of the series.

## NEW — you may not re-rate a signal to suit the decision you want

At **10:05** `cross_index` was dismissed as stale to justify an **entry**. At **10:12**,
seven minutes later, the **same verdict** was cited to justify an **exit**. The 20 Aug
session did it at 09:18 and 09:27.

v4l recorded the first occurrence with *"noted so the next occurrence is the second data
point rather than the first."* It arrived the next day, so v4m legislates — carefully.
The stale hatch **stays open**; its opening-hour scope is real and deliberate. What is
fixed is the basis: staleness is judged from the verdict's age and anchoring, never from
whether it agrees. The test the agent can run is *"would I still call it stale if it
AGREED with me right now?"*

## Agent vs IH

Basket **−12,912.00** across 68 legs — a bad day everywhere. SL Hunting **−2,300.75**
over 4 trades.

| Time | NIFTY / BNF mirror | Held |
|---|---|---|
| 09:28 | +419.25 / **−1,539.00** | 7 min |
| 09:36 | −312.00 / −768.00 | 1m47s |
| 10:00 | −240.50 / +48.00 | 1m51s |
| 10:12 | +312.00 / −220.50 | 7 min |

**v4l's cut-every-leg rule was applied correctly and immediately** — all four exits
closed both legs, two of them in v4l's own language (*"not an idiosyncratic mirror-only
issue"*). No per-leg cut was attempted. The rule is being read; it did not save the day
because the **entries** were the problem.

**Observed, not legislated:** the 09:28 exit reads *"Booked the healthy NIFTY leg
(+585)"* while the mirror was −1,539 and the basket about −1,120. The action was right
and cited the basket-exit rule, so no rule was broken — but the habit of narrating by
the favourable leg is visible again and worth watching.

**The note was followed four times and lost every time.** It also carried its own
warning — *"EVIDENCE IS WEAKER ON NIFTY AND SENSEX… demand a cleaner confirmation"* —
which the entries cite as satisfied without engaging with the weakness. Across five
sessions the note-versus-override record now points both ways with no pattern; the
honest reading is that it is one vote, exactly as its header says.

## Budget & gates

```
assembled            : 133,759
budget for assembled : 154,140
headroom             :  20,381
```

| Gate | Result |
|---|---|
| `Tests.test_nifty_multi_strategy_master` | 528 passed |
| `Tests.test_market_data_health` | 28 passed |
| `pytest "Tests/Signal Generators" "Tests/Dependencies" "Tests/Data Extractors"` | 1224 passed |
| Ruff / mypy / compileall | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
