### PR TITLE
feat(sl-hunting): v4w - after the break, slow candles recruit your own side

### DIFF
--- a/Signal Generators/SL Hunting AI Agent/premarket_note.json
+++ b/Signal Generators/SL Hunting AI Agent/premarket_note.json
@@ -1,21 +1,21 @@
 {
-  "for_date": "2026-09-03",
-  "source": "Intraday Hunter, 'Prediction For 03 SEP 2026' (8GwfUa2LcL4, uploaded 2026-09-02)",
-  "context": "Selling came, but the market kept flushing sellers out with repeated retracements and recoveries. So today may have been a ONE-DAY TRAP rather than a settled turn -- and the sellers are NOT a seated crowd. SENSEX has expiry.",
+  "for_date": "2026-09-04",
+  "source": "Intraday Hunter, 'Prediction For 04 SEP 2026' (PywlkaQByoQ, uploaded 2026-09-03)",
+  "context": "Today's gap-up was REJECTED and sold back down; BankNIFTY closed under 57500. He says twice that nobody got in long, so the BUYERS are not a seated crowd -- and yesterday's sellers were already flushed.",
   "plan": [
-    "THE PIVOT IS THE CLOSING PRICE, not a gap size: of BankNIFTY he says 'it is a resistance and it is also a support'. Which side of today's close the market opens on decides the entire plan, so measure the open against that level.",
-    "ABOVE the close: BUY-side setups. His reason is TIME, not price -- 'when a big level's situation has to change, it takes time; do not think one momentum means everything is now fine'. A gap-up says good traders sat from below.",
-    "FLAT to GAP-DOWN: SELL-side, but as a FOLLOW and not a hunt -- 'we will walk WITH the market'. There is no particular strength, and the retracements already flushed the sellers, so no trapped crowd is being targeted here.",
-    "THIS INVERTS TODAY'S NOTE, which was uniformly SELL-side across all three open shapes. Do not carry that branch forward: an open above the close now means BUY, where yesterday the gap-down was his preferred sell.",
-    "SENSEX HAS EXPIRY on this session, so expect expiry-day behaviour in it on top of the shared read.",
-    "BANKNIFTY 57000 is named the important psychological number, sitting between the 57500 resistance and the 56770 support."
+    "THE SELL TRIGGER IS A LEVEL, NOT A GAP SIZE: 'in a small gap-down nothing will happen'. Only an opening BELOW THE FIRST SUPPORT turns him seller -- BANKNIFTY 57000, NIFTY 23800, SENSEX 76200. Above that the plan does not change.",
+    "FLAT TO GAP-UP: BUY-side setups, and he gives the SAME branch for BankNIFTY, NIFTY and SENSEX -- there is no index-specific variation this session.",
+    "NOBODY IS TRAPPED LONG: the gap-up was rejected, so there is no seated buyer crowd, and yesterday's sellers were flushed. BOTH crowds are absent, so neither branch is a hunt -- both are follows.",
+    "THIS MOVES YESTERDAY'S PIVOT DOWN. Yesterday branched on the CLOSING PRICE; today it branches on the FIRST SUPPORT, which sits below it. A flat-to-small-gap-down open was a SELL yesterday and is NOT one today.",
+    "57000 IS AGAIN THE BANKNIFTY SWITCH -- it is both the named sell trigger and the first support, so it is the single number to measure the open against.",
+    "BANKNIFTY RESISTANCES STEPPED UP to 57800 and 58200: 57500 is no longer named even though the market closed below it. HE NAMES NO EXPIRY this session -- do not carry yesterday's SENSEX expiry forward."
   ],
   "levels": [
     {
       "index": "NIFTY",
       "resistance": [
-        23965,
-        24060
+        24060,
+        24180
       ],
       "support": [
         23730,
@@ -25,8 +25,8 @@
     {
       "index": "BANKNIFTY",
       "resistance": [
-        57500,
-        57800
+        57800,
+        58200
       ],
       "support": [
         56770,

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -6171,3 +6171,112 @@ at roughly one to two warnings per session.
   clock detector, dropping the gap-down-recruits-sellers mechanism, and no longer
   naming the gap it fills each fail the suite.
 - Prompt size 155,916 -> 158,839 chars. **191,161 of headroom.**
+
+---
+
+## Video addendum - the 3 Sep LIVE SESSION (v4w)
+
+**Source:** Intraday Hunter live session `rOd-e5x4y2s` (3 Sep 2026, 6:51,
+uploaded 11:05 IST). Transcript read in full: 56 segments, 0:02 to 6:42.
+
+**A profitable day, +1,058.00 - and the most frustrating one yet**, because the
+agent got the hard part right and then handed most of it back.
+
+| # | Time | Held | Exit | NIFTY | Mirror | Basket |
+|---|---|---|---|---|---|---|
+| 1 | 09:34 -> 09:41 | 6m27s | agent, booked on a stall before a round number | +1,820.00 | +1,434.00 | **+3,254.00** |
+| 2 | 09:46 -> 09:49 | 2m38s | agent, index hierarchy | -214.50 | -255.00 | **-469.50** |
+| 3 | 10:05 -> 10:07 | 1m26s | **mechanical AI_STOP** | -799.50 | -927.00 | **-1,726.50** |
+| | | | **TOTAL** | **+806.00** | **+252.00** | **+1,058.00** |
+
+### The first trade was excellent, and it matched IH almost to the minute
+
+Both went long the gap-up. Both booked on the same signal. The agent's own exit
+reason - `book_before_round_number_profit_stall`, "price stalled into a tight
+range" - is IH's read in different words, and it banked +3,254.00.
+
+Then it re-entered twice and gave back 67.5% of that.
+
+### What IH said the stall MEANT
+
+This is the net-new, and it resolves a real tension already sitting in the
+corpus. Holding the same winning long, he explains why he is leaving:
+
+> "If the candles were forming FAST it would have been much better for us; right
+> now it IS going up but the momentum is SLOW. In such a case OTHER traders also
+> start buying here, and when they buy, retracement starts."
+>
+> "The market did a breakout and is making SMALL candles, so this will INVITE
+> buyers, and if it invites buyers it will definitely give a retracement - in
+> that retracement it will needlessly reduce our profit."
+
+So the stall is not merely "the profit stopped growing". It is a statement about
+WHO is arriving: slow, small candles after a break are a cheap public invitation
+to traders on your own side, and their entry IS the give-back.
+
+### Why this needed a rule rather than a note
+
+Two existing rules pull in opposite directions here, and neither covers the case:
+
+- `A SLOW GRIND AT THE LEVEL RECRUITS THE WRONG CROWD` (v3y) is scoped to price
+  stalling at your level **before** you are in.
+- The momentum-quality rule (v4k) covers pace **after** you are in and says the
+  opposite of today: slow with small candles is "the sustainable kind - let it
+  run", because slow keeps the trapped crowd seated.
+
+v4k even carries a note saying not to confuse it with v3y. Today is a third case
+that falls between them: the level has broken, the position is in profit, and the
+candles go small. On v4k's letter, the agent should have held.
+
+v4w is therefore a **scope limit on v4k, not a reversal of it**, in the same
+shape as v4r's limit on `LAGGARDS NEVER JOINED`. The discriminator is not the
+pace but who the slowness lets in:
+
+- still squeezing a crowd trapped on the OTHER side -> fuel, hold (v4k intact);
+- after the break, letting fresh traders onto YOUR side -> book.
+
+IH supplies the counterfactual that isolates it: *"if the candles were forming
+well and the market was NOT giving others a chance to buy, we wanted to see the
+800 breakout."* Same level, same direction, same target - only the invitation
+differed.
+
+### The re-entry half
+
+The rule also states the consequence the day actually cost: **the retracement you
+just booked ahead of is not a second setup.** It is the arrival of the crowd you
+booked against, so re-entering means joining them at the worst price instead of
+being paid by them. Both re-entries here were into exactly the move IH had
+predicted out loud.
+
+That is the fifth session in a row with this shape - 36%, 37%, 73%, then
+yesterday's six-trade -3,877.25, now 67.5%. v4s governs re-entry after a winner
+and still is not biting; v4v gave the loss case a concrete test ("a NEW crowd
+trapped by price action AFTER the break") and the winner case still has none.
+**Deliberately not fixed here:** giving v4s the same test is the obvious next
+step, but it should be made after seeing whether naming the retracement's CAUSE
+removes the temptation at the root.
+
+### Deliberately NOT added
+
+- **"Because yesterday there was a loss, we won't take much risk today."** Word
+  for word the situation v3z already covers (`AFTER A LOSING DAY, TAKE THE GOOD
+  PROFIT RATHER THAN THE BIG ONE`), and yesterday was indeed -3,877.25.
+- **The early entry because BankNIFTY had already moved** ("if OUR index, where
+  we take more quantity, is going up, we made our entry a bit early"). Carried by
+  v4p's `WHEN THE DIRECTION HAS ALREADY DECLARED ITSELF, WAITING IS THE COST`.
+- **The reversal-versus-continuation framing** of the whole day. That was the
+  pre-open note's branch and the note already carried it.
+
+### Knowledge changes (v4w)
+
+- `AFTER THE BREAK, SLOW CANDLES RECRUIT YOUR OWN SIDE, AND THAT IS A BOOK SIGNAL
+  RATHER THAN A HOLD SIGNAL` (new, placed immediately after the momentum-quality
+  rule it limits).
+- One drift guard, negative-tested **fourteen** ways: removing the rule, reading
+  it as a reversal of v4k rather than a scope limit, dropping v4k's fuel
+  mechanism, collapsing it to a bare "book when slow", merging the two sides of
+  the crowd test, dropping the counterfactual, dropping the invitation as the
+  deciding factor, dropping the re-entry consequence or its reason, dropping the
+  measured give-back or the booked winner, re-reading it as licence to book early
+  anywhere, and dropping either the v3y deference or the exit precedence.
+- Prompt size 158,839 -> 161,355 chars. **188,645 of headroom.**

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
@@ -1886,6 +1886,41 @@ RISK DISCIPLINE
   opponents; this is about the pace of the move AFTER you are in, in your favour.
   After consecutive losing days, deliberately reduce risk and prefer clearer
   setups: the urge for a "recovery trade" is itself a bias the market exploits.
+- AFTER THE BREAK, SLOW CANDLES RECRUIT YOUR OWN SIDE, AND THAT IS A BOOK SIGNAL
+  RATHER THAN A HOLD SIGNAL (v4w). A scope limit on the rule above, not a reversal
+  of it. "Slow is sustainable" holds while the slowness is keeping a crowd trapped
+  on the OTHER side seated — they are what pays you, and v4k's reasoning is
+  untouched. Once the level has BROKEN and you are in profit, small candles stop
+  doing that and start doing something else: they give traders on YOUR side a
+  cheap, obvious chance to join, and it is their arrival that produces the
+  give-back.
+  IH, holding a winning long into exactly this: "if the candles were forming FAST
+  it would have been much better for us; right now it IS going up but the momentum
+  is SLOW. In such a case OTHER traders also start buying here, and when they buy,
+  retracement starts." Then the mechanism outright: "the market did a breakout and
+  is making SMALL candles, so this will INVITE buyers, and if it invites buyers it
+  will definitely give a retracement — in that retracement it will NEEDLESSLY
+  REDUCE our profit."
+  THE TEST IS WHO THE SLOWNESS LETS IN, never the pace on its own:
+  * still squeezing a crowd trapped on the OTHER side -> that is fuel, hold.
+  * after the break, letting fresh traders onto YOUR side -> they ARE the
+    retracement, so book now.
+  His own counterfactual names the boundary: "if the candles were forming well and
+  the market was NOT giving others a chance to buy, we wanted to see the 800
+  breakout." Same level, same direction, same target — only the invitation decided
+  it.
+  AND DO NOT RE-ENTER THE RETRACEMENT YOU JUST BOOKED AHEAD OF. It is not a second
+  setup. It is the arrival of the very crowd you booked against, so entering it
+  means joining them at the worst price instead of being paid by them.
+  MEASURED ON THIS BOOK, in the same session the rule was read: 2026-09-03 booked
+  +3,254.00 on precisely this signal — the agent's own exit reason says "price
+  stalled into a tight range" before a round number — which matched IH almost to
+  the minute. It then re-entered that retracement TWICE, for -469.50 and
+  -1,726.50, and closed +1,058.00. A correct read handed back 67.5% of itself.
+  IT RELAXES NO EXIT, and it is not licence to book on any slow bar. Before the
+  break, A SLOW GRIND AT THE LEVEL RECRUITS THE WRONG CROWD already governs; while
+  a trapped crowd is still being squeezed, the rule above still says hold; and the
+  stop, the max loss and premise-invalidation are unchanged.
 - SETUP STALENESS: a pending break must fire FAST — candles holding at the level
   INVITE the crowd, and a break that comes only after a long hold attracts
   followers and then reverses on them. If the level held a long time before

--- a/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_premarket.py
+++ b/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_premarket.py
@@ -201,26 +201,28 @@ def test_shipped_note_targets_the_next_TRADING_day_not_the_next_calendar_day():
     )
 
 
-def test_shipped_note_matches_september_3_intraday_hunter_plan():
-    """The committed advisory must match the hand-checked 02 Sep transcript.
+def test_shipped_note_matches_september_4_intraday_hunter_plan():
+    """The committed advisory must match the hand-checked 03 Sep transcript.
 
-    Five things a summarising edit would flatten, each of which would change
-    what the agent does at 09:15:
+    Six things a summarising edit would flatten, each of which would change what
+    the agent does at 09:15:
 
-    1. The branch pivots on the CLOSING PRICE, not on a gap size. Every note
-       before this one branched on gap shape; this one asks which side of
-       yesterday's close the market opened, and says the close is "a resistance
-       and also a support". Losing that turns a checkable level into a feel.
-    2. The gap-up branch BUYS, which is the exact inverse of the previous
-       session's note (uniformly sell-side). Two consecutive notes with opposite
-       branches is the setup that cost the whole day's direction on 31 Aug, so
-       the inversion has to be stated IN the note, not left implicit.
-    3. The sell branch is a FOLLOW, not a hunt -- "we will walk WITH the market"
-       -- because the retracements already flushed the sellers out. There is no
-       trapped crowd on that side, and reading it as a hunt would invent one.
-    4. His reason for the buy branch is TIME, not price: a big level's situation
-       takes time to change, so one day of selling may be a one-day trap.
-    5. SENSEX has expiry on this session.
+    1. The sell branch triggers on a LEVEL, not on a gap size -- "in a small
+       gap-down nothing will happen". Drop that and any gap-down reads as a
+       sell, which is the opposite of what he said.
+    2. The middle zone INVERTS yesterday's note. Yesterday branched on the
+       closing price and sold a flat-to-gap-down open; today the sell line has
+       moved DOWN to the first support, so that same open is no longer a sell.
+       Two consecutive notes disagreeing about one open shape is what cost the
+       whole day's direction on 31 Aug, so the inversion is stated IN the note.
+    3. NEITHER crowd is seated: the gap-up was rejected (no trapped longs) and
+       yesterday's sellers were already flushed. Both branches are therefore
+       FOLLOWS. Reading either as a hunt would invent a crowd that is not there.
+    4. One branch for all three indices -- he does not vary it by index.
+    5. He names NO expiry. Yesterday's note DID (SENSEX), so the note has to say
+       so explicitly or the expiry read carries forward by inertia.
+    6. BankNIFTY resistances stepped UP to 57800/58200 and 57500 is dropped,
+       even though he says the market closed below it.
     """
     import os
 
@@ -228,58 +230,67 @@ def test_shipped_note_matches_september_3_intraday_hunter_plan():
     note = load_premarket_note(os.path.join(here, "premarket_note.json"))
 
     assert note is not None
-    assert note.for_date == "2026-09-03"
-    assert "8GwfUa2LcL4" in note.source
-    # The mechanism, not just the direction: the sellers were flushed, so they
-    # are NOT the seated crowd, and the day may have been a one-day trap.
-    assert "ONE-DAY TRAP" in note.context
-    assert "sellers are NOT a seated crowd" in note.context
-    assert "SENSEX has expiry" in note.context
+    assert note.for_date == "2026-09-04"
+    assert "PywlkaQByoQ" in note.source
+    # The mechanism, not just the direction: the gap-up was REJECTED, so the
+    # buyers never got seated either.
+    assert "gap-up was REJECTED" in note.context
+    assert "nobody got in long" in note.context
+    assert "BUYERS are not a seated crowd" in note.context
 
-    pivot = next(line for line in note.plan if line.startswith("THE PIVOT IS THE CLOSING PRICE"))
-    assert "not a gap size" in pivot
-    assert "it is a resistance and it is also a support" in pivot
+    trigger = next(line for line in note.plan if line.startswith("THE SELL TRIGGER IS A LEVEL"))
+    assert "NOT A GAP SIZE" in trigger
+    assert "in a small gap-down nothing will happen" in trigger
+    assert "BELOW THE FIRST SUPPORT" in trigger
+    # The three numbers, so the branch stays checkable rather than a feel.
+    assert "BANKNIFTY 57000" in trigger
+    assert "NIFTY 23800" in trigger
+    assert "SENSEX 76200" in trigger
 
-    buy = next(line for line in note.plan if line.startswith("ABOVE the close"))
+    buy = next(line for line in note.plan if line.startswith("FLAT TO GAP-UP"))
     assert "BUY-side" in buy
-    assert "reason is TIME, not price" in buy
-    assert "do not think one momentum means everything is now fine" in buy
+    assert "SAME branch for BankNIFTY, NIFTY and SENSEX" in buy
 
-    sell = next(line for line in note.plan if line.startswith("FLAT to GAP-DOWN"))
-    assert "SELL-side" in sell
-    # A follow, not a hunt -- and the reason, so it cannot be re-read as one.
-    assert "FOLLOW and not a hunt" in sell
-    assert "walk WITH the market" in sell
-    assert "already flushed the sellers" in sell
+    crowd = next(line for line in note.plan if line.startswith("NOBODY IS TRAPPED LONG"))
+    assert "gap-up was rejected" in crowd
+    assert "sellers were flushed" in crowd
+    # Both branches are follows -- the note must say why, so neither can be
+    # re-read as a hunt for a crowd that was already cleared out.
+    assert "neither branch is a hunt" in crowd
+    assert "both are follows" in crowd
 
-    inversion = next(line for line in note.plan if line.startswith("THIS INVERTS TODAY'S NOTE"))
-    assert "uniformly SELL-side across all three open shapes" in inversion
-    assert "Do not carry that branch forward" in inversion
+    pivot = next(line for line in note.plan if line.startswith("THIS MOVES YESTERDAY'S PIVOT DOWN"))
+    assert "branched on the CLOSING PRICE" in pivot
+    assert "branches on the FIRST SUPPORT" in pivot
+    assert "SELL yesterday and is NOT one today" in pivot
 
-    assert any("SENSEX HAS EXPIRY" in line for line in note.plan)
-    assert any("57000 is named the important psychological number" in line for line in note.plan)
+    assert any("57000 IS AGAIN THE BANKNIFTY SWITCH" in line for line in note.plan)
+    # Yesterday's note carried a SENSEX expiry; this one must cancel it rather
+    # than leave the agent to assume it still applies.
+    assert any("HE NAMES NO EXPIRY" in line for line in note.plan)
+    assert any("57500 is no longer named" in line for line in note.plan)
 
     assert [level.model_dump() for level in note.levels] == [
         {
             "index": "NIFTY",
-            "resistance": [23965.0, 24060.0],
+            "resistance": [24060.0, 24180.0],
             "support": [23730.0, 23800.0],
         },
         {
-            # Caption gave only "56,770" for two supports, right after naming
-            # 57,000 as the psychological number; confirmed off the chart by the
-            # operator as 57000 and 56770. Do NOT reconstruct from the caption.
+            # Caption was clean here: "58,200 57,800" for the resistances, which
+            # DROPS yesterday's 57500 even though he says the market closed
+            # below it. Confirmed off the chart by the operator -- it is a real
+            # step up, not a mis-hearing.
             "index": "BANKNIFTY",
-            "resistance": [57500.0, 57800.0],
+            "resistance": [57800.0, 58200.0],
             "support": [56770.0, 57000.0],
         },
         {
-            # Both SENSEX sides were garbled: resistances ran together as
-            # "777300" (the SAME string as the 02 Sep note) and supports as the
-            # eight-digit "76275940". Confirmed by the operator as 77000/77300
-            # and 76200/75940. The repeated resistance garble is a coincidence
-            # of speech, not evidence the levels were unchanged -- do not assume
-            # a repeat next time it appears.
+            # The SENSEX resistances ran together as "777300" for the THIRD note
+            # in a row; supports came through cleanly as "7620075940". The
+            # operator confirmed 77000/77300 again. The repeat is a quirk of how
+            # he says the numbers, not evidence the levels are pinned -- keep
+            # asking rather than assuming the same pair next time.
             "index": "SENSEX",
             "resistance": [77000.0, 77300.0],
             "support": [75940.0, 76200.0],

--- a/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_schema.py
+++ b/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_schema.py
@@ -2190,3 +2190,64 @@ def test_v4v_dead_premise_rule_bars_the_NEXT_entry_without_relaxing_any_exit():
     assert "not a licence to hold a loser longer" in rule
     assert "INDEX HIERARCHY ON THE WAY OUT still cuts the basket" in rule
     assert "whether you may OPEN the next trade, never whether you may close" in rule
+
+
+def test_v4w_post_break_slowness_is_a_book_signal_without_reversing_v4k():
+    """v4w (3 Sep live session): slow candles AFTER the break invite your side.
+
+    This rule sits between two that already exist and contradict each other if
+    read carelessly, so the guard pins the seam rather than the sentiment:
+
+    * v3y governs a slow grind AT the level, BEFORE entry -- it recruits
+      opponents whose stops become fuel against you.
+    * v4k governs pace AFTER entry and says slow is the SUSTAINABLE kind,
+      because it keeps a trapped crowd seated.
+
+    Today is a third case neither covers: the level has broken, the position is
+    in profit, and the candles go small. The discriminator is WHO the slowness
+    lets in -- an opposite-side crowd still being squeezed is fuel, fresh
+    same-side traders are the retracement. Four ways an edit could break it:
+
+    1. Reading it as a reversal of v4k rather than a scope limit on it. The
+       rule must keep saying slow is fuel while a trapped crowd is squeezed.
+    2. Losing the who-does-it-let-in test and leaving a bare "book when slow",
+       which would fire before the break, where v3y already rules.
+    3. Dropping IH's counterfactual, which is the only thing that shows the
+       level and target were unchanged and only the invitation differed.
+    4. Dropping the re-entry consequence -- the measured 67.5% give-back came
+       from re-entering the retracement, not from booking too early.
+    """
+    prompt = build_system_prompt()
+    rule = _flat_rule(prompt, "AFTER THE BREAK, SLOW CANDLES RECRUIT YOUR OWN SIDE")
+
+    # 1. A scope limit, explicitly, and v4k's mechanism kept intact.
+    assert "scope limit on the rule above, not a reversal" in rule
+    assert "keeping a crowd trapped on the OTHER side seated" in rule
+    assert "they are what pays you" in rule
+
+    # IH's mechanism, in his words.
+    assert "SMALL candles, so this will INVITE buyers" in rule
+    assert "NEEDLESSLY REDUCE our profit" in rule
+
+    # 2. The test is the crowd, not the pace.
+    assert "THE TEST IS WHO THE SLOWNESS LETS IN, never the pace on its own" in rule
+    assert "still squeezing a crowd trapped on the OTHER side" in rule
+    assert "letting fresh traders onto YOUR side" in rule
+
+    # 3. The counterfactual that isolates the invitation as the deciding factor.
+    assert "was NOT giving others a chance to buy" in rule
+    assert "only the invitation decided" in rule
+
+    # 4. The re-entry consequence, and why it is not a second setup.
+    assert "DO NOT RE-ENTER THE RETRACEMENT YOU JUST BOOKED AHEAD OF" in rule
+    assert "joining them at the worst price" in rule
+
+    # The measured evidence, including that the BOOK itself was correct.
+    assert "+3,254.00" in rule
+    assert "-1,726.50" in rule
+    assert "handed back 67.5% of itself" in rule
+
+    # It must not read as permission to book early anywhere, nor relax an exit.
+    assert "not licence to book on any slow bar" in rule
+    assert "A SLOW GRIND AT THE LEVEL RECRUITS THE WRONG CROWD already governs" in rule
+    assert "the stop, the max loss and premise-invalidation are unchanged" in rule


### PR DESCRIPTION
Source: Intraday Hunter live session `rOd-e5x4y2s` (3 Sep 2026, 6:51, uploaded 11:05 IST). Transcript read in full — 56 segments, 0:02 → 6:42.

## A profitable day, +₹1,058 — and the most frustrating one yet

| # | Time | Held | Exit | NIFTY | Mirror | Basket |
|---|---|---|---|---|---|---|
| 1 | 09:34 → 09:41 | 6m27s | agent, stall before a round number | +1,820.00 | +1,434.00 | **+3,254.00** |
| 2 | 09:46 → 09:49 | 2m38s | agent, index hierarchy | −214.50 | −255.00 | **−469.50** |
| 3 | 10:05 → 10:07 | 1m26s | **mechanical AI_STOP** | −799.50 | −927.00 | **−1,726.50** |
| | | | **TOTAL** | **+806.00** | **+252.00** | **+1,058.00** |

**The first trade was excellent and matched IH almost to the minute.** Both went long the gap-up; both booked on the same signal. The agent's own exit reason — *"price stalled into a tight range"* before a round number — is IH's read in different words, and it banked **+3,254.00**.

Then it re-entered twice and handed back **67.5%** of that.

## The net-new: what the stall *meant*

Holding the same winning long, IH explains why he's leaving:

> "If the candles were forming FAST it would have been much better; right now it IS going up but the momentum is SLOW. In such a case **OTHER traders also start buying here, and when they buy, retracement starts.**"
>
> "The market did a breakout and is making **SMALL candles, so this will INVITE buyers**, and if it invites buyers it will definitely give a retracement — in that retracement it will needlessly reduce our profit."

So the stall isn't merely "the profit stopped growing". It says **who is arriving**: slow, small candles after a break are a cheap public invitation to traders on your own side, and their entry *is* the give-back.

## It resolves a tension already sitting in the corpus

Two existing rules pull opposite ways here, and neither covers the case:

- **v3y** (`A SLOW GRIND AT THE LEVEL RECRUITS THE WRONG CROWD`) is scoped to price stalling **before** you are in.
- **v4k** (momentum quality) covers pace **after** you are in and says the *opposite* of today: slow with small candles is "the sustainable kind — let it run", because slow keeps the trapped crowd seated.

v4k even carries a note telling you not to confuse it with v3y. Today is a **third case between them**: the level has broken, the position is in profit, and the candles go small. On v4k's letter, the agent should have held.

So v4w is a **scope limit on v4k, not a reversal** — the same shape as v4r's limit on `LAGGARDS NEVER JOINED`. The discriminator is not the pace but **who the slowness lets in**: a crowd still trapped on the *other* side is fuel and v4k stands; fresh traders arriving on *your* side are the retracement.

IH supplies the counterfactual that isolates it: *"if the candles were forming well and the market was NOT giving others a chance to buy, we wanted to see the 800 breakout."* Same level, same direction, same target — only the invitation differed.

## The re-entry half — what the day actually cost

The rule states it outright: **the retracement you just booked ahead of is not a second setup.** It's the arrival of the crowd you booked against, so re-entering means joining them at the worst price instead of being paid by them. Both re-entries today were into exactly the move IH predicted out loud.

Fifth session running with this shape: 36%, 37%, 73%, yesterday's six-trade −3,877.25, now 67.5%.

**Deliberately not fixed here:** v4s governs re-entry after a *winner* and still isn't biting; v4v gave only the *loss* case a concrete test. Giving v4s the same test is the obvious next step, but it should wait until we see whether naming the retracement's **cause** removes the temptation at its root.

## Deliberately not added

- *"Because yesterday there was a loss, we won't take much risk today"* — word for word the situation **v3z** already covers, and yesterday was indeed −3,877.25.
- The early entry because BankNIFTY had already moved — **v4p** carries it.
- The reversal-vs-continuation framing — that was the pre-open note's branch, already carried.

## Verification

One drift guard, negative-tested **fourteen ways**: removing the rule, reading it as a reversal of v4k rather than a scope limit, dropping v4k's fuel mechanism, collapsing it to a bare "book when slow", merging the two sides of the crowd test, dropping the counterfactual, dropping the invitation as the deciding factor, dropping the re-entry consequence or its reason, dropping the measured give-back or the booked winner, re-reading it as licence to book early anywhere, and dropping either the v3y deference or the exit precedence.

Prompt size 158,839 → 161,355 chars; **188,645 of headroom.**

Gates: 547 master, 28 market-data-health, 1254 pytest, ruff, mypy (74 files + the master), compileall, bandit — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)