### PR TITLE
docs(security): triage the five CodeQL alerts as false positives and guard the redaction tests

### DIFF
--- a/Tests/Dependencies/test_repository_policy.py
+++ b/Tests/Dependencies/test_repository_policy.py
@@ -596,3 +596,84 @@ def test_coverage_threshold_checker_enforces_safety_and_broker_budgets():
 
     assert len(failures) == 1
     assert safety_path in failures[0]
+
+
+def _test_function_bodies(source: str) -> dict[str, str]:
+    """Split a test module into ``{function name: body}``.
+
+    Needed because a file-wide substring count proves nothing here: this module
+    has several tests that use a logger, so "at least N logger calls exist"
+    stays true even after the one line that matters has been deleted. The
+    assertion has to be made INSIDE the function that owns the line.
+    """
+    bodies: dict[str, str] = {}
+    for match in re.finditer(r"^def (test_\w+)\(", source, re.MULTILINE):
+        name = match.group(1)
+        nxt = re.search(r"^def test_\w+\(", source[match.end() :], re.MULTILINE)
+        end = match.end() + (nxt.start() if nxt else len(source))
+        bodies[name] = source[match.start() : end]
+    return bodies
+
+
+def test_secret_redaction_canary_coverage_survives_codeql_pressure():
+    """The canary-logging redaction tests must not be "fixed" away (ADR-0013).
+
+    CodeQL flags three lines of ``Tests/Dependencies/test_secret_redaction.py``
+    as ``py/clear-text-logging-sensitive-data``. That is EXPECTED and the alerts
+    are dismissed: each line logs a fake CANARY secret through a handler that
+    has ``RedactingFilter`` installed, into an in-memory buffer, and the test
+    then asserts the secret never reached the output.
+
+    The logging call is not incidental to those tests -- it IS the test. It is
+    the only way to prove the filter scrubs a secret before it reaches a
+    handler, and that filter exists because dhanhq's marketfeed puts a live
+    access token in its websocket URL, so a connect error would otherwise write
+    a working credential into a log operators routinely share.
+
+    So the obvious way to quiet the scanner -- delete the logging call -- would
+    remove the protection while leaving a green Security tab. This guard makes
+    that edit fail loudly instead. If you are here because CodeQL complained
+    again, re-dismiss the alert and read ADR-0013; do not patch the test.
+    """
+    source = (ROOT / "Tests/Dependencies/test_secret_redaction.py").read_text(
+        encoding="utf-8"
+    )
+    bodies = _test_function_bodies(source)
+
+    # The flagged lines, by the test that owns each and the FILTER PATH it
+    # covers. Checked per path, not per test: the first test carries two of the
+    # three alerts, so "this test still logs something" stays true after one of
+    # them is deleted. CLAUDE.md names both paths -- "lazy %s args and exception
+    # tracebacks included" -- and losing either is a real hole.
+    required_paths = {
+        "test_debug_and_exception_records_never_emit_canary_secrets": (
+            (r"logger\.debug\([^)]*secret", "a lazy %s/dict argument"),
+            (r"logger\.exception\([^)]*secret", "an exception traceback"),
+        ),
+        "test_install_redaction_filter_covers_logger_and_existing_handlers": (
+            (r"logger\.debug\([^)]*secret", "a logger installed via install_redaction_filter"),
+        ),
+    }
+
+    for name, paths in required_paths.items():
+        body = bodies.get(name)
+        assert body, (
+            f"{name} has been removed or renamed. It is one of only two tests "
+            "proving the redaction filter scrubs a secret before it reaches a "
+            "handler -- see ADR-0013 before changing it."
+        )
+        for pattern, path_description in paths:
+            assert re.search(pattern, body), (
+                f"{name} no longer pushes the canary secret through {path_description}. "
+                "That is exactly the CodeQL-silencing edit ADR-0013 rejects: the "
+                "alert disappears and so does the coverage."
+            )
+        assert "assert secret not in output" in body, (
+            f"{name} no longer asserts the secret is absent from the captured "
+            "output. Logging a canary proves nothing without that check."
+        )
+
+    # The non-logging redaction test is not under CodeQL pressure, but it is the
+    # only coverage for nested containers, so keep it from drifting away too.
+    assert "test_redaction_reaches_secrets_inside_tuples_and_sets" in bodies
+    assert "CANARY" in source, "the canary marker strings have been removed"

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,6 +57,7 @@ component folder's own `Readme.md`.
 | [0010](adr/0010-tests-in-a-mirrored-tests-tree.md) | Tests consolidated into a mirrored top-level `Tests/` tree |
 | [0011](adr/0011-committed-docs-untracked-superpowers.md) | Committed `docs/` set; Superpowers workspace untracked |
 | [0012](adr/0012-crash-durable-session-state.md) | Per-trade P&L and open positions persisted during the session |
+| [0013](adr/0013-codeql-false-positive-triage.md) | Five CodeQL alerts dismissed as false positives, not patched |
 
 ## Keeping these documents honest
 

--- a/docs/adr/0013-codeql-false-positive-triage.md
+++ b/docs/adr/0013-codeql-false-positive-triage.md
@@ -1,0 +1,116 @@
+# ADR-0013: Dismiss the five CodeQL alerts rather than change the flagged code
+
+**Status:** Accepted
+**Date:** 2026-08-31
+**Deciders:** repository owner
+
+## Context
+
+GitHub code scanning reports **five open CodeQL alerts, all rated "high"**, against
+`main`. They were reviewed one by one on 2026-08-31. **None is a vulnerability**,
+and three of the five describe code whose removal would make this repository
+measurably *less* safe.
+
+| # | Rule | Location |
+|---|---|---|
+| 1 | `py/clear-text-logging-sensitive-data` | `Tests/Dependencies/test_secret_redaction.py:153` |
+| 2 | `py/clear-text-logging-sensitive-data` | `Tests/Dependencies/test_secret_redaction.py:157` |
+| 3 | `py/clear-text-logging-sensitive-data` | `Tests/Dependencies/test_secret_redaction.py:189` |
+| 4 | `py/weak-sensitive-data-hashing` | `Dependencies/Shoonya API/NorenApi.py:229` |
+| 5 | `py/weak-sensitive-data-hashing` | `Dependencies/Flattrade API/flattrade_execution.py:483` |
+
+### Alerts 1–3: the redaction tests log a canary ON PURPOSE
+
+Each flagged line logs a **canary** string — `CANARY-SUPER-SECRET`,
+`CANARY-INSTALL-SECRET` — through a logger whose handler has `RedactingFilter`
+installed, writing into an in-memory `io.StringIO`. The very next lines assert
+`secret not in output` and `REDACTED in output`.
+
+The logging call is not incidental to those tests; it **is** the test. It is the
+only way to prove the filter scrubs a secret before it reaches a handler. Deleting
+or defanging the call to satisfy the scanner would delete the coverage and leave
+the redaction filter unverified.
+
+That filter is not decorative. As `CLAUDE.md` records, `dhanhq`'s marketfeed puts
+the live access token in its websocket URL, so a connect error would otherwise
+write a working credential verbatim into a log file operators routinely share.
+These three tests are what keep that from regressing silently.
+
+The alerts are correct that a secret reaches a logging call. They cannot see that
+the secret is fake, the sink is a memory buffer, and the assertion immediately
+afterwards proves nothing escaped.
+
+### Alert 4: Shoonya's wire protocol, in vendored code
+
+`hashlib.sha256(password)` at `NorenApi.py:229` is what Shoonya's `/authorize`
+endpoint requires on the wire. Two independent reasons not to change it:
+
+- The digest format is **not ours to choose**. Substituting bcrypt/scrypt/argon2
+  produces a value the broker rejects, breaking login outright.
+- The file is a **vendored** third-party client (`CLAUDE.md`, Broker layer).
+  Editing it silently forks the vendor's code and makes the next upgrade a manual
+  merge.
+
+The rule targets password **storage**, where an expensive KDF is the right answer
+because an attacker who steals the store gets offline guesses. There is no password
+store here: this is a transport digest computed in memory and sent immediately.
+
+### Alert 5: not password hashing at all
+
+`flattrade_execution.py:483` computes
+`sha256(api_key + request_code + api_secret)`. That is Flattrade's documented
+proof-of-possession for its token exchange, and the code already carries the
+explanation:
+
+> the API secret is never sent raw. Instead `sha256(api_key + request_code +
+> api_secret)` proves we hold the secret while binding this exchange to THIS
+> request code — a replayed digest is useless once the code expires.
+
+CodeQL taints `raw_secret` as a "password" because of its name. The construction is
+a keyed one-time proof, not a stored credential, and a slow KDF would be the wrong
+primitive as well as a rejected one.
+
+### Why dismissal, and not configuration
+
+CodeQL here runs through GitHub's **default setup** (`state: configured`, no
+workflow file, no config). Default setup does **not** read
+`.github/codeql/codeql-config.yml`, so path filters and query exclusions are
+unavailable. Adding such a file would be dead configuration that reads, to a future
+maintainer, as protection that does not exist.
+
+Dismissal with a recorded reason is therefore the supported remediation. It is also
+the honest one: the finding is real as a pattern match and wrong as a conclusion,
+which is exactly what "false positive" is for.
+
+## Decision
+
+1. **Change none of the five sites.**
+2. **Dismiss all five alerts** with reasons recorded in GitHub: alerts 1–3 as *used
+   in tests*, alerts 4–5 as *false positive*.
+3. **Add a repository-policy guard** asserting the canary-logging tests still exist
+   and still assert the secret is absent, so the "fix" this ADR rejects cannot be
+   applied later by a well-meaning edit or an automated suggestion.
+4. **Treat a recurrence as a dismissal, not a defect.** If these alerts reappear —
+   after a re-scan, a CodeQL version bump, or a file move — re-dismiss them and
+   point at this ADR. Do not patch the code to silence the scanner.
+
+## Consequences
+
+- The Security tab reads clean, and each dismissal carries a reason a reviewer can
+  audit rather than an unexplained silence.
+- The redaction coverage is now protected from both directions: the tests prove the
+  filter works, and the policy guard proves the tests still exist.
+- Alerts 4 and 5 will reappear if either broker file is substantially rewritten,
+  since the flagged construction is inherent to both APIs. That is expected.
+- The repository is **public**. Checked alongside this triage, and clean:
+  `Dependencies/.env` was never committed, no credential/key/token files are
+  tracked, and the only secret-shaped literal in tracked code is
+  `"not-a-real-token"` in a broker test fixture.
+
+## Action items
+
+- [x] Review all five alerts against the source.
+- [x] Record the triage here and link it from `docs/README.md`.
+- [x] Add `test_secret_redaction_canary_coverage_survives_codeql_pressure` to
+      `Tests/Dependencies/test_repository_policy.py`.
+- [ ] Operator dismisses the five alerts in the Security tab with the reasons above.


### PR DESCRIPTION
## Summary

All five open CodeQL alerts were reviewed against the source. **None is a vulnerability**, and three of the five describe code whose removal would make this repository measurably *less* safe. Nothing is patched — the finding is recorded, the tests under scanner pressure are guarded, and the alerts are dismissed.

| # | Rule | Location | Verdict |
|---|---|---|---|
| 1,2,3 | `py/clear-text-logging-sensitive-data` | `Tests/Dependencies/test_secret_redaction.py:153,157,189` | False positive **by design** |
| 4 | `py/weak-sensitive-data-hashing` | `Dependencies/Shoonya API/NorenApi.py:229` | Wire protocol, vendored file |
| 5 | `py/weak-sensitive-data-hashing` | `Dependencies/Flattrade API/flattrade_execution.py:483` | Not password hashing at all |

**1–3** each log a fake `CANARY` secret through a handler with `RedactingFilter` installed, into an in-memory buffer, then assert the secret never reached the output. The logging call *is* the test — it's the only way to prove the filter scrubs a secret before it reaches a handler. That filter exists because dhanhq's marketfeed puts the live access token in its websocket URL.

**4** — `sha256(password)` is what Shoonya's `/authorize` requires on the wire, in a **vendored** client. A KDF produces a value the broker rejects. The rule targets password *storage*; there is no store here.

**5** — `sha256(api_key + request_code + api_secret)` is Flattrade's proof-of-possession bound to a one-time code. The existing comment already says so. CodeQL taints `raw_secret` on its name.

## Why dismissal, not configuration

CodeQL runs through GitHub **default setup**, which ignores `.github/codeql/codeql-config.yml`. Adding one would be dead config that reads as protection.

## Contents

- **`docs/adr/0013`** — per-alert evidence, what breaks if each is "fixed", and the standing instruction to re-dismiss rather than patch on recurrence. Linked from `docs/README.md` (the docs-index policy test requires it).
- **`test_secret_redaction_canary_coverage_survives_codeql_pressure`** — asserts the canary coverage survives, checked **per filter path inside each owning function** rather than by a file-wide count.

## On that guard

Its first two drafts were vacuous and the negative tests caught it: deleting either flagged logging call still passed, because the check was a file-wide `logger.` count and other tests use loggers too. It now fails on all three CodeQL-silencing edits, on renaming a protected test, and on weakening the absence assertion.

Also swept all 136 tracked `.py` files for stray control characters after a code-generation step wrote literal backspace bytes into a regex here — repository is clean.

## Also checked (public repo)

`Dependencies/.env` was never committed, no credential/key/token files are tracked, and the only secret-shaped literal in tracked code is `"not-a-real-token"` in a broker test fixture.

## Operator action

The five alerts still need dismissing in the Security tab — the `gh` token has `repo` but not `security_events`, and on a public repo the write API needs it. Reasons: **1–3 → "Used in tests"**, **4–5 → "False positive"**.