### PR TITLE
chore(sl-hunting): raise the prompt cap to 350k, move its guard to a test, and log per-decision latency (SLH-013)

### DIFF
--- a/Dependencies/env.example
+++ b/Dependencies/env.example
@@ -1413,6 +1413,14 @@ SL_HUNTING_FAST_MODE=false
 # "zombie" orders) and the agent records a fail-soft HOLD. <=0 disables the bound
 # (not recommended for the live runner).
 SL_HUNTING_SDK_TIMEOUT_SECONDS=90
+# WARN when a single decision's wall-clock reaches this many seconds. Latency --
+# not context size -- is the real ceiling on how far the knowledge prompt can
+# grow: the 90s deadline above fired 27 times in July 2026, each one a bar the
+# agent silently HELD through, and it stopped only because the model got faster.
+# This surfaces creep on the day it starts instead of weeks later. A value at or
+# above SL_HUNTING_SDK_TIMEOUT_SECONDS can never fire (the call is abandoned
+# first), which is a legitimate way to switch the warning off. Must be > 0.
+SL_HUNTING_SLOW_DECISION_WARN_SECONDS=60
 # Evaluate once per completed N-minute bar. SL Hunting trades on 1-min by design (the
 # method's "daily trades" are 1-min; 5-min is only the opening-setup nuance). NOTE: the
 # agent makes ONE LLM/subscription call PER bar, so 1-min is ~5x the calls/usage of 5-min

--- a/Nifty Multi Strategy Front Test - Master File.py
+++ b/Nifty Multi Strategy Front Test - Master File.py
@@ -15027,6 +15027,12 @@ if SL_HUNTING_AVAILABLE:
                 # Mechanical stop/target, max-loss and square-off keep polling
                 # independently while this inference is running.
                 sdk_timeout_seconds=_env_float("SL_HUNTING_SDK_TIMEOUT_SECONDS", 90.0),
+                # SLH-013: WARN when one decision takes this long. Latency is the
+                # real ceiling on prompt growth -- past the deadline a bar is held
+                # with no decision at all -- so creep needs to be visible daily.
+                slow_decision_warn_seconds=_env_float(
+                    "SL_HUNTING_SLOW_DECISION_WARN_SECONDS", 60.0
+                ),
             )
             # The order tool routes through this executor into our own safe methods.
             self._executor = SL_HUNTING_EXECUTOR_MODULE.MasterWorkerExecutor(self)

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_agent.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_agent.py
@@ -35,6 +35,7 @@ import re
 import sys
 import tempfile
 import threading
+import time
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any, Literal, SupportsFloat, cast
@@ -315,6 +316,7 @@ class SLHuntingAgent:
         lessons_block: str = "",
         premarket_block: str = "",
         sdk_timeout_seconds: float = 90.0,
+        slow_decision_warn_seconds: float = 60.0,
     ) -> None:
         if not model:
             raise ValueError("SLHuntingAgent: model is required.")
@@ -328,6 +330,19 @@ class SLHuntingAgent:
         if not math.isfinite(timeout) or not 5.0 <= timeout <= 120.0:
             raise ValueError("SLHuntingAgent: sdk_timeout_seconds must be between 5 and 120.")
         self._sdk_timeout_seconds = timeout
+        # SLH-013: the threshold above which one decision's wall-clock is WARNed
+        # about. Latency -- not context -- is the real ceiling on prompt growth:
+        # the 90s deadline fired 27 times in July, each one a bar silently held
+        # through, and it stopped only because the model got faster. A value at
+        # or above `sdk_timeout_seconds` can never fire, because the call is
+        # abandoned first; that is a legitimate way to switch the warning off
+        # rather than a misconfiguration, so it is allowed.
+        warn_after = float(slow_decision_warn_seconds)
+        if not math.isfinite(warn_after) or warn_after <= 0.0:
+            raise ValueError(
+                "SLHuntingAgent: slow_decision_warn_seconds must be a positive, finite number."
+            )
+        self._slow_decision_warn_seconds = warn_after
         # SLH-001 / Codex: a worker thread from a PRIOR timed-out call that is
         # still alive. While set, decide() gates new calls (no fresh thread or
         # subprocess) so a persistently hung CLI can accumulate at most one.
@@ -655,6 +670,7 @@ class SLHuntingAgent:
         runner = self._runner or self._default_run
 
         def _run_once() -> str:
+            started = time.perf_counter()
             run_result = self._run_sync(
                 runner(
                     prompt,
@@ -665,6 +681,29 @@ class SLHuntingAgent:
                 ),
                 timeout_seconds=self._sdk_timeout_seconds,
             )
+            elapsed = time.perf_counter() - started
+            # SLH-013: logged on EVERY decision, unlike the cost line below, which
+            # only fires when the SDK reported a cost. Latency is the number that
+            # tells you how close the prompt is to the deadline, so it must not
+            # inherit that condition. A timed-out call raises out of `_run_sync`
+            # and logs its own message naming the deadline, so it is not doubled
+            # up here.
+            logger.info(
+                "SLHuntingAgent decision latency %.1fs (deadline %.0fs).",
+                elapsed,
+                self._sdk_timeout_seconds,
+            )
+            if elapsed >= self._slow_decision_warn_seconds:
+                logger.warning(
+                    "SL Hunting: decision took %.1fs, at or past the %.0fs warning "
+                    "threshold and %.0f%% of the %.0fs deadline. Past the deadline a "
+                    "bar is HELD with no decision, so treat sustained warnings as "
+                    "prompt/latency creep rather than noise.",
+                    elapsed,
+                    self._slow_decision_warn_seconds,
+                    100.0 * elapsed / self._sdk_timeout_seconds,
+                    self._sdk_timeout_seconds,
+                )
             if run_result.cost_usd is not None:
                 logger.info("SLHuntingAgent decision cost ~$%.4f", run_result.cost_usd)
             return run_result.text

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -5279,6 +5279,19 @@ text. Two tests assert the QUIET cases - a fast decision does not warn, and a
 threshold above the deadline still constructs - so the warning cannot decay into
 noise.
 
+**One of these tests was wrong first, and the way it was wrong is worth keeping.**
+The two warning tests originally set the threshold to 0.001s and relied on "any
+real call takes longer than a millisecond". That holds on this machine and did
+NOT on CI, where the fake runner returned inside a millisecond, `elapsed` logged
+as 0.0s and the warning never fired -- green locally, red on CI. Wall-clock is
+not something a test may assume. Both now pin the clock via `_pin_decision_
+duration`, which returns 0.0 for the first reading and a fixed value after, and
+is robust to anything else in the call path reading the clock in between. The
+pinned version is strictly better than a working timing-based one would have
+been: it catches the warning being disabled AND the warning always firing AND
+the comparison being flipped, where a timing-based test could only ever catch
+the first.
+
 Full gates clean. `check-env` reports the new key as MISSING from the operator's
 `.env`, which is correct and expected: it is in `env.example`, and until it is
 copied across the in-code default of 60s applies.

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -5182,3 +5182,103 @@ test carries a comment saying not to reconstruct it from the caption.
 the premise back to follow, dropping the hunt framing, regating the gap-down
 branch on the gap's sign, softening either veto, or "correcting" the SENSEX
 support each fail the suite.
+
+---
+
+## SLH-013 - the prompt cap stops being the guard, and latency becomes visible
+
+Three changes that belong together: the cap is raised past the point where it can
+detect anything, so the detection moves to a test; and the thing that actually
+limits prompt growth gets measured for the first time.
+
+### The cap: 160,000 -> 350,000
+
+Raised so it stops being a recurring question every few knowledge versions
+(75k -> 120k -> 160k -> 350k). 350,000 characters is on the order of 90-100k
+tokens -- this corpus is ALL-CAPS-heavy and tokenises worse than the usual ~4
+chars/token -- against Sonnet 5's 200k context, so it is comfortably inside with
+room for the bar context and the agentic loop.
+
+**This raise is different in kind from the two before it, and the comment block
+now says so.** The earlier raises kept the bound tight enough to still catch a
+runaway lessons file or a malformed note, which its own top paragraph names as
+the failure it exists for. At 350,000 it cannot: the runtime can inject only
+~8,500 characters at its own caps, so nothing pathological in that material could
+ever reach the bound. Raising it without moving the detection somewhere else
+would have quietly retired the guard while leaving prose claiming it was armed.
+
+### Where the detection went
+
+`test_runtime_injected_blocks_stay_small` renders a worst-case lessons block and
+a worst-case pre-open note through the REAL `format_lessons` and
+`format_premarket_note`, and fails if the total passes 12,000 characters
+(measured today: 8,519 = lessons 4,918 + note 3,601, so ~40% of room). It trips
+if anyone widens `MAX_LESSON_CHARS`, `MAX_LIVE_LESSONS`, `MAX_PLAN_ITEMS`,
+`MAX_LINE_CHARS`, `MAX_LEVELS_PER_SIDE` or `MAX_INDEX_BLOCKS` enough to matter,
+whatever the cap says.
+
+The ceiling is deliberately a flat number rather than one derived from those
+per-field caps: a derived bound would move silently when the caps move, which is
+exactly the change worth catching.
+
+### A live inaccuracy this turned up
+
+The test being replaced, `test_prompt_cap_leaves_room_for_lessons_and_a_note`,
+assumed the runtime could add `12 * 280 + 2500 = 5,860` characters. The real
+worst case is **8,519** - it ignored each lesson's 80-character scope and its
+per-lesson formatting, and understated the note by 1,101.
+
+So the effective budget was **151,481, not the 154,140** that has been quoted in
+every knowledge addendum since the last raise, and the headroom reported at v4q
+was 6,334 rather than 8,993. Nothing was ever actually at risk - the gap was
+always larger than the error - but the number was wrong and is now measured
+rather than assumed.
+
+**Two fixture traps worth recording**, because they cost real time and the next
+person to touch this will hit them:
+
+- `StoredLesson` is tamper-evident. An approved record needs `id` equal to
+  `_slug(scope, lesson)` AND `approval_digest` equal to
+  `lesson_content_digest(record)`. Get either wrong and `_validated_records`
+  drops it silently, `format_lessons` returns `""`, and a test measuring "worst
+  case" happily measures zero and passes. The new helper asserts the fixture
+  validated, so it can never quietly measure nothing.
+- `_slug` truncates to 48 characters. Worst-case records must differ in their
+  FIRST few characters or they collide on id and `consolidate` keeps only one.
+
+### Latency: the constraint that actually binds
+
+Context was never the limit. The 90-second SDK deadline fired **27 times between
+7 and 31 July 2026**, and not once since - each of those a bar the agent silently
+HELD through, with no decision at all. It stopped firing when the model moved to
+Sonnet 5 with fast mode, NOT because the prompt shrank: the prompt has nearly
+doubled since. Prefill scales with what the cap permits, so this raise spends
+precisely the margin that fixed those timeouts.
+
+Until now there was no latency measurement anywhere - only cost. So:
+
+- Every decision logs its wall-clock at INFO beside the cost line. Deliberately
+  NOT sharing the cost line's condition: that one fires only when the SDK
+  reported a cost, and a run that reported none is exactly the kind worth timing.
+- A WARN fires at `SL_HUNTING_SLOW_DECISION_WARN_SECONDS` (default 60 of the 90s
+  budget), naming the elapsed time, the threshold, the percentage of the deadline
+  and the consequence, so one line in a shared log is enough to judge it.
+- A threshold at or above the deadline can never fire, because the call is
+  abandoned first. That is allowed rather than rejected - it is a legitimate way
+  to switch the warning off.
+
+A timed-out call raises out of `_run_sync` and already logs its own message
+naming the deadline, so it is not double-reported here.
+
+### Verification
+
+Nine mutations, each confirmed to fail the suite: widening any of the four
+lessons/note caps; logging latency at DEBUG; gating latency on `cost_usd`;
+disabling the warn branch; and dropping the deadline detail from the warning
+text. Two tests assert the QUIET cases - a fast decision does not warn, and a
+threshold above the deadline still constructs - so the warning cannot decay into
+noise.
+
+Full gates clean. `check-env` reports the new key as MISSING from the operator's
+`.env`, which is correct and expected: it is in `env.example`, and until it is
+copied across the in-code default of 60s applies.

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
@@ -2126,11 +2126,39 @@ Emit ONLY this JSON object as your final answer."""
 # still small enough to catch a runaway lessons file or a malformed note, which
 # is the failure this guard actually exists to catch.
 #
+# Raised from 160,000 to 350,000 on 2026-08-27, and this raise is DIFFERENT in
+# kind from the two above -- read this before treating the number as a guard.
+#
+# The two earlier raises kept the bound tight enough that a runaway lessons file
+# or a malformed note would still trip it. 350,000 does not: the runtime can only
+# inject ~8,500 characters at its own caps, so at this bound NOTHING pathological
+# in that material could ever reach it. The detection value has been moved out
+# deliberately, into `test_runtime_injected_blocks_stay_small`, which renders a
+# worst-case lessons block and a worst-case pre-open note through the REAL
+# formatters and fails if either grows. That test -- not this number -- is what
+# now protects against the failure the paragraph at the top describes. If you are
+# about to tighten this constant because it "feels loose", tighten that test
+# instead; this one is only here to stop something absurd.
+#
+# Two measurements behind the change. First, the ceiling: 350,000 characters is
+# on the order of 90-100k tokens (this corpus is ALL-CAPS-heavy, so it tokenises
+# worse than the usual ~4 chars/token), against Sonnet 5's 200k context -- still
+# comfortably inside, with room for the bar context and the agentic loop.
+#
+# Second, and more important, the real ceiling is NOT context: it is LATENCY. The
+# 90s SDK deadline fired 27 times between 7 and 31 July, each one a bar the agent
+# silently held through. It stopped firing when the model moved to Sonnet 5 with
+# fast mode, NOT because the prompt shrank -- the prompt has nearly doubled since.
+# Prefill scales with what is set here, so the margin that fixed those timeouts is
+# exactly what this raise spends. `SL_HUNTING_SLOW_DECISION_WARN_SECONDS` exists
+# so that creep shows up as a WARN on the day it starts, rather than as held bars
+# noticed weeks later. Watch that, not this constant.
+#
 # The rule when this is next hit is the same: check whether the growth is
 # ordinary knowledge (raise the bound) or something pathological (fix the cause).
 # Pruning genuinely superseded prose is worth doing on its own merits, but it is
 # a knowledge-quality task -- never a way to buy space under this number.
-MAX_SYSTEM_PROMPT_CHARS = 160_000
+MAX_SYSTEM_PROMPT_CHARS = 350_000
 
 
 def build_system_prompt() -> str:

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_runner.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_runner.py
@@ -231,6 +231,9 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--timeframe", type=int, default=int(_env("SL_HUNTING_DERIVED_TIMEFRAME_MINUTES", "1")),
                         help="Decision timeframe in minutes (resampled from 1-min; SL Hunting's default is 1).")
     parser.add_argument("--model", default=_env("SL_HUNTING_MODEL", "claude-opus-4-8"), help="Claude model id.")
+    parser.add_argument("--warn-after", type=float,
+                        default=float(_env("SL_HUNTING_SLOW_DECISION_WARN_SECONDS", "60")),
+                        help="WARN when one decision takes at least this many seconds.")
     parser.add_argument("--fast", action="store_true", help="Disable extended thinking (lower latency).")
     parser.add_argument("--fake", action="store_true", help="Use the built-in always-HOLD runner (no SDK/cost).")
     parser.add_argument("--warmup", type=int, default=30, help="Min completed bars before the first decision.")
@@ -296,7 +299,10 @@ def main(argv: list[str] | None = None) -> int:
         lessons_block = format_lessons(load_lessons(args.lessons_path))
         logger.info("Lessons ON: injected %d learned-lesson chars from %s.", len(lessons_block), args.lessons_path)
     runner = _AlwaysHoldRunner() if args.fake else None
-    agent = SLHuntingAgent(model=args.model, runner=runner, fast_mode=args.fast, lessons_block=lessons_block)
+    agent = SLHuntingAgent(
+        model=args.model, runner=runner, fast_mode=args.fast, lessons_block=lessons_block,
+        slow_decision_warn_seconds=args.warn_after,
+    )
     ex = StandaloneExecutor(
         lots=args.lots,
         lot_size=args.lot_size,

--- a/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_agent.py
+++ b/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_agent.py
@@ -1283,16 +1283,42 @@ def test_decision_latency_is_logged_even_when_the_sdk_reports_no_cost(caplog):
     assert "deadline" in latency[0].getMessage()
 
 
-def test_slow_decision_warns_once_past_the_threshold(caplog):
+def _pin_decision_duration(monkeypatch, seconds: float) -> None:
+    """Make one decision appear to take exactly `seconds`, deterministically.
+
+    An earlier version of these tests set the threshold to 0.001s and relied on
+    a real call taking longer than a millisecond. It does on this machine and
+    did NOT on CI, where the fake runner returned inside a millisecond and the
+    warning never fired. Wall-clock is not something a test may assume, so the
+    clock is pinned instead.
+
+    The stub returns 0.0 for the first reading and `seconds` for every reading
+    after, which is robust to anything else in the call path also reading the
+    clock between the agent's two readings.
+    """
+    import time as _time
+
+    state = {"first": True}
+
+    def _clock() -> float:
+        if state["first"]:
+            state["first"] = False
+            return 0.0
+        return float(seconds)
+
+    monkeypatch.setattr(_time, "perf_counter", _clock)
+
+
+def test_slow_decision_warns_once_past_the_threshold(caplog, monkeypatch):
     import logging
 
-    # Any real call takes longer than a millisecond, so this always trips.
     agent = SLHuntingAgent(
         model="test-model",
         runner=_FakeRunner(_HOLD_JSON),
         sdk_timeout_seconds=90,
-        slow_decision_warn_seconds=0.001,
+        slow_decision_warn_seconds=60.0,
     )
+    _pin_decision_duration(monkeypatch, 75.0)
     with caplog.at_level(logging.INFO):
         agent.decide(_candles(), StandaloneExecutor())
 
@@ -1306,7 +1332,7 @@ def test_slow_decision_warns_once_past_the_threshold(caplog):
     assert "HELD" in message
 
 
-def test_fast_decision_does_not_warn(caplog):
+def test_fast_decision_does_not_warn(caplog, monkeypatch):
     """The quiet case, asserted so the warning cannot decay into noise."""
     import logging
 
@@ -1316,6 +1342,7 @@ def test_fast_decision_does_not_warn(caplog):
         sdk_timeout_seconds=90,
         slow_decision_warn_seconds=60.0,
     )
+    _pin_decision_duration(monkeypatch, 3.0)
     with caplog.at_level(logging.INFO):
         agent.decide(_candles(), StandaloneExecutor())
 

--- a/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_agent.py
+++ b/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_agent.py
@@ -1228,3 +1228,98 @@ def test_a_normal_decision_does_not_warn(caplog):
         SLHuntingAgent(model="test-model", runner=_runner).decide(_candles(), StandaloneExecutor())
 
     assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+
+# --------------------------------------------------------------------------
+# SLH-013 — per-decision latency, the number that tracks prompt/latency creep
+# --------------------------------------------------------------------------
+
+_HOLD_JSON = '{"action": "HOLD", "confidence": 0, "reasoning": "ok", "setup": "none"}'
+
+
+def test_slow_decision_warn_seconds_must_be_positive_and_finite():
+    import pytest
+
+    for invalid in (0, -1, float("inf"), float("nan")):
+        with pytest.raises(ValueError):
+            SLHuntingAgent(
+                model="test-model",
+                runner=_FakeRunner(_HOLD_JSON),
+                slow_decision_warn_seconds=invalid,
+            )
+    # A threshold at or above the deadline is ALLOWED: the call is abandoned
+    # before it could fire, which is a legitimate way to switch the warning off
+    # rather than a misconfiguration.
+    assert SLHuntingAgent(
+        model="test-model",
+        runner=_FakeRunner(_HOLD_JSON),
+        sdk_timeout_seconds=90,
+        slow_decision_warn_seconds=1_000,
+    )
+
+
+def test_decision_latency_is_logged_even_when_the_sdk_reports_no_cost(caplog):
+    """Latency must NOT inherit the cost line's condition.
+
+    The cost line only fires when the SDK returned a cost. Latency is the number
+    that says how close the prompt is to the 90s deadline, and a run that
+    reported no cost is exactly the kind you would want timed, so it is logged
+    unconditionally.
+    """
+    import logging
+
+    agent = SLHuntingAgent(
+        model="test-model",
+        runner=_FakeRunner(_HOLD_JSON, cost_usd=None),
+        slow_decision_warn_seconds=1_000,
+    )
+    with caplog.at_level(logging.INFO):
+        agent.decide(_candles(), StandaloneExecutor())
+
+    latency = [r for r in caplog.records if "decision latency" in r.getMessage()]
+    cost = [r for r in caplog.records if "decision cost" in r.getMessage()]
+    assert len(latency) == 1, "latency must be logged exactly once per decision"
+    assert not cost, "this run reported no cost, so no cost line should appear"
+    assert "deadline" in latency[0].getMessage()
+
+
+def test_slow_decision_warns_once_past_the_threshold(caplog):
+    import logging
+
+    # Any real call takes longer than a millisecond, so this always trips.
+    agent = SLHuntingAgent(
+        model="test-model",
+        runner=_FakeRunner(_HOLD_JSON),
+        sdk_timeout_seconds=90,
+        slow_decision_warn_seconds=0.001,
+    )
+    with caplog.at_level(logging.INFO):
+        agent.decide(_candles(), StandaloneExecutor())
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    slow = [r for r in warnings if "at or past the" in r.getMessage()]
+    assert len(slow) == 1
+    message = slow[0].getMessage()
+    # It must name what was breached and what the real limit is, or an operator
+    # reading one line in a shared log cannot tell whether it mattered.
+    assert "threshold" in message and "deadline" in message
+    assert "HELD" in message
+
+
+def test_fast_decision_does_not_warn(caplog):
+    """The quiet case, asserted so the warning cannot decay into noise."""
+    import logging
+
+    agent = SLHuntingAgent(
+        model="test-model",
+        runner=_FakeRunner(_HOLD_JSON),
+        sdk_timeout_seconds=90,
+        slow_decision_warn_seconds=60.0,
+    )
+    with caplog.at_level(logging.INFO):
+        agent.decide(_candles(), StandaloneExecutor())
+
+    assert [r for r in caplog.records if "decision latency" in r.getMessage()]
+    assert not [
+        r for r in caplog.records if r.levelno == logging.WARNING and "at or past the" in r.getMessage()
+    ]

--- a/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_schema.py
+++ b/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_schema.py
@@ -577,19 +577,139 @@ def test_system_prompt_has_v3x_aggregate_inventory_and_option_rr_knowledge():
     assert "POST-EXIT RE-ENTRY GATE" in prompt
 
 
-def test_prompt_cap_leaves_room_for_lessons_and_a_note():
-    """The cap is a sanity bound, not a budget knowledge must squeeze into.
+def _worst_case_runtime_blocks() -> tuple[str, str]:
+    """Render the LARGEST lessons block and pre-open note the runtime can inject.
 
-    It was raised on 2026-07-31 because knowledge alone had reached ~68k against a
-    75k cap, leaving too little for lessons plus a pre-open note. Keep provable
-    headroom so an ordinary addendum cannot silently disable the agent.
+    Built through the REAL formatters rather than by arithmetic, because the
+    arithmetic is what went wrong before: the previous version of this test
+    assumed `12 * 280 + 2500`, which ignored each lesson's 80-character scope
+    and its per-lesson formatting, and understated the note by ~1,100. It read
+    2,659 characters light in total.
+
+    Two fixture traps, both discovered the hard way:
+
+    * `StoredLesson` is tamper-evident. An approved record needs `id` equal to
+      `_slug(scope, lesson)` AND an `approval_digest` equal to
+      `lesson_content_digest(record)`; anything else is silently rejected by
+      `_validated_records` and renders as an empty block.
+    * `_slug` truncates to 48 characters, so records whose scope shares a long
+      prefix collide on id and `consolidate` keeps only one. The varying part
+      must come FIRST.
+    """
+    import datetime as _dt
+    import json
+    import os
+    import tempfile
+
+    import sl_hunting_lessons as L
+    import sl_hunting_premarket as P
+
+    def _lesson(index: int) -> dict:
+        scope = f"s{index:02d}" + "S" * (L.MAX_SCOPE_CHARS - 3)
+        lesson = f"l{index:02d}" + "X" * (L.MAX_LESSON_CHARS - 3)
+        record = {
+            "id": L._slug(scope, lesson),
+            "scope": scope,
+            "lesson": lesson,
+            "rationale": "r" * L.MAX_RATIONALE_CHARS,
+            "evidence": {"wins": 999, "losses": 999, "sample_size": 9999},
+            "confidence": 5,
+            "status": "approved",
+            "created_at": "2026-08-27T00:00:00Z",
+            "updated_at": "2026-08-27T00:00:00Z",
+        }
+        record["approval_digest"] = L.lesson_content_digest(record)
+        return record
+
+    lessons = [_lesson(i) for i in range(L.MAX_LIVE_LESSONS)]
+    validated, rejected = L._validated_records(lessons)
+    assert not rejected and len(validated) == L.MAX_LIVE_LESSONS, (
+        "the worst-case lessons fixture is being rejected, so this test would "
+        f"measure an empty block and prove nothing (rejected={len(rejected)})"
+    )
+    lessons_block = L.format_lessons(lessons)
+
+    note = {
+        "for_date": "2026-08-28",
+        "source": "s" * P.MAX_SOURCE_CHARS,
+        "context": "c" * P.MAX_LINE_CHARS,
+        "plan": ["p" * P.MAX_LINE_CHARS for _ in range(P.MAX_PLAN_ITEMS)],
+        "levels": [
+            {
+                "index": "I" * P.MAX_INDEX_CHARS,
+                "resistance": [99999.5] * P.MAX_LEVELS_PER_SIDE,
+                "support": [99999.5] * P.MAX_LEVELS_PER_SIDE,
+            }
+            for _ in range(P.MAX_INDEX_BLOCKS)
+        ],
+    }
+    handle, path = tempfile.mkstemp(suffix=".json")
+    os.close(handle)
+    try:
+        with open(path, "w", encoding="utf-8") as stream:
+            json.dump(note, stream)
+        loaded = P.load_premarket_note(path)
+        assert loaded is not None, "the worst-case note fixture failed to validate"
+        note_block = P.format_premarket_note(loaded, _dt.date(2026, 8, 28))
+    finally:
+        os.unlink(path)
+    assert note_block, "the worst-case note rendered empty"
+    return lessons_block, note_block
+
+
+# The ceiling the runtime-injected material must stay under. Measured at 8,519
+# on 2026-08-27 (lessons 4,918 + note 3,601); 12,000 leaves ~40% of room for an
+# ordinary widening while still failing on anything that changes the order of
+# magnitude. This number is deliberately NOT derived from the per-field caps --
+# a derived bound would move silently when those caps move, which is precisely
+# the change this test exists to catch.
+MAX_RUNTIME_INJECTED_CHARS = 12_000
+
+
+def test_runtime_injected_blocks_stay_small():
+    """The real guard on runaway lessons / notes, now that the cap cannot be.
+
+    `MAX_SYSTEM_PROMPT_CHARS` was raised to 350,000 on 2026-08-27, which is far
+    too loose to catch a runaway lessons file or a malformed note -- the failure
+    its own comment block says it exists to catch. The detection was moved here
+    on purpose.
+
+    This fails if anyone widens `MAX_LESSON_CHARS`, `MAX_LIVE_LESSONS`,
+    `MAX_PLAN_ITEMS`, `MAX_LINE_CHARS`, `MAX_LEVELS_PER_SIDE` or
+    `MAX_INDEX_BLOCKS` enough to matter, regardless of what the cap says.
+    """
+    lessons_block, note_block = _worst_case_runtime_blocks()
+    total = len(lessons_block) + len(note_block)
+
+    assert total <= MAX_RUNTIME_INJECTED_CHARS, (
+        f"worst-case runtime injection is {total:,} chars "
+        f"(lessons {len(lessons_block):,} + note {len(note_block):,}), over the "
+        f"{MAX_RUNTIME_INJECTED_CHARS:,} ceiling. The prompt cap will NOT catch "
+        "this -- either narrow the per-field caps or raise this ceiling "
+        "deliberately, with the new number measured and recorded."
+    )
+
+
+def test_assembled_prompt_plus_worst_case_runtime_fits_the_cap():
+    """Knowledge + the worst the runtime can add must still fit, with room spare.
+
+    The cap is a sanity bound, not a budget knowledge must squeeze into, so this
+    asserts real headroom rather than a bare fit. It uses the MEASURED worst case
+    from `_worst_case_runtime_blocks`, not arithmetic -- the arithmetic version
+    of this test read 2,659 characters light and reported the budget as 154,140
+    when it was really 151,481.
     """
     from sl_hunting_knowledge import MAX_SYSTEM_PROMPT_CHARS
 
+    lessons_block, note_block = _worst_case_runtime_blocks()
     assembled = len(build_system_prompt() + FINAL_OUTPUT_INSTRUCTION)
-    # Worst case the runtime can add: 12 lessons at their own cap, plus a note.
-    worst_case_runtime_additions = 12 * 280 + 2_500
-    assert assembled + worst_case_runtime_additions < MAX_SYSTEM_PROMPT_CHARS
+    worst_case = assembled + len(lessons_block) + len(note_block)
+
+    assert worst_case < MAX_SYSTEM_PROMPT_CHARS, (
+        f"assembled prompt {assembled:,} plus worst-case runtime injection "
+        f"{len(lessons_block) + len(note_block):,} exceeds the "
+        f"{MAX_SYSTEM_PROMPT_CHARS:,} cap"
+    )
 
 
 def test_system_prompt_has_v3x_profit_depth_and_known_road_knowledge():


### PR DESCRIPTION

---

## SLH-013 - the prompt cap stops being the guard, and latency becomes visible

Three changes that belong together: the cap is raised past the point where it can
detect anything, so the detection moves to a test; and the thing that actually
limits prompt growth gets measured for the first time.

### The cap: 160,000 -> 350,000

Raised so it stops being a recurring question every few knowledge versions
(75k -> 120k -> 160k -> 350k). 350,000 characters is on the order of 90-100k
tokens -- this corpus is ALL-CAPS-heavy and tokenises worse than the usual ~4
chars/token -- against Sonnet 5's 200k context, so it is comfortably inside with
room for the bar context and the agentic loop.

**This raise is different in kind from the two before it, and the comment block
now says so.** The earlier raises kept the bound tight enough to still catch a
runaway lessons file or a malformed note, which its own top paragraph names as
the failure it exists for. At 350,000 it cannot: the runtime can inject only
~8,500 characters at its own caps, so nothing pathological in that material could
ever reach the bound. Raising it without moving the detection somewhere else
would have quietly retired the guard while leaving prose claiming it was armed.

### Where the detection went

`test_runtime_injected_blocks_stay_small` renders a worst-case lessons block and
a worst-case pre-open note through the REAL `format_lessons` and
`format_premarket_note`, and fails if the total passes 12,000 characters
(measured today: 8,519 = lessons 4,918 + note 3,601, so ~40% of room). It trips
if anyone widens `MAX_LESSON_CHARS`, `MAX_LIVE_LESSONS`, `MAX_PLAN_ITEMS`,
`MAX_LINE_CHARS`, `MAX_LEVELS_PER_SIDE` or `MAX_INDEX_BLOCKS` enough to matter,
whatever the cap says.

The ceiling is deliberately a flat number rather than one derived from those
per-field caps: a derived bound would move silently when the caps move, which is
exactly the change worth catching.

### A live inaccuracy this turned up

The test being replaced, `test_prompt_cap_leaves_room_for_lessons_and_a_note`,
assumed the runtime could add `12 * 280 + 2500 = 5,860` characters. The real
worst case is **8,519** - it ignored each lesson's 80-character scope and its
per-lesson formatting, and understated the note by 1,101.

So the effective budget was **151,481, not the 154,140** that has been quoted in
every knowledge addendum since the last raise, and the headroom reported at v4q
was 6,334 rather than 8,993. Nothing was ever actually at risk - the gap was
always larger than the error - but the number was wrong and is now measured
rather than assumed.

**Two fixture traps worth recording**, because they cost real time and the next
person to touch this will hit them:

- `StoredLesson` is tamper-evident. An approved record needs `id` equal to
  `_slug(scope, lesson)` AND `approval_digest` equal to
  `lesson_content_digest(record)`. Get either wrong and `_validated_records`
  drops it silently, `format_lessons` returns `""`, and a test measuring "worst
  case" happily measures zero and passes. The new helper asserts the fixture
  validated, so it can never quietly measure nothing.
- `_slug` truncates to 48 characters. Worst-case records must differ in their
  FIRST few characters or they collide on id and `consolidate` keeps only one.

### Latency: the constraint that actually binds

Context was never the limit. The 90-second SDK deadline fired **27 times between
7 and 31 July 2026**, and not once since - each of those a bar the agent silently
HELD through, with no decision at all. It stopped firing when the model moved to
Sonnet 5 with fast mode, NOT because the prompt shrank: the prompt has nearly
doubled since. Prefill scales with what the cap permits, so this raise spends
precisely the margin that fixed those timeouts.

Until now there was no latency measurement anywhere - only cost. So:

- Every decision logs its wall-clock at INFO beside the cost line. Deliberately
  NOT sharing the cost line's condition: that one fires only when the SDK
  reported a cost, and a run that reported none is exactly the kind worth timing.
- A WARN fires at `SL_HUNTING_SLOW_DECISION_WARN_SECONDS` (default 60 of the 90s
  budget), naming the elapsed time, the threshold, the percentage of the deadline
  and the consequence, so one line in a shared log is enough to judge it.
- A threshold at or above the deadline can never fire, because the call is
  abandoned first. That is allowed rather than rejected - it is a legitimate way
  to switch the warning off.

A timed-out call raises out of `_run_sync` and already logs its own message
naming the deadline, so it is not double-reported here.

### Verification

Nine mutations, each confirmed to fail the suite: widening any of the four
lessons/note caps; logging latency at DEBUG; gating latency on `cost_usd`;
disabling the warn branch; and dropping the deadline detail from the warning
text. Two tests assert the QUIET cases - a fast decision does not warn, and a
threshold above the deadline still constructs - so the warning cannot decay into
noise.

Full gates clean. `check-env` reports the new key as MISSING from the operator's
`.env`, which is correct and expected: it is in `env.example`, and until it is
copied across the in-code default of 60s applies.
