### PR TITLE
feat(sl-hunting): v4n knowledge, and record the model's own reason on an unparsed pass (SLH-011)

### DIFF
--- a/Signal Generators/SL Hunting AI Agent/premarket_note.json
+++ b/Signal Generators/SL Hunting AI Agent/premarket_note.json
@@ -1,44 +1,44 @@
 {
-  "for_date": "2026-08-24",
-  "source": "Intraday Hunter, 'Prediction For 24 AUG 2026' (rmmBLlHve1k, uploaded 2026-08-23)",
-  "context": "All three indices held near their highs after the gap-up or recovery with only modest positive or sideways momentum. Despite the two-day holiday, Friday likely left BUYERS seated; he sees no seller crowd carried into Monday.",
+  "for_date": "2026-08-25",
+  "source": "Intraday Hunter, 'Prediction For 25 AUG 2026' (epBZSyUunIk, uploaded 2026-08-24)",
+  "context": "DOUBLE EXPIRY: both NIFTY and BankNIFTY expire today. Heavy selling yesterday, but the sellers who rode it down have already booked and left - momentum makes traders book rather than hold size - so they are NOT the target.",
   "plan": [
-    "GAP-UP: do not target the seated buyers because their stops are too far away. Follow the market and identify confirmed BUY-side setups.",
-    "FLAT or GAP-DOWN: target the seated buyers and identify confirmed SELL-side setups.",
-    "Momentum has been limited for several sessions, but Monday may move better; that is context only, not permission to enter without the live pattern and confirmation."
+    "FLAT or GAP-DOWN: identify confirmed SELL-side setups. This FOLLOWS the momentum rather than hunting a crowd - he says outright the sellers are not the target - and flat/gap-down is the only shape in which a trap can form.",
+    "GAP-UP: NO PLAN, stand aside. Unusually emphatic - on a gap-up you can follow neither the momentum nor the stop-losses, because whether the market wants to stay sideways or continue down becomes unreadable.",
+    "Both basket legs are on EXPIRY contracts today, so premium decays fastest and a target set for an ordinary session is the wrong target. The RISK rules on expiry apply in full."
   ],
   "levels": [
     {
       "index": "NIFTY",
       "resistance": [
-        24320,
-        24270
+        24270,
+        24320
       ],
       "support": [
-        24186,
-        24140
+        24000,
+        24080
       ]
     },
     {
       "index": "BANKNIFTY",
       "resistance": [
-        57800,
-        58000
+        57650,
+        57800
       ],
       "support": [
-        57500,
-        57220
+        56800,
+        57000
       ]
     },
     {
       "index": "SENSEX",
       "resistance": [
-        77750,
-        78000
+        77520,
+        77750
       ],
       "support": [
-        77370,
-        77160
+        76800,
+        77050
       ]
     }
   ]

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_agent.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_agent.py
@@ -689,11 +689,33 @@ class SLHuntingAgent:
             result = tool_context.execution_result
             if result is not None and bool(result.get("accepted")):
                 action = str(result.get("action", "")).upper()
+                if reported is None:
+                    # SLH-011: the model placed an order and then failed to return a
+                    # parseable decision. The ORDER is still the truthful record and
+                    # is kept exactly as executed -- but say so loudly, because this
+                    # entry is otherwise indistinguishable at INFO from a normal one,
+                    # and the reflection coach later reads its `reasoning` as the
+                    # trade's rationale.
+                    logger.warning(
+                        "SL Hunting: order %s executed but the model returned no parseable "
+                        "decision for that bar. Recording the executed order; the journal "
+                        "entry carries the order tool's own reason and no setup or "
+                        "confidence. Treat this decision as UNREVIEWED.",
+                        action or "?",
+                    )
                 base = reported or SLHuntingDecision(
                     action="HOLD",
                     confidence=0,
                     setup="tool_execution",
-                    reasoning="The order tool accepted an action; its result is authoritative.",
+                    # Prefer the justification the model gave the order tool over a
+                    # generic placeholder: on an ENTRY it is guaranteed meaningful
+                    # (SLH-007 rejects placeholders there), and on an EXIT it is at
+                    # worst the explicit no-reason sentinel, which is itself the
+                    # honest record.
+                    reasoning=(
+                        str(result.get("model_reason") or "").strip()
+                        or "The order tool accepted an action; its result is authoritative."
+                    ),
                     model_used=self._model,
                 )
                 if action in ("ENTER_LONG", "ENTER_SHORT"):
@@ -720,6 +742,16 @@ class SLHuntingAgent:
                         }
                     )
             if reported is not None and reported.action != "HOLD":
+                # SLH-011: the other direction of the same mismatch -- the final JSON
+                # claims an action no accepted order backs. Downgrading to HOLD is
+                # right (nothing was executed), but it means the model believed it had
+                # acted when it had not, which is worth seeing.
+                logger.warning(
+                    "SL Hunting: final output claimed %s but the order tool accepted "
+                    "nothing; holding. The model may believe it has a position it does "
+                    "not have.",
+                    reported.action,
+                )
                 return SLHuntingDecision(
                     action="HOLD",
                     confidence=0,

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -4384,3 +4384,134 @@ is that it is one vote, exactly as its own header says.
   must not read as closing the stale hatch.
 - Prompt size 128,303 -> 132,468 chars. Assembled 133,759 against a 154,140
   budget: **20,381 chars of headroom.**
+
+---
+
+## Video addendum - the 24 Aug LIVE SESSION (v4n)
+
+**Source:** Intraday Hunter live session `9bTx_E3E95c` (24 Aug 2026, 10:19).
+
+**The first session where IH and our agent were on OPPOSITE sides, and the agent
+won.** IH bought calls into what he read as a range that had to break upward, the
+market fell instead, and he cut. Our agent shorted three of its four trades and
+finished +2,065.25. That divergence is worth more than another agreement, because
+it separates the method from the read.
+
+### Two new rules
+
+**DO NOT THINK YOUR WAY THROUGH A LOSS; THE THINKING IS WHAT ENLARGES IT.** The
+sharpest thing in the session and the one most specific to what we are building.
+IH, sitting under water: "there is no benefit in applying more thought here,
+because APPLYING THOUGHT WHILE IN A LOSS IS THE THING THAT MAKES THE LOSS BIGGER."
+And on what to do if his level broke: "then we are not to think about whether this
+will happen or how we might escape - those things must not be brought into the
+mind at all. Then we simply go according to the SL."
+
+This is the companion that makes v4h's permission-to-wait safe. Waiting to the
+limit is MECHANICAL waiting; it is not a licence to keep re-deriving the chart.
+The failure it prevents is one an LLM agent is built to commit: with a position
+under water, generating another plausible reading is effortless and every one of
+them argues for staying. So once price is against you and the invalidation is in
+view, the only live questions are the ones already committed to - the stop, the
+last point, the limit.
+
+It is bounded in the prose and in the test, because read too strongly it would
+disable stops: it does NOT mean stop observing, it means stop SEARCHING for a
+reading that rescues the position.
+
+**A CROWD WHOSE STOPS ARE TOO FAR AWAY IS REMOVED BY PROFIT-THEN-FADE, NOT BY A
+STOP-HUNT.** Seated inventory is not always huntable. IH on buyers who bought a
+support two sessions earlier: "their stops are going to sit at minimum below the
+500 level, so they cannot be targeted DIRECTLY. They can be targeted this way
+instead - first let them SEE some profit, then reduce that profit. In that they
+run away quickly."
+
+The operational half is that it changes the ENTRY TRIGGER: hunting a near-stop
+crowd waits for the BREAK, hunting a distant-stop crowd waits for the FADE after a
+move that went their way. Naming which one you are in stops you waiting for a
+break this crowd was never going to produce. It also warns that a move toward such
+a crowd is not evidence they were right - it can be the setup for taking it back.
+
+### One extension: v4m's re-rating rule was broken on the day it shipped
+
+v4m added YOU MAY NOT RE-RATE A SIGNAL TO SUIT THE DECISION YOU WANT after two
+sessions of `cross_index` being dismissed as stale when it disagreed and cited
+when it agreed. Today was the first session carrying that rule, and it happened
+again inside one minute:
+
+- **10:27** (entry): "This overrides the mechanical cross_index 'both at
+  resistance/bias up' read, which is stale relative to BankNIFTY's own live
+  structure."
+- **10:28** (exit): "cross_index flipped to both_at_resistance/bias UP, directly
+  opposing the short."
+
+**It had not flipped.** It was the identical verdict, forty-eight seconds later,
+and the word "flipped" made a signal that had just been overruled sound like fresh
+evidence.
+
+A disposition had already failed, so v4n adds a PROCEDURE instead: before
+describing a verdict as stale, new, or flipped, state what it read on your
+previous decision. If you cannot recall it you do not know whether it changed, and
+"flipped" is not available. If it reads the same as last time and you overruled it
+then, citing it as support now is not permitted at all.
+
+### How our agent traded the same session
+
+Basket **+1,096.75** across 51 legs. SL Hunting: **+2,065.25** over 4 trades - the
+best strategy on the board, in a session where the two biggest deterministic
+strategies lost over 3,000 each.
+
+| Time | Leg | P&L |
+|---|---|---|
+| 09:18 | NIFTY long / BNF mirror | +13.00 / +439.50 |
+| 09:48 | NIFTY short / BNF mirror | +156.00 / +2,700.00 |
+| 10:02 | NIFTY short / BNF mirror | -321.75 / -1,854.00 |
+| 10:28 | NIFTY short / BNF mirror | +227.50 / +705.00 |
+
+**1. The leg-narration habit has CORRECTED, and the pending v4n rule is therefore
+NOT being added.** The operator asked that this version add a rule against
+justifying a basket decision by the leg that flatters it, recorded after three
+occurrences on 19, 20 and 21 Aug. Today every decision quoted the BASKET figure -
+"+2221.5 basket profit", "-1872 unrealized", "+447.5" - and twice the agent
+volunteered that the NIFTY leg was the WEAK one: "the NIFTY leg alone was already
+negative (-42.25) despite spot being above entry, so the mirror was carrying the
+basket profit while the leader stalled", and "the NIFTY leg itself is flat (+97.5)
+with the mirror leg carrying almost all of the +2221.5 basket profit".
+
+That is the opposite of the recorded failure, and it applies v4l's
+movement-not-rupee-share test correctly. Adding a rule against a habit that two
+prior versions already fixed would be exactly the bloat the 2026-08-18 pruning
+pass warned about. Recorded here rather than silently dropped, so the decision is
+reviewable.
+
+**2. An ENTRY was placed with no rationale in the journal.** The 09:17:48 entry
+logged `conf=0, setup=tool_execution` with the reasoning "The order tool accepted
+an action; its result is authoritative." That is `_tool_authoritative` in
+`sl_hunting_agent.py` doing its job: the model called the order tool, the order was
+accepted, and the model then failed to return a parseable final decision, so the
+host recorded the EXECUTED action truthfully rather than inventing one.
+
+The order handling is correct. What is missing is observability, and it is the
+entry-side twin of SLH-010: a position was opened and the journal - which the
+reflection coach reads to work out what worked - carries a placeholder instead of
+a reason. It logs at INFO, indistinguishable from a normal entry. Not fixed here
+because it is a code question rather than a knowledge one.
+
+**3. The note was overridden twice and followed once, and the overrides won.** The
+09:41 short says so explicitly: "this overrides the pre-open note's default
+gap-up-long branch because live price action shows a genuine failed breakout". It
+made +2,856.00, the day's best trade. Across six sessions the note-versus-override
+record still points both ways.
+
+### Knowledge changes (v4n)
+
+- `RISK`: DO NOT THINK YOUR WAY THROUGH A LOSS (new, beside v4h's limit); v4m's
+  re-rating rule extended with the previous-verdict procedure.
+- `RETAIL_POSITIONING`: A CROWD WHOSE STOPS ARE TOO FAR AWAY IS REMOVED BY
+  PROFIT-THEN-FADE (new).
+- Three drift guards: the loss-thinking rule must not become "stop observing", the
+  distant-stop rule must keep the break-versus-fade trigger, and the re-rating
+  procedure must keep its measured case.
+- **Deliberately NOT added:** the leg-narration rule - see point 1 above.
+- Prompt size 132,468 -> 136,034 chars. Assembled 137,325 against a 154,140
+  budget: **16,815 chars of headroom.**

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -4515,3 +4515,75 @@ record still points both ways.
 - **Deliberately NOT added:** the leg-narration rule - see point 1 above.
 - Prompt size 132,468 -> 136,034 chars. Assembled 137,325 against a 154,140
   budget: **16,815 chars of headroom.**
+
+---
+
+## SLH-011 - an order executed by a pass that returned nothing parseable (2026-08-24)
+
+### What happened
+
+The 09:17:48 entry was recorded as:
+
+```
+SL Hunting AI: ENTER_LONG (conf=0, setup=tool_execution) stop=24271.1 target=24326.0
+  :: The order tool accepted an action; its result is authoritative.
+```
+
+The model called the order tool, the order was accepted, and the model then
+failed to return a parseable `SLHuntingDecision`. `_tool_authoritative` did
+exactly what it exists for: it recorded the EXECUTED action rather than
+inventing a decision or discarding a real position.
+
+### What was wrong with it
+
+Nothing in the order handling. Two things around it:
+
+1. **The journal carried a placeholder instead of a rationale.** The decision
+   journal is what `sl_hunting_coach.py` reads to work out what worked, and the
+   `reasoning` field is the trade's stated purpose. "The order tool accepted an
+   action; its result is authoritative" tells the coach nothing, and it is
+   indistinguishable from a real justification when read later.
+
+2. **It logged at INFO.** An entry with no reasoning, no setup and zero
+   confidence appeared in the log exactly like a normal one. It was found only
+   because a human happened to read the line.
+
+### The fix
+
+**Use the model's own words.** The justification the model passed to the order
+tool is a real one and was already validated: `_reason_meaning_problem` rejects
+placeholders on ENTRIES (SLH-007), so on an entry that string is guaranteed
+meaningful. `do_order` now carries it on the accepted result as `model_reason`,
+and `_tool_authoritative` prefers it over the generic sentence.
+
+On an EXIT the reason may legitimately be the `NO_REASON_SENTINEL`, which is
+itself the honest record and already raises its own SLH-010 warning.
+
+**Say it out loud.** A WARNING now names the case:
+
+> order ENTER_LONG executed but the model returned no parseable decision for that
+> bar. Recording the executed order; the journal entry carries the order tool's
+> own reason and no setup or confidence. Treat this decision as UNREVIEWED.
+
+**And the mirror case.** The other synthesised path - the final JSON claims an
+action no accepted order backs - was equally silent. Downgrading it to HOLD is
+correct because nothing executed, but it means the model believed it held a
+position it did not. That now warns too.
+
+### What deliberately did NOT change
+
+- **The recorded ACTION.** What executed is still what is recorded, unchanged.
+  Only the `reasoning` string and the log level of the surrounding event moved.
+- **`setup` stays `tool_execution` and `confidence` stays 0.** The model did not
+  supply either, and inventing them would make an unreviewed decision look
+  reviewed. The gaps are the signal.
+- **No new refusal.** Nothing is blocked; a position is never abandoned because
+  its decision failed to parse.
+
+### Verification
+
+Both guards were negative-tested rather than assumed. Removing the reason-carrying
+makes the test fail with `assert 'pivot reclaim with confirmed hammer' in 'The
+order tool accepted an action; its result is authoritative.'`, and disabling the
+claimed-action warning fails its own assertion. A third test asserts an ordinary
+pass produces NO warning, so the guards cannot decay into noise.

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
@@ -1170,6 +1170,23 @@ RISK DISCIPLINE
   becomes the fuel for a move AGAINST you — the same mechanism you were trying to
   exploit, pointed the other way. Company at a level is a warning, not comfort:
   the break should come promptly, "from about here", or the edge has inverted.
+- A CROWD WHOSE STOPS ARE TOO FAR AWAY IS REMOVED BY PROFIT-THEN-FADE, NOT BY A
+  STOP-HUNT (v4n). Seated inventory is not always huntable: when the crowd entered
+  at a level well away from price, reaching their stops would take a move too big
+  to be the day's business, so the market does not go and get them. It uses the
+  other method. IH, on buyers who bought a support two sessions earlier: "buyers
+  will certainly have come in, but their stops are going to sit at minimum below
+  the 500 level, so they cannot be targeted DIRECTLY. They can be targeted this
+  way instead — first let them SEE some profit, then reduce that profit. In that
+  they run away quickly."
+  Two consequences for reading a chart:
+  * A distant-stop crowd is a reason the market may drift TOWARD them first. A
+    move in their favour is not evidence they were right; it can be the setup for
+    taking it back, which is what actually removes them.
+  * It changes what counts as your entry trigger. Hunting a near-stop crowd waits
+    for the BREAK; hunting a distant-stop crowd waits for the FADE after a move
+    that went their way. Naming which of the two you are in stops you waiting for
+    a break that this crowd was never going to produce.
 - A CROWD THAT HAS AVERAGED DOWN EARNS A BIGGER TARGET (v4b). This is the
   counterpart to A FRESHLY RECRUITED CROWD HAS TIGHT STOPS, and the two together
   are how you SIZE a target from crowd behaviour rather than from a fixed
@@ -1297,6 +1314,25 @@ RISK DISCIPLINE
   in the time you have. When the answer needs the rest of the session, the wait has
   already failed. On an expiry day this arrives fastest, because the premium is
   draining while the range holds.
+- DO NOT THINK YOUR WAY THROUGH A LOSS; THE THINKING IS WHAT ENLARGES IT (v4n).
+  The companion to the loss-limit rule below, and the one that makes its patience
+  safe rather than dangerous. Waiting to the limit is MECHANICAL waiting — it is
+  not a licence to keep re-deriving the situation. IH, sitting in a losing trade
+  he later cut: "there is no benefit in applying more thought here, because
+  APPLYING THOUGHT WHILE IN A LOSS IS THE THING THAT MAKES THE LOSS BIGGER", and
+  on what to do if his level broke: "then we are not to think about whether this
+  will happen or how we might escape — those things must not be brought into the
+  mind at all. Then we simply go according to the SL."
+  The failure this prevents is specific and is one you are built to commit: with
+  a position under water, generating another plausible reading of the chart is
+  effortless, and every one of them argues for staying. So once price is against
+  you and the invalidation is in view, the only questions still live are the ones
+  you had ALREADY committed to — the stop, the last point, the limit. New
+  analysis produced after the loss began is evidence about your discomfort, not
+  about the market.
+  It does NOT mean stop observing: a stop, a target or a named invalidation still
+  fires on what you see. It means stop SEARCHING for a reading that rescues the
+  position.
 - THE LOSS LIMIT IS A PERMISSION TO WAIT, NOT ONLY A PLACE TO STOP (v4h). Read
   this WITH v4e's DISCIPLINE IS ASYMMETRIC, not against it: that rule says cut a
   loser mechanically, this one says cut it AT the limit and not before, because
@@ -1551,6 +1587,18 @@ RISK DISCIPLINE
   The test to apply before using the word "stale": would I still call it stale if it
   AGREED with me right now? If not, it is not stale, it is inconvenient — and an
   inconvenient signal is the one worth reading.
+  THE RULE ABOVE WAS BROKEN ON THE DAY IT SHIPPED, SO HERE IS THE PROCEDURE (v4n).
+  2026-08-24, the first session carrying it: at 10:27 the verdict "both at
+  resistance / bias up" was dismissed as "stale relative to BankNIFTY's own live
+  structure" to justify a SHORT entry; at 10:28, forty-eight seconds later, the
+  exit reasoning said cross_index "FLIPPED to both_at_resistance/bias UP, directly
+  opposing the short". It had not flipped. It was the identical verdict, and the
+  word "flipped" made a signal that had been overruled sound like fresh evidence.
+  So, mechanically, before you describe a verdict as stale, new, or flipped:
+  STATE WHAT IT READ ON YOUR PREVIOUS DECISION. If you cannot recall it, you do
+  not know whether it changed, and "flipped" is not available to you. If it reads
+  the same as last time and you overruled it then, overruling it again needs a
+  reason that is also new — and citing it as support now is not permitted at all.
 - POST-EXIT RE-ENTRY GATE (the MECHANICAL check for the two rules above — they are
   judgement, and judgement alone has proven too easy to talk past): after ANY exit,
   before you may open the NEXT position in EITHER direction, ALL of these must hold.

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_tools.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_tools.py
@@ -504,6 +504,7 @@ class SLHuntingToolContext:
             if note_problem:
                 return {"accepted": False, "reason": note_problem}
             entry_reason = bounded_reason(reason)
+            recorded_reason = entry_reason
             def executor_call() -> dict[str, Any]:
                 return self.executor.enter(
                     direction, stop, target, entry_reason, self.last_price
@@ -517,6 +518,7 @@ class SLHuntingToolContext:
             # explicit sentinel instead, so the journal and the coach are told plainly
             # that no justification was given rather than being handed a lie.
             exit_reason = _safe_exit_reason(reason)
+            recorded_reason = exit_reason
             if exit_reason == NO_REASON_SENTINEL:
                 # SLH-010: the exit still goes through -- SLH-007 above is not
                 # being reversed -- but a deliberate exit always carries a
@@ -561,7 +563,12 @@ class SLHuntingToolContext:
                 self.state = ToolContextState.EXPIRED
                 raise
             if bool(result.get("accepted")):
-                self._execution_result = dict(result)
+                # SLH-011: keep the model's OWN justification on the result. If this
+                # pass later fails to return a parseable decision, the journal can
+                # record why the order was placed rather than a placeholder -- and
+                # for an ENTRY that string is guaranteed meaningful, because
+                # `_reason_meaning_problem` above rejects placeholders on entries.
+                self._execution_result = {**result, "model_reason": recorded_reason}
                 self.state = ToolContextState.CONSUMED
             else:
                 # Rejected validation/execution may be corrected once within the

--- a/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_agent.py
+++ b/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_agent.py
@@ -1123,3 +1123,108 @@ def test_exit_with_a_real_reason_does_not_warn(caplog):
         ctx.do_order("EXIT", stop=0, target=0, reason="double top rejection, premise gone")
 
     assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+
+# --------------------------------------------------------------------------
+# SLH-011: an order executed by a pass that then returned nothing parseable.
+#
+# On 2026-08-24 09:17 an ENTRY was recorded as `conf=0, setup=tool_execution`
+# with the reasoning "The order tool accepted an action; its result is
+# authoritative." The ORDER handling was correct -- `_tool_authoritative`
+# records what actually executed rather than inventing a decision -- but the
+# journal the reflection coach reads carried a placeholder instead of a
+# rationale, and it logged at INFO, indistinguishable from a normal entry.
+# --------------------------------------------------------------------------
+
+def test_executed_order_without_parseable_decision_keeps_the_models_own_reason(caplog):
+    """The justification given to the order tool is a real one; use it.
+
+    On an ENTRY that string is guaranteed meaningful, because SLH-007 rejects
+    placeholder reasons on entries. Recording it beats a generic sentence, and
+    it is what the coach will later read as the trade's rationale.
+    """
+    import logging
+
+    async def _runner(prompt, *, system_prompt, model, max_turns, tool_context=None):
+        result = tool_context.do_order(
+            "ENTER_LONG", stop=25000, target=25080,
+            reason="pivot reclaim with confirmed hammer at the first-candle low",
+        )
+        assert result["accepted"] is True
+        return AgentRunResult(text="not json at all -- the model never closed its answer")
+
+    ex = StandaloneExecutor()
+    with caplog.at_level(logging.WARNING):
+        decision = SLHuntingAgent(model="test-model", runner=_runner).decide(_candles(), ex)
+
+    # The executed order is still the record, unchanged.
+    assert decision.action == "ENTER_LONG"
+    assert decision.stop == 25000 and decision.target == 25080
+    assert ex.snapshot()["in_position"] is True
+
+    # ...but it now carries the model's OWN words rather than a placeholder.
+    assert "pivot reclaim with confirmed hammer" in decision.reasoning
+    assert "its result is authoritative" not in decision.reasoning
+    # The honest gaps stay honest: no setup name and no confidence were given.
+    assert decision.setup == "tool_execution"
+    assert decision.confidence == 0
+
+    # And the operator is told, because this is otherwise invisible.
+    warnings = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any("no parseable" in m and "UNREVIEWED" in m for m in warnings)
+
+
+def test_unexecuted_action_claim_warns_that_the_model_may_believe_it_traded(caplog):
+    """The other direction of the same mismatch.
+
+    Downgrading to HOLD is correct because nothing executed, but the model
+    believed it had acted -- worth seeing rather than silently correcting.
+    """
+    import logging
+
+    claimed = json.dumps(
+        {
+            "action": "ENTER_LONG",
+            "stop": 25000,
+            "target": 25080,
+            "confidence": 9,
+            "setup": "claimed_only",
+            "reasoning": "Claims an entry without calling the order tool.",
+        }
+    )
+    with caplog.at_level(logging.WARNING):
+        decision = SLHuntingAgent(model="test-model", runner=_FakeRunner(claimed)).decide(
+            _candles(), StandaloneExecutor()
+        )
+
+    assert decision.action == "HOLD"
+    assert decision.setup == "unexecuted_action"
+    warnings = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any("claimed ENTER_LONG" in m and "accepted nothing" in m for m in warnings)
+
+
+def test_a_normal_decision_does_not_warn(caplog):
+    """The guards must stay quiet on an ordinary pass or they become noise."""
+    import logging
+
+    async def _runner(prompt, *, system_prompt, model, max_turns, tool_context=None):
+        tool_context.do_order(
+            "ENTER_LONG", stop=25000, target=25080, reason="pivot bounce with confirmation"
+        )
+        return AgentRunResult(
+            text=json.dumps(
+                {
+                    "action": "ENTER_LONG",
+                    "stop": 25000,
+                    "target": 25080,
+                    "confidence": 7,
+                    "setup": "pivot_support_hammer",
+                    "reasoning": "Hammer at pivot with bullish confirmation.",
+                }
+            )
+        )
+
+    with caplog.at_level(logging.WARNING):
+        SLHuntingAgent(model="test-model", runner=_runner).decide(_candles(), StandaloneExecutor())
+
+    assert not [r for r in caplog.records if r.levelno >= logging.WARNING]

--- a/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_premarket.py
+++ b/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_premarket.py
@@ -201,13 +201,20 @@ def test_shipped_note_targets_the_next_TRADING_day_not_the_next_calendar_day():
     )
 
 
-def test_shipped_note_matches_august_24_intraday_hunter_plan():
-    """The committed advisory must match the hand-checked 23 Aug transcript.
+def test_shipped_note_matches_august_25_intraday_hunter_plan():
+    """The committed advisory must match the hand-checked 24 Aug transcript.
 
-    This catches the three dangerous daily-note mutations: a stale date, an
-    inverted gap branch, or a level copied from the prior session. The holiday
-    context matters because IH still reads Friday's buyers as seated despite
-    the two-day carry gap; the note must not silently erase that evidence call.
+    Three things a summarising edit would flatten:
+
+    1. DOUBLE EXPIRY -- both NIFTY and BankNIFTY expire, so BOTH basket legs
+       are on expiry contracts. The agent trades NIFTY and mirrors BankNIFTY,
+       so this is the first note where the expiry RISK rules bind on both.
+    2. The sell-side plan does NOT hunt the sellers. He says outright they
+       booked and left, so the trade FOLLOWS momentum. A note read as
+       "sell-side, therefore target the sellers" inverts the premise while
+       keeping the direction, which is the subtlest way to get it wrong.
+    3. The GAP-UP branch is a stand-aside, and an unusually strong one:
+       neither the momentum nor the stop-losses can be followed there.
     """
     import os
 
@@ -216,34 +223,40 @@ def test_shipped_note_matches_august_24_intraday_hunter_plan():
     note = load_premarket_note(shipped)
 
     assert note is not None
-    assert note.for_date == "2026-08-24"
-    assert "rmmBLlHve1k" in note.source
-    assert "Friday likely left BUYERS seated" in note.context
-    assert "two-day holiday" in note.context
-    assert note.plan == [
-        "GAP-UP: do not target the seated buyers because their stops are too far "
-        "away. Follow the market and identify confirmed BUY-side setups.",
-        "FLAT or GAP-DOWN: target the seated buyers and identify confirmed "
-        "SELL-side setups.",
-        "Momentum has been limited for several sessions, but Monday may move "
-        "better; that is context only, not permission to enter without the live "
-        "pattern and confirmation.",
-    ]
+    assert note.for_date == "2026-08-25"
+    assert "epBZSyUunIk" in note.source
+    assert "DOUBLE EXPIRY" in note.context
+    assert "NOT the target" in note.context
+
+    sell = next(line for line in note.plan if line.startswith("FLAT or GAP-DOWN"))
+    assert "SELL-side" in sell
+    # The premise, not just the direction.
+    assert "FOLLOWS the momentum rather than hunting a crowd" in sell
+    assert "only shape in which a trap can form" in sell
+
+    gap_up = next(line for line in note.plan if line.startswith("GAP-UP"))
+    assert "NO PLAN" in gap_up
+    assert "neither the momentum nor the stop-losses" in gap_up
+
+    # Expiry is a plan line of its own because it binds on BOTH legs.
+    assert any("EXPIRY contracts" in line for line in note.plan)
 
     assert [level.model_dump() for level in note.levels] == [
         {
+            # Caption gave the first support as "2480", a dropped digit; read
+            # off the chart by the operator as 24080 rather than inferred.
             "index": "NIFTY",
-            "resistance": [24320.0, 24270.0],
-            "support": [24186.0, 24140.0],
+            "resistance": [24270.0, 24320.0],
+            "support": [24000.0, 24080.0],
         },
         {
             "index": "BANKNIFTY",
-            "resistance": [57800.0, 58000.0],
-            "support": [57500.0, 57220.0],
+            "resistance": [57650.0, 57800.0],
+            "support": [56800.0, 57000.0],
         },
         {
             "index": "SENSEX",
-            "resistance": [77750.0, 78000.0],
-            "support": [77370.0, 77160.0],
+            "resistance": [77520.0, 77750.0],
+            "support": [76800.0, 77050.0],
         },
     ]

--- a/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_schema.py
+++ b/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_schema.py
@@ -1504,3 +1504,64 @@ def test_v4m_stale_hatch_may_not_be_used_selectively():
     # The check the agent can actually run.
     assert "would I still call it stale if it" in rule
     assert "it is inconvenient" in rule
+
+
+def test_v4n_do_not_think_through_a_loss_does_not_become_stop_observing():
+    """v4n (24 Aug live session): the thinking is what enlarges the loss.
+
+    This is the rule most likely to be mis-drafted into something dangerous.
+    Read too strongly it says ignore the chart while losing, which would
+    disable stops and named invalidations. It must keep BOTH the ban on
+    searching for a rescuing reading AND the licence to keep observing.
+    """
+    prompt = build_system_prompt()
+    rule = _flat_rule(prompt, "DO NOT THINK YOUR WAY THROUGH A LOSS")
+
+    assert "APPLYING THOUGHT WHILE IN A LOSS IS THE THING THAT MAKES THE LOSS BIGGER" in rule
+    # The mechanism, aimed at what an LLM does by construction.
+    assert "generating another plausible reading of the chart is" in rule
+    assert "evidence about your discomfort" in rule
+    # Only pre-committed questions stay live.
+    assert "you had ALREADY committed to" in rule
+    # ...and the guard against over-reading it.
+    assert "It does NOT mean stop observing" in rule
+    assert "stop SEARCHING for a reading that rescues the position" in rule
+
+
+def test_v4n_distant_stop_crowd_rule_keeps_both_removal_mechanisms():
+    """Not every seated crowd is huntable; some are faded out instead.
+
+    The rule is only useful if it changes the ENTRY TRIGGER, so the
+    break-versus-fade distinction is asserted rather than the colour.
+    """
+    prompt = build_system_prompt()
+    rule = _flat_rule(prompt, "A CROWD WHOSE STOPS ARE TOO FAR AWAY")
+
+    assert "first let them SEE some profit, then reduce that profit" in rule
+    # A move their way is not evidence they were right.
+    assert "not evidence they were right" in rule
+    # The operational half: which trigger applies.
+    assert "waits for the BREAK" in rule and "waits for the FADE" in rule
+    assert "a break that this crowd was never going to produce" in rule
+
+
+def test_v4n_re_rating_rule_gains_a_procedure_after_being_broken():
+    """v4m's rule was violated 48 seconds apart on its first live session.
+
+    The addition is mechanical on purpose -- a disposition ("be consistent")
+    had already failed, so what is asserted here is the CHECK, and the
+    measured evidence that motivated it.
+    """
+    prompt = build_system_prompt()
+    rule = _flat_rule(prompt, "YOU MAY NOT RE-RATE A SIGNAL")
+
+    # The original test survives.
+    assert "would I still call it stale if it" in rule
+    # The new procedure, and the fact that it is a procedure.
+    assert "STATE WHAT IT READ ON YOUR PREVIOUS DECISION" in rule
+    assert '"flipped" is not available to you' in rule
+    # The measured case, including the detail that makes it damning.
+    assert "It had not flipped" in rule
+    assert "forty-eight seconds later" in rule
+    # Overruling then citing the same verdict is the banned combination.
+    assert "citing it as support now is not permitted" in rule


### PR DESCRIPTION

---

## Video addendum - the 24 Aug LIVE SESSION (v4n)

**Source:** Intraday Hunter live session `9bTx_E3E95c` (24 Aug 2026, 10:19).

**The first session where IH and our agent were on OPPOSITE sides, and the agent
won.** IH bought calls into what he read as a range that had to break upward, the
market fell instead, and he cut. Our agent shorted three of its four trades and
finished +2,065.25. That divergence is worth more than another agreement, because
it separates the method from the read.

### Two new rules

**DO NOT THINK YOUR WAY THROUGH A LOSS; THE THINKING IS WHAT ENLARGES IT.** The
sharpest thing in the session and the one most specific to what we are building.
IH, sitting under water: "there is no benefit in applying more thought here,
because APPLYING THOUGHT WHILE IN A LOSS IS THE THING THAT MAKES THE LOSS BIGGER."
And on what to do if his level broke: "then we are not to think about whether this
will happen or how we might escape - those things must not be brought into the
mind at all. Then we simply go according to the SL."

This is the companion that makes v4h's permission-to-wait safe. Waiting to the
limit is MECHANICAL waiting; it is not a licence to keep re-deriving the chart.
The failure it prevents is one an LLM agent is built to commit: with a position
under water, generating another plausible reading is effortless and every one of
them argues for staying. So once price is against you and the invalidation is in
view, the only live questions are the ones already committed to - the stop, the
last point, the limit.

It is bounded in the prose and in the test, because read too strongly it would
disable stops: it does NOT mean stop observing, it means stop SEARCHING for a
reading that rescues the position.

**A CROWD WHOSE STOPS ARE TOO FAR AWAY IS REMOVED BY PROFIT-THEN-FADE, NOT BY A
STOP-HUNT.** Seated inventory is not always huntable. IH on buyers who bought a
support two sessions earlier: "their stops are going to sit at minimum below the
500 level, so they cannot be targeted DIRECTLY. They can be targeted this way
instead - first let them SEE some profit, then reduce that profit. In that they
run away quickly."

The operational half is that it changes the ENTRY TRIGGER: hunting a near-stop
crowd waits for the BREAK, hunting a distant-stop crowd waits for the FADE after a
move that went their way. Naming which one you are in stops you waiting for a
break this crowd was never going to produce. It also warns that a move toward such
a crowd is not evidence they were right - it can be the setup for taking it back.

### One extension: v4m's re-rating rule was broken on the day it shipped

v4m added YOU MAY NOT RE-RATE A SIGNAL TO SUIT THE DECISION YOU WANT after two
sessions of `cross_index` being dismissed as stale when it disagreed and cited
when it agreed. Today was the first session carrying that rule, and it happened
again inside one minute:

- **10:27** (entry): "This overrides the mechanical cross_index 'both at
  resistance/bias up' read, which is stale relative to BankNIFTY's own live
  structure."
- **10:28** (exit): "cross_index flipped to both_at_resistance/bias UP, directly
  opposing the short."

**It had not flipped.** It was the identical verdict, forty-eight seconds later,
and the word "flipped" made a signal that had just been overruled sound like fresh
evidence.

A disposition had already failed, so v4n adds a PROCEDURE instead: before
describing a verdict as stale, new, or flipped, state what it read on your
previous decision. If you cannot recall it you do not know whether it changed, and
"flipped" is not available. If it reads the same as last time and you overruled it
then, citing it as support now is not permitted at all.

### How our agent traded the same session

Basket **+1,096.75** across 51 legs. SL Hunting: **+2,065.25** over 4 trades - the
best strategy on the board, in a session where the two biggest deterministic
strategies lost over 3,000 each.

| Time | Leg | P&L |
|---|---|---|
| 09:18 | NIFTY long / BNF mirror | +13.00 / +439.50 |
| 09:48 | NIFTY short / BNF mirror | +156.00 / +2,700.00 |
| 10:02 | NIFTY short / BNF mirror | -321.75 / -1,854.00 |
| 10:28 | NIFTY short / BNF mirror | +227.50 / +705.00 |

**1. The leg-narration habit has CORRECTED, and the pending v4n rule is therefore
NOT being added.** The operator asked that this version add a rule against
justifying a basket decision by the leg that flatters it, recorded after three
occurrences on 19, 20 and 21 Aug. Today every decision quoted the BASKET figure -
"+2221.5 basket profit", "-1872 unrealized", "+447.5" - and twice the agent
volunteered that the NIFTY leg was the WEAK one: "the NIFTY leg alone was already
negative (-42.25) despite spot being above entry, so the mirror was carrying the
basket profit while the leader stalled", and "the NIFTY leg itself is flat (+97.5)
with the mirror leg carrying almost all of the +2221.5 basket profit".

That is the opposite of the recorded failure, and it applies v4l's
movement-not-rupee-share test correctly. Adding a rule against a habit that two
prior versions already fixed would be exactly the bloat the 2026-08-18 pruning
pass warned about. Recorded here rather than silently dropped, so the decision is
reviewable.

**2. An ENTRY was placed with no rationale in the journal.** The 09:17:48 entry
logged `conf=0, setup=tool_execution` with the reasoning "The order tool accepted
an action; its result is authoritative." That is `_tool_authoritative` in
`sl_hunting_agent.py` doing its job: the model called the order tool, the order was
accepted, and the model then failed to return a parseable final decision, so the
host recorded the EXECUTED action truthfully rather than inventing one.

The order handling is correct. What is missing is observability, and it is the
entry-side twin of SLH-010: a position was opened and the journal - which the
reflection coach reads to work out what worked - carries a placeholder instead of
a reason. It logs at INFO, indistinguishable from a normal entry. Not fixed here
because it is a code question rather than a knowledge one.

**3. The note was overridden twice and followed once, and the overrides won.** The
09:41 short says so explicitly: "this overrides the pre-open note's default
gap-up-long branch because live price action shows a genuine failed breakout". It
made +2,856.00, the day's best trade. Across six sessions the note-versus-override
record still points both ways.

### Knowledge changes (v4n)

- `RISK`: DO NOT THINK YOUR WAY THROUGH A LOSS (new, beside v4h's limit); v4m's
  re-rating rule extended with the previous-verdict procedure.
- `RETAIL_POSITIONING`: A CROWD WHOSE STOPS ARE TOO FAR AWAY IS REMOVED BY
  PROFIT-THEN-FADE (new).
- Three drift guards: the loss-thinking rule must not become "stop observing", the
  distant-stop rule must keep the break-versus-fade trigger, and the re-rating
  procedure must keep its measured case.
- **Deliberately NOT added:** the leg-narration rule - see point 1 above.
- Prompt size 132,468 -> 136,034 chars. Assembled 137,325 against a 154,140
  budget: **16,815 chars of headroom.**
