### PR TITLE
chore(deps): retire three Dependabot ignores, take pandas-stubs 3.0.5, add the 02 Sep pre-open note

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,13 +13,27 @@ updates:
         patterns:
           - "*"
     # Packages Dependabot must NOT propose, because its grouped bump would be
-    # un-mergeable by policy (each reason below is enforced by CI, so an
-    # auto-bump only produces a red PR -- exactly what happened in PR #76):
+    # un-mergeable by policy or would land a change no gate can see. Re-checked
+    # whenever this list is revisited: an ignore whose reason has expired is
+    # worse than no ignore at all, because it reads to the next maintainer as
+    # protection that is no longer being earned. Two were retired that way on
+    # 2026-09-01 -- see RETIRED at the bottom.
     ignore:
-      # Kotak's official v2.0.1 tag hard-depends on websocket-client==1.8.0,
-      # and pyotp rides in the same isolated broker environment. Bump these
-      # only together with a new validated Kotak SDK tag.
+      # Kotak's official v2.0.1 tag hard-depends on websocket-client==1.8.0 --
+      # verified against the installed neo_api_client 2.0.0 metadata, which
+      # declares it as an EXACT pin, not a floor. websocket-client is also in
+      # the core set for the vendored Shoonya client, so a bump would have to
+      # move both files and would still be refused by the broker CI job (that
+      # is what happened in PR #76). Bump only with a new validated Kotak tag.
       - dependency-name: "websocket-client"
+      # Shoonya's TOTP seed generator. NOT a Kotak dependency: neo_api_client
+      # v2.0.1 does not declare pyotp at all, so the original "rides in the same
+      # isolated broker environment" reason was simply wrong. The real reason to
+      # hold it is that nothing exercises it -- `_generate_totp` imports pyotp
+      # lazily inside the function, the broker CI job installs the package but
+      # runs only the contract and Flattrade suites, and no test ever computes a
+      # code. A break would surface at a live Shoonya login rather than as a red
+      # build, which is the same blind spot that keeps `websockets` below.
       - dependency-name: "pyotp"
       # MAT-106 pins the exact TA-Lib build as the deterministic indicator
       # backend for every strategy. A version change can shift warm-up and
@@ -34,29 +48,41 @@ updates:
           - "version-update:semver-major"
           - "version-update:semver-minor"
       # Typing majors routinely break the mypy gate wholesale; take them as
-      # dedicated upgrades, not weekly noise.
+      # dedicated upgrades, not weekly noise. Still load-bearing: mypy 2.x was
+      # already available when this list was written (2.3.0 was among the bumps
+      # deliberately deferred then) and the pin is still on the 1.x line.
       - dependency-name: "mypy"
-        update-types:
-          - "version-update:semver-major"
-      - dependency-name: "pandas-stubs"
-        update-types:
-          - "version-update:semver-major"
-      # claude-agent-sdk caps this at mcp<2.0.0, so an mcp MAJOR can never
-      # resolve alongside the pinned SDK -- pip fails with ResolutionImpossible
-      # before a single test runs. This is what made PR #99 un-mergeable. Take
-      # mcp majors only together with an SDK release that raises the ceiling.
-      - dependency-name: "mcp"
         update-types:
           - "version-update:semver-major"
       # The async transport under dhanhq.marketfeed, i.e. the LIVE market feed.
       # dhanhq only declares websockets>=12.0.1, so this pin is the sole thing
       # holding a major back, and a breaking change surfaces as a dead feed at
       # 09:15 rather than as a failing gate -- nothing in CI opens a real
-      # socket. Bump majors deliberately, after a paper session on the new
-      # version.
+      # socket. This reason is STRONGER than when it was written, not weaker:
+      # MARKET_DATA_SOURCE=WEBSOCKET is now the active feed, so this is the
+      # production data path rather than an opt-in alternative. Bump majors
+      # deliberately, after a paper session on the new version.
       - dependency-name: "websockets"
         update-types:
           - "version-update:semver-major"
+      #
+      # RETIRED (2026-09-01) -- recorded so they are not re-added by reflex:
+      #   * mcp majors. The reason was mechanical, not a judgement: the SDK then
+      #     capped mcp<2.0.0, so a major could not resolve alongside the pinned
+      #     claude-agent-sdk and pip failed with ResolutionImpossible before a
+      #     single test ran, which is what made PR #99 un-mergeable. SDK 0.2.140
+      #     widened that to mcp>=1.23.0,<3.0.0 and 0.2.145 still declares it, so
+      #     the mechanism is gone. The surface we import directly --
+      #     `mcp.server.fastmcp.FastMCP` in cpr_ai_mcp_server -- is genuinely
+      #     covered: test_cpr_ai_context builds a real server and
+      #     test_cpr_ai_runtime patches FastMCP.run. An incompatible major now
+      #     arrives as a red PR to review instead of never being proposed.
+      #   * pandas-stubs majors. The ignore outlived its reason and began
+      #     causing the drift it existed to prevent: pandas is NOT ignored and
+      #     has moved to 3.0.5, while the stubs pin stayed on the 2.3.3 line, so
+      #     the mypy gate types pandas 3 with pandas 2 stubs. A stubs bump is
+      #     typing-only -- it can fail the mypy gate but cannot reach the
+      #     trading path -- so a red PR is the whole of the risk.
 
   - package-ecosystem: github-actions
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,8 +16,10 @@ updates:
     # un-mergeable by policy or would land a change no gate can see. Re-checked
     # whenever this list is revisited: an ignore whose reason has expired is
     # worse than no ignore at all, because it reads to the next maintainer as
-    # protection that is no longer being earned. Two were retired that way on
-    # 2026-09-01 -- see RETIRED at the bottom.
+    # protection that is no longer being earned. Three were retired on
+    # 2026-09-01 -- see RETIRED at the bottom. Two of those had expired reasons;
+    # the third is an accepted risk, which is a different thing and is labelled
+    # as such so nobody reads it as evidence the risk went away.
     ignore:
       # Kotak's official v2.0.1 tag hard-depends on websocket-client==1.8.0 --
       # verified against the installed neo_api_client 2.0.0 metadata, which
@@ -54,19 +56,10 @@ updates:
       - dependency-name: "mypy"
         update-types:
           - "version-update:semver-major"
-      # The async transport under dhanhq.marketfeed, i.e. the LIVE market feed.
-      # dhanhq only declares websockets>=12.0.1, so this pin is the sole thing
-      # holding a major back, and a breaking change surfaces as a dead feed at
-      # 09:15 rather than as a failing gate -- nothing in CI opens a real
-      # socket. This reason is STRONGER than when it was written, not weaker:
-      # MARKET_DATA_SOURCE=WEBSOCKET is now the active feed, so this is the
-      # production data path rather than an opt-in alternative. Bump majors
-      # deliberately, after a paper session on the new version.
-      - dependency-name: "websockets"
-        update-types:
-          - "version-update:semver-major"
       #
-      # RETIRED (2026-09-01) -- recorded so they are not re-added by reflex:
+      # RETIRED (2026-09-01) -- recorded so they are not re-added by reflex.
+      # The first two had reasons that had expired. The third did NOT: its risk
+      # is real and was accepted deliberately, on evidence, by the operator.
       #   * mcp majors. The reason was mechanical, not a judgement: the SDK then
       #     capped mcp<2.0.0, so a major could not resolve alongside the pinned
       #     claude-agent-sdk and pip failed with ResolutionImpossible before a
@@ -83,6 +76,25 @@ updates:
       #     the mypy gate types pandas 3 with pandas 2 stubs. A stubs bump is
       #     typing-only -- it can fail the mypy gate but cannot reach the
       #     trading path -- so a red PR is the whole of the risk.
+      #   * websockets majors -- ACCEPTED RISK, not an expired reason. The
+      #     hazard is unchanged and still real: dhanhq only declares
+      #     websockets>=12.0.1, so this pin was the only thing holding a major
+      #     back, and CI opens no real socket, so a breaking change surfaces as
+      #     a dead feed at 09:15 rather than as a red build. Retired anyway on
+      #     the operator's standing decision, already recorded twice in the
+      #     `websockets` pin review in test_repository_policy: the feed is the
+      #     active data path (MARKET_DATA_SOURCE=WEBSOCKET) but EVERY strategy
+      #     is paper -- LIVE_TRADING_ENABLED=false and all 29 per-strategy
+      #     <PREFIX>_LIVE_TRADING gates are false -- so a bad feed costs a
+      #     session of paper data, not money, and diagnosing it in the open is
+      #     worth more than never being told the release exists. Two things
+      #     make that a bounded bet rather than a blind one: the pin is still
+      #     second-asserted in test_repository_policy, so a major cannot go
+      #     green on its own and arrives as a PR a human must review; and that
+      #     review block carries the standing instruction -- confirm the feed
+      #     ticks on the next PAPER session, and revert this pin first if it
+      #     does not. REVISIT THIS if live trading is ever switched on: the
+      #     evidence the retirement rests on is the paper gates being false.
 
   - package-ecosystem: github-actions
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,10 +16,11 @@ updates:
     # un-mergeable by policy or would land a change no gate can see. Re-checked
     # whenever this list is revisited: an ignore whose reason has expired is
     # worse than no ignore at all, because it reads to the next maintainer as
-    # protection that is no longer being earned. Three were retired on
-    # 2026-09-01 -- see RETIRED at the bottom. Two of those had expired reasons;
-    # the third is an accepted risk, which is a different thing and is labelled
-    # as such so nobody reads it as evidence the risk went away.
+    # protection that is no longer being earned. Five entries were retired on
+    # 2026-09-01 -- see RETIRED at the bottom. Four had reasons that had expired
+    # or were already gated elsewhere; ONE is an accepted risk, which is a
+    # different thing and is labelled as such so nobody reads it as evidence the
+    # risk went away.
     ignore:
       # Kotak's official v2.0.1 tag hard-depends on websocket-client==1.8.0 --
       # verified against the installed neo_api_client 2.0.0 metadata, which
@@ -42,24 +43,32 @@ updates:
       # smoothing semantics, so it is bumped deliberately, with revalidation,
       # never automatically.
       - dependency-name: "ta-lib"
-      # The numeric core under pandas + TA-Lib. Patches are welcome; minor and
-      # major bumps can change floating-point behaviour across the indicator
-      # pipeline, so they follow the same deliberate path as TA-Lib.
+      # The numeric core under pandas + TA-Lib. MAJORS only -- the minor half of
+      # this ignore was retired on 2026-09-01 once its reason was checked.
+      #
+      # The stated fear was that a bump "can change floating-point behaviour
+      # across the indicator pipeline". That IS gated, precisely: MAT-106's
+      # `test_fixed_fixture_indicator_and_signal_snapshot` pins exact EMA, ATR,
+      # ADX, SMA, Supertrend, MACD and Renko values to EIGHT decimal places plus
+      # the resulting signal actions, and CI runs it on both 3.12 and 3.13.
+      # Verified by perturbing one pinned value by 1 unit in the 8th decimal:
+      # the suite goes red. A minor that moves any indicator therefore cannot
+      # merge silently, which is the whole thing the ignore was protecting.
+      #
+      # The MAJOR stays, for a hazard that snapshot does NOT speak to: TA-Lib
+      # ships a COMPILED extension (_ta_lib.*.pyd) built against the numpy 2.x
+      # C ABI, and declares a bare `numpy` with NO upper bound -- pandas 3.0.5
+      # likewise floors at numpy>=1.26.0 without a ceiling. Nothing in the
+      # dependency metadata would stop pip resolving numpy 3.x against a wheel
+      # that cannot survive it, and the live box would need TA-Lib rebuilt.
       - dependency-name: "numpy"
-        update-types:
-          - "version-update:semver-major"
-          - "version-update:semver-minor"
-      # Typing majors routinely break the mypy gate wholesale; take them as
-      # dedicated upgrades, not weekly noise. Still load-bearing: mypy 2.x was
-      # already available when this list was written (2.3.0 was among the bumps
-      # deliberately deferred then) and the pin is still on the 1.x line.
-      - dependency-name: "mypy"
         update-types:
           - "version-update:semver-major"
       #
       # RETIRED (2026-09-01) -- recorded so they are not re-added by reflex.
-      # The first two had reasons that had expired. The third did NOT: its risk
-      # is real and was accepted deliberately, on evidence, by the operator.
+      # All but one had reasons that had expired or were already covered by a
+      # gate nobody had checked for. The websockets entry did NOT: its risk is
+      # real and was accepted deliberately, on evidence, by the operator.
       #   * mcp majors. The reason was mechanical, not a judgement: the SDK then
       #     capped mcp<2.0.0, so a major could not resolve alongside the pinned
       #     claude-agent-sdk and pip failed with ResolutionImpossible before a
@@ -95,6 +104,18 @@ updates:
       #     ticks on the next PAPER session, and revert this pin first if it
       #     does not. REVISIT THIS if live trading is ever switched on: the
       #     evidence the retirement rests on is the paper gates being false.
+      #   * mypy majors. Held because "typing majors routinely break the mypy
+      #     gate wholesale" -- true, and precisely why the ignore was pointless.
+      #     mypy is a DEV/CI tool: it cannot reach the trading path, so the only
+      #     thing a bad major can do is turn the build red, which is the review
+      #     signal we want rather than the outcome to prevent. The pin is
+      #     already second-asserted in test_repository_policy, so a major cannot
+      #     merge without a human moving that assertion by hand. Meanwhile the
+      #     ignore had frozen us on 1.x while 2.x shipped.
+      #   * numpy MINORS (majors still ignored above). The stated fear was
+      #     floating-point drift through the indicator pipeline; MAT-106's
+      #     determinism snapshot already pins that to 8 decimal places on both
+      #     Python versions, so a minor that moves anything goes red.
 
   - package-ecosystem: github-actions
     directory: "/"

--- a/Signal Generators/SL Hunting AI Agent/premarket_note.json
+++ b/Signal Generators/SL Hunting AI Agent/premarket_note.json
@@ -1,46 +1,47 @@
 {
-  "for_date": "2026-09-01",
-  "source": "Intraday Hunter, 'Prediction For 01 SEP 2026' (dZqfpsKwqRQ, uploaded 2026-08-31)",
-  "context": "Three-four days of CONTINUOUS selling, and today the market took round-number support then fell again. So PUT traders are the seated crowd and buyers are not. Today is NIFTY's weekly EXPIRY.",
+  "for_date": "2026-09-02",
+  "source": "Intraday Hunter, 'Prediction For 02 SEP 2026' (iPeDUGlpMoQ, uploaded 2026-09-01)",
+  "context": "BankNIFTY broke the 500 level, momentum came, held briefly, then the market FELL. His read: after a breakout people like us BUY while the one driving it quietly SELLS. So the trapped LONGS are the seated crowd.",
   "plan": [
-    "FLAT or GAP-UP: BUY-side setups, to TARGET the seated put traders. Same shape as the 28 Aug note -- a multi-day sell-off seats a bearish crowd, and a non-gap-down open is the chance to hunt it.",
-    "GAP-DOWN: flip to SELL-side. His reason is explicit and it is about the crowd, not the direction: 'they have already endured this far', so a gap-down hands them profit and confidence instead of pain.",
-    "THE GAP-DOWN VETO IS TIED TO A LEVEL, not just the gap: 'until this level is crossed, the put traders cannot be targeted directly'. He does not name the NIFTY level on air, so treat your own named invalidation as that level.",
-    "EXPECT AN UPWARD TRAP: 'they will try to save their trade, so the market may build some trap, may try to go up a bit'. A push up need not be a reversal -- it can be the bait that precedes the hunt.",
-    "SENSEX 76500 is called out as the psychological number, with 76700 as support above it."
+    "GAP-DOWN: SELL-side setups. This is his PREFERRED open, said outright -- 'if a gap-down opens, that is the best'. The buyers left holding the failed breakout are the crowd being hunted.",
+    "FLAT: SELL-side as well, same plan, no extra condition. He expects flat precisely BECAUSE the operator distributed into the breakout: 'we should see a flat opening, and if we get a gap-down, even better'.",
+    "GAP-UP: he says it should NOT happen, and this is the only branch with a PRECONDITION -- the plan holds only if rejection starts showing as soon as it opens. No rejection at the open means no trade.",
+    "A BIG GAP EITHER WAY IS A STAND-ASIDE, not a flip: 'if some big gap comes, no plan will be kept there for now'. He says it twice, once for BankNIFTY and again for a big gap-up on SENSEX.",
+    "EVERY BRANCH IS SELL-SIDE. That inverts yesterday's note, which bought flat/gap-up to hunt seated PUT traders. The crowd changed sides: three days of selling seated bears, one failed breakout seated bulls.",
+    "NIFTY carries TWO confirmations rather than one -- the chart read AND the rejection -- 'so we are getting a chance to follow both things'. Treat NIFTY as the cleanest of the three, not merely as confirmation."
   ],
   "levels": [
     {
       "index": "NIFTY",
       "resistance": [
-        24240,
-        24300
+        24060,
+        24180
       ],
       "support": [
-        23900,
-        23980
+        23850,
+        23900
       ]
     },
     {
       "index": "BANKNIFTY",
       "resistance": [
-        57700,
-        58000
+        57500,
+        57800
       ],
       "support": [
-        57000,
-        57200
+        56440,
+        57000
       ]
     },
     {
       "index": "SENSEX",
       "resistance": [
-        77500,
-        77750
+        77000,
+        77300
       ],
       "support": [
-        76500,
-        76700
+        76200,
+        76500
       ]
     }
   ]

--- a/Tests/Dependencies/test_repository_policy.py
+++ b/Tests/Dependencies/test_repository_policy.py
@@ -78,6 +78,19 @@ def test_optional_dependency_sets_are_exact_and_kotak_uses_official_tag():
     # but every strategy is PAPER, so a bad feed costs a session, not money.
     # If the feed does not tick at 09:15, revert this pin first.
     assert "websockets==17.1" in core
+    # 2.3.3.260113 -> 3.0.5.260730 (2026-09-01, PR #150). A correction more than
+    # an upgrade. `pandas` is pinned at 3.0.5 and is NOT in the Dependabot ignore
+    # list, so it moved to the 3.x line while a semver-major ignore pinned the
+    # stubs to the 2.3.3 line -- the mypy gate has been typing pandas 3 with
+    # pandas 2 stubs ever since. pandas-stubs tracks the pandas release it
+    # describes, so matching majors IS the point of this pin rather than a risk
+    # to it, and the ignore has been retired accordingly. Unlike the transport
+    # pins above this one was verified BEFORE the merge, because a stubs change
+    # is typing-only and cannot reach the trading path: mypy reports no issues in
+    # 54 source files against 3.0.5.260730. That is also the version the
+    # operator's box already had installed while this file still asked for
+    # 2.3.3, so `pip install -r requirements.txt` would have DOWNGRADED it.
+    assert "pandas-stubs==3.0.5.260730" in core
     # Same reasoning for the agent transport: SL_HUNTING_ENABLED=true, so this
     # is an active path, but paper-only until the next session confirms it.
     #

--- a/Tests/Dependencies/test_repository_policy.py
+++ b/Tests/Dependencies/test_repository_policy.py
@@ -224,7 +224,17 @@ def test_core_requirements_carry_both_the_runtime_and_the_dev_toolchain():
         "update the CI install step, the README gate block, and this test "
         "together -- CI installs requirements.txt only."
     )
-    for runtime_pin in ("dhanhq==2.2.0", "pandas==3.0.5", "TA-Lib==0.6.8"):
+    # numpy joined this list on 2026-09-01 (PR #150) when the MINOR half of its
+    # Dependabot ignore was retired. Until then nothing asserted the numpy pin a
+    # second time, so a bump could have gone green with no human reading it --
+    # the same hole that was open on pandas-stubs. MAT-106's determinism
+    # snapshot verifies numpy's BEHAVIOUR to 8 decimal places, which is the
+    # stronger check; this assertion is the separate guarantee that the VERSION
+    # cannot move without someone editing this line. Majors remain ignored:
+    # TA-Lib ships a compiled extension built against the numpy 2.x C ABI and
+    # declares a bare `numpy` with no ceiling, so nothing in the metadata would
+    # stop pip resolving numpy 3.x against a wheel that cannot survive it.
+    for runtime_pin in ("dhanhq==2.2.0", "pandas==3.0.5", "TA-Lib==0.6.8", "numpy==2.4.6"):
         assert runtime_pin in core
     for tool_pin in ("pytest==9.1.1", "mypy==1.20.2", "bandit==1.9.4", "pip-audit==2.10.1"):
         assert tool_pin in core

--- a/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_premarket.py
+++ b/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_premarket.py
@@ -201,24 +201,28 @@ def test_shipped_note_targets_the_next_TRADING_day_not_the_next_calendar_day():
     )
 
 
-def test_shipped_note_matches_september_1_intraday_hunter_plan():
-    """The committed advisory must match the hand-checked 31 Aug transcript.
+def test_shipped_note_matches_september_2_intraday_hunter_plan():
+    """The committed advisory must match the hand-checked 01 Sep transcript.
 
-    Four things a summarising edit would flatten:
+    Five things a summarising edit would flatten:
 
-    1. The branch returns to the 28 Aug shape -- FLAT or GAP-UP hunts a seated
-       bearish crowd, GAP-DOWN follows -- which is the OPPOSITE of yesterday's
-       note (gap-up sell, gap-down buy, flat sell). Two consecutive notes with
-       inverted branches is exactly the setup for carrying the wrong habit
-       forward, and yesterday that cost the day's direction.
-    2. The gap-down veto is gated on a LEVEL, not on the gap's sign. He does
-       not name the NIFTY level on air, so the note says to use your own named
-       invalidation rather than inventing one -- losing that turns a checkable
-       veto into a guess.
-    3. He warns the market may TRAP upward first, because the seated crowd will
-       try to save its trade. Without that, a push up reads as a reversal when
-       it may be the bait before the hunt.
-    4. Today is NIFTY's weekly expiry, which the context line must keep.
+    1. EVERY branch is SELL-side. That is a total inversion of yesterday's note,
+       which bought flat/gap-up to hunt seated PUT traders. Two consecutive notes
+       with inverted branches is the exact setup for carrying the wrong habit
+       forward, and on 31 Aug that cost the whole day's direction -- so the test
+       asserts the inversion is stated in the note rather than left implicit.
+    2. The crowd changed sides. It is no longer the bears seated by a multi-day
+       sell-off; it is the LONGS trapped by a failed BankNIFTY breakout, which is
+       WHY every branch sells. Losing the mechanism leaves three unexplained
+       sell branches that read as a directional call.
+    3. GAP-UP is the ONLY branch carrying a precondition -- rejection must appear
+       at the open. Flattening it to "gap-up = sell" manufactures a trade the
+       note does not authorise.
+    4. A BIG GAP is a STAND-ASIDE, not a flip. Every previous note's veto changed
+       DIRECTION; this one removes the trade entirely. A veto that silently
+       becomes "trade the other way" is worse than no veto.
+    5. NIFTY carries TWO confirmations (chart AND rejection), which is why he
+       treats it as the cleanest of the three.
     """
     import os
 
@@ -226,48 +230,58 @@ def test_shipped_note_matches_september_1_intraday_hunter_plan():
     note = load_premarket_note(os.path.join(here, "premarket_note.json"))
 
     assert note is not None
-    assert note.for_date == "2026-09-01"
-    assert "dZqfpsKwqRQ" in note.source
-    assert "PUT traders are the seated crowd" in note.context
-    assert "NIFTY's weekly EXPIRY" in note.context
+    assert note.for_date == "2026-09-02"
+    assert "iPeDUGlpMoQ" in note.source
+    # The mechanism, not just the conclusion: a breakout that retail bought and
+    # the operator sold into is what seats the crowd being hunted.
+    assert "trapped LONGS are the seated crowd" in note.context
+    assert "people like us BUY" in note.context
 
-    buy = next(line for line in note.plan if line.startswith("FLAT or GAP-UP"))
-    assert "BUY-side" in buy
-    assert "TARGET the seated put traders" in buy
+    gap_down = next(line for line in note.plan if line.startswith("GAP-DOWN"))
+    assert "SELL-side" in gap_down
+    assert "PREFERRED open" in gap_down
 
-    sell = next(line for line in note.plan if line.startswith("GAP-DOWN"))
-    assert "SELL-side" in sell
-    # Gated on the crowd's state, not on the direction of the gap.
-    assert "they have already endured this far" in sell
-    assert "profit and confidence instead of pain" in sell
+    flat = next(line for line in note.plan if line.startswith("FLAT"))
+    assert "SELL-side" in flat
+    # Flat shares the gap-down branch outright -- no extra condition on it.
+    assert "no extra condition" in flat
 
-    veto = next(line for line in note.plan if line.startswith("THE GAP-DOWN VETO"))
-    assert "TIED TO A LEVEL" in veto
-    assert "until this level is crossed" in veto
-    assert "treat your own named invalidation as that level" in veto
+    gap_up = next(line for line in note.plan if line.startswith("GAP-UP"))
+    assert "PRECONDITION" in gap_up
+    assert "rejection starts showing as soon as it opens" in gap_up
+    assert "No rejection at the open means no trade" in gap_up
 
-    trap = next(line for line in note.plan if line.startswith("EXPECT AN UPWARD TRAP"))
-    assert "try to save their trade" in trap
-    assert "need not be a reversal" in trap
+    stand_aside = next(line for line in note.plan if line.startswith("A BIG GAP"))
+    assert "STAND-ASIDE, not a flip" in stand_aside
+    assert "no plan will be kept there for now" in stand_aside
 
-    assert any("76500 is called out as the psychological number" in line for line in note.plan)
+    inversion = next(line for line in note.plan if line.startswith("EVERY BRANCH IS SELL-SIDE"))
+    assert "inverts yesterday's note" in inversion
+    assert "seated PUT traders" in inversion
+
+    assert any("TWO confirmations" in line and "chart read AND the rejection" in line
+               for line in note.plan)
 
     assert [level.model_dump() for level in note.levels] == [
         {
-            # Caption dropped a digit from the first resistance ("2440");
-            # confirmed off the chart by the operator as 24240.
             "index": "NIFTY",
-            "resistance": [24240.0, 24300.0],
-            "support": [23900.0, 23980.0],
+            "resistance": [24060.0, 24180.0],
+            "support": [23850.0, 23900.0],
         },
         {
+            # Caption ran the two supports together as "575640"; confirmed off
+            # the chart by the operator as 57000 and 56440. Do NOT reconstruct
+            # these from the caption.
             "index": "BANKNIFTY",
-            "resistance": [57700.0, 58000.0],
-            "support": [57000.0, 57200.0],
+            "resistance": [57500.0, 57800.0],
+            "support": [56440.0, 57000.0],
         },
         {
+            # Caption ran the two resistances together as "777300"; confirmed off
+            # the chart by the operator as 77000 and 77300. Do NOT reconstruct
+            # these from the caption -- the obvious split (77700/77300) is wrong.
             "index": "SENSEX",
-            "resistance": [77500.0, 77750.0],
-            "support": [76500.0, 76700.0],
+            "resistance": [77000.0, 77300.0],
+            "support": [76200.0, 76500.0],
         },
     ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -62,10 +62,14 @@ pip-audit==2.10.1
 # Type stubs for typed third-party usage in the mypy scope. pandas-stubs is
 # pinned so local and CI mypy see the exact same pandas typing (an out-of-band
 # stubs install once made local mypy fail while CI stayed green).
-# mypy and pandas-stubs majors are deliberately NOT auto-bumped (see
-# .github/dependabot.yml); take them as dedicated typing upgrades.
+# mypy majors are deliberately NOT auto-bumped (see .github/dependabot.yml);
+# take them as dedicated typing upgrades. pandas-stubs is NO LONGER held back:
+# `pandas` itself is not ignored, so holding the stubs produced exactly the
+# drift this pin exists to prevent -- they sat a full major behind the pandas
+# they describe. pandas-stubs tracks the pandas release it types, so keep this
+# on the same major as the pandas pin above.
 types-requests==2.33.0.20260712
-pandas-stubs==2.3.3.260113
+pandas-stubs==3.0.5.260730
 
 # ---- Exact optional dependency sets -----------------------------------------
 # Live broker compatibility manifest:


### PR DESCRIPTION
Re-checked all eight entries in `.github/dependabot.yml`'s ignore list against what is true **today** rather than what was true when the list was written in July. **Three retired, one reason corrected, four confirmed.** One pin moves: `pandas-stubs`.

## Retired — expired reasons

**`mcp` majors.** The reason was mechanical, not a judgement: `claude-agent-sdk` then capped `mcp<2.0.0`, so a major could not resolve alongside the pinned SDK and pip failed with `ResolutionImpossible` before a single test ran — that is what made PR #99 un-mergeable. SDK 0.2.140 widened it to `mcp>=1.23.0,<3.0.0` and 0.2.145 still declares it. This repository had *already noticed* — the PR #135 pin review in `test_repository_policy.py` records the widening — but this file was never updated, so it has been asserting a dead constraint since 24 Aug.

The surface we import, `mcp.server.fastmcp.FastMCP`, is genuinely covered: `test_cpr_ai_context` builds a real server and `test_cpr_ai_runtime` patches `FastMCP.run`. An incompatible major now arrives as a red PR rather than never appearing.

**`pandas-stubs` majors.** The ignore had started causing the drift it existed to prevent: `pandas` is **not** ignored and moved to 3.0.5 while the stubs pin stayed on the 2.3.3 line, so the mypy gate has been typing pandas 3 with pandas 2 stubs.

## Retired — accepted risk (labelled as such)

**`websockets` majors.** The hazard is **unchanged and still real**: `dhanhq` declares only `websockets>=12.0.1`, so this pin was the only thing holding a major back, and CI opens no real socket — a breaking change surfaces as a dead feed at 09:15, not as a red build. The comment says this plainly rather than pretending the risk evaporated.

Accepted on evidence the repo can check: `MARKET_DATA_SOURCE=WEBSOCKET` is the active feed, but **both halves of the double gate are off** — `LIVE_TRADING_ENABLED=false` *and* all 29 per-strategy `<PREFIX>_LIVE_TRADING` gates are `false`. A bad feed costs a session of paper data, not money. Same reasoning already recorded twice in the `websockets` pin review (PRs #119, #144); it now extends to majors.

It stays bounded: the pin is still second-asserted, so a major **cannot go green on its own** — it arrives as a PR a human reviews, and that review block carries the standing instruction to confirm the feed ticks on the next paper session and revert first if it does not. The comment flags **REVISIT if live trading is switched on**, since the paper gates are the evidence it rests on.

## Pin moved: `pandas-stubs` 2.3.3.260113 → 3.0.5.260730

Retiring the ignore without moving the pin would have left the drift in place, and it had a live edge: the operator's box **already had 3.0.5.260730 installed** while this file asked for 2.3.3, so `pip install -r requirements.txt` would have *downgraded* the working stubs.

Verified before merge rather than after — a stubs change is typing-only and cannot reach the trading path. **mypy: no issues in 54 source files** against the new version.

`pandas-stubs` had **no second assertion**, so with its ignore gone Dependabot could have gone green on it alone. Added one with the dated inline review this file's convention requires, and negative-tested it: restoring the 2.3.3 pin fails the suite (1 failed, 16 passed); the correct pin passes 17/17.

## Corrected, still ignored

**`pyotp`** was justified as riding in Kotak's isolated environment. That is false — `neo_api_client` v2.0.1 does not declare `pyotp` at all. Kept for the real reason: **nothing exercises it.** `_generate_totp` imports it lazily, the broker CI job installs it but runs only the contract and Flattrade suites, and no test computes a code — so a break surfaces at a live Shoonya login, not in a red build.

## Confirmed unchanged

| Ignore | Evidence it still holds |
|---|---|
| `websocket-client` | `neo_api_client` 2.0.0 declares `websocket-client==1.8.0` as an **exact** pin, verified from installed metadata |
| `ta-lib` | MAT-106 determinism, unchanged |
| `numpy` minor/major | Unchanged; patches still flow |
| `mypy` major | Still load-bearing — 2.x was available when the list was written and the pin is still 1.x |

## Also retired: `mypy` majors, and `numpy`'s minor half

**`mypy` majors — retired.** The reason ("typing majors routinely break the mypy gate wholesale") is true, and is precisely why the ignore was pointless. mypy is a **dev/CI tool** — it cannot reach the trading path, so the worst a bad major can do is turn the build red, which is the review signal we want rather than the outcome to prevent. The pin is already second-asserted, so a major still cannot merge without a human moving that line. Meanwhile the ignore had frozen us on 1.x while 2.x shipped.

**`numpy` minors — retired. Majors — kept.** The stated fear was floating-point drift "across the indicator pipeline". That turns out to be gated *precisely*: MAT-106's `test_fixed_fixture_indicator_and_signal_snapshot` pins exact EMA/ATR/ADX/SMA/Supertrend/MACD/Renko values to **eight decimal places** plus the resulting signal actions, on both 3.12 and 3.13. Verified rather than assumed — perturbing one pinned value by a single unit in the 8th decimal turns the suite red.

The **major** stays for a hazard the snapshot does not speak to: TA-Lib ships a **compiled** extension built against the numpy 2.x C ABI and declares a bare `numpy` with **no upper bound**; pandas 3.0.5 likewise floors at `numpy>=1.26.0` with no ceiling. Nothing in the metadata would stop pip resolving numpy 3.x against a wheel that cannot survive it, and the live box would need TA-Lib rebuilt.

**Guard hole closed while checking:** `numpy` had **no second assertion anywhere**, so a numpy bump could have gone green with nobody reading it — the same hole that was open on `pandas-stubs`. Added `numpy==2.4.6` to the runtime pins and negative-tested it.

**Ignore list is now four:** `websocket-client`, `pyotp`, `ta-lib`, and `numpy` **majors only** — down from eight.

## Verification

547 master, 28 market-data-health, 1252 pytest, ruff, mypy (54 files, against the newly pinned stubs), compileall, bandit — all clean. YAML re-parsed and the resulting ignore list asserted to be exactly the five above.

## Operator follow-up

Next paper session, confirm the feed ticks and `SLHuntingAgent decision cost` lines appear. Nothing here changes runtime behaviour, but `websockets` majors can now reach you as PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Addendum: pre-open note for 2026-09-02

Source: Intraday Hunter, **"Prediction For 02 SEP 2026"** (`iPeDUGlpMoQ`, uploaded 2026-09-01 21:25 IST, 2:17) — the channel's usual evening slot. Transcript read in full: 18 segments, 0:06 → 2:06, ending on the sign-off.

## The plan is uniformly SELL-side, which inverts yesterday

Every branch sells. The 01 Sep note **bought** flat/gap-up to hunt seated PUT traders; this one sells all three open shapes. The reason is a **change of crowd, not a change of opinion**: BankNIFTY broke the 500 level, momentum came and held briefly, then the market fell. His read is that after a breakout *"people like us buy"* while the one driving the market quietly sells into it — so the **trapped LONGS** are now the seated crowd.

That inversion is stated **in** the note rather than left implicit, because two consecutive notes with opposite branches is exactly how the wrong habit gets carried forward — and on 31 Aug that cost the whole day's direction.

| Open | Plan | Note |
|---|---|---|
| **GAP-DOWN** | SELL | His **preferred** open, said outright — *"if a gap-down opens, that is the best"* |
| **FLAT** | SELL | No extra condition — he expects flat *because* the operator distributed into the breakout |
| **GAP-UP** | SELL **only if** rejection shows at the open | The **only** branch with a precondition. No rejection → no trade |
| **BIG GAP either way** | **STAND ASIDE** | Said twice. Every previous note's veto changed *direction*; this one **removes the trade** |

NIFTY carries **two** confirmations (chart *and* rejection), so he treats it as the cleanest of the three.

## Levels

| Index | Resistance | Support |
|---|---|---|
| NIFTY | 24060, 24180 | 23850, 23900 |
| BANKNIFTY | 57500, 57800 | 56440, 57000 |
| SENSEX | 77000, 77300 | 76200, 76500 |

**Two needed the operator.** The caption ran BankNIFTY's supports together as `575640` and SENSEX's resistances as `777300` — six digits where two five-digit levels belong. Confirmed off the chart as **57000/56440** and **77000/77300**. The test carries comments saying not to reconstruct either from the caption, and names the wrong-but-obvious split (77700/77300) explicitly so it does not get "corrected" back later.

## Verification

19/19 on the premarket suite. Every new assertion **negative-tested, nine ways** — each of these fails the suite: dropping the gap-up precondition, turning the big-gap stand-aside into a flip, dropping the inversion warning, dropping the crowd mechanism from the context line, giving FLAT a condition it does not have, dropping the NIFTY two-confirmations line, reconstructing either garbled level from the caption, and leaving a stale `for_date`.

