### PR TITLE
feat(sl-hunting): v4q knowledge from the 27 Aug IH live session, and the 28 Aug pre-open note

### DIFF
--- a/Signal Generators/SL Hunting AI Agent/premarket_note.json
+++ b/Signal Generators/SL Hunting AI Agent/premarket_note.json
@@ -1,23 +1,24 @@
 {
-  "for_date": "2026-08-27",
-  "source": "Intraday Hunter, 'Prediction For 27 AUG 2026' (auAi14O0HOk, uploaded 2026-08-26)",
-  "context": "Gap-up today, then a fall once a little strength showed; neither NIFTY nor BankNIFTY could cross its level. The market did not break the closing price, so no sellers are seated -- and few here trade puts, so no seller crowd to hunt.",
+  "for_date": "2026-08-28",
+  "source": "Intraday Hunter, 'Prediction For 28 AUG 2026' (IwYyOclpDR8, uploaded 2026-08-27)",
+  "context": "All three indices sold off today, so retail SELLERS are now seated and become tomorrow's target. This is the first HUNT-the-crowd plan in three sessions -- the last two followed momentum precisely because nobody was trapped.",
   "plan": [
-    "SELL-side on ALL THREE open shapes -- gap-up, flat or gap-down. He gives the same plan for a flat open as for the gapped ones, so the sign of the gap does NOT switch the branch tomorrow.",
-    "FOLLOW the momentum; do NOT hunt a crowd. His stated reason is that nobody is trapped: very few trade puts here so those sellers need not be targeted, and an unbroken closing price means sellers are not seated either.",
-    "BANKNIFTY GAP-UP IS AN EXPLICIT STAND-ASIDE: until it crosses the round number nothing can be done. Rejection at the open keeps the sell-side plan; if it starts running UP he says NO plan can be made there at all.",
-    "Tomorrow is a SENSEX/BANKEX expiry day. Execution stays NIFTY-only, but treat the cross-index read as noisier than usual."
+    "FLAT or GAP-UP: BUY-side setups, to TARGET the seated sellers. This is a HUNT, not a follow -- the opposite premise to the last two sessions, and the premise flips even where the direction looks familiar.",
+    "GAP-DOWN: flip to SELL-side and go WITH the market. His reason is the profit half of the two-condition test -- on a gap-down the sellers are already in decent profit, and a crowd in profit is not a target.",
+    "FLAT VETO, the level must NOT break: 'once the level breaks the sellers come into confidence, and then targeting them will not be easy for us'. A break converts a trapped crowd into a validated one and voids the buy-side hunt.",
+    "HE DOES NOT WANT A BREAKDOWN: 'as soon as a breakdown happens, any seated selling trader will not cut his trade, so we will not get the SLs'. The hunt needs sellers who are WRONG and forced to cut, not sellers proven right.",
+    "24,000 is named as NIFTY's psychological number, with 23,920 as the second support beneath it."
   ],
   "levels": [
     {
       "index": "NIFTY",
       "resistance": [
-        24320,
-        24380
+        24200,
+        24270
       ],
       "support": [
-        24120,
-        24180
+        23920,
+        24000
       ]
     },
     {
@@ -27,19 +28,19 @@
         58200
       ],
       "support": [
-        57420,
-        57720
+        57200,
+        57500
       ]
     },
     {
       "index": "SENSEX",
       "resistance": [
-        77750,
-        78000
+        77400,
+        77750
       ],
       "support": [
-        77000,
-        77250
+        76550,
+        77000
       ]
     }
   ]

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -4976,3 +4976,135 @@ returns only what is on screen. Scroll the panel's scrollable ancestor in steps
 and accumulate segments keyed by timestamp until the count stops growing. This
 video was short enough that one screenful was the whole transcript, which would
 have made the virtualization easy to miss on a longer one.
+
+---
+
+## Video addendum - the 27 Aug LIVE SESSION (v4q)
+
+**Source:** Intraday Hunter live session `npth0OPyFSY` (27 Aug 2026, 6:29).
+
+A flat-to-small-gap-up open that sold off. IH shorted it at the open across
+BankNIFTY (58000 then 57900 PE), SENSEX (SENSEX expiry day, 1000 qty) and NIFTY
+(1365 qty), held through a pullback, and booked with the target over-achieved.
+Our agent was short the same open, twice, and finished **+549.00**.
+
+Most of this session CONFIRMS rules already in the corpus rather than adding to
+it - which is itself the finding, and is why v4q is small.
+
+### What was already there
+
+Three of the four candidates turned out to be covered:
+
+- **His two-condition test for when NOT to hunt** - stated twice as the doctrine
+  ("in SL hunting: either the trader is sitting in PROFIT, or the trader does not
+  have big QUANTITY - we target neither, and then we follow the chart"). The
+  profit half is `TARGET-BOOKED crowd test`; the quantity half is
+  `AGGREGATE-INVENTORY TEST`, which already ends "if neither side is likely
+  carrying meaningful size, follow the current momentum or HOLD rather than
+  inventing a hunt". Adding his single-sentence pairing would buy a formulation,
+  not a behaviour.
+- **Not booking into a fast leg** - "the profit had been more than this, but the
+  momentum was very fast there; there was no plan to exit. More momentum will
+  come, and in that we get the chance to make the exit plan." This is v4b's
+  `EXPECT A SECOND LEG AFTER THE PAUSE, THEN BOOK`. Deliberately not restated,
+  and not sharpened: on live money a rule that reads as "sit through a giving-back
+  of profit" is the dangerous direction, and it would have argued against the
+  agent's 09:35 exit, which was correct (below).
+- **The laggard timing the exit** - "SENSEX and NIFTY have done good momentum,
+  BankNIFTY still has a little left; after that we get the chance to book."
+  That is the FIFTH session to touch `THE LAGGING INDEX DECIDES THE BASKET'S
+  EXIT` (v4i, amended v4k, v4l, v4o). Recorded as confirmation and deliberately
+  NOT added as a fifth amendment - the standing note that this rule should be
+  re-read whole rather than extended again still applies.
+
+### What was net new (v4q)
+
+**1. The completed-stop-hunt test also gates the ENTRY.** `A COMPLETED STOP-HUNT
+ENDS THAT DIRECTION` (v4g) reads naturally as a reason to close, and that is how
+it gets used. It disqualifies an entry the same way, and the mechanical form is
+your own target: if the level you are about to name as the target has already
+printed this session, the move you are entering has already happened. Added as a
+sub-bullet on the existing rule rather than a new one, because it is the same
+idea applied at the other end of the trade.
+
+This was not taken from the video - it was taken from our own trade 2, below.
+
+**2. `THE HOLD IS LICENSED BY THE EARLY IMPULSE AND EXPIRES WHEN THE MOVE BECOMES
+OBVIOUS`.** A genuinely new exit trigger, keyed on participation rather than on
+price, rate or time: "the sitting was only up to the point where the momentum
+appeared in all two or three indices at the START. Now that a good deal of
+momentum has already happened... now other people can also participate. So
+before other people apply their minds, apply yours first, book the profit and get
+out." The licence to sit comes from being positioned before the crowd; once a
+late reader would take the same trade, the remaining participants are buyers of
+your position rather than fuel for it.
+
+The rule is written so it can never be read as permission to hold - v4f, the
+stop, the max loss and premise-invalidation are all ranked above it explicitly,
+and a drift guard asserts that ranking survives.
+
+### How our agent traded the same session
+
+Two shorts, both closed, flat well before the 10:30 no-new-entry cutoff.
+
+| Time | Exit | NIFTY | Mirror | Basket |
+|---|---|---|---|---|
+| 09:23 -> 09:35 | agent, flush exhaustion at support | +962.00 | -105.00 | **+857.00** |
+| 09:52 -> 09:54 | agent, premise invalidation | +52.00 | -360.00 | **-308.00** |
+| | | **+1,014.00** | **-465.00** | **+549.00** |
+
+**The pre-open note worked.** It injected (2,055 chars, the exact size measured
+when it was written) and was cited in the entry reasoning by its substance, not
+just its direction: "this matches the pre-open note's sell-side/follow-momentum
+branch (no seated seller crowd, closing price unbroken yesterday, so hunt is off
+and continuation is the trade)". The follow-not-hunt premise - the half most
+likely to be flattened - is the half it used.
+
+**Trade 1 was right, including the exit.** Entered short at spot 24227.95 on a
+confirmed evening star after the gap-up to 24297 was rejected; exited at 09:35
+when price stalled at 24200-24208 with a bullish morning star on NIFTY and a
+hammer plus full-body bull candle on BankNIFTY at its own 57800 support. The
+session's low to that point (24188) had printed at 09:32, and price then bounced
+to 24228 by 09:51. Booking there was `BOOK WHEN THE PROFIT STOPS GROWING` applied
+correctly. A lower low (~24156, i.e. trade 1's 24155 target) did print later in
+the morning, but only after that bounce and roughly an hour and a half later;
+`TIME SPENT IN THE TRADE SHRINKS THE ACHIEVABLE TARGET` covers why that is not a
+missed hold. (My log sampling of spot is too sparse to time that low to the
+minute; the value is solid, the minute is not.)
+
+**Trade 2 is the real error, and the agent diagnosed it itself two minutes
+late.** At 09:52 it re-shorted the bounce, naming a trapped dip-buyer crowd, with
+the target set at **24188.6 - a level the session had already tagged at 09:32**.
+At 09:54 it exited with: "the completed stop-hunt has spent its fuel". That is
+v4g, quoted almost verbatim - so the agent had the rule, and ran it as an exit
+check two minutes after an entry the same rule forbade. The cost was -308 on the
+basket and it is the reason for addition 1.
+
+**The mirror cost 465 today**, losing on both legs while NIFTY won both. That is
+the mirror image of 26 Aug, where the mirror turned a stopped-out NIFTY leg into
+a +842 basket. Two sessions, opposite signs, which is the honest summary of the
+mirror so far: it is variance, not edge. Nothing added to the knowledge for it -
+the basket economics belong in the operator's ledger, not the prompt.
+
+### A small observability note
+
+Trade 1's exit reasoning quotes its own P&L as "NIFTY leg +793, mirror -372, net
++421"; the fills were +962 / -105 / +857. The order tool executes DURING
+reasoning, so those numbers are computed from cached LTPs a few seconds before
+the fill - here the market moved favourably in between. Harmless, and not worth a
+rule, but worth knowing before anyone treats a decision's quoted P&L as the
+record. The trade log is the record.
+
+### Knowledge changes (v4q)
+
+- `A COMPLETED STOP-HUNT ENDS THAT DIRECTION` (v4g) gains a sub-bullet: run the
+  test before the ENTRY, with the already-printed-target form.
+- `RISK`: THE HOLD IS LICENSED BY THE EARLY IMPULSE AND EXPIRES WHEN THE MOVE
+  BECOMES OBVIOUS (new).
+- Two drift guards, both negative-tested: dropping the entry-side framing, the
+  already-printed mechanic, the hold rule's ranking guard, or its participation
+  framing each fail the suite.
+- **Deliberately NOT added:** the two-condition hunt test, the do-not-book-into-a-
+  fast-leg half, and a fifth amendment to the lagging-index rule - see above.
+- Prompt size 141,841 -> 143,854 chars. Assembled 145,147 against a 154,140
+  budget: **8,993 chars of headroom.**

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -5108,3 +5108,77 @@ record. The trade log is the record.
   fast-leg half, and a fifth amendment to the lagging-index rule - see above.
 - Prompt size 141,841 -> 143,854 chars. Assembled 145,147 against a 154,140
   budget: **8,993 chars of headroom.**
+
+---
+
+## Pre-open note for 2026-08-28
+
+**Source:** Intraday Hunter, "Nifty & Bank nifty | SENSEX Analysis | Prediction
+For 28 AUG 2026" (`IwYyOclpDR8`, uploaded 2026-08-27 21:25 IST, 1:55).
+
+### The plan
+
+**The premise flips to HUNT.** The last two notes both said follow the momentum
+because nobody was trapped. Three indices selling off all day has now seated a
+retail SELLER crowd, and tomorrow's plan targets it. This is the more dangerous
+of the two reversals to miss: an editor working from the previous notes would
+keep the follow premise, land on a plausible direction, and be right for the
+wrong reason - which is exactly the failure v4o's THE METHOD IS NOT ALWAYS A FADE
+names, running the other way.
+
+**The sign of the gap splits the branch this time.** The last two notes
+deliberately put a flat open on the same side as the gapped ones, and both carry
+a test asserting it. Here FLAT sits with GAP-UP on the buy side, and GAP-DOWN
+alone takes the sell side. The habit those two tests built is the wrong habit for
+this note, so the new test asserts the split explicitly.
+
+**Both branches are gated, and the gates are the checkable part.** He states the
+same mechanism twice, once per index:
+
+- On a flat open, the level must NOT break: "once the level breaks the sellers
+  come into confidence, and then targeting them will not be easy for us."
+- Generally: "we do not want any breakdown - as soon as a breakdown happens, any
+  seated selling trader will not cut his trade, so we will not get the SLs."
+
+A break VALIDATES the seated sellers. Validated sellers hold instead of cutting,
+so the stops the hunt feeds on never appear. Losing these two lines would turn a
+gated plan into a plain directional bias.
+
+The gap-down branch carries its own gate rather than the gap's sign: "on a
+gap-down the sellers can come into decent profit anyway, so we will have to walk
+with the market."
+
+**24,000 is named as NIFTY's psychological number**, with 23,920 as the second
+support beneath it.
+
+### It is today's doctrine, used as a forecast
+
+This note is the two-condition test from the 27 Aug live session applied
+prospectively: sellers seated and WRONG, so hunt them; sellers in profit on a
+gap-down, so follow instead. v4q declined to add that test as a new rule because
+both halves already exist (`TARGET-BOOKED crowd test` and `AGGREGATE-INVENTORY
+TEST`). Seeing IH use it as the whole basis of a forecast the same evening is
+good evidence that call was right - the agent already carries both halves, and
+what it needed was the day's specific reading, which is what the note supplies.
+
+### Levels
+
+| Index | Resistance | Support |
+|---|---|---|
+| NIFTY | 24200, 24270 | 23920, 24000 |
+| BANKNIFTY | 58000, 58200 | 57200, 57500 |
+| SENSEX | 77400, 77750 | 76550, 77000 |
+
+The SENSEX reading needed the operator again, and for a new reason: the caption
+gave the resistances cleanly but lost the second support between two transcript
+segments, leaving a single "77650" that would have sat ABOVE the 77400
+resistance. That impossibility is what made it catchable - an ordinary-looking
+wrong number would not have been. Confirmed off the chart as 77000/76550. The
+test carries a comment saying not to reconstruct it from the caption.
+
+### Verification
+
+19/19 on the premarket suite, and each new assertion negative-tested: flipping
+the premise back to follow, dropping the hunt framing, regating the gap-down
+branch on the gap's sign, softening either veto, or "correcting" the SENSEX
+support each fail the suite.

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
@@ -684,6 +684,16 @@ Conditions (ALL must hold — otherwise this branch simply does not apply):
   chase the retracement. Trade the original direction, and treat the bounce's
   end as the entry. The one thing that voids this is a fresh large gap, which
   recruits a new crowd and restarts the question (see the gap branches above).
+  * RUN THIS TEST BEFORE THE ENTRY, NOT ONLY AS AN EXIT CHECK (v4q). The rule
+    reads naturally as a reason to CLOSE, and that is how it gets used: the hunt
+    completes, the fuel is spent, so leave. It disqualifies an ENTRY the same
+    way, and the cheapest mechanical form is your own target -- if the level you
+    are about to name as the target has ALREADY printed in this session, the
+    move you are entering has already happened. A bounce back toward your entry
+    is then the completed hunt TURNING, not a fresh trap forming, and the R:R
+    computed off that target is arithmetic on a move that is over. Name the
+    target first, ask whether the session has already traded there, and if it
+    has, require a NEW trap rather than the exhausted one.
 - THE ROUND NUMBER IS WHERE THE THESIS DIES, NOT JUST WHERE IT PAYS (v4g).
   Earlier versions used round numbers to locate targets (v4d BOOK BEFORE THE
   ROUND NUMBER) and recruitment (v4c ROUND NUMBERS AMPLIFY RECRUITMENT). This
@@ -1316,6 +1326,23 @@ RISK DISCIPLINE
   This is the general form of BOOK BEFORE THE ROUND NUMBER (v4d): that rule names
   WHERE the late crowd's targets sit, this one names WHEN your own edge has been
   spent regardless of where price is.
+- THE HOLD IS LICENSED BY THE EARLY IMPULSE AND EXPIRES WHEN THE MOVE BECOMES
+  OBVIOUS (v4q). A distinct exit trigger from v4f's rate-of-profit test and from
+  v4b's second leg: this one keys on WHO ELSE CAN NOW SEE THE TRADE. IH, having
+  held a short through the morning: "the sitting was only up to the point where
+  the momentum appeared in all two or three indices at the START. Now that a good
+  deal of momentum has already happened... now other people can also participate.
+  So before other people apply their minds, apply yours first, book the profit and
+  get out."
+  The licence to keep sitting comes from being positioned BEFORE the crowd, while
+  the move is still visible only to whoever read the open correctly. Once it is
+  large and clear enough that a late reader would take the same trade, the edge
+  that justified holding is gone: the remaining participants are buyers of your
+  position, not fuel for it. Treat "a newcomer would now enter here" as an exit
+  condition in its own right, even while the position is still gaining and no
+  reversal has printed.
+  It does NOT license sitting through a stall -- v4f still books when the rate of
+  gain dies -- and the stop, the max loss and premise-invalidation all outrank it.
 - FEAR IS NOT A SIGNAL — NEVER CONVERT IT INTO AN EXIT (v4g). The single most
   important guard on the rule directly above, and the two must be read together:
   BOOK WHEN THE PROFIT STOPS GROWING is a MEASUREMENT (the rate of accrual has

--- a/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_premarket.py
+++ b/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_premarket.py
@@ -201,26 +201,28 @@ def test_shipped_note_targets_the_next_TRADING_day_not_the_next_calendar_day():
     )
 
 
-def test_shipped_note_matches_august_27_intraday_hunter_plan():
-    """The committed advisory must match the hand-checked 26 Aug transcript.
+def test_shipped_note_matches_august_28_intraday_hunter_plan():
+    """The committed advisory must match the hand-checked 27 Aug transcript.
 
-    Four things a summarising edit would flatten:
+    Four things a summarising edit would flatten, and this note is unusually
+    easy to flatten because it reverses TWO different habits at once:
 
-    1. The branch INVERTED overnight. Yesterday all three open shapes shared a
-       BUY-side plan; today all three share a SELL-side one. An editor working
-       from the previous note rather than the transcript would keep the
-       direction and change only the levels, which is the whole plan wrong.
-    2. FLAT is on the sell side. He gives the same plan for a flat open as for
-       the gapped ones, so the sign of the gap does not switch the branch --
-       the same structural point as yesterday, opposite direction.
-    3. The premise is FOLLOW, not hunt, and it carries its reason: nobody is
-       trapped (few trade puts here, and the closing price was not broken).
-       "Sell-side, therefore hunt the buyers" keeps the direction and inverts
-       the premise, which is the subtlest way to be wrong -- and it is exactly
-       what v4o's THE METHOD IS NOT ALWAYS A FADE exists to prevent.
-    4. BankNIFTY carries an explicit STAND-ASIDE on a gap-up that runs. A note
-       that keeps only the sell-side half turns a no-trade instruction into a
-       licence to short strength.
+    1. The premise is HUNT, not follow. The last two notes both said "follow
+       the momentum, nobody is trapped"; three indices selling off all day
+       has now SEATED a seller crowd, and this plan targets it. An editor
+       working from the previous notes would keep the follow premise and get
+       the direction right for the wrong reason -- the failure mode v4o's THE
+       METHOD IS NOT ALWAYS A FADE names in the other direction.
+    2. The sign of the gap DOES split the branch this time. The last two
+       notes deliberately put flat on the same side as the gapped opens, and
+       both carried a test asserting it. Here flat sits with GAP-UP on the
+       buy side and gap-down alone takes the sell side.
+    3. Both branches carry a stated VETO, and the vetoes are the checkable
+       part: a level break, or any breakdown, converts the trapped sellers
+       into validated ones who will not cut -- so there are no stops to
+       collect and the hunt is off. Losing these turns a gated plan into a
+       directional bias.
+    4. 24,000 is named as a psychological number, not merely a support.
     """
     import os
 
@@ -229,47 +231,54 @@ def test_shipped_note_matches_august_27_intraday_hunter_plan():
     note = load_premarket_note(shipped)
 
     assert note is not None
-    assert note.for_date == "2026-08-27"
-    assert "auAi14O0HOk" in note.source
-    assert "neither NIFTY nor BankNIFTY could cross its level" in note.context
-    assert "no sellers are seated" in note.context
+    assert note.for_date == "2026-08-28"
+    assert "IwYyOclpDR8" in note.source
+    assert "SELLERS are now seated" in note.context
+    # The premise reversal, stated in the context so it cannot be lost.
+    assert "first HUNT-the-crowd plan in three sessions" in note.context
 
-    sell = next(line for line in note.plan if line.startswith("SELL-side"))
-    assert "ALL THREE open shapes" in sell
-    assert "gap-up, flat or gap-down" in sell
-    # Flat sits on the sell side, and the gap's sign is explicitly not the gate.
-    assert "does NOT switch the branch" in sell
+    buy = next(line for line in note.plan if line.startswith("FLAT or GAP-UP"))
+    assert "BUY-side" in buy
+    assert "TARGET the seated sellers" in buy
+    assert "This is a HUNT, not a follow" in buy
 
-    # The premise, with the reason that makes it checkable rather than a slogan.
-    follow = next(line for line in note.plan if line.startswith("FOLLOW the momentum"))
-    assert "do NOT hunt a crowd" in follow
-    assert "nobody is trapped" in follow
+    sell = next(line for line in note.plan if line.startswith("GAP-DOWN"))
+    assert "SELL-side" in sell
+    # Gated on the crowd being in profit, not merely on the gap's sign.
+    assert "a crowd in profit is not a target" in sell
 
-    # The stand-aside must survive as a no-trade, not collapse into the plan.
-    bnf = next(line for line in note.plan if line.startswith("BANKNIFTY GAP-UP"))
-    assert "STAND-ASIDE" in bnf
-    assert "NO plan can be made" in bnf
+    # Veto 1: the flat-open branch dies if the level breaks.
+    veto_level = next(line for line in note.plan if line.startswith("FLAT VETO"))
+    assert "the level must NOT break" in veto_level
+    assert "converts a trapped crowd into a validated one" in veto_level
 
-    assert any("SENSEX/BANKEX expiry" in line for line in note.plan)
+    # Veto 2: a breakdown removes the stops the hunt feeds on.
+    veto_break = next(
+        line for line in note.plan if line.startswith("HE DOES NOT WANT A BREAKDOWN")
+    )
+    assert "will not cut his trade" in veto_break
+    assert "sellers who are WRONG and forced to cut" in veto_break
+
+    assert any("psychological number" in line for line in note.plan)
 
     assert [level.model_dump() for level in note.levels] == [
         {
             "index": "NIFTY",
-            "resistance": [24320.0, 24380.0],
-            "support": [24120.0, 24180.0],
+            "resistance": [24200.0, 24270.0],
+            "support": [23920.0, 24000.0],
         },
         {
             "index": "BANKNIFTY",
             "resistance": [58000.0, 58200.0],
-            "support": [57420.0, 57720.0],
+            "support": [57200.0, 57500.0],
         },
         {
-            # The caption merged both resistances again ("78000750"), as it did
-            # yesterday ("7800750"). Confirmed off the chart by the operator as
-            # 77750/78000 -- unchanged from yesterday, not a transcription of
-            # yesterday's file. Do not "correct" this to a moved level.
+            # The caption gave the resistances cleanly but lost the second
+            # support between segments, leaving an impossible "77650" support
+            # above the 77400 resistance. Confirmed off the chart by the
+            # operator as 77000/76550 -- do not reconstruct from the caption.
             "index": "SENSEX",
-            "resistance": [77750.0, 78000.0],
-            "support": [77000.0, 77250.0],
+            "resistance": [77400.0, 77750.0],
+            "support": [76550.0, 77000.0],
         },
     ]

--- a/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_schema.py
+++ b/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_schema.py
@@ -1669,3 +1669,64 @@ def test_v4p_stop_is_a_nifty_trigger_note_does_not_argue_for_wider_stops():
     # The conclusion it must NOT support.
     assert "not a reason to widen the stop" in rule
     assert "protects the NIFTY premise" in rule
+
+
+def test_v4q_completed_stop_hunt_test_also_gates_the_entry():
+    """v4q (27 Aug live session): the rule reads as an exit, but it disqualifies entries.
+
+    Measured the same morning: the agent cited "the completed stop-hunt has
+    spent its fuel" to EXIT trade 2 at 09:54 -- two minutes after opening it
+    with a target (24188.6) the session had already tagged at 09:32. It had
+    the rule and ran it in only one of the two places that matter.
+
+    The already-printed-target form is what makes it mechanical rather than a
+    judgement call, so it must survive verbatim.
+    """
+    prompt = build_system_prompt()
+    rule = _flat_rule(prompt, "A COMPLETED STOP-HUNT ENDS THAT DIRECTION")
+
+    assert "RUN THIS TEST BEFORE THE ENTRY, NOT ONLY AS AN EXIT CHECK" in rule
+
+    # The mechanical form. Without this the extension is just an exhortation.
+    assert (
+        "the level you are about to name as the target has ALREADY printed in "
+        "this session" in rule
+    )
+    assert "the move you are entering has already happened" in rule
+
+    # Why a bounce toward the entry is not a fresh trap.
+    assert "the completed hunt TURNING" in rule
+    assert "require a NEW trap rather than the exhausted one" in rule
+
+
+def test_v4q_obviousness_exit_never_becomes_a_licence_to_sit():
+    """v4q: an exit trigger keyed on who else can now see the trade.
+
+    Two ways this rule could go wrong, both asserted against:
+
+    1. It could be read as permission to HOLD (it arrives from a session where
+       IH held through a pullback), which on live money is the dangerous
+       direction. The prose must keep v4f, the stop, the max loss and
+       premise-invalidation ranked above it.
+    2. It could lose the reason -- that the edge was being positioned before
+       the crowd -- and decay into "exit when the move is big", which is a
+       price rule, not a participation one.
+    """
+    prompt = build_system_prompt()
+    rule = _flat_rule(prompt, "THE HOLD IS LICENSED BY THE EARLY IMPULSE")
+
+    # It is about participation, not size or rate.
+    assert "WHO ELSE CAN NOW SEE THE TRADE" in rule
+    assert (
+        "before other people apply their minds, apply yours first, book the "
+        "profit and get out" in rule
+    )
+    assert "buyers of your position, not fuel for it" in rule
+
+    # Usable as a test at the moment of decision.
+    assert "a newcomer would now enter here" in rule
+
+    # And it must never outrank the rules that protect the account.
+    assert "It does NOT license sitting through a stall" in rule
+    assert "v4f still books when the rate of gain dies" in rule
+    assert "the stop, the max loss and premise-invalidation all outrank it" in rule


### PR DESCRIPTION

---

## Video addendum - the 27 Aug LIVE SESSION (v4q)

**Source:** Intraday Hunter live session `npth0OPyFSY` (27 Aug 2026, 6:29).

A flat-to-small-gap-up open that sold off. IH shorted it at the open across
BankNIFTY (58000 then 57900 PE), SENSEX (SENSEX expiry day, 1000 qty) and NIFTY
(1365 qty), held through a pullback, and booked with the target over-achieved.
Our agent was short the same open, twice, and finished **+549.00**.

Most of this session CONFIRMS rules already in the corpus rather than adding to
it - which is itself the finding, and is why v4q is small.

### What was already there

Three of the four candidates turned out to be covered:

- **His two-condition test for when NOT to hunt** - stated twice as the doctrine
  ("in SL hunting: either the trader is sitting in PROFIT, or the trader does not
  have big QUANTITY - we target neither, and then we follow the chart"). The
  profit half is `TARGET-BOOKED crowd test`; the quantity half is
  `AGGREGATE-INVENTORY TEST`, which already ends "if neither side is likely
  carrying meaningful size, follow the current momentum or HOLD rather than
  inventing a hunt". Adding his single-sentence pairing would buy a formulation,
  not a behaviour.
- **Not booking into a fast leg** - "the profit had been more than this, but the
  momentum was very fast there; there was no plan to exit. More momentum will
  come, and in that we get the chance to make the exit plan." This is v4b's
  `EXPECT A SECOND LEG AFTER THE PAUSE, THEN BOOK`. Deliberately not restated,
  and not sharpened: on live money a rule that reads as "sit through a giving-back
  of profit" is the dangerous direction, and it would have argued against the
  agent's 09:35 exit, which was correct (below).
- **The laggard timing the exit** - "SENSEX and NIFTY have done good momentum,
  BankNIFTY still has a little left; after that we get the chance to book."
  That is the FIFTH session to touch `THE LAGGING INDEX DECIDES THE BASKET'S
  EXIT` (v4i, amended v4k, v4l, v4o). Recorded as confirmation and deliberately
  NOT added as a fifth amendment - the standing note that this rule should be
  re-read whole rather than extended again still applies.

### What was net new (v4q)

**1. The completed-stop-hunt test also gates the ENTRY.** `A COMPLETED STOP-HUNT
ENDS THAT DIRECTION` (v4g) reads naturally as a reason to close, and that is how
it gets used. It disqualifies an entry the same way, and the mechanical form is
your own target: if the level you are about to name as the target has already
printed this session, the move you are entering has already happened. Added as a
sub-bullet on the existing rule rather than a new one, because it is the same
idea applied at the other end of the trade.

This was not taken from the video - it was taken from our own trade 2, below.

**2. `THE HOLD IS LICENSED BY THE EARLY IMPULSE AND EXPIRES WHEN THE MOVE BECOMES
OBVIOUS`.** A genuinely new exit trigger, keyed on participation rather than on
price, rate or time: "the sitting was only up to the point where the momentum
appeared in all two or three indices at the START. Now that a good deal of
momentum has already happened... now other people can also participate. So
before other people apply their minds, apply yours first, book the profit and get
out." The licence to sit comes from being positioned before the crowd; once a
late reader would take the same trade, the remaining participants are buyers of
your position rather than fuel for it.

The rule is written so it can never be read as permission to hold - v4f, the
stop, the max loss and premise-invalidation are all ranked above it explicitly,
and a drift guard asserts that ranking survives.

### How our agent traded the same session

Two shorts, both closed, flat well before the 10:30 no-new-entry cutoff.

| Time | Exit | NIFTY | Mirror | Basket |
|---|---|---|---|---|
| 09:23 -> 09:35 | agent, flush exhaustion at support | +962.00 | -105.00 | **+857.00** |
| 09:52 -> 09:54 | agent, premise invalidation | +52.00 | -360.00 | **-308.00** |
| | | **+1,014.00** | **-465.00** | **+549.00** |

**The pre-open note worked.** It injected (2,055 chars, the exact size measured
when it was written) and was cited in the entry reasoning by its substance, not
just its direction: "this matches the pre-open note's sell-side/follow-momentum
branch (no seated seller crowd, closing price unbroken yesterday, so hunt is off
and continuation is the trade)". The follow-not-hunt premise - the half most
likely to be flattened - is the half it used.

**Trade 1 was right, including the exit.** Entered short at spot 24227.95 on a
confirmed evening star after the gap-up to 24297 was rejected; exited at 09:35
when price stalled at 24200-24208 with a bullish morning star on NIFTY and a
hammer plus full-body bull candle on BankNIFTY at its own 57800 support. The
session's low to that point (24188) had printed at 09:32, and price then bounced
to 24228 by 09:51. Booking there was `BOOK WHEN THE PROFIT STOPS GROWING` applied
correctly. A lower low (~24156, i.e. trade 1's 24155 target) did print later in
the morning, but only after that bounce and roughly an hour and a half later;
`TIME SPENT IN THE TRADE SHRINKS THE ACHIEVABLE TARGET` covers why that is not a
missed hold. (My log sampling of spot is too sparse to time that low to the
minute; the value is solid, the minute is not.)

**Trade 2 is the real error, and the agent diagnosed it itself two minutes
late.** At 09:52 it re-shorted the bounce, naming a trapped dip-buyer crowd, with
the target set at **24188.6 - a level the session had already tagged at 09:32**.
At 09:54 it exited with: "the completed stop-hunt has spent its fuel". That is
v4g, quoted almost verbatim - so the agent had the rule, and ran it as an exit
check two minutes after an entry the same rule forbade. The cost was -308 on the
basket and it is the reason for addition 1.

**The mirror cost 465 today**, losing on both legs while NIFTY won both. That is
the mirror image of 26 Aug, where the mirror turned a stopped-out NIFTY leg into
a +842 basket. Two sessions, opposite signs, which is the honest summary of the
mirror so far: it is variance, not edge. Nothing added to the knowledge for it -
the basket economics belong in the operator's ledger, not the prompt.

### A small observability note

Trade 1's exit reasoning quotes its own P&L as "NIFTY leg +793, mirror -372, net
+421"; the fills were +962 / -105 / +857. The order tool executes DURING
reasoning, so those numbers are computed from cached LTPs a few seconds before
the fill - here the market moved favourably in between. Harmless, and not worth a
rule, but worth knowing before anyone treats a decision's quoted P&L as the
record. The trade log is the record.

### Knowledge changes (v4q)

- `A COMPLETED STOP-HUNT ENDS THAT DIRECTION` (v4g) gains a sub-bullet: run the
  test before the ENTRY, with the already-printed-target form.
- `RISK`: THE HOLD IS LICENSED BY THE EARLY IMPULSE AND EXPIRES WHEN THE MOVE
  BECOMES OBVIOUS (new).
- Two drift guards, both negative-tested: dropping the entry-side framing, the
  already-printed mechanic, the hold rule's ranking guard, or its participation
  framing each fail the suite.
- **Deliberately NOT added:** the two-condition hunt test, the do-not-book-into-a-
  fast-leg half, and a fifth amendment to the lagging-index rule - see above.
- Prompt size 141,841 -> 143,854 chars. Assembled 145,147 against a 154,140
  budget: **8,993 chars of headroom.**
