### PR TITLE
fix(ops): say WHY a Google Sheet update wrote nothing (OPS-002)

### DIFF
--- a/Nifty Multi Strategy Front Test - Master File.py
+++ b/Nifty Multi Strategy Front Test - Master File.py
@@ -16771,6 +16771,54 @@ def _compute_pnl_sheet_updates(values, pnl_by_day, today_str):
     return updates, sorted(unmatched)
 
 
+def _diagnose_empty_sheet_update(values, pnl_by_day, today_str, month_tab):
+    """Explain WHY a sheet update produced no cells, or None if that is normal.
+
+    OPS-002. An empty update used to log one bland INFO line, "nothing to write",
+    which is indistinguishable from a genuinely quiet day. On 2026-09-01 that hid
+    a real failure for a whole session: the new "September 2026" tab had been
+    copied from August and still carried 2026-08-01..2026-08-30 as its date
+    headers, so `_compute_pnl_sheet_updates` skipped every day at
+
+        if date_str[:7] != current_month or date_str not in date_to_col: continue
+
+    -- today for the missing column, August for the wrong month. Both `updates`
+    and `unmatched` came back empty, because `unmatched` only tracks strategy ROW
+    labels and the loop never reached the strategy inner loop. Nothing warned.
+
+    This is the SAME failure mode `_parse_eod_pnl_by_day` already records for the
+    time window ("the only symptom was a Google Sheet that quietly stayed blank"),
+    and it is more likely, because it recurs at EVERY month boundary rather than
+    on an unusual shutdown.
+
+    Returns a warning string when the emptiness is a fault the operator must fix,
+    and None when there was genuinely nothing to write.
+    """
+    if not values:
+        return (
+            f"Google Sheet P&L update wrote nothing: the {month_tab!r} tab is EMPTY "
+            "(no header row), so there is nothing to line figures up against. Add "
+            "the date header row and the strategy row labels."
+        )
+    header = values[0]
+    date_columns = {
+        str(cell).strip()
+        for cell in header
+        if re.fullmatch(r"\d{4}-\d{2}-\d{2}", str(cell).strip())
+    }
+    if today_str in pnl_by_day and today_str not in date_columns:
+        sample = ", ".join(sorted(date_columns)[:3]) or "none"
+        return (
+            f"Google Sheet P&L update wrote nothing: today ({today_str}) has "
+            f"{len(pnl_by_day[today_str])} strategy figures, but the {month_tab!r} "
+            f"tab has NO column headed {today_str!r} (its date columns start: "
+            f"{sample}). This is the month-boundary trap -- a new tab copied from "
+            "the previous month keeps the old date headers. Relabel the header "
+            "row, and the next run backfills today automatically."
+        )
+    return None
+
+
 def _update_pnl_google_sheet() -> bool:
     """
     End-of-day: write each strategy's realised P&L into the current month's tab of
@@ -16850,7 +16898,15 @@ def _update_pnl_google_sheet() -> bool:
                 ", ".join(unmatched),
             )
         if not updates:
-            logger.info("Google Sheet P&L update: nothing to write.")
+            # OPS-002: distinguish a quiet day from a broken sheet. See
+            # `_diagnose_empty_sheet_update` for the 2026-09-01 incident.
+            problem = _diagnose_empty_sheet_update(
+                values, pnl_by_day, today_str, month_tab
+            )
+            if problem:
+                logger.warning("%s", problem)
+            else:
+                logger.info("Google Sheet P&L update: nothing to write.")
             return False
         # Step 7: gspread's Cell is 1-based, our tuples are 0-based, so add 1 to
         # each. One batched update_cells call is far fewer API hits than writing

--- a/Tests/test_nifty_multi_strategy_master.py
+++ b/Tests/test_nifty_multi_strategy_master.py
@@ -12735,3 +12735,59 @@ if __name__ == "__main__":
     # Use the custom runner so both `python file.py` and any other direct
     # invocation produce verbose per-test output PLUS the final summary.
     sys.exit(0 if _run_with_logging() else 1)
+
+
+class SheetEmptyUpdateDiagnosisTests(unittest.TestCase):
+    """OPS-002: an empty Google Sheet update must say WHY when it is a fault.
+
+    On 2026-09-01 the runner logged one bland INFO line, "nothing to write",
+    and the day's P&L never reached the tracker. The new "September 2026" tab
+    had been copied from August and still carried 2026-08-01..2026-08-30 as its
+    date headers, so every day was skipped: today for the missing column, and
+    August for the wrong month. Both `updates` and `unmatched` came back empty,
+    because `unmatched` only tracks strategy ROW labels and the loop never
+    reached the strategy inner loop -- so nothing warned, for a whole session.
+    """
+
+    HEADER_SEPT = ["", "2026-09-01", "2026-09-02"]
+    HEADER_AUG = ["", "2026-08-01", "2026-08-02"]
+
+    def _diagnose(self, values, pnl_by_day, today="2026-09-01", tab="September 2026"):
+        if master_file is None:
+            self.skipTest("master module unavailable")
+        return master_file._diagnose_empty_sheet_update(values, pnl_by_day, today, tab)
+
+    def test_month_boundary_tab_with_stale_date_headers_is_reported(self):
+        """The 2026-09-01 incident itself: right tab, previous month's headers."""
+        values = [self.HEADER_AUG, ["Renko Strategy", "", ""]]
+        pnl = {"2026-09-01": {"Renko": 100.0, "CPR": -50.0}}
+
+        message = self._diagnose(values, pnl)
+
+        self.assertIsNotNone(message, "a stale-header tab must not fail silently")
+        # It has to name the date, the tab, and the count, or the operator cannot
+        # tell this from an ordinary quiet day.
+        self.assertIn("2026-09-01", message)
+        self.assertIn("September 2026", message)
+        self.assertIn("2 strategy figures", message)
+        self.assertIn("month-boundary trap", message)
+        # And it must say the data is recoverable, so nobody re-keys it by hand.
+        self.assertIn("backfills today automatically", message)
+
+    def test_completely_empty_tab_is_reported(self):
+        message = self._diagnose([], {"2026-09-01": {"Renko": 1.0}})
+        self.assertIsNotNone(message)
+        self.assertIn("EMPTY", message)
+
+    def test_a_genuinely_quiet_day_stays_quiet(self):
+        """The column exists and today has figures -> not this helper's business.
+
+        Asserted so the warning cannot decay into noise on every normal run.
+        """
+        values = [self.HEADER_SEPT, ["Renko Strategy", "", ""]]
+        self.assertIsNone(self._diagnose(values, {"2026-09-01": {"Renko": 1.0}}))
+
+    def test_no_figures_for_today_at_all_is_not_a_fault(self):
+        """A day the runner produced nothing for is quiet, not broken."""
+        values = [self.HEADER_SEPT, ["Renko Strategy", "", ""]]
+        self.assertIsNone(self._diagnose(values, {"2026-08-31": {"Renko": 1.0}}))


### PR DESCRIPTION
## What happened

On **2026-09-01** the runner finished cleanly, all 29 strategies logged their P&L, and the Sheet never got it. The only symptom was one bland INFO line:

```
Google Sheet P&L update: nothing to write.
```

## Cause

The new **"September 2026" tab had been copied from August** and still carried `2026-08-01..2026-08-30` as its date headers. `_compute_pnl_sheet_updates` then skipped every day at:

```python
if date_str[:7] != current_month or date_str not in date_to_col:
    continue
```

— today because the tab had no `2026-09-01` column, and every August day because it was the wrong month.

Both `updates` **and** `unmatched` came back empty, because `unmatched` only tracks strategy *row* labels and the loop never reached the strategy inner loop. So nothing warned, and a full session of P&L was silently dropped.

## Why this needed a code change

This is the **same failure mode** `_parse_eod_pnl_by_day` already documents for the time window:

> *on 2026-08-03 a late shutdown put 53 of 54 summaries past the cutoff and the only symptom was a Google Sheet that quietly stayed blank*

That instance was fixed with a `skipped_today` counter that announces itself. The missing-column case had no equivalent — and it is the **more likely** of the two, because it recurs at *every month boundary* rather than on an unusual shutdown.

## The fix

`_diagnose_empty_sheet_update` — a new pure helper that separates a fault from a quiet day. The empty-update branch now WARNs instead of INFOs when it is a fault, naming the date, the tab, how many figures are being dropped, and the month-boundary cause. It also states the data is recoverable, so nobody re-keys it by hand: the parser reads the whole append-mode log and backfills a blank earlier-day cell on the next run.

The helper is deliberately separate from `_compute_pnl_sheet_updates`, whose `(updates, unmatched)` tuple is pinned by existing tests.

## Verification

Four regression tests. Negative-tested — reverting to the silent branch, silencing the empty-tab case, removing the date from the message entirely, and dropping the recoverability note each fail the suite. **Two tests assert the quiet cases** (a real column with figures; a day with no figures at all) so the warning cannot decay into noise.

Verified against the live tracker: with the headers corrected, the production writer wrote **29/29 cells for 2026-09-01 with zero mismatches** against the log. The pre-existing window guard also behaved correctly during that run, ignoring 58 result-summary lines from an after-hours re-run rather than letting them overwrite the real session.

Full gates: 547 master tests, 28 market-data-health, 1,252 pytest, ruff, mypy, compileall.
