### PR TITLE
feat(sl-hunting): v4t knowledge from the 31 Aug IH live session, and the 1 Sep pre-open note

### DIFF
--- a/Signal Generators/SL Hunting AI Agent/premarket_note.json
+++ b/Signal Generators/SL Hunting AI Agent/premarket_note.json
@@ -1,12 +1,13 @@
 {
-  "for_date": "2026-08-31",
-  "source": "Intraday Hunter, 'Prediction For 31 AUG 2026' (62oH6ARjxAQ, uploaded 2026-08-30)",
-  "context": "Friday closed with small rejections and little momentum across the board, and SENSEX never crossed 77,000 - so few sellers are seated. He calls an exactly FLAT open the PROBLEM case: either gap is easier for him than no gap.",
+  "for_date": "2026-09-01",
+  "source": "Intraday Hunter, 'Prediction For 01 SEP 2026' (dZqfpsKwqRQ, uploaded 2026-08-31)",
+  "context": "Three-four days of CONTINUOUS selling, and today the market took round-number support then fell again. So PUT traders are the seated crowd and buyers are not. Today is NIFTY's weekly EXPIRY.",
   "plan": [
-    "GAP-UP: SELL-side setups. Everyone buys a gap-up directly, so there are no seated stops above to hunt -- the fresh buyers ARE the crowd, and the trade is the other side of them.",
-    "GAP-DOWN: BUY-side setups. The same psychology inverted -- 'seeing the market fall, others will try to sell directly' -- so the fresh sellers become the crowd to take the other side of.",
-    "FLAT: SELL-side, but by FOLLOWING the market, not hunting. He calls flat the problem case because 'the situation will not be very clear', so this branch goes WITH the move rather than against a crowd.",
-    "THE METHOD DIFFERS BY BRANCH, which no previous note has done: both gapped branches are counter-crowd HUNTS, the flat branch is a FOLLOW. Do not carry the hunt premise into flat, or the follow premise into a gap."
+    "FLAT or GAP-UP: BUY-side setups, to TARGET the seated put traders. Same shape as the 28 Aug note -- a multi-day sell-off seats a bearish crowd, and a non-gap-down open is the chance to hunt it.",
+    "GAP-DOWN: flip to SELL-side. His reason is explicit and it is about the crowd, not the direction: 'they have already endured this far', so a gap-down hands them profit and confidence instead of pain.",
+    "THE GAP-DOWN VETO IS TIED TO A LEVEL, not just the gap: 'until this level is crossed, the put traders cannot be targeted directly'. He does not name the NIFTY level on air, so treat your own named invalidation as that level.",
+    "EXPECT AN UPWARD TRAP: 'they will try to save their trade, so the market may build some trap, may try to go up a bit'. A push up need not be a reversal -- it can be the bait that precedes the hunt.",
+    "SENSEX 76500 is called out as the psychological number, with 76700 as support above it."
   ],
   "levels": [
     {
@@ -16,8 +17,8 @@
         24300
       ],
       "support": [
-        23980,
-        24070
+        23900,
+        23980
       ]
     },
     {
@@ -38,8 +39,8 @@
         77750
       ],
       "support": [
-        76700,
-        77000
+        76500,
+        76700
       ]
     }
   ]

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -5876,3 +5876,57 @@ latency becomes the binding constraint.
   covered by `EVENT / HOLIDAY PARTICIPATION`), and the "a pattern is not a crowd"
   sharpening of v4s - see above.
 - Prompt size 149,224 -> 152,587 chars. Assembled 153,878: **187,603 of headroom.**
+
+---
+
+## Pre-open note for 2026-09-01
+
+**Source:** Intraday Hunter, "Prediction For 01 SEP 2026" (`dZqfpsKwqRQ`, uploaded
+2026-08-31 21:25 IST, 2:28).
+
+### The plan
+
+**The branch returns to the 28 Aug shape, inverting yesterday's.** Three-to-four
+days of continuous selling have SEATED a bearish crowd - "put-side traders will be
+the ones sitting here" - so:
+
+- **FLAT or GAP-UP -> BUY side**, to hunt them.
+- **GAP-DOWN -> SELL side**, because a gap-down hands that crowd profit instead of
+  pain: "they have already waited this far", and a gap-down leaves them sitting in
+  confidence rather than forcing them out.
+
+That is the exact opposite of the 31 Aug note (gap-up sell, gap-down buy, flat
+sell). Two consecutive notes with inverted branches is precisely the setup for
+carrying yesterday's habit forward - and yesterday a misclassified open cost the
+day's direction, which is what v4t's CLASSIFY THE OPEN rule now guards.
+
+**The gap-down veto is tied to a LEVEL, not to the gap's sign**: "until this level
+is crossed, the put traders cannot be targeted directly." He points at the chart
+rather than naming the NIFTY level on air, so the note says to treat your own named
+invalidation as that level rather than inventing his.
+
+**He warns of an upward trap first**: the seated crowd "will try to save their
+trade, so the market may build some trap, may try to go up a bit." A push up need
+not be a reversal - it can be the bait before the hunt. That pairs directly with
+v4t's THE EARLY RETRACEMENT IS THE TRAP, arriving from the opposite direction.
+
+**Today is NIFTY's weekly expiry.**
+
+### Levels
+
+| Index | Resistance | Support |
+|---|---|---|
+| NIFTY | 24240, 24300 | 23900, 23980 |
+| BANKNIFTY | 57700, 58000 | 57000, 57200 |
+| SENSEX | 77500, 77750 | 76500, 76700 |
+
+SENSEX 76500 is named as the psychological number. The caption dropped a digit from
+NIFTY's first resistance ("2440"); confirmed off the chart by the operator as 24240,
+and the test says not to reconstruct it from the caption.
+
+### Verification
+
+19/19 on the premarket suite, each new assertion negative-tested: flipping the
+branches back to yesterday's, regating the veto on the gap's sign, dropping the
+upward-trap warning, dropping the expiry from the context, and "correcting" the
+NIFTY resistance each fail.

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -5756,3 +5756,123 @@ saying not to reconstruct either from the caption.
 19/19 on the premarket suite, each new assertion negative-tested: unifying flat
 with the gapped branches, removing the method split, dropping the gap-up reason,
 demoting flat from the problem case, and "correcting" the NIFTY support each fail.
+
+---
+
+## Video addendum - the 31 Aug LIVE SESSION (v4t)
+
+**Source:** Intraday Hunter live session `BJksj4JrtxU` (31 Aug 2026, 6:45).
+
+The most instructive session in this series so far, because IH and the agent read
+the SAME open from the SAME pre-open note and took OPPOSITE sides. He sold it and
+booked a good profit. We bought it three times for **+368.75**, with the last two
+trades giving back 73% of the first.
+
+Nothing downstream was wrong. The patterns, levels, fibs and crowd reads in all six
+decisions were competently done. The whole day turned on one word.
+
+### The one word
+
+The 31 Aug note branched: GAP-UP to the SELL side, GAP-DOWN to the BUY side, FLAT
+to the SELL side. NIFTY opened **58 points below the prior close, about 0.24%**;
+BankNIFTY about 0.25%.
+
+- **IH called it "almost FLAT"** and said so repeatedly through the session. He also
+  said what a real gap-down would have meant for him: "if a gap-down opens directly,
+  then the OTHER people also start selling, and then our thing does not work." He
+  took the flat branch, sold, and booked.
+- **The agent called it a gap-down** - explicitly, in writing: "Shared gap-down open
+  (NIFTY -58pts, BankNIFTY -142pts, both ~0.25%) matches the pre-open note's
+  GAP-DOWN=BUY-side branch." It took the buy branch three times.
+
+Both applied the note faithfully. Only the classification differed, and the note
+sent them opposite ways on it.
+
+**Nothing in the corpus said where the line is.** `DEFAULT FLAT-OPEN READ`,
+`GAP SIZE IS A RISK DIAL` and `SHARED-GAP REQUIREMENT` all explain at length what a
+gap MEANS versus what flat MEANS - and every one of them assumes you already know
+which you are looking at. Worse, `DEFAULT FLAT-OPEN READ` would have put the agent
+on IH's side ("a flat-open rally into a level is normally a SHORT candidate"), and
+it never got consulted because the open had already been labelled a gap.
+
+### What v4t adds
+
+**1. `CLASSIFY THE OPEN BEFORE YOU BRANCH ON IT, AND SAY WHY`.** The test is
+PARTICIPATION, not arithmetic, and it is the same question `DEFAULT FLAT-OPEN READ`
+turns on: did the open itself RECRUIT the other side directly? A real gap acts
+before anyone can decide. An open small enough that the crowd is still deciding is
+flat, whatever the sign of the number.
+
+The percentage is carried as CALIBRATION rather than as the rule - a quarter of a
+percent is not a gap; somewhere around half a percent, or an open clean past the
+nearby stop clusters, is where the gap reading starts to earn itself - with an
+explicit tie-break: **if you are hesitating between the two words, that hesitation
+IS the answer, and it is flat.** A bare threshold would misfire the first time a
+0.4% open behaves like a gap, so the guard asserts the participation test survives
+alongside the number.
+
+It also requires the classification and its reason to appear in the entry
+reasoning, so a wrong call is visible as a wrong CALL rather than buried inside a
+good-looking setup - which is exactly how today's went unnoticed for three trades.
+
+**2. `THE EARLY RETRACEMENT IS THE TRAP, NOT THE TURN`.** IH's read of the actual
+session: "when it opens flat and falls directly, the market gives a small
+retracement so that other people cannot sell directly", and "because of the
+retracement nobody will be seated short - this retracement is JUST A TRAP." So the
+pull-back is where YOU join ("now a retracement has come, especially in BankNIFTY,
+so now we can sell here"), and it also tells you who is NOT there: a crowd kept out
+never got seated, so the trade is a FOLLOW of the original move, not a fade of a
+trapped crowd. The rule sends the reader to `THE METHOD IS NOT ALWAYS A FADE`
+rather than to a hunt, and a guard asserts that.
+
+### v4s did not bite, one session after shipping
+
+All three entries name the same crowd - the gap-down sellers - and none of the six
+decisions mentions the trade count, the re-entry bar, or v4s at all.
+
+| Time | NIFTY | Mirror | Basket |
+|---|---|---|---|
+| 09:19 -> 09:24 | -19.50 | +1,377.00 | **+1,357.50** |
+| 09:33 -> 09:35 | +65.00 | -202.50 | **-137.50** |
+| 10:00 -> 10:01 | -302.25 | -549.00 | **-851.25** |
+| | **-256.75** | **+625.50** | **+368.75** |
+
+Give-back has gone the wrong way three sessions running: 36%, 37%, now **73%**.
+
+The likely reason v4s missed is worth recording rather than fixing blind: its test
+is "a genuinely NEW trapped crowd", and the agent named a fresh PATTERN each time
+(flush reversal, double bottom, psych-support hammer) and treated the pattern as
+the setup. The crowd was identical in all three. **A pattern is not a crowd** - but
+that sharpening should be made after seeing whether v4t's classification rule
+removes the problem at the root, since on a correct FLAT read none of the three
+longs would have been taken at all. Deliberately NOT added this version.
+
+Trade 1 is also worth noting on its own: the basket was carried entirely by the
+MIRROR (+1,377.00 against a NIFTY leg of -19.50). The NIFTY read was wrong and the
+basket paid anyway, which is the pending
+[[v4n-narrating-by-favourable-leg]] concern in its cleanest form yet.
+
+### SLH-013's first live data
+
+The latency line shipped two days ago and produced its first session: **73
+decisions, median 41.1s, p90 50.0s, max 61.2s** against a 90s deadline. Exactly one
+crossed the 60s warn threshold and exactly one WARN fired; nothing came near the
+deadline.
+
+That is a well-calibrated threshold (1.4% fire rate) and a useful datum for the cap
+question: at a median of 41s of a 90s budget, the prompt has real room before
+latency becomes the binding constraint.
+
+### Knowledge changes (v4t)
+
+- `OPENING_DRIVE`: CLASSIFY THE OPEN BEFORE YOU BRANCH ON IT, AND SAY WHY (new,
+  placed immediately before DEFAULT FLAT-OPEN READ, which it gates).
+- `OPENING_DRIVE`: THE EARLY RETRACEMENT IS THE TRAP, NOT THE TURN (new).
+- Two drift guards, negative-tested seven ways: removing either rule, turning the
+  participation test into an arithmetic one, dropping the calibration, dropping the
+  tie-break, dropping the measured consequence, and flipping the retracement rule
+  from a follow to a fade each fail the suite.
+- **Deliberately NOT added:** the holiday-clears-inventory observation (already
+  covered by `EVENT / HOLIDAY PARTICIPATION`), and the "a pattern is not a crowd"
+  sharpening of v4s - see above.
+- Prompt size 149,224 -> 152,587 chars. Assembled 153,878: **187,603 of headroom.**

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
@@ -552,6 +552,50 @@ Conditions (ALL must hold — otherwise this branch simply does not apply):
   / opening range, and there must be no bullish rejection reclaiming those levels.
   Default gap-down logic still looks UP; use this short branch only when sellers
   are not huntable and buyer inventory / failed recovery is the active trap.
+- CLASSIFY THE OPEN BEFORE YOU BRANCH ON IT, AND SAY WHY (v4t). Every open-shape
+  rule below, and every pre-open note, branches on flat vs gap — and none of them
+  tells you where the line is. Treat that classification as a JUDGEMENT you make
+  and state, not a fact you read off the tape, because a pre-open plan can send you
+  the OPPOSITE way depending on which word you pick.
+  THE TEST IS PARTICIPATION, NOT ARITHMETIC, and it is the same question
+  DEFAULT FLAT-OPEN READ turns on: did the open itself RECRUIT the other side
+  directly? A real gap acts before anyone can decide — on a genuine gap-down "the
+  other people also start selling straight away, and then our thing does not work",
+  as IH puts it. An open small enough that the crowd is still deciding is FLAT,
+  whatever the sign of the number, and the flat reading governs.
+  CALIBRATION, measured 2026-08-31: NIFTY opened 58 points below the previous close,
+  about 0.24%, and BankNIFTY about 0.25%. IH called that "almost FLAT" all session
+  and said explicitly that a direct gap-down would have VOIDED the plan he was
+  running. So a quarter of a percent is not a gap. Something in the region of half
+  a percent, or an open clean past the nearby stop clusters, is where the gap
+  reading starts to earn itself — and if you are hesitating between the two words,
+  that hesitation IS the answer: it is flat.
+  WHY IT MATTERS MORE THAN IT LOOKS: this is a one-word decision that inverts the
+  whole day. On that session the pre-open note branched GAP-DOWN to the BUY side
+  and FLAT to the SELL side. IH read flat, sold, and booked a good profit. We read
+  "gap-down", bought it three times, and finished +368.75 with the last two trades
+  giving back 73% of the first. Nothing downstream was wrong: the patterns, the
+  levels and the crowd read were all competently done, on the wrong side of the
+  day. State the classification and the reason for it in your entry reasoning, so a
+  wrong call is visible as a wrong CALL rather than hidden inside a good-looking
+  setup.
+- THE EARLY RETRACEMENT IS THE TRAP, NOT THE TURN (v4t). After a session opens and
+  moves directly one way, the small pull-back that follows is usually there to keep
+  the crowd OUT of the move, not to end it. IH, on exactly that: "when it opens flat
+  and falls directly, the market gives a small retracement so that other people
+  cannot sell directly", and later, "because of the retracement nobody will be
+  seated short — this retracement that is coming is JUST A TRAP."
+  The operational consequence is the entry timing: the retracement is where YOU
+  join, because it is the only moment the move offers a price. "Now a retracement
+  has come, especially in BankNIFTY, so now we can sell here."
+  It also tells you who is NOT there. A crowd kept out by the retracement never got
+  seated, so there is nobody to hunt on that side — which makes the trade a FOLLOW
+  of the original move rather than a fade of a trapped crowd. Do not go looking for
+  a crowd to squeeze in the direction the retracement came from; it does not exist,
+  and this is a case of THE METHOD IS NOT ALWAYS A FADE (v4o).
+  Distinct from A REJECTION BEFORE THE FLUSH IS NOISE, which is about ignoring a
+  bounce BEFORE the move has begun; this is about reading the bounce AFTER the
+  first leg as recruitment-prevention, and entering into it.
 - DEFAULT FLAT-OPEN READ: A FLAT OPEN CANNOT RUN THE WAY A GAP CAN (v4d), and the
   reason is participation rather than momentum. This is the DEFAULT after an
   ordinary or recently rising session; the strict multi-day-down seller-hunt

--- a/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_premarket.py
+++ b/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_premarket.py
@@ -201,23 +201,24 @@ def test_shipped_note_targets_the_next_TRADING_day_not_the_next_calendar_day():
     )
 
 
-def test_shipped_note_matches_august_31_intraday_hunter_plan():
-    """The committed advisory must match the hand-checked 30 Aug transcript.
+def test_shipped_note_matches_september_1_intraday_hunter_plan():
+    """The committed advisory must match the hand-checked 31 Aug transcript.
 
-    This note breaks a pattern every previous one held, and that is the whole
-    risk in editing it:
+    Four things a summarising edit would flatten:
 
-    1. THE METHOD DIFFERS BY BRANCH. Both gapped branches are counter-crowd
-       HUNTS; the flat branch is a FOLLOW. Every prior note applied one method
-       across all three shapes, so an editor working from habit would unify
-       them and destroy half the plan.
-    2. The gap branches are gated on CROWD PSYCHOLOGY, not on levels: a gap-up
-       is sold because everyone buys it directly and leaves no stops above; a
-       gap-down is bought for the mirror-image reason. Losing the reason turns
-       two checkable reads into "fade the gap".
-    3. FLAT is named the PROBLEM case -- "either gap is easier than no gap" --
-       which is the opposite of the last three notes, where flat shared a
-       branch with a gapped open and was never singled out.
+    1. The branch returns to the 28 Aug shape -- FLAT or GAP-UP hunts a seated
+       bearish crowd, GAP-DOWN follows -- which is the OPPOSITE of yesterday's
+       note (gap-up sell, gap-down buy, flat sell). Two consecutive notes with
+       inverted branches is exactly the setup for carrying the wrong habit
+       forward, and yesterday that cost the day's direction.
+    2. The gap-down veto is gated on a LEVEL, not on the gap's sign. He does
+       not name the NIFTY level on air, so the note says to use your own named
+       invalidation rather than inventing one -- losing that turns a checkable
+       veto into a guess.
+    3. He warns the market may TRAP upward first, because the seated crowd will
+       try to save its trade. Without that, a push up reads as a reversal when
+       it may be the bait before the hunt.
+    4. Today is NIFTY's weekly expiry, which the context line must keep.
     """
     import os
 
@@ -225,39 +226,39 @@ def test_shipped_note_matches_august_31_intraday_hunter_plan():
     note = load_premarket_note(os.path.join(here, "premarket_note.json"))
 
     assert note is not None
-    assert note.for_date == "2026-08-31"
-    assert "62oH6ARjxAQ" in note.source
-    assert "few sellers are seated" in note.context
-    # Flat singled out as the hard case, not folded into a gapped branch.
-    assert "calls an exactly FLAT open the PROBLEM case" in note.context
+    assert note.for_date == "2026-09-01"
+    assert "dZqfpsKwqRQ" in note.source
+    assert "PUT traders are the seated crowd" in note.context
+    assert "NIFTY's weekly EXPIRY" in note.context
 
-    up = next(line for line in note.plan if line.startswith("GAP-UP"))
-    assert "SELL-side" in up
-    assert "no seated stops above to hunt" in up
-    assert "the fresh buyers ARE the crowd" in up
+    buy = next(line for line in note.plan if line.startswith("FLAT or GAP-UP"))
+    assert "BUY-side" in buy
+    assert "TARGET the seated put traders" in buy
 
-    down = next(line for line in note.plan if line.startswith("GAP-DOWN"))
-    assert "BUY-side" in down
-    assert "others will try to sell directly" in down
+    sell = next(line for line in note.plan if line.startswith("GAP-DOWN"))
+    assert "SELL-side" in sell
+    # Gated on the crowd's state, not on the direction of the gap.
+    assert "they have already endured this far" in sell
+    assert "profit and confidence instead of pain" in sell
 
-    flat = next(line for line in note.plan if line.startswith("FLAT"))
-    assert "SELL-side" in flat
-    # The flat branch FOLLOWS -- it does not hunt.
-    assert "by FOLLOWING the market, not hunting" in flat
-    assert "rather than against a crowd" in flat
+    veto = next(line for line in note.plan if line.startswith("THE GAP-DOWN VETO"))
+    assert "TIED TO A LEVEL" in veto
+    assert "until this level is crossed" in veto
+    assert "treat your own named invalidation as that level" in veto
 
-    # The split itself must survive as an explicit instruction.
-    method = next(line for line in note.plan if line.startswith("THE METHOD DIFFERS"))
-    assert "both gapped branches are counter-crowd HUNTS, the flat branch is a FOLLOW" in method
-    assert "Do not carry the hunt premise into flat" in method
+    trap = next(line for line in note.plan if line.startswith("EXPECT AN UPWARD TRAP"))
+    assert "try to save their trade" in trap
+    assert "need not be a reversal" in trap
+
+    assert any("76500 is called out as the psychological number" in line for line in note.plan)
 
     assert [level.model_dump() for level in note.levels] == [
         {
-            # Caption ran the supports together as "24072980"; confirmed off the
-            # chart by the operator as 23980/24070, not reconstructed.
+            # Caption dropped a digit from the first resistance ("2440");
+            # confirmed off the chart by the operator as 24240.
             "index": "NIFTY",
             "resistance": [24240.0, 24300.0],
-            "support": [23980.0, 24070.0],
+            "support": [23900.0, 23980.0],
         },
         {
             "index": "BANKNIFTY",
@@ -265,11 +266,8 @@ def test_shipped_note_matches_august_31_intraday_hunter_plan():
             "support": [57000.0, 57200.0],
         },
         {
-            # Caption gave six digits ("776700") where two five-digit levels
-            # belong; confirmed as 76700/77000. 77000 is the level he names
-            # repeatedly as the one SENSEX did NOT cross.
             "index": "SENSEX",
             "resistance": [77500.0, 77750.0],
-            "support": [76700.0, 77000.0],
+            "support": [76500.0, 76700.0],
         },
     ]

--- a/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_schema.py
+++ b/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_schema.py
@@ -1990,3 +1990,67 @@ def test_v4s_accuracy_method_rule_limits_trade_COUNT_not_holding_time():
     # It must never read as permission to hold.
     assert "not a licence to hold longer" in rule
     assert "It governs HOW MANY times you enter, not when you leave" in rule
+
+
+def test_v4t_open_classification_rule_is_behavioural_and_carries_its_calibration():
+    """v4t (31 Aug live session): the flat/gap call inverts the whole day.
+
+    Every open-shape rule and every pre-open note branches on flat vs gap, and
+    nothing said where the line is. Measured that morning: NIFTY opened 58
+    points (~0.24%) below the prior close. IH called it "almost flat" all
+    session and traded the SELL side; the agent called it a gap-down and bought
+    it three times, finishing +368.75 with the last two trades giving back 73%
+    of the first.
+
+    Two things this rule must keep or it stops working:
+
+    1. The test is PARTICIPATION, not arithmetic -- did the open recruit the
+       other side directly? The percentage is calibration, not the rule. If it
+       decays into a bare threshold it will misfire the first time a 0.4% open
+       behaves like a gap.
+    2. The tie-break must survive: hesitating between the two words means flat.
+       Without it the rule adds a judgement call without resolving one.
+    """
+    prompt = build_system_prompt()
+    rule = _flat_rule(prompt, "CLASSIFY THE OPEN BEFORE YOU BRANCH ON IT")
+
+    # Participation is the test; arithmetic is only calibration.
+    assert "THE TEST IS PARTICIPATION, NOT ARITHMETIC" in rule
+    assert "did the open itself RECRUIT the other side" in rule
+    assert "then our thing does not work" in rule
+
+    # The measured calibration point, with both halves of the number.
+    assert "58 points below the previous close" in rule
+    assert "0.24%" in rule
+    assert "a quarter of a percent is not a gap" in rule
+
+    # The tie-break.
+    assert "that hesitation IS the answer: it is flat" in rule
+
+    # The consequence, stated so the rule cannot be read as bookkeeping.
+    assert "+368.75" in rule
+    assert "on the wrong side of the day" in rule
+    assert "State the classification and the reason for it" in rule
+
+
+def test_v4t_early_retracement_rule_points_at_follow_not_fade():
+    """v4t: the first pull-back keeps the crowd OUT, so nobody gets seated.
+
+    The dangerous misreading is to treat the retracement as a trapped crowd to
+    squeeze -- it is the opposite, an absence of one -- so the rule has to send
+    the reader to THE METHOD IS NOT ALWAYS A FADE rather than to a hunt.
+    """
+    prompt = build_system_prompt()
+    rule = _flat_rule(prompt, "THE EARLY RETRACEMENT IS THE TRAP")
+
+    assert "keep the crowd OUT of the move, not to end it" in rule
+    assert "cannot sell directly" in rule
+    assert "JUST A TRAP" in rule
+
+    # Entry timing: it is where you join.
+    assert "the retracement is where YOU" in rule
+
+    # And who is NOT there -- the half that prevents an inverted read.
+    assert "never got seated, so there is nobody to hunt" in rule
+    assert "makes the trade a FOLLOW" in rule
+    assert "THE METHOD IS NOT ALWAYS A FADE" in rule


### PR DESCRIPTION

---

## Video addendum - the 31 Aug LIVE SESSION (v4t)

**Source:** Intraday Hunter live session `BJksj4JrtxU` (31 Aug 2026, 6:45).

The most instructive session in this series so far, because IH and the agent read
the SAME open from the SAME pre-open note and took OPPOSITE sides. He sold it and
booked a good profit. We bought it three times for **+368.75**, with the last two
trades giving back 73% of the first.

Nothing downstream was wrong. The patterns, levels, fibs and crowd reads in all six
decisions were competently done. The whole day turned on one word.

### The one word

The 31 Aug note branched: GAP-UP to the SELL side, GAP-DOWN to the BUY side, FLAT
to the SELL side. NIFTY opened **58 points below the prior close, about 0.24%**;
BankNIFTY about 0.25%.

- **IH called it "almost FLAT"** and said so repeatedly through the session. He also
  said what a real gap-down would have meant for him: "if a gap-down opens directly,
  then the OTHER people also start selling, and then our thing does not work." He
  took the flat branch, sold, and booked.
- **The agent called it a gap-down** - explicitly, in writing: "Shared gap-down open
  (NIFTY -58pts, BankNIFTY -142pts, both ~0.25%) matches the pre-open note's
  GAP-DOWN=BUY-side branch." It took the buy branch three times.

Both applied the note faithfully. Only the classification differed, and the note
sent them opposite ways on it.

**Nothing in the corpus said where the line is.** `DEFAULT FLAT-OPEN READ`,
`GAP SIZE IS A RISK DIAL` and `SHARED-GAP REQUIREMENT` all explain at length what a
gap MEANS versus what flat MEANS - and every one of them assumes you already know
which you are looking at. Worse, `DEFAULT FLAT-OPEN READ` would have put the agent
on IH's side ("a flat-open rally into a level is normally a SHORT candidate"), and
it never got consulted because the open had already been labelled a gap.

### What v4t adds

**1. `CLASSIFY THE OPEN BEFORE YOU BRANCH ON IT, AND SAY WHY`.** The test is
PARTICIPATION, not arithmetic, and it is the same question `DEFAULT FLAT-OPEN READ`
turns on: did the open itself RECRUIT the other side directly? A real gap acts
before anyone can decide. An open small enough that the crowd is still deciding is
flat, whatever the sign of the number.

The percentage is carried as CALIBRATION rather than as the rule - a quarter of a
percent is not a gap; somewhere around half a percent, or an open clean past the
nearby stop clusters, is where the gap reading starts to earn itself - with an
explicit tie-break: **if you are hesitating between the two words, that hesitation
IS the answer, and it is flat.** A bare threshold would misfire the first time a
0.4% open behaves like a gap, so the guard asserts the participation test survives
alongside the number.

It also requires the classification and its reason to appear in the entry
reasoning, so a wrong call is visible as a wrong CALL rather than buried inside a
good-looking setup - which is exactly how today's went unnoticed for three trades.

**2. `THE EARLY RETRACEMENT IS THE TRAP, NOT THE TURN`.** IH's read of the actual
session: "when it opens flat and falls directly, the market gives a small
retracement so that other people cannot sell directly", and "because of the
retracement nobody will be seated short - this retracement is JUST A TRAP." So the
pull-back is where YOU join ("now a retracement has come, especially in BankNIFTY,
so now we can sell here"), and it also tells you who is NOT there: a crowd kept out
never got seated, so the trade is a FOLLOW of the original move, not a fade of a
trapped crowd. The rule sends the reader to `THE METHOD IS NOT ALWAYS A FADE`
rather than to a hunt, and a guard asserts that.

### v4s did not bite, one session after shipping

All three entries name the same crowd - the gap-down sellers - and none of the six
decisions mentions the trade count, the re-entry bar, or v4s at all.

| Time | NIFTY | Mirror | Basket |
|---|---|---|---|
| 09:19 -> 09:24 | -19.50 | +1,377.00 | **+1,357.50** |
| 09:33 -> 09:35 | +65.00 | -202.50 | **-137.50** |
| 10:00 -> 10:01 | -302.25 | -549.00 | **-851.25** |
| | **-256.75** | **+625.50** | **+368.75** |

Give-back has gone the wrong way three sessions running: 36%, 37%, now **73%**.

The likely reason v4s missed is worth recording rather than fixing blind: its test
is "a genuinely NEW trapped crowd", and the agent named a fresh PATTERN each time
(flush reversal, double bottom, psych-support hammer) and treated the pattern as
the setup. The crowd was identical in all three. **A pattern is not a crowd** - but
that sharpening should be made after seeing whether v4t's classification rule
removes the problem at the root, since on a correct FLAT read none of the three
longs would have been taken at all. Deliberately NOT added this version.

Trade 1 is also worth noting on its own: the basket was carried entirely by the
MIRROR (+1,377.00 against a NIFTY leg of -19.50). The NIFTY read was wrong and the
basket paid anyway, which is the pending
[[v4n-narrating-by-favourable-leg]] concern in its cleanest form yet.

### SLH-013's first live data

The latency line shipped two days ago and produced its first session: **73
decisions, median 41.1s, p90 50.0s, max 61.2s** against a 90s deadline. Exactly one
crossed the 60s warn threshold and exactly one WARN fired; nothing came near the
deadline.

That is a well-calibrated threshold (1.4% fire rate) and a useful datum for the cap
question: at a median of 41s of a 90s budget, the prompt has real room before
latency becomes the binding constraint.

### Knowledge changes (v4t)

- `OPENING_DRIVE`: CLASSIFY THE OPEN BEFORE YOU BRANCH ON IT, AND SAY WHY (new,
  placed immediately before DEFAULT FLAT-OPEN READ, which it gates).
- `OPENING_DRIVE`: THE EARLY RETRACEMENT IS THE TRAP, NOT THE TURN (new).
- Two drift guards, negative-tested seven ways: removing either rule, turning the
  participation test into an arithmetic one, dropping the calibration, dropping the
  tie-break, dropping the measured consequence, and flipping the retracement rule
  from a follow to a fade each fail the suite.
- **Deliberately NOT added:** the holiday-clears-inventory observation (already
  covered by `EVENT / HOLIDAY PARTICIPATION`), and the "a pattern is not a crowd"
  sharpening of v4s - see above.
- Prompt size 149,224 -> 152,587 chars. Assembled 153,878: **187,603 of headroom.**
