### PR TITLE
feat(sl-hunting): v4o knowledge from the 25 Aug IH live session

### DIFF
--- a/Signal Generators/SL Hunting AI Agent/premarket_note.json
+++ b/Signal Generators/SL Hunting AI Agent/premarket_note.json
@@ -1,44 +1,44 @@
 {
-  "for_date": "2026-08-25",
-  "source": "Intraday Hunter, 'Prediction For 25 AUG 2026' (epBZSyUunIk, uploaded 2026-08-24)",
-  "context": "DOUBLE EXPIRY: both NIFTY and BankNIFTY expire today. Heavy selling yesterday, but the sellers who rode it down have already booked and left - momentum makes traders book rather than hold size - so they are NOT the target.",
+  "for_date": "2026-08-26",
+  "source": "Intraday Hunter, 'Prediction For 26 AUG 2026' (hFmttyfw5Io, uploaded 2026-08-25)",
+  "context": "The MONTHLY expiry is now complete, so the market may start working to the support it has built. After that selling, few people will have gone long even where price held - so there are few seated buyers and room above.",
   "plan": [
-    "FLAT or GAP-DOWN: identify confirmed SELL-side setups. This FOLLOWS the momentum rather than hunting a crowd - he says outright the sellers are not the target - and flat/gap-down is the only shape in which a trap can form.",
-    "GAP-UP: NO PLAN, stand aside. Unusually emphatic - on a gap-up you can follow neither the momentum nor the stop-losses, because whether the market wants to stay sideways or continue down becomes unreadable.",
-    "Both basket legs are on EXPIRY contracts today, so premium decays fastest and a target set for an ordinary session is the wrong target. The RISK rules on expiry apply in full."
+    "FLAT, GAP-UP or a SMALL GAP-DOWN: identify confirmed BUY-side setups. All three shapes share one plan; only a large gap-down changes it.",
+    "LARGE GAP-DOWN ONLY: flip to confirmed SELL-side setups and go WITH the market. The threshold is defined - for BANKNIFTY an opening BELOW its support (57200/57000); on a big gap-down the buyers' strength is not visible at all.",
+    "Both branches FOLLOW the market rather than hunt a crowd. He says so directly for the gap-down case, and the buy-side case rests on few buyers being seated rather than on a trapped crowd to squeeze."
   ],
   "levels": [
     {
       "index": "NIFTY",
       "resistance": [
-        24270,
-        24320
+        24320,
+        24380
       ],
       "support": [
-        24000,
-        24080
+        24080,
+        24180
       ]
     },
     {
       "index": "BANKNIFTY",
       "resistance": [
         57650,
-        57800
+        58000
       ],
       "support": [
-        56800,
-        57000
+        57000,
+        57200
       ]
     },
     {
       "index": "SENSEX",
       "resistance": [
-        77520,
-        77750
+        77750,
+        78000
       ],
       "support": [
-        76800,
-        77050
+        76900,
+        77150
       ]
     }
   ]

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -4587,3 +4587,134 @@ makes the test fail with `assert 'pivot reclaim with confirmed hammer' in 'The
 order tool accepted an action; its result is authoritative.'`, and disabling the
 claimed-action warning fails its own assertion. A third test asserts an ordinary
 pass produces NO warning, so the guards cannot decay into noise.
+
+---
+
+## Video addendum - the 25 Aug LIVE SESSION (v4o)
+
+**Source:** Intraday Hunter live session `-KpWuMvUgUQ` (25 Aug 2026, 8:24).
+
+Double expiry, both indices. IH bought puts, sat through a BankNIFTY move
+against him, and booked a good profit. Our agent shorted four times and made
+**+6,112.50**, its best session of the series. Same side, same read, both right -
+but the session's most useful material is a place where they DISAGREED and the
+disagreement is instructive rather than settled.
+
+### The headline: the method is not always a fade
+
+A method-level correction, in his own words:
+
+> You say that when we work according to SL HUNTING we always have to work
+> OPPOSITE the market. **That is NOT so.** If the sellers' stop-losses are not
+> visible, and the opening is fine, then we can work ACCORDING TO the market.
+
+Our whole prompt is built around finding seated inventory and fading it, so this
+is a real widening: hunting a trapped crowd is the method's BEST trade, not its
+only one.
+
+It is also the most dangerous addition in the series, because read loosely it
+licenses entering with no crowd read at all - which is exactly the 11 Aug loss v4e
+was written from. So it ships with both reconciliations attached:
+
+- **A FORECAST OF WHO WILL ARRIVE IS NOT EVIDENCE OF WHO IS SEATED (v4e)** bans
+  inventing a crowd and trading the prediction. Following momentum is not that: it
+  claims no crowd at all, so there is nothing to be wrong about.
+- **AN EMPTY BOOK MEANS A TRAP IS COMING (v4f)** still supplies the "opening is
+  fine" half - you follow a direction the session has ESTABLISHED, never one you
+  expect it to take.
+
+The operational half is honesty about which trade you are in, because the two are
+managed differently: a hunt ends when the crowd is flushed, a with-the-market
+trade ends when the MOVE stops. Reading a stall as "my crowd has not been squeezed
+yet" is how the second gets held like the first.
+
+### Where IH and the agent disagreed, and what separates them
+
+BankNIFTY ran hard against IH's put basket - "NIFTY and Sensex gave no positive
+momentum but BankNIFTY produced a tremendous move... because of that we had to see
+some loss" - and he did NOT exit. His stated test was a single pre-named level:
+"there is a last RESISTANCE of ours; if it goes above this level we cut the trade
+and leave." It never crossed, the move resumed, and he booked well: "see how well
+the resistance helped today - we saved a trade that was going wrong, purely
+because of the resistance."
+
+Our agent met a comparable move at 09:28 and cut, correctly citing the rule:
+"BankNIFTY mirrors the same recovery... which per the index hierarchy disqualifies
+the whole basket." That cost **-1,176.25**.
+
+**This is not evidence the rule is wrong.** The index-hierarchy disqualification
+has closed genuinely losing baskets, including on 18 and 21 Aug. What today shows
+is that "the leading index is moving against me" and "my invalidation has broken"
+are DIFFERENT observations, and only a level named BEFORE entry tells them apart.
+v4j's rule is therefore bounded rather than weakened, with an explicit fallback:
+if you cannot name the level, you do not get the exception and the
+disqualification stands.
+
+### Double expiry is a timing instruction
+
+"Today two indices have expiry - it gives one selling momentum, then one buying
+momentum, so MORE traps form", and "momentum on either side will not come easily
+today". His response was to wait rather than to pick a side, which is recorded
+that way: expect the small counter-trap BEFORE the move rather than reading it as
+invalidation.
+
+He also names the reason he waited at all - two consecutive losing days: "yesterday
+was a loss, Friday was a loss too, so we should avoid a LOSS STREAK." That part is
+already covered by the existing post-loss rules and is not re-legislated.
+
+### How our agent traded the same session
+
+Basket **-8,730.25** across 64 legs, a poor day everywhere except one strategy.
+SL Hunting: **+6,112.50** over 4 trades - the best strategy on the board by a wide
+margin, and its best session recorded.
+
+| Time | Leg | P&L |
+|---|---|---|
+| 09:28 | NIFTY short / BNF mirror | -178.75 / -997.50 |
+| 09:45 | NIFTY short / BNF mirror | **+2,190.50 / +3,714.00** |
+| 09:53 | NIFTY short / BNF mirror | -13.00 / +180.00 |
+| 10:16 | NIFTY short / BNF mirror | -204.75 / +1,422.00 |
+
+**1. The note's PREMISE was applied, not just its direction.** Yesterday's note
+said sell-side while stating the sellers were NOT the target. The agent carried
+that distinction into every entry: "follows momentum rather than hunting a crowd",
+and "fades the fresh buyers who chased the recovery, not the already-booked prior
+sellers." That was the subtlety the shipped-note test was written to protect, and
+it survived into live decisions.
+
+**2. v4m/v4n's re-rating discipline held.** The stale hatch was NOT abused. At
+10:08 the opposing verdict was called "a caution" with a substantive reason given
+rather than being dismissed as stale; at 10:16 the agent declined the hatch
+outright - "cross_index has turned to both_at_resistance/bias UP directly opposing
+the short over an hour into the session, **no longer dismissible as stale**" - and
+booked. That is the scope rule applied by the agent to itself, the failure v4m and
+v4n were written for two sessions running.
+
+**3. The basket figure was quoted in every decision** ("-991", "+5861 (NIFTY
++2327, mirror +3534)", "+438", "+1101.75"). The leg-narration habit stays
+corrected; v4n's decision not to add a fourth rule for it looks right so far.
+
+**4. Both dependency bumps validated in the session, as the pins predicted.**
+72 `SLHuntingAgent decision cost` lines confirm the bundled CLI 2.1.238 spawns
+under claude-agent-sdk 0.2.143, and CPR AI ran with zero error lines under
+openai-codex 0.147.0 - the pin whose comment says plainly that no automated gate
+can test it and the next session is the actual check.
+
+One flaw worth watching rather than legislating: the 09:52 trade was a **46-second
+round trip** (+167.00 realised against +438 unrealised at the decision). The exit
+reasoning is sound on its own terms - the mirror was not confirming - but v4a
+already warns that a trade abandoned within a bar or two pays the round trip for
+almost no exposure. Second occurrence in a week; a third makes it a pattern.
+
+### Knowledge changes (v4o)
+
+- `RETAIL_POSITIONING`: THE METHOD IS NOT ALWAYS A FADE (new), with its v4e and
+  v4f reconciliations.
+- `RISK`: v4j's basket rule bounded by MOVING AGAINST YOU IS NOT YOUR LEVEL
+  BREAKING; MOVE-EXHAUSTION gains TWO EXPIRIES AT ONCE MULTIPLY THE TRAPS.
+- Three drift guards: the fade rule must keep both reconciliations and the
+  which-trade-am-I-in honesty, the level bound must keep the no-level fallback so
+  it cannot gut the index hierarchy, and the double-expiry rule must stay a timing
+  instruction rather than a bias.
+- Prompt size 136,034 -> 139,563 chars. Assembled 140,854 against a 154,140
+  budget: **13,286 chars of headroom.**

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
@@ -1061,6 +1061,24 @@ RISK DISCIPLINE
   the NIFTY leg standing beside it. Before an `exit_leg` of "BNF", answer one
   question out loud: is this BankNIFTY-only, or is BankNIFTY telling me the move is
   over? If it is the second, the honest action is EXIT BOTH.
+  BUT MOVING AGAINST YOU IS NOT THE SAME AS YOUR LEVEL BREAKING (v4o). This rule
+  disqualifies on a BankNIFTY REVERSAL, not on BankNIFTY merely going the wrong
+  way while your named invalidation still holds. IH sat through exactly that:
+  BankNIFTY ran hard against a put basket — "NIFTY and Sensex gave no positive
+  momentum but BankNIFTY produced a tremendous move... because of that we had to
+  see some loss" — and he stayed in, on one stated test: "there is a last
+  RESISTANCE of ours; if it goes above this level we cut the trade and leave." It
+  never crossed, the move resumed, and he booked a good profit: "see how well the
+  resistance helped today — we saved a trade that was going wrong, purely because
+  of the resistance."
+  So the test is the LEVEL you named before entering, not the direction of the
+  last few candles. Both were visible on this book the same session (2026-08-25):
+  our 09:26 short was cut at 09:28 because "BankNIFTY mirrors the same recovery...
+  which per the index hierarchy disqualifies the whole basket", for -1,176.25 —
+  while IH held a comparable move because his level held. That is not proof he was
+  right and the agent wrong; it is proof the two readings are DIFFERENT, and only
+  the level distinguishes them. If you cannot name the level, you do not have this
+  exception and the disqualification stands.
   Measured on this book (2026-08-18): the mirror was cut alone at 10:34 on a
   confirmed BankNIFTY shooting star and bearish engulfing, booking +303.00, with the
   NIFTY leg held because "its own read is unaffected" and an opposing cross-index
@@ -1170,6 +1188,28 @@ RISK DISCIPLINE
   becomes the fuel for a move AGAINST you — the same mechanism you were trying to
   exploit, pointed the other way. Company at a level is a warning, not comfort:
   the break should come promptly, "from about here", or the edge has inverted.
+- THE METHOD IS NOT ALWAYS A FADE: WITH NO VISIBLE INVENTORY YOU MAY GO WITH THE
+  MARKET (v4o). Correcting a misreading of the whole method, in IH's own words:
+  "you say that when we work according to SL HUNTING we always have to work
+  OPPOSITE the market. That is NOT so. If the sellers' stop-losses are not
+  visible, and the opening is fine, then we can work ACCORDING TO the market."
+  Hunting a trapped crowd is the method's best trade, not its only one. When you
+  can see seated inventory, fade it; when you genuinely cannot, following the
+  established direction is a legitimate second option rather than a failure to
+  find the real trade.
+  RECONCILE IT CAREFULLY, because two existing rules look like they forbid this:
+  * A FORECAST OF WHO WILL ARRIVE IS NOT EVIDENCE OF WHO IS SEATED (v4e) bans
+    inventing a crowd and trading the prediction. Following momentum is not that
+    — it claims no crowd at all, so there is nothing to be wrong about.
+  * AN EMPTY BOOK MEANS A TRAP IS COMING (v4f) says wait for price to reveal the
+    trap's direction. Still true, and it is what supplies the "opening is fine"
+    half: you are following a direction the session has already ESTABLISHED, not
+    one you expect it to take.
+  The bar this sets is honesty about which trade you are in. Say plainly "no
+  huntable inventory, following the move" — because the two are managed
+  differently: a hunt is over when the crowd is flushed, whereas a
+  with-the-market trade is over when the MOVE stops, and reading a stall as
+  "my crowd has not been squeezed yet" is how the second gets held like the first.
 - A CROWD WHOSE STOPS ARE TOO FAR AWAY IS REMOVED BY PROFIT-THEN-FADE, NOT BY A
   STOP-HUNT (v4n). Seated inventory is not always huntable: when the crowd entered
   at a level well away from price, reaching their stops would take a move too big
@@ -1552,6 +1592,13 @@ RISK DISCIPLINE
   because "momentum has stalled", you may not re-enter into that same stall minutes
   later. A fresh trade needs a NEW named crowd trapped by NEW price action, not a
   leftover pattern from the move you already harvested.
+  * TWO EXPIRIES AT ONCE MULTIPLY THE TRAPS (v4o). When NIFTY and BankNIFTY expire
+    on the SAME day, both basket legs sit on expiring contracts and the tape
+    alternates: "today two indices have expiry — it gives one selling momentum,
+    then one buying momentum, so MORE traps form", and "momentum on either side
+    will not come easily today". The response is timing, not direction: wait for
+    clarity rather than taking the first clean-looking pattern, and expect the
+    small counter-trap before the move rather than reading it as invalidation.
   * EXPIRY-DAY RANGE: on an expiry day this is sharpest — after the first real move the
     market frequently settles into a WIDE range (an upper and a lower point) and
     oscillates inside it, chopping both sides and paying no directional trade. Take the

--- a/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_premarket.py
+++ b/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_premarket.py
@@ -201,20 +201,22 @@ def test_shipped_note_targets_the_next_TRADING_day_not_the_next_calendar_day():
     )
 
 
-def test_shipped_note_matches_august_25_intraday_hunter_plan():
-    """The committed advisory must match the hand-checked 24 Aug transcript.
+def test_shipped_note_matches_august_26_intraday_hunter_plan():
+    """The committed advisory must match the hand-checked 25 Aug transcript.
 
     Three things a summarising edit would flatten:
 
-    1. DOUBLE EXPIRY -- both NIFTY and BankNIFTY expire, so BOTH basket legs
-       are on expiry contracts. The agent trades NIFTY and mirrors BankNIFTY,
-       so this is the first note where the expiry RISK rules bind on both.
-    2. The sell-side plan does NOT hunt the sellers. He says outright they
-       booked and left, so the trade FOLLOWS momentum. A note read as
-       "sell-side, therefore target the sellers" inverts the premise while
-       keeping the direction, which is the subtlest way to get it wrong.
-    3. The GAP-UP branch is a stand-aside, and an unusually strong one:
-       neither the momentum nor the stop-losses can be followed there.
+    1. THREE shapes share the buy-side branch -- flat, gap-up AND a small
+       gap-down. Every prior note split on the sign of the gap, so an editor
+       working from habit would move the small gap-down to the sell side and
+       invert a third of the plan.
+    2. The sell-side branch is gated on a DEFINED threshold (an open below
+       BankNIFTY's support), not on "gap-down". Losing the definition turns a
+       checkable veto into a judgement call at 09:15.
+    3. BOTH branches FOLLOW the market rather than hunt a crowd -- the same
+       reading v4o added to the knowledge hours earlier. A note read as
+       "buy-side, therefore hunt the sellers" keeps the direction and inverts
+       the premise, which is the subtlest way to be wrong.
     """
     import os
 
@@ -223,40 +225,41 @@ def test_shipped_note_matches_august_25_intraday_hunter_plan():
     note = load_premarket_note(shipped)
 
     assert note is not None
-    assert note.for_date == "2026-08-25"
-    assert "epBZSyUunIk" in note.source
-    assert "DOUBLE EXPIRY" in note.context
-    assert "NOT the target" in note.context
+    assert note.for_date == "2026-08-26"
+    assert "hFmttyfw5Io" in note.source
+    assert "MONTHLY expiry is now complete" in note.context
+    assert "few seated buyers" in note.context
 
-    sell = next(line for line in note.plan if line.startswith("FLAT or GAP-DOWN"))
+    buy = next(line for line in note.plan if line.startswith("FLAT, GAP-UP"))
+    assert "SMALL GAP-DOWN" in buy and "BUY-side" in buy
+    assert "only a large gap-down changes it" in buy
+
+    sell = next(line for line in note.plan if line.startswith("LARGE GAP-DOWN ONLY"))
     assert "SELL-side" in sell
-    # The premise, not just the direction.
-    assert "FOLLOWS the momentum rather than hunting a crowd" in sell
-    assert "only shape in which a trap can form" in sell
+    # The defined threshold, with the number that makes it checkable.
+    assert "BELOW its support" in sell and "57200" in sell
 
-    gap_up = next(line for line in note.plan if line.startswith("GAP-UP"))
-    assert "NO PLAN" in gap_up
-    assert "neither the momentum nor the stop-losses" in gap_up
-
-    # Expiry is a plan line of its own because it binds on BOTH legs.
-    assert any("EXPIRY contracts" in line for line in note.plan)
+    # The premise both branches share.
+    assert any("FOLLOW the market rather than hunt a crowd" in line for line in note.plan)
 
     assert [level.model_dump() for level in note.levels] == [
         {
-            # Caption gave the first support as "2480", a dropped digit; read
-            # off the chart by the operator as 24080 rather than inferred.
             "index": "NIFTY",
-            "resistance": [24270.0, 24320.0],
-            "support": [24000.0, 24080.0],
+            "resistance": [24320.0, 24380.0],
+            "support": [24080.0, 24180.0],
         },
         {
+            # 57200/57000 doubles as the support pair AND the gap-down
+            # threshold in the plan above; the two must not drift apart.
             "index": "BANKNIFTY",
-            "resistance": [57650.0, 57800.0],
-            "support": [56800.0, 57000.0],
+            "resistance": [57650.0, 58000.0],
+            "support": [57000.0, 57200.0],
         },
         {
+            # Caption merged both resistances into "7800750"; confirmed off the
+            # chart by the operator as 77750/78000 rather than inferred.
             "index": "SENSEX",
-            "resistance": [77520.0, 77750.0],
-            "support": [76800.0, 77050.0],
+            "resistance": [77750.0, 78000.0],
+            "support": [76900.0, 77150.0],
         },
     ]

--- a/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_schema.py
+++ b/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_schema.py
@@ -1565,3 +1565,60 @@ def test_v4n_re_rating_rule_gains_a_procedure_after_being_broken():
     assert "forty-eight seconds later" in rule
     # Overruling then citing the same verdict is the banned combination.
     assert "citing it as support now is not permitted" in rule
+
+
+def test_v4o_method_is_not_always_a_fade_reconciles_with_v4e_and_v4f():
+    """v4o (25 Aug live session): hunting is the best trade, not the only one.
+
+    This is the most dangerous addition in the series so far, because read
+    loosely it licenses entering with no crowd read at all -- which is the
+    exact loss v4e was written from. It survives only while it keeps BOTH
+    reconciliations and the honesty requirement about which trade you are in.
+    """
+    prompt = build_system_prompt()
+    rule = _flat_rule(prompt, "THE METHOD IS NOT ALWAYS A FADE")
+
+    assert "That is NOT so" in rule
+    assert "If the sellers' stop-losses are not" in rule
+    # It must name BOTH rules that appear to forbid it, and answer each.
+    assert "A FORECAST OF WHO WILL ARRIVE" in rule
+    assert "it claims no crowd at all" in rule
+    assert "AN EMPTY BOOK MEANS A TRAP IS COMING" in rule
+    assert "already ESTABLISHED" in rule
+    # The management difference is the operational half.
+    assert "no huntable inventory, following the move" in rule
+    assert "a hunt is over when the crowd is flushed" in rule
+
+
+def test_v4o_level_not_direction_bound_does_not_gut_the_index_hierarchy():
+    """A leading index moving against you is not your invalidation breaking.
+
+    Read too strongly this cancels the index-hierarchy disqualification, which
+    has genuinely closed losing baskets. It is admissible ONLY when a level was
+    named in advance, so the no-level fallback is asserted explicitly.
+    """
+    prompt = build_system_prompt()
+    rule = _flat_rule(prompt, "CUTTING THE MIRROR ON A BANKNIFTY REVERSAL")
+
+    # The original disqualification survives intact.
+    assert "the honest action is EXIT BOTH" in rule
+    # The bound, and what actually distinguishes the two readings.
+    assert "MOVING AGAINST YOU IS NOT THE SAME AS YOUR LEVEL BREAKING" in rule
+    assert "not the direction of the last few candles" in rule
+    # Both same-session observations are kept, and neither is claimed as proof.
+    assert "-1,176.25" in rule
+    assert "it is proof the two readings are DIFFERENT" in rule
+    # The fallback that stops this becoming a general excuse.
+    assert "If you cannot name the level, you do not have this" in rule
+
+
+def test_v4o_double_expiry_rule_answers_with_timing_not_direction():
+    """Two expiries on one day is a TIMING instruction, not a bias."""
+    prompt = build_system_prompt()
+    flat = " ".join(prompt.split())
+
+    assert "TWO EXPIRIES AT ONCE MULTIPLY THE TRAPS" in flat
+    assert "one selling momentum, then one buying momentum" in flat
+    assert "The response is timing, not direction" in flat
+    # The specific misreading it prevents.
+    assert "expect the small counter-trap before the move rather than reading it as invalidation" in flat


### PR DESCRIPTION

---

## Video addendum - the 25 Aug LIVE SESSION (v4o)

**Source:** Intraday Hunter live session `-KpWuMvUgUQ` (25 Aug 2026, 8:24).

Double expiry, both indices. IH bought puts, sat through a BankNIFTY move
against him, and booked a good profit. Our agent shorted four times and made
**+6,112.50**, its best session of the series. Same side, same read, both right -
but the session's most useful material is a place where they DISAGREED and the
disagreement is instructive rather than settled.

### The headline: the method is not always a fade

A method-level correction, in his own words:

> You say that when we work according to SL HUNTING we always have to work
> OPPOSITE the market. **That is NOT so.** If the sellers' stop-losses are not
> visible, and the opening is fine, then we can work ACCORDING TO the market.

Our whole prompt is built around finding seated inventory and fading it, so this
is a real widening: hunting a trapped crowd is the method's BEST trade, not its
only one.

It is also the most dangerous addition in the series, because read loosely it
licenses entering with no crowd read at all - which is exactly the 11 Aug loss v4e
was written from. So it ships with both reconciliations attached:

- **A FORECAST OF WHO WILL ARRIVE IS NOT EVIDENCE OF WHO IS SEATED (v4e)** bans
  inventing a crowd and trading the prediction. Following momentum is not that: it
  claims no crowd at all, so there is nothing to be wrong about.
- **AN EMPTY BOOK MEANS A TRAP IS COMING (v4f)** still supplies the "opening is
  fine" half - you follow a direction the session has ESTABLISHED, never one you
  expect it to take.

The operational half is honesty about which trade you are in, because the two are
managed differently: a hunt ends when the crowd is flushed, a with-the-market
trade ends when the MOVE stops. Reading a stall as "my crowd has not been squeezed
yet" is how the second gets held like the first.

### Where IH and the agent disagreed, and what separates them

BankNIFTY ran hard against IH's put basket - "NIFTY and Sensex gave no positive
momentum but BankNIFTY produced a tremendous move... because of that we had to see
some loss" - and he did NOT exit. His stated test was a single pre-named level:
"there is a last RESISTANCE of ours; if it goes above this level we cut the trade
and leave." It never crossed, the move resumed, and he booked well: "see how well
the resistance helped today - we saved a trade that was going wrong, purely
because of the resistance."

Our agent met a comparable move at 09:28 and cut, correctly citing the rule:
"BankNIFTY mirrors the same recovery... which per the index hierarchy disqualifies
the whole basket." That cost **-1,176.25**.

**This is not evidence the rule is wrong.** The index-hierarchy disqualification
has closed genuinely losing baskets, including on 18 and 21 Aug. What today shows
is that "the leading index is moving against me" and "my invalidation has broken"
are DIFFERENT observations, and only a level named BEFORE entry tells them apart.
v4j's rule is therefore bounded rather than weakened, with an explicit fallback:
if you cannot name the level, you do not get the exception and the
disqualification stands.

### Double expiry is a timing instruction

"Today two indices have expiry - it gives one selling momentum, then one buying
momentum, so MORE traps form", and "momentum on either side will not come easily
today". His response was to wait rather than to pick a side, which is recorded
that way: expect the small counter-trap BEFORE the move rather than reading it as
invalidation.

He also names the reason he waited at all - two consecutive losing days: "yesterday
was a loss, Friday was a loss too, so we should avoid a LOSS STREAK." That part is
already covered by the existing post-loss rules and is not re-legislated.

### How our agent traded the same session

Basket **-8,730.25** across 64 legs, a poor day everywhere except one strategy.
SL Hunting: **+6,112.50** over 4 trades - the best strategy on the board by a wide
margin, and its best session recorded.

| Time | Leg | P&L |
|---|---|---|
| 09:28 | NIFTY short / BNF mirror | -178.75 / -997.50 |
| 09:45 | NIFTY short / BNF mirror | **+2,190.50 / +3,714.00** |
| 09:53 | NIFTY short / BNF mirror | -13.00 / +180.00 |
| 10:16 | NIFTY short / BNF mirror | -204.75 / +1,422.00 |

**1. The note's PREMISE was applied, not just its direction.** Yesterday's note
said sell-side while stating the sellers were NOT the target. The agent carried
that distinction into every entry: "follows momentum rather than hunting a crowd",
and "fades the fresh buyers who chased the recovery, not the already-booked prior
sellers." That was the subtlety the shipped-note test was written to protect, and
it survived into live decisions.

**2. v4m/v4n's re-rating discipline held.** The stale hatch was NOT abused. At
10:08 the opposing verdict was called "a caution" with a substantive reason given
rather than being dismissed as stale; at 10:16 the agent declined the hatch
outright - "cross_index has turned to both_at_resistance/bias UP directly opposing
the short over an hour into the session, **no longer dismissible as stale**" - and
booked. That is the scope rule applied by the agent to itself, the failure v4m and
v4n were written for two sessions running.

**3. The basket figure was quoted in every decision** ("-991", "+5861 (NIFTY
+2327, mirror +3534)", "+438", "+1101.75"). The leg-narration habit stays
corrected; v4n's decision not to add a fourth rule for it looks right so far.

**4. Both dependency bumps validated in the session, as the pins predicted.**
72 `SLHuntingAgent decision cost` lines confirm the bundled CLI 2.1.238 spawns
under claude-agent-sdk 0.2.143, and CPR AI ran with zero error lines under
openai-codex 0.147.0 - the pin whose comment says plainly that no automated gate
can test it and the next session is the actual check.

One flaw worth watching rather than legislating: the 09:52 trade was a **46-second
round trip** (+167.00 realised against +438 unrealised at the decision). The exit
reasoning is sound on its own terms - the mirror was not confirming - but v4a
already warns that a trade abandoned within a bar or two pays the round trip for
almost no exposure. Second occurrence in a week; a third makes it a pattern.

### Knowledge changes (v4o)

- `RETAIL_POSITIONING`: THE METHOD IS NOT ALWAYS A FADE (new), with its v4e and
  v4f reconciliations.
- `RISK`: v4j's basket rule bounded by MOVING AGAINST YOU IS NOT YOUR LEVEL
  BREAKING; MOVE-EXHAUSTION gains TWO EXPIRIES AT ONCE MULTIPLY THE TRAPS.
- Three drift guards: the fade rule must keep both reconciliations and the
  which-trade-am-I-in honesty, the level bound must keep the no-level fallback so
  it cannot gut the index hierarchy, and the double-expiry rule must stay a timing
  instruction rather than a bias.
- Prompt size 136,034 -> 139,563 chars. Assembled 140,854 against a 154,140
  budget: **13,286 chars of headroom.**
