### PR TITLE
feat(sl-hunting): v4u knowledge from the 1 Sep IH live session

### DIFF
--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -5930,3 +5930,105 @@ and the test says not to reconstruct it from the caption.
 branches back to yesterday's, regating the veto on the gap's sign, dropping the
 upward-trap warning, dropping the expiry from the context, and "correcting" the
 NIFTY resistance each fail.
+
+---
+
+## Video addendum - the 1 Sep LIVE SESSION (v4u)
+
+**Source:** Intraday Hunter live session `kUZDZ42c-y8` (1 Sep 2026, 12:00 - the
+longest in this series).
+
+The first LOSING session in this stretch: **-1,488.25 over three trades**, against
+IH booking his target on a single held position. Both halves of the loss have a
+named cause, and neither was a bad pattern read.
+
+| Time | Held | Exit | NIFTY | Mirror | Basket |
+|---|---|---|---|---|---|
+| 09:51 -> 09:52 | **43s** | agent, index hierarchy | +149.50 | -180.00 | **-30.50** |
+| 09:58 -> 10:04 | 6m | **mechanical AI_STOP** | -604.50 | -1,084.50 | **-1,689.00** |
+| 10:11 -> 10:12 | **51s** | agent, index hierarchy | +276.25 | -45.00 | **+231.25** |
+
+### 1. The open was measured against the wrong price
+
+v4t told the agent to classify the open by participation. It never said what to
+compare it TO, and that gap decided the day.
+
+NIFTY opened flat on any reference (24077.55 against 24080.40). BankNIFTY was read
+as **"gapped down hard (~0.8%)"** against its OFFICIAL close - and that reading
+flipped the pre-open note's branch from BUY to SELL, producing both shorts.
+
+IH judges the same thing off a different price, and says so plainly:
+
+> "You will see BankNIFTY has closed somewhere here. But more than the closing, we
+> go by where the market closed AROUND 3:15."
+
+The last fifteen minutes carry auction and settlement prints that no crowd traded
+around, so a gap measured to 15:30 can be an artefact of the close rather than a
+fact about positioning - and positioning is the only thing the classification is
+trying to read. On the 3:15 reference the session was flat, IH stayed on the buy
+side, and booked.
+
+v4u adds this as a sub-bullet on `CLASSIFY THE OPEN`, with the disagreement case:
+**when the indices disagree, the flat one is the honest read.** That is
+`SHARED-GAP REQUIREMENT` applied in the direction it does not currently name - that
+rule covers a flat BankNIFTY beside a gapped NIFTY, and today was the mirror.
+
+### 2. The hierarchy was read one candle at a time
+
+The long was opened at 09:51:49 and closed at 09:52:32 - **43 seconds** - because
+"BankNIFTY is in an accelerating downtrend... disqualifies the whole basket". The
+third trade was opened at 10:11:52 and closed at 10:12:43 - **51 seconds** - on the
+OPPOSITE reading: "BankNIFTY printed a confirmed bullish morning-star...
+disqualifies the whole basket."
+
+The leading index disqualified a long for falling and a short for rising inside
+twenty minutes. That is not the hierarchy working; it is a chop being read one
+candle at a time.
+
+IH spends the session on exactly the move that triggered the first cut:
+
+> "It went down first, because what does the market have to do? It has to CREATE
+> the stop-losses. So we had to see a slight loss. But when the market produced
+> positive momentum, it did exactly what we expected."
+
+The first minute after entry is the one the setup PREDICTED would go against you.
+So `ONE CANDLE IS NOT A REVERSAL` requires, before the hierarchy may close a trade
+you just opened, that the leading index has printed a confirmed reversal **on the
+timeframe you entered on - the same bar you would demand to ENTER on it** - and not
+merely a move against you. If the only thing that has changed since entry is price,
+nothing has changed; that was priced in when the stop was placed.
+
+**Written against the dangerous reading.** "Hold through reversals" is how a small
+loss becomes a large one, so the rule ranks the stop, the max loss and
+premise-invalidation above itself and keeps the counter-evidence: the same
+session's second trade was stopped mechanically for -1,689.00, and that stop was
+right. A drift guard asserts both.
+
+### Deliberately NOT added
+
+- **The holiday explanation** for why he followed momentum on 31 Aug and hunts
+  today ("in a holiday traders take less risk... but if someone took risk
+  yesterday, they took it in selling"). It is the cleanest account yet of why two
+  consecutive notes inverted, but `EVENT / HOLIDAY PARTICIPATION` already carries
+  it, including the "two days can print an almost IDENTICAL chart" framing.
+- **The 15-minute time budget** ("assume 15 minutes is the max; profit will come
+  before 11:15") and the small-candle tell. Close to v4q's obviousness rule and
+  v4b's second leg; recorded here rather than added.
+- **"One rejection is understandable; a SECOND rejection means the market may be
+  doing something to you"** - covered by the existing two-rejections /
+  third-momentum rule.
+
+### SLH-013 latency, second session
+
+**57 decisions, median 41.8s, p90 56.1s, max 70.8s** against the 90s deadline; one
+crossed the 60s threshold. Consistent with session one (median 41.1s, p90 50.0s),
+so the threshold is holding its calibration at roughly one warning per session.
+
+### Knowledge changes (v4u)
+
+- `CLASSIFY THE OPEN BEFORE YOU BRANCH ON IT` gains COMPARE THE OPEN TO THE 3:15
+  LEVEL, NOT THE OFFICIAL CLOSE, plus the indices-disagree rule.
+- `ONE CANDLE IS NOT A REVERSAL: THE HIERARCHY NEEDS TIME TO SPEAK` (new).
+- Two drift guards, negative-tested nine ways. One assertion was found too weak by
+  that pass (it checked "never overrides the" without checking WHAT) and tightened.
+- Prompt size 152,587 -> 155,916 chars. Assembled 157,207: **184,274 of headroom.**

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
@@ -579,6 +579,22 @@ Conditions (ALL must hold — otherwise this branch simply does not apply):
   day. State the classification and the reason for it in your entry reasoning, so a
   wrong call is visible as a wrong CALL rather than hidden inside a good-looking
   setup.
+  * COMPARE THE OPEN TO THE 3:15 LEVEL, NOT THE OFFICIAL CLOSE (v4u). IH is
+    explicit that this is the reference he uses: "you will see BankNIFTY has
+    closed somewhere here, but more than the closing, we go by where the market
+    closed AROUND 3:15." The last fifteen minutes carry auction and settlement
+    prints that no crowd traded around, so a gap measured against 15:30 can be
+    an artefact of the close rather than a fact about positioning — and
+    positioning is the only thing the classification is trying to read.
+    Measured 2026-09-01: NIFTY opened flat on any reference (24077.55 vs 24080.40),
+    but BankNIFTY was read as "gapped down hard (~0.8%)" against its official
+    close. That reading flipped the pre-open note's branch from BUY to SELL and
+    produced two shorts. IH, judging the same session off the 3:15 level, called
+    it flat, stayed on the buy side, and booked his target. Our day was -1,488.25.
+    WHEN THE INDICES DISAGREE, the flat one is the honest read — which is
+    SHARED-GAP REQUIREMENT applied in the direction it does not currently name:
+    that rule covers a flat BankNIFTY beside a gapped NIFTY, and this is the
+    mirror case. A gap in ONE index is not a gapped market.
 - THE EARLY RETRACEMENT IS THE TRAP, NOT THE TURN (v4t). After a session opens and
   moves directly one way, the small pull-back that follows is usually there to keep
   the crowd OUT of the move, not to end it. IH, on exactly that: "when it opens flat
@@ -1992,6 +2008,34 @@ you size or place the NIFTY trade. Advisory, not a hard gate.
   buys a move the other two may never join (that is LAGGARDS NEVER JOINED, seen
   from the front), while exiting on the leader alone only costs you a trade.
   Be slow to enter on BankNIFTY alone; be fast to leave on it.
+- ONE CANDLE IS NOT A REVERSAL: THE HIERARCHY NEEDS TIME TO SPEAK (v4u). The
+  index-hierarchy disqualification is real and stays real. What it cannot do is
+  fire on the price action of the first minute after entry, because that minute
+  is the one the setup PREDICTED would go against you. IH on the same session:
+  "it went down first, because what does the market have to do? It has to CREATE
+  the stop-losses. So we had to see a slight loss. But when the market produced
+  positive momentum, it did exactly what we expected." He sat through it and
+  booked his target.
+  Measured 2026-09-01: a long was opened at 09:51:49 on a confirmed hammer at the
+  24000 psych support and closed at 09:52:32 — FORTY-THREE SECONDS later — because
+  "BankNIFTY is in an accelerating downtrend... disqualifies the whole basket".
+  A second trade was opened at 10:11:52 and closed at 10:12:43, fifty-one seconds,
+  on the OPPOSITE hierarchy read: "BankNIFTY printed a confirmed bullish
+  morning-star... disqualifies the whole basket". The leading index disqualified a
+  long for falling and a short for rising inside twenty minutes. That is not the
+  hierarchy working, it is a chop being read one candle at a time.
+  PRACTICAL FORM: before citing the hierarchy to close a trade you just opened,
+  require that the leading index has printed a CONFIRMED reversal on the timeframe
+  you entered on — pattern plus confirmation candle, the same bar you would demand
+  to ENTER on it — and not merely a move against you. If the only thing that has
+  changed since entry is price, nothing has changed: that was priced in when the
+  stop was placed. The stop is what handles being wrong early; the hierarchy is
+  for when the READ is wrong.
+  This does NOT license sitting through a real reversal, and it never overrides the
+  stop, the max loss or premise-invalidation — the same session's second trade was
+  stopped out mechanically for -1,689.00, and that stop did its job. It narrows one
+  specific move: using the leading index as a reason to cut before the trade has
+  had the time its own setup asked for.
 - INDEX HIERARCHY ON THE WAY OUT — the indices are NOT equal when a position is
   going against you (v3y). NIFTY and Sensex drifting against the trade is
   TOLERABLE; that is handleable noise and does not by itself end the trade.

--- a/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_schema.py
+++ b/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_schema.py
@@ -2054,3 +2054,75 @@ def test_v4t_early_retracement_rule_points_at_follow_not_fade():
     assert "never got seated, so there is nobody to hunt" in rule
     assert "makes the trade a FOLLOW" in rule
     assert "THE METHOD IS NOT ALWAYS A FADE" in rule
+
+
+def test_v4u_open_is_compared_to_the_315_level_not_the_official_close():
+    """v4u (1 Sep live session): which price the open is measured against.
+
+    v4t said to classify the open by participation. It did not say what to
+    compare it TO, and that gap cost a day: NIFTY opened flat on any reference,
+    but BankNIFTY read as "gapped down hard (~0.8%)" against its OFFICIAL close,
+    which flipped the pre-open note's branch from BUY to SELL. IH, judging the
+    same session off the 3:15 level, called it flat and booked his target.
+
+    The rule must keep the REASON (the last fifteen minutes carry prints no
+    crowd traded around) or it decays into an arbitrary preference for one
+    timestamp, and it must keep the disagreement case, which is what actually
+    fired here.
+    """
+    prompt = build_system_prompt()
+    rule = _flat_rule(prompt, "CLASSIFY THE OPEN BEFORE YOU BRANCH ON IT")
+
+    assert "COMPARE THE OPEN TO THE 3:15 LEVEL, NOT THE OFFICIAL CLOSE" in rule
+    assert "more than the closing, we go by where the market" in rule
+    # The reason, not just the instruction.
+    assert "an artefact of the close rather than a fact about positioning" in rule
+
+    # The measured case, both sides of it.
+    assert "gapped down hard (~0.8%)" in rule
+    assert "-1,488.25" in rule
+
+    # The disagreement rule, and its link to the existing one it mirrors.
+    assert "the flat one is the honest read" in rule
+    assert "SHARED-GAP REQUIREMENT" in rule
+    assert "A gap in ONE index is not a gapped market" in rule
+
+
+def test_v4u_hierarchy_needs_time_and_never_overrides_the_stop():
+    """v4u: the leading index cannot disqualify a trade seconds after entry.
+
+    Measured the same session: a long was cut 43 seconds after entry because
+    BankNIFTY was falling, and a short was cut 51 seconds after entry because
+    BankNIFTY was rising. The hierarchy disqualified opposite directions inside
+    twenty minutes.
+
+    The dangerous misreading is "so hold through reversals", which on a live
+    book is how a small loss becomes a large one. The rule must keep the stop,
+    the max loss and premise-invalidation ranked above it, and must keep the
+    counter-evidence: the same session's second trade was stopped mechanically
+    for -1,689.00 and that stop was right.
+    """
+    prompt = build_system_prompt()
+    rule = _flat_rule(prompt, "ONE CANDLE IS NOT A REVERSAL")
+
+    # The mechanism: the first minute is the one the setup predicted.
+    assert "the market have to do? It has to CREATE" in rule
+    assert "that minute" in rule or "the first minute after entry" in rule
+
+    # Both measured cuts, and the point that they contradicted each other.
+    assert "FORTY-THREE SECONDS later" in rule
+    assert "fifty-one seconds" in rule
+    assert "disqualified a" in rule and "long for falling and a short for rising" in rule
+
+    # The bar it sets, tied to the entry standard rather than a new one.
+    assert "the same bar you would demand" in rule
+    assert "If the only thing that has changed since entry is price" in rule
+
+    # And the ranking that stops it being read as permission to hold. Named in
+    # full: asserting only "never overrides the" passes while the list of what
+    # it does not override is deleted, which is the half that does the work.
+    assert "never overrides the" in rule
+    assert "the max loss or premise-invalidation" in rule
+    assert "does NOT license sitting through a real reversal" in rule
+    assert "-1,689.00" in rule
+    assert "that stop did its job" in rule


### PR DESCRIPTION

---

## Video addendum - the 1 Sep LIVE SESSION (v4u)

**Source:** Intraday Hunter live session `kUZDZ42c-y8` (1 Sep 2026, 12:00 - the
longest in this series).

The first LOSING session in this stretch: **-1,488.25 over three trades**, against
IH booking his target on a single held position. Both halves of the loss have a
named cause, and neither was a bad pattern read.

| Time | Held | Exit | NIFTY | Mirror | Basket |
|---|---|---|---|---|---|
| 09:51 -> 09:52 | **43s** | agent, index hierarchy | +149.50 | -180.00 | **-30.50** |
| 09:58 -> 10:04 | 6m | **mechanical AI_STOP** | -604.50 | -1,084.50 | **-1,689.00** |
| 10:11 -> 10:12 | **51s** | agent, index hierarchy | +276.25 | -45.00 | **+231.25** |

### 1. The open was measured against the wrong price

v4t told the agent to classify the open by participation. It never said what to
compare it TO, and that gap decided the day.

NIFTY opened flat on any reference (24077.55 against 24080.40). BankNIFTY was read
as **"gapped down hard (~0.8%)"** against its OFFICIAL close - and that reading
flipped the pre-open note's branch from BUY to SELL, producing both shorts.

IH judges the same thing off a different price, and says so plainly:

> "You will see BankNIFTY has closed somewhere here. But more than the closing, we
> go by where the market closed AROUND 3:15."

The last fifteen minutes carry auction and settlement prints that no crowd traded
around, so a gap measured to 15:30 can be an artefact of the close rather than a
fact about positioning - and positioning is the only thing the classification is
trying to read. On the 3:15 reference the session was flat, IH stayed on the buy
side, and booked.

v4u adds this as a sub-bullet on `CLASSIFY THE OPEN`, with the disagreement case:
**when the indices disagree, the flat one is the honest read.** That is
`SHARED-GAP REQUIREMENT` applied in the direction it does not currently name - that
rule covers a flat BankNIFTY beside a gapped NIFTY, and today was the mirror.

### 2. The hierarchy was read one candle at a time

The long was opened at 09:51:49 and closed at 09:52:32 - **43 seconds** - because
"BankNIFTY is in an accelerating downtrend... disqualifies the whole basket". The
third trade was opened at 10:11:52 and closed at 10:12:43 - **51 seconds** - on the
OPPOSITE reading: "BankNIFTY printed a confirmed bullish morning-star...
disqualifies the whole basket."

The leading index disqualified a long for falling and a short for rising inside
twenty minutes. That is not the hierarchy working; it is a chop being read one
candle at a time.

IH spends the session on exactly the move that triggered the first cut:

> "It went down first, because what does the market have to do? It has to CREATE
> the stop-losses. So we had to see a slight loss. But when the market produced
> positive momentum, it did exactly what we expected."

The first minute after entry is the one the setup PREDICTED would go against you.
So `ONE CANDLE IS NOT A REVERSAL` requires, before the hierarchy may close a trade
you just opened, that the leading index has printed a confirmed reversal **on the
timeframe you entered on - the same bar you would demand to ENTER on it** - and not
merely a move against you. If the only thing that has changed since entry is price,
nothing has changed; that was priced in when the stop was placed.

**Written against the dangerous reading.** "Hold through reversals" is how a small
loss becomes a large one, so the rule ranks the stop, the max loss and
premise-invalidation above itself and keeps the counter-evidence: the same
session's second trade was stopped mechanically for -1,689.00, and that stop was
right. A drift guard asserts both.

### Deliberately NOT added

- **The holiday explanation** for why he followed momentum on 31 Aug and hunts
  today ("in a holiday traders take less risk... but if someone took risk
  yesterday, they took it in selling"). It is the cleanest account yet of why two
  consecutive notes inverted, but `EVENT / HOLIDAY PARTICIPATION` already carries
  it, including the "two days can print an almost IDENTICAL chart" framing.
- **The 15-minute time budget** ("assume 15 minutes is the max; profit will come
  before 11:15") and the small-candle tell. Close to v4q's obviousness rule and
  v4b's second leg; recorded here rather than added.
- **"One rejection is understandable; a SECOND rejection means the market may be
  doing something to you"** - covered by the existing two-rejections /
  third-momentum rule.

### SLH-013 latency, second session

**57 decisions, median 41.8s, p90 56.1s, max 70.8s** against the 90s deadline; one
crossed the 60s threshold. Consistent with session one (median 41.1s, p90 50.0s),
so the threshold is holding its calibration at roughly one warning per session.

### Knowledge changes (v4u)

- `CLASSIFY THE OPEN BEFORE YOU BRANCH ON IT` gains COMPARE THE OPEN TO THE 3:15
  LEVEL, NOT THE OFFICIAL CLOSE, plus the indices-disagree rule.
- `ONE CANDLE IS NOT A REVERSAL: THE HIERARCHY NEEDS TIME TO SPEAK` (new).
- Two drift guards, negative-tested nine ways. One assertion was found too weak by
  that pass (it checked "never overrides the" without checking WHAT) and tightened.
- Prompt size 152,587 -> 155,916 chars. Assembled 157,207: **184,274 of headroom.**
