### PR TITLE
fix(sl-hunting): make a lesson id depend on the lesson, not just its scope (SLH-014)

### DIFF
--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -5295,3 +5295,102 @@ the first.
 Full gates clean. `check-env` reports the new key as MISSING from the operator's
 `.env`, which is correct and expected: it is in `env.example`, and until it is
 copied across the in-code default of 60s applies.
+## SLH-014 - a lesson id decided by the scope alone, and the lesson it swallowed
+
+### The bug
+
+`_slug(scope, lesson)` built a lesson id by lowercasing `scope + "-" + lesson`,
+replacing non-alphanumerics with hyphens, and truncating to **48 characters**.
+`MAX_SCOPE_CHARS` is **80**. So for any scope longer than roughly 48 characters
+the id was decided ENTIRELY by the scope and the lesson text never reached it.
+
+Two genuinely different lessons filed under one descriptive scope therefore
+shared an id, and `consolidate` -- which dedupes by id, keeping the
+better-evidenced copy -- silently discarded one. It never appeared in the prompt
+block again and nothing logged its loss. A realistic 55-character scope is enough
+to trigger it:
+
+```
+scope  = "entries on a gap-up morning after a monthly expiry week"
+lesson A -> entries-on-a-gap-up-morning-after-a-monthly-expi
+lesson B -> entries-on-a-gap-up-morning-after-a-monthly-expi
+```
+
+Severity today was low -- `SL_HUNTING_LESSONS_ENABLED` is off by default and the
+existing scopes are short -- but it is silent data loss in the learning loop, and
+it would have bitten the first time lessons were switched on with descriptive
+scopes, which is exactly the natural way to write them.
+
+It surfaced while building the SLH-013 worst-case fixture: twelve records with
+identical scopes rendered an EMPTY lessons block, and the test would have
+happily measured nothing and passed.
+
+### The fix
+
+The id is now a readable prefix plus a digest of the full content:
+
+```
+39 chars of readable slug + "-" + 8 hex of sha256(scope NUL lesson)   = 48
+```
+
+Both halves earn their place. The readable prefix keeps `--list` output and log
+lines legible; the digest makes the id depend on every character of both fields,
+whatever the prefix does. The separator is NUL rather than a hyphen so
+`("a-b", "c")` and `("a", "b-c")` cannot hash alike, and it is built with
+`chr(0)` rather than an escape sequence so no code-generation step can collapse
+it into a literal NUL in the source (which happened once while writing this).
+
+It also tightens tamper-evidence slightly. `StoredLesson` asserts
+`id == _slug(scope, lesson)`; previously an edit past the 48-character prefix
+left that check passing and only `approval_digest` caught it. Now the id moves
+too. The digest remains the real guard -- this is defence in depth, not a
+replacement.
+
+### No migration was needed
+
+Changing the slug changes every id, and `lesson_content_digest` covers the id, so
+every approved record would have been invalidated. That would normally force a
+migration or a documented one-time re-approval, and the operator would have to
+choose which.
+
+It did not arise: **both stores are empty.** `lessons.json` holds zero records
+and the proposed store (`Backtest Outputs/sl_hunting_lessons_proposed.json`) does
+not exist. So there is nothing to invalidate, and this is the cheapest moment the
+fix will ever have. Worth stating explicitly, because if it had been deferred
+until after the first approved lessons landed, it would have cost a re-approval
+cycle instead.
+
+### Verification
+
+Two regression tests in `test_sl_hunting_lessons.py`, both negative-tested by
+mutating `_slug`:
+
+| mutation | result |
+|---|---|
+| revert to the original `slug(scope + lesson)[:48]` | 2 tests fail |
+| digest over the scope only | 1 fails |
+| readable prefix widened to 48 (id overruns its cap) | 3 fail |
+| hyphen separator instead of NUL | 1 fails |
+
+The first row is the point: a literal revert to the shipped bug fails the suite.
+
+Full gates clean.
+
+### Unrelated damage found on the way, and how
+
+The master file would not import at all: `load_dotenv` raised
+`ValueError: embedded null character`. The cause was in `Dependencies/.env`, not
+the repo -- its last three lines were
+`SL_HUNTING_SLOW_DECISION_WARN_SECONDS=60` written TWICE in UTF-16LE, every
+character followed by a NUL.
+
+The source was a command suggested in the SLH-013 hand-off, given in a `bash`
+fence and run in **Windows PowerShell 5.1, whose `>>` defaults to UTF-16LE**.
+Appending UTF-16 to a UTF-8 file produces exactly this. The file was repaired
+(backed up first, corruption proven confined to the trailing three lines, 610 ->
+609 key lines: two corrupt duplicates removed, one clean UTF-8 line added).
+
+The lesson is for future hand-offs: **never suggest appending to `.env` with a
+shell redirect on this machine.** Edit the file, or use
+`Add-Content -Encoding utf8`. A silently corrupted `.env` takes the whole trading
+system down at import, and the error names neither the file nor the line.

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_lessons.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_lessons.py
@@ -198,16 +198,50 @@ class StoredLesson(StrictAIModel):
         return self
 
 
+# The id is capped at 48 characters by ``StoredLesson._validate_id``. Split that
+# budget between a human-readable prefix (so ``--list`` and log lines stay
+# legible) and a hash of the FULL content, which is what actually makes the id
+# unique. 39 + "-" + 8 lands exactly on the cap.
+_SLUG_READABLE_CHARS = 39
+_SLUG_HASH_CHARS = 8
+# NUL, which cannot occur in a scope or a lesson, so ('a-b', 'c') and
+# ('a', 'b-c') cannot hash alike. Built with chr() rather than an escape so
+# no code-generation step can collapse it into a real NUL in this file.
+_SLUG_SEPARATOR = chr(0)
+
+
 def _slug(scope: str, lesson: str) -> str:
-    """Build a STABLE id from scope + lesson text (lowercase, non-alphanumerics → '-').
+    """Build a STABLE id from scope + lesson text: readable prefix + content hash.
 
     Because the same lesson always slugs to the same id, ``consolidate`` can recognise
-    duplicates across coach runs and keep just the best-evidenced copy. Capped to 48
-    chars; falls back to ``"lesson"`` if the text had nothing alphanumeric.
+    duplicates across coach runs and keep just the best-evidenced copy.
+
+    The readable half alone is NOT enough to identify a lesson, and assuming it was
+    is the bug this shape exists to prevent. Earlier this function was simply
+    ``slug(scope + lesson)[:48]``. ``MAX_SCOPE_CHARS`` is 80, so for any scope longer
+    than ~48 characters the id was determined ENTIRELY by the scope and the lesson
+    text never reached it -- two genuinely different lessons filed under one
+    descriptive scope collided, and ``consolidate`` silently kept only the
+    better-evidenced one. The operator would never see the other again: it simply
+    would not appear in the prompt block. Appending a digest of the full
+    ``scope + lesson`` makes the id depend on every character of both, whatever the
+    prefix does.
+
+    It also tightens tamper-evidence a little. ``StoredLesson`` asserts
+    ``id == _slug(scope, lesson)``; previously an edit past the 48-character prefix
+    left that check passing, and only ``approval_digest`` caught it. Now the id
+    itself moves. (The digest remains the real guard -- see
+    ``lesson_content_digest`` -- this is defence in depth, not a replacement.)
+
+    The separator is NUL rather than a hyphen so that ("a-b", "c") and ("a", "b-c")
+    cannot hash alike; neither can appear in the fields themselves.
     """
     base = f"{scope}-{lesson}".lower()
     cleaned = "".join(c if c.isalnum() else "-" for c in base)
-    return "-".join(filter(None, cleaned.split("-")))[:48] or "lesson"
+    readable = "-".join(filter(None, cleaned.split("-")))[:_SLUG_READABLE_CHARS].rstrip("-")
+    digest = hashlib.sha256(f"{scope}{_SLUG_SEPARATOR}{lesson}".encode()).hexdigest()[:_SLUG_HASH_CHARS]
+    # A scope+lesson with nothing alphanumeric still gets a unique, valid id.
+    return f"{readable}-{digest}" if readable else f"lesson-{digest}"
 
 
 def _now() -> str:

--- a/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_lessons.py
+++ b/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_lessons.py
@@ -301,3 +301,74 @@ def test_agent_injects_lessons_block_before_output_contract():
     assert prompt.index("LEARNED LESSONS") < prompt.index("FINAL OUTPUT FORMAT")
     # No lessons by default.
     assert "LEARNED LESSONS" not in SLHuntingAgent(model="test-model")._system_prompt
+
+
+# --------------------------------------------------------------------------
+# SLH-014 — lesson ids must not be decided by the scope alone
+# --------------------------------------------------------------------------
+
+def test_lessons_sharing_a_long_scope_do_not_collide_on_id():
+    """A verbose scope must not swallow the lesson text out of the id.
+
+    `_slug` used to be `slug(scope + lesson)[:48]`. `MAX_SCOPE_CHARS` is 80, so
+    for any scope longer than ~48 characters the id was decided ENTIRELY by the
+    scope and the lesson text never reached it. Two genuinely different lessons
+    filed under one descriptive scope then shared an id, and `consolidate` --
+    which dedupes by id -- silently kept only the better-evidenced one. The
+    other never appeared in the prompt block again, and nothing logged it.
+
+    Found while writing the SLH-013 worst-case fixture, which rendered an EMPTY
+    lessons block because all twelve records collapsed onto a single id.
+    """
+    scope = "entries on a gap-up morning after a monthly expiry week"
+    assert len(scope) > 48, "this scope must be long enough to have swallowed the id"
+    assert len(scope) <= sl_hunting_lessons.MAX_SCOPE_CHARS, "and still be a legal scope"
+
+    first = proposed_to_record(
+        ProposedLesson(
+            scope=scope,
+            lesson="wait for the confirmation candle before entering",
+            rationale="r", wins=3, losses=1, sample_size=4, confidence=6,
+        )
+    )
+    second = proposed_to_record(
+        ProposedLesson(
+            scope=scope,
+            lesson="do not fade the first thrust of the session",
+            rationale="r", wins=9, losses=1, sample_size=10, confidence=7,
+        )
+    )
+
+    assert first["id"] != second["id"], "the lesson text must reach the id"
+
+    kept = consolidate([first, second])
+    assert len(kept) == 2, "a distinct lesson was silently dropped by an id collision"
+    assert {rec["lesson"] for rec in kept} == {first["lesson"], second["lesson"]}
+
+
+def test_slug_honours_the_id_contract_at_the_field_limits():
+    """The id is capped at 48 chars and may hold only letters, numbers, hyphens.
+
+    Asserted at the FIELD limits rather than on tidy inputs, because the bug this
+    replaces only appeared once the scope got long. `StoredLesson._validate_id`
+    rejects anything outside that contract, and a rejected record is dropped
+    silently by `_validated_records`.
+    """
+    slug = sl_hunting_lessons._slug
+
+    longest = slug(
+        "S" * sl_hunting_lessons.MAX_SCOPE_CHARS,
+        "X" * sl_hunting_lessons.MAX_LESSON_CHARS,
+    )
+    assert len(longest) <= 48
+    assert all(char.isalnum() or char == "-" for char in longest)
+
+    # Deterministic: consolidate's dedup across coach runs depends on it.
+    assert slug("a scope", "a lesson") == slug("a scope", "a lesson")
+
+    # Input with nothing alphanumeric still yields a usable, legal id.
+    fallback = slug("!!!", "###")
+    assert fallback and all(char.isalnum() or char == "-" for char in fallback)
+
+    # The joiner must not let different field splits hash alike.
+    assert slug("a-b", "c") != slug("a", "b-c")


### PR DESCRIPTION

---

## SLH-014 - a lesson id decided by the scope alone, and the lesson it swallowed

### The bug

`_slug(scope, lesson)` built a lesson id by lowercasing `scope + "-" + lesson`,
replacing non-alphanumerics with hyphens, and truncating to **48 characters**.
`MAX_SCOPE_CHARS` is **80**. So for any scope longer than roughly 48 characters
the id was decided ENTIRELY by the scope and the lesson text never reached it.

Two genuinely different lessons filed under one descriptive scope therefore
shared an id, and `consolidate` -- which dedupes by id, keeping the
better-evidenced copy -- silently discarded one. It never appeared in the prompt
block again and nothing logged its loss. A realistic 55-character scope is enough
to trigger it:

```
scope  = "entries on a gap-up morning after a monthly expiry week"
lesson A -> entries-on-a-gap-up-morning-after-a-monthly-expi
lesson B -> entries-on-a-gap-up-morning-after-a-monthly-expi
```

Severity today was low -- `SL_HUNTING_LESSONS_ENABLED` is off by default and the
existing scopes are short -- but it is silent data loss in the learning loop, and
it would have bitten the first time lessons were switched on with descriptive
scopes, which is exactly the natural way to write them.

It surfaced while building the SLH-013 worst-case fixture: twelve records with
identical scopes rendered an EMPTY lessons block, and the test would have
happily measured nothing and passed.

### The fix

The id is now a readable prefix plus a digest of the full content:

```
39 chars of readable slug + "-" + 8 hex of sha256(scope NUL lesson)   = 48
```

Both halves earn their place. The readable prefix keeps `--list` output and log
lines legible; the digest makes the id depend on every character of both fields,
whatever the prefix does. The separator is NUL rather than a hyphen so
`("a-b", "c")` and `("a", "b-c")` cannot hash alike, and it is built with
`chr(0)` rather than an escape sequence so no code-generation step can collapse
it into a literal NUL in the source (which happened once while writing this).

It also tightens tamper-evidence slightly. `StoredLesson` asserts
`id == _slug(scope, lesson)`; previously an edit past the 48-character prefix
left that check passing and only `approval_digest` caught it. Now the id moves
too. The digest remains the real guard -- this is defence in depth, not a
replacement.

### No migration was needed

Changing the slug changes every id, and `lesson_content_digest` covers the id, so
every approved record would have been invalidated. That would normally force a
migration or a documented one-time re-approval, and the operator would have to
choose which.

It did not arise: **both stores are empty.** `lessons.json` holds zero records
and the proposed store (`Backtest Outputs/sl_hunting_lessons_proposed.json`) does
not exist. So there is nothing to invalidate, and this is the cheapest moment the
fix will ever have. Worth stating explicitly, because if it had been deferred
until after the first approved lessons landed, it would have cost a re-approval
cycle instead.

### Verification

Two regression tests in `test_sl_hunting_lessons.py`, both negative-tested by
mutating `_slug`:

| mutation | result |
|---|---|
| revert to the original `slug(scope + lesson)[:48]` | 2 tests fail |
| digest over the scope only | 1 fails |
| readable prefix widened to 48 (id overruns its cap) | 3 fail |
| hyphen separator instead of NUL | 1 fails |

The first row is the point: a literal revert to the shipped bug fails the suite.

Full gates clean.

### Unrelated damage found on the way, and how

The master file would not import at all: `load_dotenv` raised
`ValueError: embedded null character`. The cause was in `Dependencies/.env`, not
the repo -- its last three lines were
`SL_HUNTING_SLOW_DECISION_WARN_SECONDS=60` written TWICE in UTF-16LE, every
character followed by a NUL.

The source was a command suggested in the SLH-013 hand-off, given in a `bash`
fence and run in **Windows PowerShell 5.1, whose `>>` defaults to UTF-16LE**.
Appending UTF-16 to a UTF-8 file produces exactly this. The file was repaired
(backed up first, corruption proven confined to the trailing three lines, 610 ->
609 key lines: two corrupt duplicates removed, one clean UTF-8 line added).

The lesson is for future hand-offs: **never suggest appending to `.env` with a
shell redirect on this machine.** Edit the file, or use
`Add-Content -Encoding utf8`. A silently corrupted `.env` takes the whole trading
system down at import, and the error names neither the file nor the line.
