### PR TITLE
feat(sl-hunting): v4p knowledge, SLH-012 stale-pass journal fix, and the 27 Aug pre-open note

### DIFF
--- a/Nifty Multi Strategy Front Test - Master File.py
+++ b/Nifty Multi Strategy Front Test - Master File.py
@@ -15862,9 +15862,44 @@ if SL_HUNTING_AVAILABLE:
             if payload is None:
                 return
             generation, decision, was_active, strategy_frame, bnf_candles = payload
+            opened_a_position = (
+                self._journal is not None
+                and self._open_trade_id is None
+                and not was_active
+                and self.pos.active
+            )
             if generation != self._agent_generation:
-                self.log.info("Discarding late SL Hunting result for stale generation %s.", generation)
-                return
+                # SLH-012: the guard is about ACTING, not about record-keeping.
+                # A stale pass may still have executed a real order through the
+                # locked tool context before it went stale, and dropping the
+                # whole payload then loses the only record of WHY.
+                #
+                # That is not merely a missing log line. `_finalize_journal`
+                # returns early when `_open_trade_id is None`, so a trade whose
+                # open row was skipped here gets no close row either -- it is
+                # absent from the per-trade journal entirely, which is what the
+                # reflection coach reads. Measured on 2026-08-26: the 09:15 long
+                # executed, the pass was discarded as stale generation 2, and the
+                # trade (+842.25, closed by the mechanical stop) never reached the
+                # journal in any form.
+                #
+                # So when a stale pass left a position open, still record it --
+                # the decision is stale as GUIDANCE but it is the accurate
+                # account of an order that really happened, and
+                # `_tool_authoritative` has already forced it to match what
+                # executed. Nothing here acts: no order is placed, and a stale
+                # pass that opened nothing is still simply dropped.
+                if not opened_a_position:
+                    self.log.info(
+                        "Discarding late SL Hunting result for stale generation %s.", generation
+                    )
+                    return
+                self.log.warning(
+                    "Late SL Hunting result for stale generation %s left a position OPEN; "
+                    "recording its journal row and decision so the trade is not invisible to "
+                    "the coach. The decision is stale as guidance and was NOT acted on.",
+                    generation,
+                )
             if decision.action != "HOLD":
                 self.log.info(
                     "SL Hunting AI: %s (conf=%d, setup=%s) stop=%s target=%s :: %s",
@@ -15881,12 +15916,7 @@ if SL_HUNTING_AVAILABLE:
                     )
                 except Exception as exc:
                     self.log.warning("SL Hunting decision-log failed: %s", exc)
-            if (
-                self._journal is not None
-                and self._open_trade_id is None
-                and not was_active
-                and self.pos.active
-            ):
+            if opened_a_position:
                 self._journal_open_row(decision, strategy_frame, bnf_candles)
 
         def _start_agent_inference(

--- a/Signal Generators/SL Hunting AI Agent/premarket_note.json
+++ b/Signal Generators/SL Hunting AI Agent/premarket_note.json
@@ -1,11 +1,12 @@
 {
-  "for_date": "2026-08-26",
-  "source": "Intraday Hunter, 'Prediction For 26 AUG 2026' (hFmttyfw5Io, uploaded 2026-08-25)",
-  "context": "The MONTHLY expiry is now complete, so the market may start working to the support it has built. After that selling, few people will have gone long even where price held - so there are few seated buyers and room above.",
+  "for_date": "2026-08-27",
+  "source": "Intraday Hunter, 'Prediction For 27 AUG 2026' (auAi14O0HOk, uploaded 2026-08-26)",
+  "context": "Gap-up today, then a fall once a little strength showed; neither NIFTY nor BankNIFTY could cross its level. The market did not break the closing price, so no sellers are seated -- and few here trade puts, so no seller crowd to hunt.",
   "plan": [
-    "FLAT, GAP-UP or a SMALL GAP-DOWN: identify confirmed BUY-side setups. All three shapes share one plan; only a large gap-down changes it.",
-    "LARGE GAP-DOWN ONLY: flip to confirmed SELL-side setups and go WITH the market. The threshold is defined - for BANKNIFTY an opening BELOW its support (57200/57000); on a big gap-down the buyers' strength is not visible at all.",
-    "Both branches FOLLOW the market rather than hunt a crowd. He says so directly for the gap-down case, and the buy-side case rests on few buyers being seated rather than on a trapped crowd to squeeze."
+    "SELL-side on ALL THREE open shapes -- gap-up, flat or gap-down. He gives the same plan for a flat open as for the gapped ones, so the sign of the gap does NOT switch the branch tomorrow.",
+    "FOLLOW the momentum; do NOT hunt a crowd. His stated reason is that nobody is trapped: very few trade puts here so those sellers need not be targeted, and an unbroken closing price means sellers are not seated either.",
+    "BANKNIFTY GAP-UP IS AN EXPLICIT STAND-ASIDE: until it crosses the round number nothing can be done. Rejection at the open keeps the sell-side plan; if it starts running UP he says NO plan can be made there at all.",
+    "Tomorrow is a SENSEX/BANKEX expiry day. Execution stays NIFTY-only, but treat the cross-index read as noisier than usual."
   ],
   "levels": [
     {
@@ -15,19 +16,19 @@
         24380
       ],
       "support": [
-        24080,
+        24120,
         24180
       ]
     },
     {
       "index": "BANKNIFTY",
       "resistance": [
-        57650,
-        58000
+        58000,
+        58200
       ],
       "support": [
-        57000,
-        57200
+        57420,
+        57720
       ]
     },
     {
@@ -37,8 +38,8 @@
         78000
       ],
       "support": [
-        76900,
-        77150
+        77000,
+        77250
       ]
     }
   ]

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -4826,3 +4826,81 @@ normally afterwards, so this is recorded as an observation rather than a fault.
 - **Deliberately NOT added:** the capital-size/execution-speed advice - see above.
 - Prompt size 139,563 -> 141,841 chars. Assembled 143,132 against a 154,140
   budget: **11,008 chars of headroom.**
+
+---
+
+## SLH-012 - a stale inference pass that still left a position open (2026-08-26)
+
+### What happened
+
+At 09:15:49 the agent placed a LONG through the locked tool context. The pass
+completed, and at 09:16:41 the worker logged:
+
+```
+Discarding late SL Hunting result for stale generation 2.
+```
+
+The trade was real: entered at 24347.55, closed by the mechanical stop at 09:16:31
+for a basket **+842.25**. It appears in the trade log, the Telegram alert and the
+session P&L.
+
+It does not appear in the decision journal, and it has **no journal row at all**.
+
+### Why that is more than a missing log line
+
+The generation guard is correct and its docstring is accurate - "a stale generation
+here only skips the bookkeeping, never an order". No order path is affected. But
+the `return` skipped three things, and the third is the expensive one:
+
+1. the `SL Hunting AI: ...` decision log line,
+2. `append_decision(...)` to the decision journal,
+3. `_journal_open_row(...)`.
+
+`_finalize_journal` begins `if self._journal is None or self._open_trade_id is
+None: return`. So a trade whose OPEN row was skipped never gets a CLOSE row
+either - it is absent from the per-trade journal entirely. That journal is what
+`sl_hunting_coach.py` reads to work out what worked, so the trade is invisible to
+the learning loop in both directions.
+
+This is the third path of the family, after the two SLH-011 closed. It did not
+trigger an SLH-011 warning because `reported` was not None: the decision existed
+and parsed perfectly well, it was simply dropped downstream.
+
+### The fix
+
+The guard is about ACTING, not record-keeping. When a stale pass left a position
+OPEN, `_consume_agent_decision` now records it - the journal row and the decision -
+and warns:
+
+> Late SL Hunting result for stale generation N left a position OPEN; recording its
+> journal row and decision so the trade is not invisible to the coach. The decision
+> is stale as guidance and was NOT acted on.
+
+Recording a stale decision is defensible precisely here: it is stale as GUIDANCE,
+but it is the accurate account of an order that really happened, and
+`_tool_authoritative` (SLH-011) has already forced the decision to match what
+executed. Nothing in this path places an order.
+
+The open-row gate is now computed once as `opened_a_position` and reused by both
+branches, so the stale recovery and the normal path can never drift apart.
+
+### What deliberately did NOT change
+
+- **The guard still refuses to act.** No order is placed here and none ever was;
+  the change is confined to bookkeeping.
+- **A stale pass that opened nothing is still simply dropped**, at INFO, exactly as
+  before. That is the ordinary case and making it noisy would bury the real signal.
+- **A pass whose trade is already journalled** (`_open_trade_id` set) writes
+  nothing and does not warn.
+
+### Verification
+
+Four tests, called against a light stub rather than a full worker, because the
+method touches ten attributes and building a real worker would drag in the SDK, a
+broker and a data store to cover ten lines. They skip when the agent deps are
+absent, per the repository convention.
+
+The recovery was negative-tested rather than assumed: reverting the branch to the
+old unconditional discard fails `test_stale_pass_that_opened_a_position_is_journalled_and_warned`
+with `AssertionError: 0 != 1`. Two of the four tests assert the QUIET cases, so the
+warning cannot decay into noise.

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -4718,3 +4718,111 @@ almost no exposure. Second occurrence in a week; a third makes it a pattern.
   instruction rather than a bias.
 - Prompt size 136,034 -> 139,563 chars. Assembled 140,854 against a 154,140
   budget: **13,286 chars of headroom.**
+
+---
+
+## Video addendum - the 26 Aug LIVE SESSION (v4p)
+
+**Source:** Intraday Hunter live session `H5g8T7xllLk` (26 Aug 2026, 7:34).
+
+Gap-up, bought immediately into the run, booked a good profit. Our agent was long
+the same open and finished **+3,634.25**, best on the board for the second session
+running. Both right, both bullish - and the session's most valuable content
+directly CONTRADICTS a rule shipped four days ago, which is why it earns a version
+of its own.
+
+### The headline: waiting is sometimes the cost
+
+> Sometimes it happens in the market that **THE MORE YOU WAIT, THE MORE YOU LOSE.**
+> And today's market is like that. Here you have to enter QUICKLY, without waiting -
+> only then will you gain.
+
+And on the entry itself: "we bought into a RUNNING market. Not that we waited, not
+that we looked for a retracement. The market was going straight up and we bought
+straight away."
+
+Two sessions earlier the same analyst waited deliberately and said why (two losing
+days, double expiry, traps forming both ways). So the instruction is not "be fast";
+it is that the choice between entering now and holding out for a pullback is
+CONDITIONAL on whether a direction has already declared itself. Both branches are
+in the prose, because a rule with only the fast half is a standing bias.
+
+**The scope limit matters more than the rule.** Read carelessly this says skip
+confirmation, which would gut the method. It governs WHERE you enter once a setup
+is confirmed - at the break or on a pullback - never WHETHER a setup was needed.
+The prose says so and `test_v4p_enter_quickly_rule_never_relaxes_the_confirmation_requirement`
+asserts it, because this is the single most dangerous misreading available in the
+knowledge base.
+
+It also does not contradict v4l's ENTRY TIME IS A RISK DIAL: that rule prices the
+hour you choose, this one says a declared direction removes the pullback option
+from the menu.
+
+### Deliberately NOT added
+
+He spends a full minute on capital size and execution speed - "keep capital as
+LOW as you need to, but trade so that you can enter smoothly", and "many traders
+know the momentum is coming but have so much capital committed that they cannot
+enter quickly, so the trade is missed."
+
+It is good advice for a human and does not transfer. This agent's size is computed
+mechanically to a ~Rs.2500 risk budget, it does not choose capital, and it does not
+hesitate. Adding it would be prompt weight against a failure the agent cannot
+commit. Recorded here rather than dropped silently.
+
+### How our agent traded the same session
+
+Basket **-13,236.50** across 73 legs, a poor day broadly. SL Hunting: **+3,634.25**
+over 3 trades, top of the board.
+
+| Time | Exit type | NIFTY / mirror | Net |
+|---|---|---|---|
+| 09:16 | **mechanical AI_STOP** | -399.75 / +1,242.00 | **+842.25** |
+| 09:26 | agent, round-number stall | +760.50 / +1,269.00 | +2,029.50 |
+| 10:23 | agent, premise invalidation | +474.50 / +288.00 | +762.50 |
+
+**1. A stop fired on NIFTY spot and closed a basket that was in PROFIT.** The 09:15
+long was stopped at spot 24333 against a 24335 stop - a loss on the leg the stop
+watches (-399.75) - while the BankNIFTY mirror was +1,242.00, so the basket exited
+**+842.25**. That is a structural fact about the basket rather than a mistake:
+the stop is a NIFTY invalidation measured on NIFTY alone, and it closes both legs.
+v4p records it in the BASKET NOTE, explicitly WITHOUT concluding that stops should
+be wider - a NIFTY stop protects the NIFTY premise, which is the one that was
+traded.
+
+**2. That trade has NO decision-journal entry, and nothing warned.** The order
+executed at 09:15:49 through the locked tool context, the pass completed, and at
+09:16:41 the worker logged "Discarding late SL Hunting result for stale generation
+2." The design is deliberate and the docstring is explicit - "a stale generation
+here only skips the bookkeeping, never an order" - and the order path is safe.
+
+But it is the THIRD path in which an executed order reaches the trade log while the
+decision journal gets nothing, after the two SLH-011 closed. The reflection coach
+reads that journal. No SLH-011 warning fired because `reported` was not None - the
+decision existed, it was simply discarded downstream. **Not fixed here** because
+this is a code question rather than a knowledge one, and it deserves the same
+treatment SLH-011 got rather than being bolted onto a knowledge PR.
+
+**3. A parsing note for future sessions.** SL Hunting exits appear under TWO logger
+names: `sl-hunting-sdk-call` for agent exits and `SL Hunting AIThread` for
+mechanical stop/target/square-off exits. A sweep on the first alone under-counts -
+it showed 2,792.00 against the true 3,634.25 here and hid the stopped trade
+entirely. This is the third variant of the same class of mistake in this journal
+(after `MIRROR EXIT` and the `sl-hunting-sdk-call` thread name); the reliable check
+remains the worker's own `Result summary` line.
+
+**4. The runner restarted three times before the open** (08:17, 08:23, 08:27, each
+with a zero-trade `Result summary`). No errors accompany them and the session ran
+normally afterwards, so this is recorded as an observation rather than a fault.
+
+### Knowledge changes (v4p)
+
+- `RISK`: WHEN THE DIRECTION HAS ALREADY DECLARED ITSELF, WAITING IS THE COST (new,
+  beside v4l's entry-time rule); the BASKET NOTE gains YOUR STOP IS A NIFTY-SPOT
+  TRIGGER ON A TWO-INDEX BASKET.
+- Two drift guards: the enter-quickly rule must keep its scope limit and both
+  branches of the conditional, and the stop note must keep the explicit refusal to
+  argue for wider stops.
+- **Deliberately NOT added:** the capital-size/execution-speed advice - see above.
+- Prompt size 139,563 -> 141,841 chars. Assembled 143,132 against a 154,140
+  budget: **11,008 chars of headroom.**

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -4904,3 +4904,75 @@ The recovery was negative-tested rather than assumed: reverting the branch to th
 old unconditional discard fails `test_stale_pass_that_opened_a_position_is_journalled_and_warned`
 with `AssertionError: 0 != 1`. Two of the four tests assert the QUIET cases, so the
 warning cannot decay into noise.
+
+---
+
+## Pre-open note for 2026-08-27
+
+**Source:** Intraday Hunter, "Nifty & Bank nifty | SENSEX Analysis | Prediction For
+27 AUG 2026" (`auAi14O0HOk`, uploaded 2026-08-26, 1:38).
+
+### The plan
+
+**The branch inverted overnight.** Yesterday all three open shapes shared a
+BUY-side plan; tomorrow all three share a SELL-side one. He says it twice, once
+over the SENSEX chart and once over NIFTY, in the same words both times: on a
+gap-up, flat-to-gap-down open, identify SELLING-side setups - "and in flat and so
+on, our same plan remains."
+
+That last clause is the one worth protecting. FLAT sits on the SELL side. It is
+the same structural point as yesterday's note - the sign of the gap does not
+switch the branch - pointing the opposite way, which makes it exactly the thing a
+habit-driven edit gets wrong.
+
+**The premise is FOLLOW, not hunt, and he gives the reason.** Two of them: very
+few people here trade puts, so those sellers do not need to be targeted; and the
+market did not break the closing price, so sellers are not seated either. With
+nobody trapped on either side, the method is momentum-following rather than a
+squeeze. This is a clean second instance of v4o's THE METHOD IS NOT ALWAYS A FADE,
+arriving one session after that rule shipped.
+
+**BankNIFTY carries an explicit stand-aside.** On a gap-up, "until it crosses the
+round number we cannot do anything." If rejection shows at the open, the sell-side
+plan holds. If it starts running up - "no plan can be made there at all." A note
+that kept only the sell-side half would convert a no-trade instruction into a
+licence to short strength, so the test asserts the stand-aside survives as such.
+
+**Tomorrow is a SENSEX/BANKEX expiry day** (he says so over the SENSEX chart, and
+the other channels' titles for 27 Aug agree). Execution stays NIFTY-only; this is
+context for the cross-index read, which is noisier than usual on those days.
+
+### Levels
+
+| Index | Resistance | Support |
+|---|---|---|
+| NIFTY | 24320, 24380 | 24120, 24180 |
+| BANKNIFTY | 58000, 58200 | 57420, 57720 |
+| SENSEX | 77750, 78000 | 77000, 77250 |
+
+Two readings were confirmed by the operator off the chart rather than inferred:
+
+- **SENSEX resistance.** The caption merged the pair into the run-on "78000750",
+  the same failure as yesterday's "7800750". Confirmed as 77750/78000 - i.e.
+  UNCHANGED from yesterday, despite the gap-up. The test carries a comment saying
+  so, because the natural assumption on seeing a repeated pair is that the note
+  was copied from the previous day's file and needs "correcting".
+- **NIFTY first support.** The caption gave "24,187"; confirmed as 24180. He does
+  give precise levels in this same video (BankNIFTY 57720/57420), so the caption
+  was not obviously wrong and guessing would have been a coin flip.
+
+### An extraction note for future sessions
+
+**YouTube's `timedtext` endpoint no longer works.** It now answers HTTP 200 with a
+zero-length body for every format (plain, `fmt=json3`, `fmt=srv3`) without a POT
+token, so the caption-track URL lifted out of the watch-page HTML - the method used
+for previous notes - silently yields nothing rather than erroring.
+
+What works: open the transcript panel in the visible browser pane and scrape the
+DOM. The segment element is `transcript-segment-view-model` (not the older
+`ytd-transcript-segment-renderer`, which no longer exists), and the list is
+VIRTUALIZED - roughly 13 segments are rendered at a time, so a single query
+returns only what is on screen. Scroll the panel's scrollable ancestor in steps
+and accumulate segments keyed by timestamp until the count stops growing. This
+video was short enough that one screenful was the whole transcript, which would
+have made the virtualization easy to miss on a longer one.

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
@@ -1007,6 +1007,15 @@ RISK DISCIPLINE
   shows the mirror as its own leg with its own P&L; `unrealized_pnl` there is BASKET P&L
   (both legs) while `nifty_leg_pnl` and the `mirror` block give you each leg alone. When in
   doubt, EXIT BOTH.
+  YOUR STOP IS A NIFTY-SPOT TRIGGER ON A TWO-INDEX BASKET (v4p). The stop you name
+  is measured on NIFTY spot alone but closes BOTH legs, and the mirror can be moving
+  the other way when it fires. Measured on this book (2026-08-26): a long stopped at
+  spot 24333 against a 24335 stop closed with the NIFTY leg at -399.75 and the
+  BankNIFTY mirror at +1,242.00 — the basket exited +842.25 on what was, for the leg
+  the stop watches, a loss. Know this when you place the stop: it is a NIFTY
+  invalidation, and whether the basket is up or down when it fires is not something
+  the stop can see. It is not a reason to widen the stop — a NIFTY stop protects the
+  NIFTY premise, which is the one you traded.
 - THE LAGGING INDEX DECIDES THE BASKET'S EXIT, NOT THE LEADING ONE (v4i). When the
   indices are moving together and one falls BEHIND, the laggard is where the
   retracement starts and it caps what the basket can actually collect — so a trade
@@ -1717,6 +1726,28 @@ RISK DISCIPLINE
   attempt. Recover a BIG loss across MULTIPLE ordinary trades, never in one, and
   distrust the "one last trade" of the day — taking the next trade immediately is
   where revenge trading starts, and that last trade is where over-trading does.
+- WHEN THE DIRECTION HAS ALREADY DECLARED ITSELF, WAITING IS THE COST (v4p). The
+  conditional half of the rule below, from the same analyst four sessions later
+  and pointing the other way: "sometimes it happens in the market that THE MORE
+  YOU WAIT, THE MORE YOU LOSE. And today's market is like that. Here you have to
+  enter QUICKLY, without waiting — only then will you gain." He describes the
+  entry itself as taken into the run: "we bought into a RUNNING market. Not that
+  we waited, not that we looked for a retracement. The market was going straight
+  up and we bought straight away."
+  So the choice between "enter now" and "hold out for a pullback" is CONDITIONAL,
+  not a fixed preference:
+  * Direction already established at the open and momentum running — waiting for
+    a retracement that may never arrive forfeits the move. Take the entry.
+  * Sideways, unclear, or a chop-prone session (he waited deliberately on the
+    double-expiry day two sessions earlier, and said why) — waiting is right.
+  WHAT THIS DOES NOT RELAX: the pattern-plus-confirmation requirement is
+  untouched. This governs WHERE you enter once a setup is confirmed — at the
+  break or on a pullback — never WHETHER a setup was needed. "Enter quickly"
+  means do not hold out for a better price on a confirmed signal; it never means
+  enter without one.
+  It also does not contradict ENTRY TIME IS A RISK DIAL below: that rule prices
+  the hour you choose, this one says a declared direction removes the pullback
+  option from the menu. Both are about paying for what you get.
 - ENTRY TIME IS A RISK DIAL — YOU GET THE MOMENTUM YOUR RISK BUYS (v4l). How early
   you enter is a choice about risk, not only about opportunity, and the two move
   together. IH: "you can trade early, or you can wait a little — you should decide

--- a/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_premarket.py
+++ b/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_premarket.py
@@ -201,22 +201,26 @@ def test_shipped_note_targets_the_next_TRADING_day_not_the_next_calendar_day():
     )
 
 
-def test_shipped_note_matches_august_26_intraday_hunter_plan():
-    """The committed advisory must match the hand-checked 25 Aug transcript.
+def test_shipped_note_matches_august_27_intraday_hunter_plan():
+    """The committed advisory must match the hand-checked 26 Aug transcript.
 
-    Three things a summarising edit would flatten:
+    Four things a summarising edit would flatten:
 
-    1. THREE shapes share the buy-side branch -- flat, gap-up AND a small
-       gap-down. Every prior note split on the sign of the gap, so an editor
-       working from habit would move the small gap-down to the sell side and
-       invert a third of the plan.
-    2. The sell-side branch is gated on a DEFINED threshold (an open below
-       BankNIFTY's support), not on "gap-down". Losing the definition turns a
-       checkable veto into a judgement call at 09:15.
-    3. BOTH branches FOLLOW the market rather than hunt a crowd -- the same
-       reading v4o added to the knowledge hours earlier. A note read as
-       "buy-side, therefore hunt the sellers" keeps the direction and inverts
-       the premise, which is the subtlest way to be wrong.
+    1. The branch INVERTED overnight. Yesterday all three open shapes shared a
+       BUY-side plan; today all three share a SELL-side one. An editor working
+       from the previous note rather than the transcript would keep the
+       direction and change only the levels, which is the whole plan wrong.
+    2. FLAT is on the sell side. He gives the same plan for a flat open as for
+       the gapped ones, so the sign of the gap does not switch the branch --
+       the same structural point as yesterday, opposite direction.
+    3. The premise is FOLLOW, not hunt, and it carries its reason: nobody is
+       trapped (few trade puts here, and the closing price was not broken).
+       "Sell-side, therefore hunt the buyers" keeps the direction and inverts
+       the premise, which is the subtlest way to be wrong -- and it is exactly
+       what v4o's THE METHOD IS NOT ALWAYS A FADE exists to prevent.
+    4. BankNIFTY carries an explicit STAND-ASIDE on a gap-up that runs. A note
+       that keeps only the sell-side half turns a no-trade instruction into a
+       licence to short strength.
     """
     import os
 
@@ -225,41 +229,47 @@ def test_shipped_note_matches_august_26_intraday_hunter_plan():
     note = load_premarket_note(shipped)
 
     assert note is not None
-    assert note.for_date == "2026-08-26"
-    assert "hFmttyfw5Io" in note.source
-    assert "MONTHLY expiry is now complete" in note.context
-    assert "few seated buyers" in note.context
+    assert note.for_date == "2026-08-27"
+    assert "auAi14O0HOk" in note.source
+    assert "neither NIFTY nor BankNIFTY could cross its level" in note.context
+    assert "no sellers are seated" in note.context
 
-    buy = next(line for line in note.plan if line.startswith("FLAT, GAP-UP"))
-    assert "SMALL GAP-DOWN" in buy and "BUY-side" in buy
-    assert "only a large gap-down changes it" in buy
+    sell = next(line for line in note.plan if line.startswith("SELL-side"))
+    assert "ALL THREE open shapes" in sell
+    assert "gap-up, flat or gap-down" in sell
+    # Flat sits on the sell side, and the gap's sign is explicitly not the gate.
+    assert "does NOT switch the branch" in sell
 
-    sell = next(line for line in note.plan if line.startswith("LARGE GAP-DOWN ONLY"))
-    assert "SELL-side" in sell
-    # The defined threshold, with the number that makes it checkable.
-    assert "BELOW its support" in sell and "57200" in sell
+    # The premise, with the reason that makes it checkable rather than a slogan.
+    follow = next(line for line in note.plan if line.startswith("FOLLOW the momentum"))
+    assert "do NOT hunt a crowd" in follow
+    assert "nobody is trapped" in follow
 
-    # The premise both branches share.
-    assert any("FOLLOW the market rather than hunt a crowd" in line for line in note.plan)
+    # The stand-aside must survive as a no-trade, not collapse into the plan.
+    bnf = next(line for line in note.plan if line.startswith("BANKNIFTY GAP-UP"))
+    assert "STAND-ASIDE" in bnf
+    assert "NO plan can be made" in bnf
+
+    assert any("SENSEX/BANKEX expiry" in line for line in note.plan)
 
     assert [level.model_dump() for level in note.levels] == [
         {
             "index": "NIFTY",
             "resistance": [24320.0, 24380.0],
-            "support": [24080.0, 24180.0],
+            "support": [24120.0, 24180.0],
         },
         {
-            # 57200/57000 doubles as the support pair AND the gap-down
-            # threshold in the plan above; the two must not drift apart.
             "index": "BANKNIFTY",
-            "resistance": [57650.0, 58000.0],
-            "support": [57000.0, 57200.0],
+            "resistance": [58000.0, 58200.0],
+            "support": [57420.0, 57720.0],
         },
         {
-            # Caption merged both resistances into "7800750"; confirmed off the
-            # chart by the operator as 77750/78000 rather than inferred.
+            # The caption merged both resistances again ("78000750"), as it did
+            # yesterday ("7800750"). Confirmed off the chart by the operator as
+            # 77750/78000 -- unchanged from yesterday, not a transcription of
+            # yesterday's file. Do not "correct" this to a moved level.
             "index": "SENSEX",
             "resistance": [77750.0, 78000.0],
-            "support": [76900.0, 77150.0],
+            "support": [77000.0, 77250.0],
         },
     ]

--- a/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_schema.py
+++ b/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_schema.py
@@ -1622,3 +1622,50 @@ def test_v4o_double_expiry_rule_answers_with_timing_not_direction():
     assert "The response is timing, not direction" in flat
     # The specific misreading it prevents.
     assert "expect the small counter-trap before the move rather than reading it as invalidation" in flat
+
+
+def test_v4p_enter_quickly_rule_never_relaxes_the_confirmation_requirement():
+    """v4p (26 Aug live session): "the more you wait, the more you lose".
+
+    This is the rule most likely to be misread into skipping confirmation,
+    which would gut the method. It must keep BOTH the scope limit (it governs
+    WHERE you enter, not WHETHER a setup was needed) and the conditional -- he
+    waited deliberately two sessions earlier and the prose has to say so, or
+    "enter quickly" becomes a standing bias.
+    """
+    prompt = build_system_prompt()
+    rule = _flat_rule(prompt, "WHEN THE DIRECTION HAS ALREADY DECLARED ITSELF")
+
+    assert "THE MORE YOU WAIT, THE MORE YOU LOSE" in rule
+    assert "we bought into a RUNNING market" in rule
+
+    # The scope limit -- the half that keeps the method intact.
+    assert "WHAT THIS DOES NOT RELAX" in rule
+    assert "pattern-plus-confirmation requirement is" in rule
+    assert "it never means enter without one" in rule
+
+    # Both branches of the conditional, so it cannot collapse into a bias.
+    assert "Direction already established at the open" in rule
+    assert "waiting is right" in rule
+
+    # And the reconciliation with the rule it sits beside.
+    assert "ENTRY TIME IS A RISK DIAL" in rule
+
+
+def test_v4p_stop_is_a_nifty_trigger_note_does_not_argue_for_wider_stops():
+    """The stop watches one index but closes two legs.
+
+    Stated as a FACT about the basket, with the tempting wrong conclusion
+    ruled out explicitly -- a rule that quietly licensed wider stops on a
+    live-money system would be the worst possible reading of it.
+    """
+    prompt = build_system_prompt()
+    rule = _flat_rule(prompt, "BASKET NOTE (BankNIFTY mirror)")
+
+    assert "YOUR STOP IS A NIFTY-SPOT TRIGGER ON A TWO-INDEX BASKET" in rule
+    # The measured case, both legs.
+    assert "-399.75" in rule and "+1,242.00" in rule
+    assert "the basket exited +842.25" in rule
+    # The conclusion it must NOT support.
+    assert "not a reason to widen the stop" in rule
+    assert "protects the NIFTY premise" in rule

--- a/Tests/test_nifty_multi_strategy_master.py
+++ b/Tests/test_nifty_multi_strategy_master.py
@@ -12642,6 +12642,95 @@ class TestSessionStatePersistence(unittest.TestCase):
             )
 
 
+# --------------------------------------------------------------------------
+# SLH-012: a stale inference pass that still left a position open.
+#
+# The generation guard exists so a decision computed against old market state
+# can never ACT. It was also dropping the bookkeeping, and that is not just a
+# missing log line: `_finalize_journal` returns early when `_open_trade_id is
+# None`, so a trade whose open row was skipped gets no close row either and is
+# absent from the per-trade journal the reflection coach reads.
+#
+# Measured on 2026-08-26: the 09:15 long executed through the locked tool
+# context, the pass was discarded as "stale generation 2", and that trade
+# (+842.25, closed by the mechanical stop) never reached the journal at all.
+# --------------------------------------------------------------------------
+
+class SLHuntingStaleGenerationJournalTests(unittest.TestCase):
+    """`_consume_agent_decision` is called unbound against a light stub.
+
+    Building a real worker would drag in the SDK, a broker and a data store to
+    exercise ten lines of bookkeeping; the method only touches the attributes
+    stubbed below, so this keeps the test honest about what it covers.
+    """
+
+    def _stub(self, *, generation, current_generation, position_open, was_active=False):
+        decision = SimpleNamespace(
+            action="ENTER_LONG", confidence=7, setup="stale_pass_setup",
+            stop=24338.0, target=24400.0, reasoning="opened during the pass",
+        )
+        stub = SimpleNamespace(
+            _agent_inference_lock=threading.Lock(),
+            _agent_inference_thread=SimpleNamespace(is_alive=lambda: False),
+            _agent_inference_result=(
+                generation, decision, was_active, pd.DataFrame(), None,
+            ),
+            _agent_generation=current_generation,
+            _journal=object(),
+            _open_trade_id=None,
+            _decisions_path=None,          # decision-journal append is skipped
+            pos=SimpleNamespace(active=position_open),
+            log=MagicMock(),
+        )
+        stub.opened_rows = []
+        stub._journal_open_row = lambda *a: stub.opened_rows.append(a)
+        return stub
+
+    def _consume(self, stub):
+        worker_cls = getattr(master_file, "SLHuntingAIWorker", None)
+        if worker_cls is None:
+            self.skipTest("SL Hunting agent deps not installed; worker class is None")
+        worker_cls._consume_agent_decision(stub)
+
+    def test_stale_pass_that_opened_a_position_is_journalled_and_warned(self):
+        stub = self._stub(generation=2, current_generation=3, position_open=True)
+        self._consume(stub)
+
+        # The trade reaches the journal instead of vanishing.
+        self.assertEqual(len(stub.opened_rows), 1)
+        # ...and the operator is told, at WARNING.
+        warned = " ".join(str(c) for c in stub.log.warning.call_args_list)
+        self.assertIn("stale generation", warned)
+        self.assertIn("OPEN", warned)
+        self.assertIn("NOT acted on", warned)
+
+    def test_stale_pass_that_opened_nothing_is_still_simply_dropped(self):
+        """The guard's ordinary case must not become noisy."""
+        stub = self._stub(generation=2, current_generation=3, position_open=False)
+        self._consume(stub)
+
+        self.assertEqual(stub.opened_rows, [])
+        self.assertEqual(stub.log.warning.call_count, 0)
+        info = " ".join(str(c) for c in stub.log.info.call_args_list)
+        self.assertIn("Discarding late SL Hunting result", info)
+
+    def test_a_fresh_pass_is_unaffected(self):
+        """Same generation: normal path, journalled, no warning."""
+        stub = self._stub(generation=4, current_generation=4, position_open=True)
+        self._consume(stub)
+
+        self.assertEqual(len(stub.opened_rows), 1)
+        self.assertEqual(stub.log.warning.call_count, 0)
+
+    def test_a_stale_pass_never_reopens_an_already_journalled_trade(self):
+        """`_open_trade_id` set means the row exists; do not write a second."""
+        stub = self._stub(generation=2, current_generation=3, position_open=True)
+        stub._open_trade_id = "already-open"
+        self._consume(stub)
+
+        self.assertEqual(stub.opened_rows, [])
+        self.assertEqual(stub.log.warning.call_count, 0)
+
 if __name__ == "__main__":
     # Use the custom runner so both `python file.py` and any other direct
     # invocation produce verbose per-test output PLUS the final summary.


### PR DESCRIPTION

---

## Video addendum - the 26 Aug LIVE SESSION (v4p)

**Source:** Intraday Hunter live session `H5g8T7xllLk` (26 Aug 2026, 7:34).

Gap-up, bought immediately into the run, booked a good profit. Our agent was long
the same open and finished **+3,634.25**, best on the board for the second session
running. Both right, both bullish - and the session's most valuable content
directly CONTRADICTS a rule shipped four days ago, which is why it earns a version
of its own.

### The headline: waiting is sometimes the cost

> Sometimes it happens in the market that **THE MORE YOU WAIT, THE MORE YOU LOSE.**
> And today's market is like that. Here you have to enter QUICKLY, without waiting -
> only then will you gain.

And on the entry itself: "we bought into a RUNNING market. Not that we waited, not
that we looked for a retracement. The market was going straight up and we bought
straight away."

Two sessions earlier the same analyst waited deliberately and said why (two losing
days, double expiry, traps forming both ways). So the instruction is not "be fast";
it is that the choice between entering now and holding out for a pullback is
CONDITIONAL on whether a direction has already declared itself. Both branches are
in the prose, because a rule with only the fast half is a standing bias.

**The scope limit matters more than the rule.** Read carelessly this says skip
confirmation, which would gut the method. It governs WHERE you enter once a setup
is confirmed - at the break or on a pullback - never WHETHER a setup was needed.
The prose says so and `test_v4p_enter_quickly_rule_never_relaxes_the_confirmation_requirement`
asserts it, because this is the single most dangerous misreading available in the
knowledge base.

It also does not contradict v4l's ENTRY TIME IS A RISK DIAL: that rule prices the
hour you choose, this one says a declared direction removes the pullback option
from the menu.

### Deliberately NOT added

He spends a full minute on capital size and execution speed - "keep capital as
LOW as you need to, but trade so that you can enter smoothly", and "many traders
know the momentum is coming but have so much capital committed that they cannot
enter quickly, so the trade is missed."

It is good advice for a human and does not transfer. This agent's size is computed
mechanically to a ~Rs.2500 risk budget, it does not choose capital, and it does not
hesitate. Adding it would be prompt weight against a failure the agent cannot
commit. Recorded here rather than dropped silently.

### How our agent traded the same session

Basket **-13,236.50** across 73 legs, a poor day broadly. SL Hunting: **+3,634.25**
over 3 trades, top of the board.

| Time | Exit type | NIFTY / mirror | Net |
|---|---|---|---|
| 09:16 | **mechanical AI_STOP** | -399.75 / +1,242.00 | **+842.25** |
| 09:26 | agent, round-number stall | +760.50 / +1,269.00 | +2,029.50 |
| 10:23 | agent, premise invalidation | +474.50 / +288.00 | +762.50 |

**1. A stop fired on NIFTY spot and closed a basket that was in PROFIT.** The 09:15
long was stopped at spot 24333 against a 24335 stop - a loss on the leg the stop
watches (-399.75) - while the BankNIFTY mirror was +1,242.00, so the basket exited
**+842.25**. That is a structural fact about the basket rather than a mistake:
the stop is a NIFTY invalidation measured on NIFTY alone, and it closes both legs.
v4p records it in the BASKET NOTE, explicitly WITHOUT concluding that stops should
be wider - a NIFTY stop protects the NIFTY premise, which is the one that was
traded.

**2. That trade has NO decision-journal entry, and nothing warned.** The order
executed at 09:15:49 through the locked tool context, the pass completed, and at
09:16:41 the worker logged "Discarding late SL Hunting result for stale generation
2." The design is deliberate and the docstring is explicit - "a stale generation
here only skips the bookkeeping, never an order" - and the order path is safe.

But it is the THIRD path in which an executed order reaches the trade log while the
decision journal gets nothing, after the two SLH-011 closed. The reflection coach
reads that journal. No SLH-011 warning fired because `reported` was not None - the
decision existed, it was simply discarded downstream. **Not fixed here** because
this is a code question rather than a knowledge one, and it deserves the same
treatment SLH-011 got rather than being bolted onto a knowledge PR.

**3. A parsing note for future sessions.** SL Hunting exits appear under TWO logger
names: `sl-hunting-sdk-call` for agent exits and `SL Hunting AIThread` for
mechanical stop/target/square-off exits. A sweep on the first alone under-counts -
it showed 2,792.00 against the true 3,634.25 here and hid the stopped trade
entirely. This is the third variant of the same class of mistake in this journal
(after `MIRROR EXIT` and the `sl-hunting-sdk-call` thread name); the reliable check
remains the worker's own `Result summary` line.

**4. The runner restarted three times before the open** (08:17, 08:23, 08:27, each
with a zero-trade `Result summary`). No errors accompany them and the session ran
normally afterwards, so this is recorded as an observation rather than a fault.

### Knowledge changes (v4p)

- `RISK`: WHEN THE DIRECTION HAS ALREADY DECLARED ITSELF, WAITING IS THE COST (new,
  beside v4l's entry-time rule); the BASKET NOTE gains YOUR STOP IS A NIFTY-SPOT
  TRIGGER ON A TWO-INDEX BASKET.
- Two drift guards: the enter-quickly rule must keep its scope limit and both
  branches of the conditional, and the stop note must keep the explicit refusal to
  argue for wider stops.
- **Deliberately NOT added:** the capital-size/execution-speed advice - see above.
- Prompt size 139,563 -> 141,841 chars. Assembled 143,132 against a 154,140
  budget: **11,008 chars of headroom.**
