### PR TITLE
feat(data-extractors): expired NIFTY option history, and fix fetch-data

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,14 +91,19 @@ One process, cooperating threads:
 ## Repository layout
 ```
 nifty_multi_strategy_master.py   # the multithreaded paper/live runner (the "big one")
-algo.py                                             # unified CLI: fetch-data / backtest / run / setup-token / diagnose / check-env
+algo.py                                             # unified CLI: fetch-data / fetch-expired-options / backtest / run / setup-token / diagnose / check-env
 Tests/                                             # EVERY test, mirroring the source tree (docs/adr/0010)
   test_nifty_multi_strategy_master.py              #   unittest suite for the master
   test_market_data_health.py                       #   unittest suite for the shared feed-health gates
 requirements.txt                                   # exact core runtime + dev/CI tooling
 requirements-brokers.txt                           # exact Kotak/Shoonya optional live set
 requirements-ai.txt                                # exact optional AI-agent stack (Claude + Codex)
-Data Extractors/                                   # DhanHQ 1-min OHLC downloaders (shared engine + per-index wrappers)
+Data Extractors/                                   # DhanHQ downloaders (shared engine + per-index wrappers)
+                                                   #   index 1-min OHLC, plus expired-OPTION history
+                                                   #   (premium/OI/IV) via expired_options_fetch_dhan_common.py
+                                                   #   + expiry_calendar.py -- read docs/adr/0015 first: strikes
+                                                   #   are RELATIVE (ATM+/-n), not contracts, and the expiry
+                                                   #   date is derived rather than returned by the API
 My Backtest Files (For Reference)/                 # backtesting.py backtests (+ Subhamoy Strategies/)
 Signal Generators/                                 # strategy signal logic (+ CPR Strategy/, Subhamoy Strategies/,
                                                    #   SL Hunting AI Agent/ — optional Claude-agent strategy;
@@ -183,9 +188,11 @@ Backtest Outputs/                                  # generated CSVs/logs (gitign
   `logging.getLogger(__name__)` logger, **not `print()`**. Strategy FOLDERS still have spaces, so
   their modules are imported via `load_module()` (master ~L1024), not regular imports; the
   filenames themselves were renamed to identifiers by ADR-0014.
-- **CLI:** prefer `python algo.py <command>` (`fetch-data` / `backtest` / `run` / `setup-token` /
-  `diagnose` / `check-env`); each underlying script still runs standalone, and any flag beyond the
-  selector passes straight through. A bare `python algo.py` prints help.
+- **CLI:** prefer `python algo.py <command>` (`fetch-data` / `fetch-expired-options` / `backtest` /
+  `run` / `setup-token` / `diagnose` / `check-env`); each underlying script still runs standalone, and
+  any flag beyond the selector passes straight through. A bare `python algo.py` prints help.
+  `fetch-expired-options` is a long job (~2,700 calls for a 5-year NIFTY backfill) -- it takes
+  `--dry-run` to print the call plan first, and resumes per chunk from its `_manifest.json`.
 - **Config drift:** `python algo.py check-env` (`Dependencies/check_env_config.py`) audits
   `Dependencies/.env` against `env.example` and against the keys the code's `_env_*` calls actually
   read, reporting settings missing from `.env` (an unseen in-code default is in force), mistyped or

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,14 +91,19 @@ One process, cooperating threads:
 ## Repository layout
 ```
 nifty_multi_strategy_master.py   # the multithreaded paper/live runner (the "big one")
-algo.py                                             # unified CLI: fetch-data / backtest / run / setup-token / diagnose / check-env
+algo.py                                             # unified CLI: fetch-data / fetch-expired-options / backtest / run / setup-token / diagnose / check-env
 Tests/                                             # EVERY test, mirroring the source tree (docs/adr/0010)
   test_nifty_multi_strategy_master.py              #   unittest suite for the master
   test_market_data_health.py                       #   unittest suite for the shared feed-health gates
 requirements.txt                                   # exact core runtime + dev/CI tooling
 requirements-brokers.txt                           # exact Kotak/Shoonya optional live set
 requirements-ai.txt                                # exact optional AI-agent stack (Claude + Codex)
-Data Extractors/                                   # DhanHQ 1-min OHLC downloaders (shared engine + per-index wrappers)
+Data Extractors/                                   # DhanHQ downloaders (shared engine + per-index wrappers)
+                                                   #   index 1-min OHLC, plus expired-OPTION history
+                                                   #   (premium/OI/IV) via expired_options_fetch_dhan_common.py
+                                                   #   + expiry_calendar.py -- read docs/adr/0015 first: strikes
+                                                   #   are RELATIVE (ATM+/-n), not contracts, and the expiry
+                                                   #   date is derived rather than returned by the API
 My Backtest Files (For Reference)/                 # backtesting.py backtests (+ Subhamoy Strategies/)
 Signal Generators/                                 # strategy signal logic (+ CPR Strategy/, Subhamoy Strategies/,
                                                    #   SL Hunting AI Agent/ — optional Claude-agent strategy;
@@ -183,9 +188,11 @@ Backtest Outputs/                                  # generated CSVs/logs (gitign
   `logging.getLogger(__name__)` logger, **not `print()`**. Strategy FOLDERS still have spaces, so
   their modules are imported via `load_module()` (master ~L1024), not regular imports; the
   filenames themselves were renamed to identifiers by ADR-0014.
-- **CLI:** prefer `python algo.py <command>` (`fetch-data` / `backtest` / `run` / `setup-token` /
-  `diagnose` / `check-env`); each underlying script still runs standalone, and any flag beyond the
-  selector passes straight through. A bare `python algo.py` prints help.
+- **CLI:** prefer `python algo.py <command>` (`fetch-data` / `fetch-expired-options` / `backtest` /
+  `run` / `setup-token` / `diagnose` / `check-env`); each underlying script still runs standalone, and
+  any flag beyond the selector passes straight through. A bare `python algo.py` prints help.
+  `fetch-expired-options` is a long job (~2,700 calls for a 5-year NIFTY backfill) -- it takes
+  `--dry-run` to print the call plan first, and resumes per chunk from its `_manifest.json`.
 - **Config drift:** `python algo.py check-env` (`Dependencies/check_env_config.py`) audits
   `Dependencies/.env` against `env.example` and against the keys the code's `_env_*` calls actually
   read, reporting settings missing from `.env` (an unseen in-code default is in force), mistyped or

--- a/Data Extractors/expired_options_fetch_dhan_common.py
+++ b/Data Extractors/expired_options_fetch_dhan_common.py
@@ -65,8 +65,10 @@ import importlib
 import json
 import logging
 import os
+import statistics
 import sys
 import time
+from collections import Counter
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import date, timedelta
@@ -521,6 +523,47 @@ def extract_payload(data: Any) -> dict[str, Any] | None:
 # ---------------------------------------------------------------------------
 
 
+def _null_impossible_counters(frame: pd.DataFrame, strike_label: str, option_type: str) -> int:
+    """
+    Blank out negative volume/OI, which are counters and cannot be negative.
+
+    Dhan serves the occasional corrupt one: 26 bars in ~19.4 million across the
+    five-year backfill. They are not scattered at random -- every one fell on an
+    expiry day, most at 14:15 exactly, which is the busiest minute of the
+    busiest session and just where a counter would overflow upstream.
+
+    They are blanked, never repaired. The first one found looked repairable:
+    ``-4253276221 + 2**32`` gives 41,691,075, neatly inside that day's range, as
+    though an unsigned counter had lost its top bit. Later ones killed that
+    theory -- the same arithmetic turned them into ~1.1 billion, roughly 25x a
+    normal day's volume. The tidy first case was a coincidence, and trusting it
+    would have written fabricated volume into two-thirds of the affected bars.
+    Blanking says "unknown", which is the truth.
+
+    Only volume and OI are treated this way. A negative PRICE is not a counter
+    glitch and still aborts the chunk in `validate_options_frame` -- prices are
+    what a backtest computes P&L from.
+
+    Returns how many values were blanked, and logs each one.
+    """
+    blanked = 0
+    for column in ("volume", "oi"):
+        if column not in frame:
+            continue
+        bad = frame[column] < 0
+        if not bad.any():
+            continue
+        blanked += int(bad.sum())
+        for position in frame.index[bad]:
+            log.warning(
+                "%s %s: negative %s (%s) at raw timestamp %s -- blanked as unknown",
+                strike_label, option_type, column,
+                frame.at[position, column], frame.at[position, "timestamp_raw"],
+            )
+        frame.loc[bad, column] = pd.NA
+    return blanked
+
+
 def normalize_rolling_payload(payload: dict[str, Any] | None, option_type: str, strike_label: str) -> pd.DataFrame:
     """
     Convert one side of the response into a tidy frame.
@@ -559,6 +602,7 @@ def normalize_rolling_payload(payload: dict[str, Any] | None, option_type: str, 
     frame = pd.DataFrame(columns)
     for field in REQUIRED_DATA_FIELDS:
         frame[field] = pd.to_numeric(frame[field], errors="coerce")
+    _null_impossible_counters(frame, strike_label, option_type)
 
     validate_single_epoch_unit(frame["timestamp_raw"])
     unit = infer_epoch_unit(frame["timestamp_raw"])
@@ -734,6 +778,48 @@ def trading_days_from_frames(frames: Sequence[pd.DataFrame]) -> list[date]:
     return sorted(days)
 
 
+# A Diwali Muhurat session runs about an hour against a normal ~6h15m day, so
+# any sane cutoff separates them. 0.5 of the median sits in the wide gap
+# between the two, and is interval-independent because it compares bar counts
+# with bar counts.
+FULL_SESSION_MIN_FRACTION = 0.5
+
+
+def full_session_days(
+    frames: Sequence[pd.DataFrame],
+    min_fraction: float = FULL_SESSION_MIN_FRACTION,
+) -> list[date]:
+    """
+    The subset of sessions long enough to be normal trading days.
+
+    NSE's Diwali Muhurat session is roughly an hour and appears in the data as
+    an ordinary date. It cannot host a weekly expiry -- the exchange moves that
+    week's expiry earlier -- so it must be excluded from expiry CANDIDATES,
+    though it stays a trading day in every other respect.
+
+    Measured over the five-year backfill, the split is unambiguous: normal
+    sessions carry 375 or 376 one-minute bars, the special ones 60 to 107.
+    """
+    counts: Counter[date] = Counter()
+    for frame in frames:
+        if frame.empty:
+            continue
+        counts.update(frame["timestamp"].dt.date.tolist())
+    if not counts:
+        return []
+
+    typical = statistics.median(counts.values())
+    threshold = typical * min_fraction
+    full = sorted(day for day, n in counts.items() if n >= threshold)
+    short = sorted(day for day, n in counts.items() if n < threshold)
+    if short:
+        log.info(
+            "%d short session(s) excluded from expiry candidates (Muhurat and the like): %s",
+            len(short), ", ".join(f"{d.isoformat()} [{counts[d]} bars]" for d in short),
+        )
+    return full
+
+
 def write_calendar_csv(path: Path, trading_days: Sequence[date], expiry_map: dict[date, date]) -> pd.DataFrame:
     """Write the derived calendar out so the labelling can be audited by eye."""
 
@@ -803,26 +889,38 @@ def read_calendar_csv(path: Path) -> dict[date, date]:
 # Verification
 # ---------------------------------------------------------------------------
 
-# On expiry afternoon an at-the-money straddle is nearly all gone: both legs sit
-# within half a strike of spot with minutes of life left. One session earlier it
-# still carries a day of time value. The gap between those two states is wide
-# enough to check a derived calendar against, without pretending to be exact.
-EXPIRY_STRADDLE_CEILING = 40.0
+# An expiring ATM straddle is nearly worthless by the close; one session earlier
+# it still carries a day of time value. What matters is the RATIO between those
+# two, not the absolute level.
+#
+# An absolute ceiling was tried first and was wrong. Because ATM is the nearest
+# 50-point strike, the expiring straddle still holds up to 25 points of
+# intrinsic, and a 40-point ceiling therefore flagged 38 of 261 real expiries as
+# suspicious -- so much noise that the two genuinely wrong ones were invisible
+# in it. Measured across the five-year backfill the ratio is decisive: median
+# 0.12, p90 0.35. Half is a wide margin above that and still far below the
+# not-an-expiry cases, which came in at 0.53 and up.
+EXPIRY_STRADDLE_MAX_RATIO = 0.5
 
 
 def verify_expiries(
     call_frame: pd.DataFrame,
     put_frame: pd.DataFrame,
     expiry_dates: Sequence[date],
-    ceiling: float = EXPIRY_STRADDLE_CEILING,
+    max_ratio: float = EXPIRY_STRADDLE_MAX_RATIO,
 ) -> list[str]:
     """
     Cross-check derived expiry dates against what the option prices actually did.
 
+    On a real expiry the ATM straddle's closing value collapses against the
+    previous session's. Where it does not, either the date is not an expiry or
+    something unusual happened that day -- both worth a human look.
+
     Returns a list of human-readable complaints; empty means every derived
-    expiry behaved like an expiry. This is a smell test, not a proof, and it is
-    aimed squarely at the failure mode worth catching: a calendar that is off by
-    a day, or that missed an exchange rule change.
+    expiry behaved like one. A smell test, not a proof, and aimed squarely at
+    the failure mode worth catching: a calendar off by a day, or one that missed
+    an exchange rule change. It earned its keep on the first full backfill by
+    catching both Diwali weeks.
     """
     problems: list[str] = []
     if call_frame.empty or put_frame.empty:
@@ -836,17 +934,26 @@ def verify_expiries(
 
     calls = last_close_by_day(call_frame)
     puts = last_close_by_day(put_frame)
+    sessions = sorted(set(calls) & set(puts))
+    position = {day: i for i, day in enumerate(sessions)}
+    straddle = {day: calls[day] + puts[day] for day in sessions}
 
     for expiry in expiry_dates:
-        call_close, put_close = calls.get(expiry), puts.get(expiry)
-        if call_close is None or put_close is None:
+        if expiry not in straddle:
             problems.append(f"{expiry.isoformat()}: derived as an expiry but has no ATM close")
             continue
-        straddle = call_close + put_close
-        if straddle > ceiling:
+        index = position[expiry]
+        if index == 0:
+            continue  # nothing before it in the data to compare against
+        previous = sessions[index - 1]
+        if straddle[previous] <= 0:
+            continue
+        ratio = straddle[expiry] / straddle[previous]
+        if ratio >= max_ratio:
             problems.append(
-                f"{expiry.isoformat()}: ATM straddle closed at {straddle:.2f}, above the "
-                f"{ceiling:.0f} ceiling -- this may not be an expiry day"
+                f"{expiry.isoformat()}: ATM straddle closed at {straddle[expiry]:.2f} against "
+                f"{straddle[previous]:.2f} on {previous.isoformat()} (ratio {ratio:.2f}, "
+                f"expected below {max_ratio:.2f}) -- this may not be an expiry day"
             )
     return problems
 
@@ -936,7 +1043,9 @@ def build_expiry_calendar(
             "calendar pre-pass returned no bars at all, so trading days cannot be derived. "
             "Check the date range, and that the Data API subscription is active."
         )
-    expiry_map = build_expiry_map(trading_days)
+    # Short sessions stay trading days but cannot host an expiry -- see
+    # `full_session_days` and `expiry_calendar.weekly_expiry_dates`.
+    expiry_map = build_expiry_map(trading_days, full_sessions=full_session_days([call_frame, put_frame]))
     log.info(
         "derived %d trading days and %d weekly expiries (%s -> %s)",
         len(trading_days),

--- a/Data Extractors/expired_options_fetch_dhan_common.py
+++ b/Data Extractors/expired_options_fetch_dhan_common.py
@@ -22,11 +22,18 @@ file only ever holds live contracts. Instead you ask for "the ATM call", or
 
 Two consequences, and they drive most of the design here:
 
-1. `ATM+3 CE` on Monday and `ATM+3 CE` on Wednesday are *different contracts* if
-   spot moved in between. A rolling label is not a tradeable instrument. That is
-   why we always request the `strike` field and write it out as `strike_price`:
-   it is the only way to recover a fixed-strike series afterwards, by re-keying
-   on `(expiry_date, strike_price, option_type)`.
+1. A rolling label is not a tradeable instrument, and the churn is far faster
+   than "day to day" -- it is **minute to minute**. Measured against the live
+   API on 2025-01-06: the `ATM` call series switched strike **69 times in that
+   single session**, and one four-day `ATM` file held 13 distinct contracts.
+   The rule is simply the nearest 50-point strike to spot, re-evaluated every
+   bar (verified: `strike_price` equalled the nearest 50 to `spot` on 1500 of
+   1500 rows, never more than 25 points away).
+
+   This is why we always request the `strike` field and write it out as
+   `strike_price`. Without it the data would be unusable: re-keying on
+   `(expiry_date, strike_price, option_type)` is the only way to recover a
+   series that corresponds to something you could actually have held.
 
 2. The response carries no expiry date at all. We derive one -- see
    `expiry_calendar.py` -- from a published exchange rule plus the trading days
@@ -155,8 +162,9 @@ CALENDAR_COLUMNS: tuple[str, ...] = (
     "trading_days_to_expiry",
 )
 
-# Dhan documents a 30-day ceiling per call. 29 is the default so an off-by-one in
-# how the exchange treats `toDate` cannot silently truncate a chunk.
+# Dhan documents a 30-day ceiling per call, and `toDate` is inclusive (measured
+# -- see `chunk_ranges`), so a 29-day window spans 29 days and keeps a day of
+# headroom under the cap.
 MAX_CHUNK_DAYS = 30
 DEFAULT_CHUNK_DAYS = 29
 
@@ -340,13 +348,21 @@ def series_plan(strike_range: int, option_types: Sequence[str]) -> list[tuple[st
 
 def chunk_ranges(start: date, end: date, chunk_days: int) -> list[tuple[date, date]]:
     """
-    Split ``[start, end]`` into API-sized windows.
+    Split ``[start, end]`` into API-sized windows, both ends INCLUSIVE.
 
-    Dhan documents ``toDate`` as non-inclusive, so each window is returned as a
-    half-open ``[from, to)`` pair and the next one begins exactly where the last
-    ended. The writer de-duplicates on timestamp anyway, so a boundary bar
-    arriving twice (if the exchange in fact treats ``toDate`` as inclusive) is
-    dropped rather than duplicated.
+    Dhan's documentation calls ``toDate`` non-inclusive. It is not. Measured
+    against the live API on 2026-09-05, asking for 06-Jan to 08-Jan returns
+    three sessions ending on the 8th, and 06-Jan to 10-Jan returns five ending
+    on the 10th -- the end date is served.
+
+    Getting this wrong is not cosmetic. Half-open windows made adjacent chunks
+    overlap by a day, and the last chunk then carried bars dated ``to_date``
+    that `validate_options_frame` rejected as out-of-window. It only survived a
+    five-day smoke run because that window happened to end on a Saturday.
+
+    So windows tile the range exactly: no overlap, no gap. The writer still
+    de-duplicates on timestamp, which now costs nothing and would absorb the
+    behaviour changing back.
     """
     if start > end:
         raise ValueError(f"start {start.isoformat()} is after end {end.isoformat()}")
@@ -355,11 +371,10 @@ def chunk_ranges(start: date, end: date, chunk_days: int) -> list[tuple[date, da
 
     windows: list[tuple[date, date]] = []
     cursor = start
-    final = end + timedelta(days=1)  # exclusive upper bound of the whole range
-    while cursor < final:
-        window_end = min(cursor + timedelta(days=chunk_days), final)
+    while cursor <= end:
+        window_end = min(cursor + timedelta(days=chunk_days - 1), end)
         windows.append((cursor, window_end))
-        cursor = window_end
+        cursor = window_end + timedelta(days=1)
     return windows
 
 
@@ -583,7 +598,9 @@ def validate_options_frame(frame: pd.DataFrame, from_date: date, to_date: date, 
     if stamps.duplicated().any():
         raise MarketDataValidationError(f"{label}: chunk contains duplicate timestamps")
 
-    outside = stamps[(stamps.dt.date < from_date) | (stamps.dt.date >= to_date)]
+    # Both ends inclusive, because that is what the API actually serves for
+    # `toDate` regardless of what the documentation says. See `chunk_ranges`.
+    outside = stamps[(stamps.dt.date < from_date) | (stamps.dt.date > to_date)]
     if not outside.empty:
         raise MarketDataValidationError(
             f"{label}: {len(outside)} candle(s) outside the requested window "
@@ -620,7 +637,15 @@ def label_with_expiry(frame: pd.DataFrame, expiry_map: dict[date, date]) -> pd.D
     ]
     # A bar past the last derived expiry cannot be labelled honestly, and an
     # unlabelled bar is worse than no bar for a positional backtest.
-    return labelled[labelled["expiry_date"].notna()].reset_index(drop=True)
+    kept = labelled[labelled["expiry_date"].notna()].reset_index(drop=True)
+    dropped = len(labelled) - len(kept)
+    if dropped:
+        # Debug, not warning: the systematic cause is the tail of the requested
+        # range, and `warn_about_unlabelled_tail` says that once up front rather
+        # than once per series per chunk.
+        lost = sorted({d.isoformat() for d, e in zip(trade_dates, expiries, strict=True) if not isinstance(e, date)})
+        log.debug("dropped %d bar(s) with no derivable expiry, on %s", dropped, ", ".join(lost))
+    return kept
 
 
 # ---------------------------------------------------------------------------
@@ -729,6 +754,34 @@ def write_calendar_csv(path: Path, trading_days: Sequence[date], expiry_map: dic
     path.parent.mkdir(parents=True, exist_ok=True)
     frame.to_csv(path, index=False)
     return frame
+
+
+def warn_about_unlabelled_tail(trading_days: Sequence[date], expiry_map: dict[date, date], end: date) -> str | None:
+    """
+    Say up front which sessions will be dropped for want of an expiry.
+
+    Every bar is labelled with the expiry that was current on it, and the last
+    derived expiry is the last one that actually happened inside the requested
+    range. Sessions after it therefore cannot be labelled -- their expiry lies
+    in the future, beyond the data. Those bars are discarded.
+
+    That is the honest thing to do with them, but it is silent data loss unless
+    somebody says so: a five-year backfill ending today quietly loses the whole
+    current part-week. Returns the message (also logged), or None when the range
+    ends neatly on an expiry.
+    """
+    unlabelled = [day for day in trading_days if day not in expiry_map]
+    if not unlabelled:
+        return None
+
+    message = (
+        f"{len(unlabelled)} session(s) at the end of the range have no expiry yet "
+        f"({unlabelled[0].isoformat()} to {unlabelled[-1].isoformat()}) and will be SKIPPED. "
+        f"Their weekly expiry falls after --end-date {end.isoformat()}. "
+        f"To keep them, extend --end-date past that expiry and re-run."
+    )
+    log.warning("%s", message)
+    return message
 
 
 def read_calendar_csv(path: Path) -> dict[date, date]:
@@ -1004,6 +1057,7 @@ def run_expired_options_fetcher(defaults: ExpiredOptionsDefaults, argv: Sequence
         trading_days, expiry_map, call_frame, put_frame = build_expiry_calendar(dhan, args, start, end, limiter)
         write_calendar_csv(output_dir / CALENDAR_FILENAME, trading_days, expiry_map)
         log.info("wrote %s", output_dir / CALENDAR_FILENAME)
+        warn_about_unlabelled_tail(trading_days, expiry_map, end)
 
     windows = chunk_ranges(start, end, args.chunk_days)
     option_types = parse_option_types(args.option_types)

--- a/Data Extractors/expired_options_fetch_dhan_common.py
+++ b/Data Extractors/expired_options_fetch_dhan_common.py
@@ -1,0 +1,1056 @@
+"""
+Shared engine for downloading EXPIRED index-option history from DhanHQ.
+
+What this gets you that the index fetchers do not
+-------------------------------------------------
+`index_1m_5y_data_fetch_dhan_common.py` downloads the NIFTY *index* itself, so
+every options backtest built on it has to model option premium rather than read
+it. This module downloads the real thing: minute bars of actual expired NIFTY
+option contracts, with open interest, implied volatility and the spot level that
+was printing at the time.
+
+The endpoint is `POST /v2/charts/rollingoption`, reached through the pinned
+`dhanhq` SDK's `expired_options_data()`. Five years of history are available.
+
+The one thing to understand before reading further
+--------------------------------------------------
+This endpoint is **strike-relative, not contract-based**. You do not ask for
+"the 24000 CE expiring on 12 March". There is no security ID for an expired
+contract, and none exists in `Dependencies/all_instrument *.csv` either -- that
+file only ever holds live contracts. Instead you ask for "the ATM call", or
+"three strikes above ATM", and Dhan resolves that against the spot of the day.
+
+Two consequences, and they drive most of the design here:
+
+1. `ATM+3 CE` on Monday and `ATM+3 CE` on Wednesday are *different contracts* if
+   spot moved in between. A rolling label is not a tradeable instrument. That is
+   why we always request the `strike` field and write it out as `strike_price`:
+   it is the only way to recover a fixed-strike series afterwards, by re-keying
+   on `(expiry_date, strike_price, option_type)`.
+
+2. The response carries no expiry date at all. We derive one -- see
+   `expiry_calendar.py` -- from a published exchange rule plus the trading days
+   the data itself reveals, and `--verify-expiries` then checks that derivation
+   against the option prices.
+
+And one hard limit worth stating loudly: the API offers ATM +/- 10 strikes,
+which at NIFTY's 50-point spacing is a **+/-500 point band**. A contract whose
+strike drifts further than that from spot simply stops appearing. A backtest
+must not read that silence as "the option expired worthless".
+
+Flow
+----
+1. Parse arguments and resolve a concrete date range.
+2. Download the ATM call at a coarse interval to learn which days the market was
+   open, and build the weekly expiry calendar from that.
+3. For each (strike label, option type) series in turn, walk the date range in
+   chunks, label each bar with its expiry, and append to that series' CSV.
+
+Step 3 is deliberately series-outer rather than chunk-outer: it keeps exactly one
+file open and writes it straight through, which matters a great deal more than it
+looks like it should on a slow disk.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import logging
+import os
+import sys
+import time
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import date, timedelta
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pandas as pd
+from dhanhq import DhanContext, dhanhq
+from dotenv import load_dotenv
+
+# Run as a script (which is how `algo.py` launches us), Python puts only THIS
+# folder on sys.path. Both roots are needed: the repo root for `Dependencies.`
+# imports, and this folder for the sibling extractor modules.
+_HERE = Path(__file__).resolve().parent
+_REPO_ROOT = _HERE.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+
+from expiry_calendar import (  # noqa: E402
+    build_expiry_map,
+    trading_days_to_expiry,
+)
+from index_1m_5y_data_fetch_dhan_common import (  # noqa: E402
+    infer_epoch_unit,
+    resolve_date_range,
+    validate_single_epoch_unit,
+)
+
+if TYPE_CHECKING:
+    # mypy_path lists Dependencies/, so these modules are known there by their
+    # bare names. Importing them as `Dependencies.x` at type-check time would
+    # give one file two module names and mypy refuses that outright.
+    #
+    # At RUNTIME the dotted form is the correct one, and not merely a style
+    # choice: `index_1m_5y_data_fetch_dhan_common` (imported just above) already
+    # loaded market_data_health as `Dependencies.market_data_health`. A bare
+    # import here would build a SECOND module object with a second, unrelated
+    # MarketDataValidationError -- and `except MarketDataValidationError` would
+    # then quietly fail to catch the one that was raised.
+    from broker_rate_limit import RollingWindowRateLimiter
+    from market_data_health import MarketDataValidationError
+else:
+    from Dependencies.broker_rate_limit import RollingWindowRateLimiter
+    from Dependencies.market_data_health import MarketDataValidationError
+
+# Credentials come from Dependencies/.env, exactly as everywhere else.
+load_dotenv(dotenv_path=_REPO_ROOT / "Dependencies" / ".env", override=False)
+
+log = logging.getLogger(__name__)
+
+# Everything the endpoint can return. We always ask for all of it: the marginal
+# cost is bytes on an already-large response, and `strike`/`spot` in particular
+# are what make the rolling labels usable at all.
+REQUIRED_DATA_FIELDS: tuple[str, ...] = (
+    "open",
+    "high",
+    "low",
+    "close",
+    "iv",
+    "volume",
+    "strike",
+    "oi",
+    "spot",
+)
+
+# Column order of every per-series CSV. `strike_label` and `option_type` are
+# constant within a file and therefore redundant per row -- they are written
+# anyway so that concatenating all the files and re-keying on the real strike is
+# a one-liner, which is the whole point for a positional backtest.
+OUTPUT_COLUMNS: tuple[str, ...] = (
+    "timestamp",
+    "open",
+    "high",
+    "low",
+    "close",
+    "volume",
+    "oi",
+    "iv",
+    "strike_price",
+    "spot",
+    "strike_label",
+    "option_type",
+    "expiry_date",
+    "days_to_expiry",
+)
+
+CALENDAR_COLUMNS: tuple[str, ...] = (
+    "trade_date",
+    "weekly_expiry_date",
+    "days_to_expiry",
+    "trading_days_to_expiry",
+)
+
+# Dhan documents a 30-day ceiling per call. 29 is the default so an off-by-one in
+# how the exchange treats `toDate` cannot silently truncate a chunk.
+MAX_CHUNK_DAYS = 30
+DEFAULT_CHUNK_DAYS = 29
+
+# The API's own strike ceiling for index options.
+MAX_STRIKE_RANGE = 10
+
+CALENDAR_FILENAME = "_weekly_expiry_calendar.csv"
+MANIFEST_FILENAME = "_manifest.json"
+
+
+@dataclass(frozen=True)
+class ExpiredOptionsDefaults:
+    """Per-underlying settings; everything else is identical between indices."""
+
+    display_name: str
+    security_id: int
+    default_output_dir: str
+    exchange_segment: str = "NSE_FNO"
+    instrument_type: str = "OPTIDX"
+    interval: int = 1
+    expiry_flag: str = "WEEK"
+    # 1, not 0. Dhan's annexure documents 0 = current expiry, but that table
+    # describes /charts/historical. This endpoint rejects 0 outright with
+    # "DH-905 expiryCode is required" -- it reads a zero as a missing field --
+    # so the near expiry is 1, the next is 2, and so on. Confirmed against the
+    # live API on 2026-09-05; see docs/adr/0015.
+    expiry_code: int = 1
+    strike_range: int = MAX_STRIKE_RANGE
+    lookback: str = "5y"
+    # Coarse interval for the trading-day pre-pass. Hourly bars are ~1/60th the
+    # payload of minute bars and answer the only question being asked: was the
+    # market open on this date?
+    calendar_interval: int = 60
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_args(defaults: ExpiredOptionsDefaults, argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Build and parse the CLI. The access token is attached afterwards."""
+
+    parser = argparse.ArgumentParser(
+        description=f"Download expired {defaults.display_name} option history from DhanHQ.",
+    )
+    # As in the index fetchers: --client-id may be overridden, the ACCESS TOKEN
+    # never can. A token typed on a command line lands in shell history and in
+    # every process listing on the machine.
+    parser.add_argument("--client-id", default=os.getenv("DHAN_CLIENT_CODE", ""))
+    parser.add_argument(
+        "--security-id",
+        type=int,
+        default=int(defaults.security_id),
+        help=f"Underlying security ID for {defaults.display_name}.",
+    )
+    parser.add_argument("--exchange-segment", default=defaults.exchange_segment)
+    parser.add_argument("--instrument-type", default=defaults.instrument_type)
+    parser.add_argument("--interval", type=int, default=int(defaults.interval), choices=[1, 5, 15, 25, 60])
+    parser.add_argument("--expiry-flag", default=defaults.expiry_flag, choices=["WEEK", "MONTH"])
+    parser.add_argument(
+        "--expiry-code",
+        type=int,
+        default=int(defaults.expiry_code),
+        help="1 = near expiry, 2 = next, 3 = far. This endpoint rejects 0.",
+    )
+    parser.add_argument(
+        "--strike-range",
+        type=int,
+        default=int(defaults.strike_range),
+        help=f"Strikes each side of ATM (0-{MAX_STRIKE_RANGE}); 10 gives 21 labels.",
+    )
+    parser.add_argument(
+        "--option-types",
+        default="CALL,PUT",
+        help="Comma-separated subset of CALL,PUT.",
+    )
+    parser.add_argument(
+        "--lookback",
+        default=defaults.lookback,
+        choices=["1d", "7d", "15d", "1m", "3m", "6m", "1y", "5y"],
+        help="Period to fetch when explicit start/end dates are not given.",
+    )
+    parser.add_argument("--start-date", default="")
+    parser.add_argument("--end-date", default="")
+    parser.add_argument(
+        "--chunk-days",
+        type=int,
+        default=DEFAULT_CHUNK_DAYS,
+        help=f"Days per API call (1-{MAX_CHUNK_DAYS}).",
+    )
+    parser.add_argument(
+        "--requests-per-second",
+        type=float,
+        default=2.0,
+        help="Request pacing. Dhan allows ~5/s on data APIs; 2 leaves headroom.",
+    )
+    parser.add_argument("--max-retries", type=int, default=4, help="Retries per chunk on transient failures.")
+    parser.add_argument("--output-dir", default=defaults.default_output_dir)
+    parser.add_argument(
+        "--calendar-interval",
+        type=int,
+        default=int(defaults.calendar_interval),
+        choices=[1, 5, 15, 25, 60],
+        help="Interval for the cheap trading-day pre-pass.",
+    )
+    parser.add_argument(
+        "--calendar-csv",
+        default="",
+        help="Skip calendar derivation and read trade_date,weekly_expiry_date from this CSV.",
+    )
+    parser.add_argument(
+        "--verify-expiries",
+        action="store_true",
+        help="After downloading, check derived expiries against ATM straddle collapse.",
+    )
+    parser.add_argument("--no-resume", action="store_true", help="Ignore any existing manifest and start over.")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the full call plan and exit without touching the network.",
+    )
+    args = parser.parse_args(argv)
+
+    # Attached after parsing so it can never arrive from the command line.
+    args.access_token = os.getenv("DHAN_ACCESS_TOKEN") or os.getenv("DHAN_TOKEN_ID") or ""
+    return args
+
+
+def validate_args(args: argparse.Namespace) -> list[str]:
+    """Return every problem with the parsed arguments, rather than just the first."""
+
+    problems: list[str] = []
+    if not 1 <= int(args.chunk_days) <= MAX_CHUNK_DAYS:
+        problems.append(f"--chunk-days must be between 1 and {MAX_CHUNK_DAYS}, got {args.chunk_days}")
+    if not 0 <= int(args.strike_range) <= MAX_STRIKE_RANGE:
+        problems.append(f"--strike-range must be between 0 and {MAX_STRIKE_RANGE}, got {args.strike_range}")
+    if int(args.expiry_code) < 1:
+        problems.append(f"--expiry-code must be >= 1 (this endpoint reads 0 as absent), got {args.expiry_code}")
+    if float(args.requests_per_second) <= 0:
+        problems.append(f"--requests-per-second must be positive, got {args.requests_per_second}")
+    for option_type in parse_option_types(args.option_types):
+        if option_type not in {"CALL", "PUT"}:
+            problems.append(f"--option-types accepts CALL and PUT, got {option_type!r}")
+    if not parse_option_types(args.option_types):
+        problems.append("--option-types must name at least one of CALL,PUT")
+    return problems
+
+
+def parse_option_types(raw: str) -> list[str]:
+    """Split and normalise the --option-types value."""
+
+    return [part.strip().upper() for part in str(raw).split(",") if part.strip()]
+
+
+# ---------------------------------------------------------------------------
+# The download plan
+# ---------------------------------------------------------------------------
+
+
+def strike_labels(strike_range: int) -> list[str]:
+    """Return the relative strike labels, deepest put side first.
+
+    ``strike_range=2`` gives ``['ATM-2', 'ATM-1', 'ATM', 'ATM+1', 'ATM+2']``.
+    """
+    width = int(strike_range)
+    labels = []
+    for offset in range(-width, width + 1):
+        if offset == 0:
+            labels.append("ATM")
+        else:
+            labels.append(f"ATM{offset:+d}")
+    return labels
+
+
+def series_plan(strike_range: int, option_types: Sequence[str]) -> list[tuple[str, str]]:
+    """Every (strike label, option type) pair that will get its own CSV."""
+
+    return [(label, option_type) for label in strike_labels(strike_range) for option_type in option_types]
+
+
+def chunk_ranges(start: date, end: date, chunk_days: int) -> list[tuple[date, date]]:
+    """
+    Split ``[start, end]`` into API-sized windows.
+
+    Dhan documents ``toDate`` as non-inclusive, so each window is returned as a
+    half-open ``[from, to)`` pair and the next one begins exactly where the last
+    ended. The writer de-duplicates on timestamp anyway, so a boundary bar
+    arriving twice (if the exchange in fact treats ``toDate`` as inclusive) is
+    dropped rather than duplicated.
+    """
+    if start > end:
+        raise ValueError(f"start {start.isoformat()} is after end {end.isoformat()}")
+    if chunk_days < 1:
+        raise ValueError(f"chunk_days must be >= 1, got {chunk_days}")
+
+    windows: list[tuple[date, date]] = []
+    cursor = start
+    final = end + timedelta(days=1)  # exclusive upper bound of the whole range
+    while cursor < final:
+        window_end = min(cursor + timedelta(days=chunk_days), final)
+        windows.append((cursor, window_end))
+        cursor = window_end
+    return windows
+
+
+def series_csv_path(output_dir: Path, defaults: ExpiredOptionsDefaults, args: argparse.Namespace,
+                    strike_label: str, option_type: str) -> Path:
+    """Where one series lives, e.g. ``nifty_1m_WEEK_ATM+3_CALL.csv``."""
+
+    stem = (
+        f"{defaults.display_name.lower()}_{args.interval}m_{args.expiry_flag}_"
+        f"{strike_label}_{option_type}"
+    )
+    return output_dir / f"{stem}.csv"
+
+
+# ---------------------------------------------------------------------------
+# Talking to the API
+# ---------------------------------------------------------------------------
+
+
+def classify_failure(remarks: Any) -> str:
+    """
+    Decide whether a failed envelope is worth retrying.
+
+    The Dhan SDK collapses two very different things into one shape. A *dict*
+    `remarks` is a structured refusal that reached us from the server -- it
+    means the request was seen and rejected. A *str* `remarks` is the SDK's
+    bare `except Exception` handler stringifying a transport error, so we do
+    not actually know whether the server saw anything.
+
+    This is the same distinction `Dependencies/Dhan API/dhan_execution.py`
+    exists to draw, applied here to reads instead of orders. Reads are safe to
+    repeat, so the indeterminate case retries; a genuine refusal does not,
+    unless it is a rate-limit complaint.
+    """
+    if isinstance(remarks, dict):
+        blob = " ".join(str(value) for value in remarks.values()).lower()
+        if "rate" in blob and "limit" in blob:
+            return "retryable"
+        if "too many" in blob:
+            return "retryable"
+        return "fatal"
+    return "retryable"
+
+
+def is_empty_window(remarks: Any) -> bool:
+    """True when the server is saying 'nothing here', not 'you asked wrongly'."""
+
+    text = " ".join(str(value) for value in remarks.values()) if isinstance(remarks, dict) else str(remarks)
+    lowered = text.lower()
+    return any(token in lowered for token in ("no data", "no records", "not found", "does not exist"))
+
+
+def fetch_rolling_chunk(
+    dhan: Any,
+    *,
+    args: argparse.Namespace,
+    strike_label: str,
+    option_type: str,
+    interval: int,
+    from_date: date,
+    to_date: date,
+    limiter: RollingWindowRateLimiter | None = None,
+    sleeper: Any = time.sleep,
+) -> dict[str, Any] | None:
+    """
+    Fetch one window for one series, retrying only what is safe to retry.
+
+    Returns the inner ``{'ce': ..., 'pe': ...}`` mapping, or ``None`` when the
+    window genuinely holds no data (a long market closure, or a strike that was
+    never that far from spot).
+    """
+    attempts = max(1, int(args.max_retries) + 1)
+    last_error: Any = None
+
+    for attempt in range(attempts):
+        if limiter is not None:
+            limiter.acquire()
+        response = dhan.expired_options_data(
+            security_id=int(args.security_id),
+            exchange_segment=str(args.exchange_segment),
+            instrument_type=str(args.instrument_type),
+            expiry_flag=str(args.expiry_flag),
+            expiry_code=int(args.expiry_code),
+            strike=strike_label,
+            drv_option_type=option_type,
+            required_data=list(REQUIRED_DATA_FIELDS),
+            from_date=from_date.strftime("%Y-%m-%d"),
+            to_date=to_date.strftime("%Y-%m-%d"),
+            interval=int(interval),
+        )
+        if not isinstance(response, dict):
+            raise RuntimeError(f"Unexpected API response type: {type(response).__name__}")
+
+        status = str(response.get("status", "")).strip().lower()
+        if status == "success":
+            return extract_payload(response.get("data"))
+
+        remarks = response.get("remarks")
+        last_error = remarks
+        if is_empty_window(remarks):
+            return None
+        if classify_failure(remarks) == "fatal":
+            raise RuntimeError(
+                f"API refused {strike_label} {option_type} "
+                f"{from_date.isoformat()} -> {to_date.isoformat()}: {remarks}"
+            )
+        if attempt < attempts - 1:
+            # Exponential backoff. Reads are idempotent, so repeating one is
+            # free apart from the rate-limit budget.
+            delay = min(2.0**attempt, 30.0)
+            log.warning(
+                "transient failure on %s %s %s (attempt %d/%d), retrying in %.1fs: %s",
+                strike_label, option_type, from_date.isoformat(), attempt + 1, attempts, delay, remarks,
+            )
+            sleeper(delay)
+
+    raise RuntimeError(
+        f"API failed {attempts}x for {strike_label} {option_type} "
+        f"{from_date.isoformat()} -> {to_date.isoformat()}: {last_error}"
+    )
+
+
+def extract_payload(data: Any) -> dict[str, Any] | None:
+    """
+    Peel the response envelope down to the ``{'ce': ..., 'pe': ...}`` mapping.
+
+    The SDK assigns the entire JSON body to its own ``data`` key, and the body
+    itself has a ``data`` key, so the real payload usually sits one level deeper
+    than it looks. Both shapes are accepted so a change on either side does not
+    break the parse silently.
+    """
+    if not isinstance(data, dict):
+        return None
+    inner = data.get("data")
+    if isinstance(inner, dict):
+        data = inner
+    if "ce" not in data and "pe" not in data:
+        return None
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Turning parallel arrays into rows
+# ---------------------------------------------------------------------------
+
+
+def normalize_rolling_payload(payload: dict[str, Any] | None, option_type: str, strike_label: str) -> pd.DataFrame:
+    """
+    Convert one side of the response into a tidy frame.
+
+    The endpoint answers in *column* form -- a separate equal-length array per
+    field, aligned by position -- rather than a list of bars. Any length
+    mismatch means the alignment assumption is broken, so it raises instead of
+    silently zipping mismatched data together.
+    """
+    empty = pd.DataFrame(columns=list(OUTPUT_COLUMNS))
+    if payload is None:
+        return empty
+
+    side = "ce" if option_type.upper() == "CALL" else "pe"
+    block = payload.get(side)
+    if not isinstance(block, dict):
+        return empty
+
+    stamps = block.get("timestamp")
+    if not isinstance(stamps, list) or not stamps:
+        return empty
+
+    columns: dict[str, Any] = {"timestamp_raw": stamps}
+    for field in REQUIRED_DATA_FIELDS:
+        values = block.get(field)
+        if not isinstance(values, list) or not values:
+            columns[field] = [None] * len(stamps)
+            continue
+        if len(values) != len(stamps):
+            raise MarketDataValidationError(
+                f"{strike_label} {option_type}: field {field!r} has {len(values)} values "
+                f"for {len(stamps)} timestamps"
+            )
+        columns[field] = values
+
+    frame = pd.DataFrame(columns)
+    for field in REQUIRED_DATA_FIELDS:
+        frame[field] = pd.to_numeric(frame[field], errors="coerce")
+
+    validate_single_epoch_unit(frame["timestamp_raw"])
+    unit = infer_epoch_unit(frame["timestamp_raw"])
+    stamped = pd.to_datetime(frame["timestamp_raw"], unit=unit, errors="coerce", utc=True)
+    # India market time, tz-naive -- the convention every other CSV in this repo
+    # and every backtest already uses.
+    frame["timestamp"] = stamped.dt.tz_convert("Asia/Kolkata").dt.tz_localize(None)
+
+    frame = frame.rename(columns={"strike": "strike_price"})
+    frame["strike_label"] = strike_label
+    frame["option_type"] = option_type.upper()
+    frame["expiry_date"] = pd.NA
+    frame["days_to_expiry"] = pd.NA
+
+    frame = frame.dropna(subset=["timestamp", "close"])
+    frame = frame.sort_values("timestamp").drop_duplicates(subset=["timestamp"])
+    return frame[list(OUTPUT_COLUMNS)].reset_index(drop=True)
+
+
+def validate_options_frame(frame: pd.DataFrame, from_date: date, to_date: date, label: str) -> None:
+    """
+    Sanity-check one chunk before it is written.
+
+    Deliberately NOT `Dependencies/market_data_health.validate_ohlc_frame`: that
+    one rejects any non-positive price, which is right for an index and wrong
+    for a deep out-of-the-money option that can legitimately print at the 0.05
+    tick floor. It also has no concept of open interest, IV, strike or spot.
+    """
+    if frame.empty:
+        return
+
+    stamps = frame["timestamp"]
+    if stamps.isna().any():
+        raise MarketDataValidationError(f"{label}: chunk contains unparseable timestamps")
+    if not stamps.is_monotonic_increasing:
+        raise MarketDataValidationError(f"{label}: chunk timestamps are not ascending")
+    if stamps.duplicated().any():
+        raise MarketDataValidationError(f"{label}: chunk contains duplicate timestamps")
+
+    outside = stamps[(stamps.dt.date < from_date) | (stamps.dt.date >= to_date)]
+    if not outside.empty:
+        raise MarketDataValidationError(
+            f"{label}: {len(outside)} candle(s) outside the requested window "
+            f"{from_date.isoformat()} -> {to_date.isoformat()}, first {outside.iloc[0]}"
+        )
+
+    highs, lows = frame["high"], frame["low"]
+    opens, closes = frame["open"], frame["close"]
+    if (highs < lows).any():
+        raise MarketDataValidationError(f"{label}: chunk has a candle with high < low")
+    if (highs < opens.combine(closes, max)).any() or (lows > opens.combine(closes, min)).any():
+        raise MarketDataValidationError(f"{label}: chunk has a candle whose body escapes its range")
+    for column in ("open", "high", "low", "close"):
+        if (frame[column] < 0).any():
+            raise MarketDataValidationError(f"{label}: chunk has a negative {column}")
+    for column in ("volume", "oi"):
+        series = frame[column].dropna()
+        if not series.empty and (series < 0).any():
+            raise MarketDataValidationError(f"{label}: chunk has a negative {column}")
+
+
+def label_with_expiry(frame: pd.DataFrame, expiry_map: dict[date, date]) -> pd.DataFrame:
+    """Attach expiry_date and days_to_expiry, dropping bars we cannot label."""
+
+    if frame.empty:
+        return frame
+
+    trade_dates = frame["timestamp"].dt.date
+    expiries = trade_dates.map(expiry_map.get)
+    labelled = frame.copy()
+    labelled["expiry_date"] = [e.isoformat() if isinstance(e, date) else pd.NA for e in expiries]
+    labelled["days_to_expiry"] = [
+        (e - d).days if isinstance(e, date) else pd.NA for d, e in zip(trade_dates, expiries, strict=True)
+    ]
+    # A bar past the last derived expiry cannot be labelled honestly, and an
+    # unlabelled bar is worse than no bar for a positional backtest.
+    return labelled[labelled["expiry_date"].notna()].reset_index(drop=True)
+
+
+# ---------------------------------------------------------------------------
+# Resumable writing
+# ---------------------------------------------------------------------------
+
+
+def load_manifest(path: Path) -> dict[str, Any]:
+    """Read the resume manifest, treating any damage as 'start over'."""
+
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except (OSError, ValueError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def save_manifest(path: Path, manifest: dict[str, Any]) -> None:
+    """Write the manifest atomically so a crash cannot leave it half-written."""
+
+    tmp = path.with_suffix(".tmp")
+    with tmp.open("w", encoding="utf-8") as handle:
+        json.dump(manifest, handle, indent=2, sort_keys=True)
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(tmp, path)
+
+
+def append_chunk(csv_path: Path, frame: pd.DataFrame, *, last_timestamp: str | None) -> tuple[int, int, str | None]:
+    """
+    Append one chunk to a series CSV.
+
+    Returns ``(rows_written, file_size, newest_timestamp)``. Rows at or before
+    ``last_timestamp`` are dropped, which is what makes a re-run idempotent and
+    what absorbs a duplicated boundary bar between adjacent chunks.
+    """
+    if last_timestamp is not None and not frame.empty:
+        frame = frame[frame["timestamp"] > pd.Timestamp(last_timestamp)]
+
+    csv_path.parent.mkdir(parents=True, exist_ok=True)
+    if frame.empty:
+        size = csv_path.stat().st_size if csv_path.exists() else 0
+        return 0, size, last_timestamp
+
+    write_header = not csv_path.exists() or csv_path.stat().st_size == 0
+    with csv_path.open("a", encoding="utf-8", newline="") as handle:
+        frame.to_csv(handle, header=write_header, index=False)
+        handle.flush()
+        os.fsync(handle.fileno())
+
+    newest = str(frame["timestamp"].iloc[-1])
+    return len(frame), csv_path.stat().st_size, newest
+
+
+def truncate_to(csv_path: Path, size: int) -> None:
+    """
+    Roll a series file back to its last manifest-recorded byte length.
+
+    The manifest is written after the data, so a crash between the two leaves a
+    file that is longer than the manifest believes. Those trailing bytes are a
+    partially written chunk; discarding them is what lets the resume start from
+    a known-good boundary.
+    """
+    if not csv_path.exists():
+        return
+    actual = csv_path.stat().st_size
+    if actual > size:
+        log.warning("trimming %s from %d to %d bytes (interrupted chunk)", csv_path.name, actual, size)
+        with csv_path.open("r+b") as handle:
+            handle.truncate(size)
+
+
+# ---------------------------------------------------------------------------
+# The trading-day / expiry calendar
+# ---------------------------------------------------------------------------
+
+
+def trading_days_from_frames(frames: Sequence[pd.DataFrame]) -> list[date]:
+    """Every distinct session date present in the given frames."""
+
+    days: set[date] = set()
+    for frame in frames:
+        if not frame.empty:
+            days.update(frame["timestamp"].dt.date.tolist())
+    return sorted(days)
+
+
+def write_calendar_csv(path: Path, trading_days: Sequence[date], expiry_map: dict[date, date]) -> pd.DataFrame:
+    """Write the derived calendar out so the labelling can be audited by eye."""
+
+    rows = []
+    for day in trading_days:
+        expiry = expiry_map.get(day)
+        if expiry is None:
+            continue
+        rows.append(
+            {
+                "trade_date": day.isoformat(),
+                "weekly_expiry_date": expiry.isoformat(),
+                "days_to_expiry": (expiry - day).days,
+                "trading_days_to_expiry": trading_days_to_expiry(trading_days, day, expiry),
+            }
+        )
+    frame = pd.DataFrame(rows, columns=list(CALENDAR_COLUMNS))
+    path.parent.mkdir(parents=True, exist_ok=True)
+    frame.to_csv(path, index=False)
+    return frame
+
+
+def read_calendar_csv(path: Path) -> dict[date, date]:
+    """Load an operator-supplied calendar, bypassing derivation entirely."""
+
+    frame = pd.read_csv(path)
+    missing = {"trade_date", "weekly_expiry_date"} - set(frame.columns)
+    if missing:
+        raise ValueError(f"{path} is missing column(s): {', '.join(sorted(missing))}")
+    # Parse column-wise rather than per row: `itertuples` erases the column
+    # types, and pandas' own vectorised parse is both faster and the shape the
+    # type checker can actually verify.
+    trade_dates = pd.to_datetime(frame["trade_date"]).dt.date
+    expiry_dates = pd.to_datetime(frame["weekly_expiry_date"]).dt.date
+    return dict(zip(trade_dates, expiry_dates, strict=True))
+
+
+# ---------------------------------------------------------------------------
+# Verification
+# ---------------------------------------------------------------------------
+
+# On expiry afternoon an at-the-money straddle is nearly all gone: both legs sit
+# within half a strike of spot with minutes of life left. One session earlier it
+# still carries a day of time value. The gap between those two states is wide
+# enough to check a derived calendar against, without pretending to be exact.
+EXPIRY_STRADDLE_CEILING = 40.0
+
+
+def verify_expiries(
+    call_frame: pd.DataFrame,
+    put_frame: pd.DataFrame,
+    expiry_dates: Sequence[date],
+    ceiling: float = EXPIRY_STRADDLE_CEILING,
+) -> list[str]:
+    """
+    Cross-check derived expiry dates against what the option prices actually did.
+
+    Returns a list of human-readable complaints; empty means every derived
+    expiry behaved like an expiry. This is a smell test, not a proof, and it is
+    aimed squarely at the failure mode worth catching: a calendar that is off by
+    a day, or that missed an exchange rule change.
+    """
+    problems: list[str] = []
+    if call_frame.empty or put_frame.empty:
+        return ["no ATM data available to verify expiries against"]
+
+    def last_close_by_day(frame: pd.DataFrame) -> dict[date, float]:
+        ordered = frame.sort_values("timestamp")
+        days = ordered["timestamp"].dt.date
+        closes = ordered["close"]
+        return {day: float(close) for day, close in zip(days, closes, strict=True)}
+
+    calls = last_close_by_day(call_frame)
+    puts = last_close_by_day(put_frame)
+
+    for expiry in expiry_dates:
+        call_close, put_close = calls.get(expiry), puts.get(expiry)
+        if call_close is None or put_close is None:
+            problems.append(f"{expiry.isoformat()}: derived as an expiry but has no ATM close")
+            continue
+        straddle = call_close + put_close
+        if straddle > ceiling:
+            problems.append(
+                f"{expiry.isoformat()}: ATM straddle closed at {straddle:.2f}, above the "
+                f"{ceiling:.0f} ceiling -- this may not be an expiry day"
+            )
+    return problems
+
+
+# ---------------------------------------------------------------------------
+# The runner
+# ---------------------------------------------------------------------------
+
+
+def describe_plan(args: argparse.Namespace, start: date, end: date) -> str:
+    """Render the whole call plan as text, for --dry-run and for the log."""
+
+    option_types = parse_option_types(args.option_types)
+    series = series_plan(args.strike_range, option_types)
+    windows = chunk_ranges(start, end, args.chunk_days)
+    calendar_calls = 0 if args.calendar_csv else len(windows) * 2
+    lines = [
+        f"range          : {start.isoformat()} -> {end.isoformat()}",
+        f"interval       : {args.interval} minute",
+        f"expiry         : {args.expiry_flag}, expiryCode={args.expiry_code}",
+        f"strikes        : {', '.join(strike_labels(args.strike_range))}",
+        f"option types   : {', '.join(option_types)}",
+        f"series         : {len(series)} files",
+        f"chunks/series  : {len(windows)} windows of up to {args.chunk_days} days",
+        f"calendar pass  : {calendar_calls} calls at {args.calendar_interval} minute",
+        f"TOTAL API CALLS: {len(series) * len(windows) + calendar_calls}",
+        f"pacing         : {args.requests_per_second}/s",
+        f"output         : {args.output_dir}",
+    ]
+    return "\n".join(f"  {line}" for line in lines)
+
+
+def build_client(args: argparse.Namespace) -> Any:
+    """Construct the DhanHQ client, failing clearly when credentials are absent."""
+
+    if not args.client_id or not args.access_token:
+        raise ValueError(
+            "Missing credentials. Set DHAN_CLIENT_CODE and DHAN_ACCESS_TOKEN in "
+            "Dependencies/.env (run `python algo.py setup-token` to refresh the "
+            "token). Only --client-id may be overridden on the command line; "
+            "the token is environment-only."
+        )
+    return dhanhq(DhanContext(args.client_id, args.access_token))
+
+
+def build_expiry_calendar(
+    dhan: Any,
+    args: argparse.Namespace,
+    start: date,
+    end: date,
+    limiter: RollingWindowRateLimiter | None,
+) -> tuple[list[date], dict[date, date], pd.DataFrame, pd.DataFrame]:
+    """
+    Learn the trading days from a cheap pre-pass, then derive the expiry map.
+
+    Hourly ATM bars are a fraction of the payload of minute bars and answer the
+    only question being asked here: was the market open that day? Deriving the
+    calendar from the data itself means it can never disagree with the bars it
+    is about to label.
+    """
+    log.info("calendar pre-pass: ATM CALL/PUT at %d-minute resolution", args.calendar_interval)
+    collected: dict[str, pd.DataFrame] = {}
+    for option_type in ("CALL", "PUT"):
+        parts = []
+        for from_date, to_date in chunk_ranges(start, end, args.chunk_days):
+            payload = fetch_rolling_chunk(
+                dhan,
+                args=args,
+                strike_label="ATM",
+                option_type=option_type,
+                interval=args.calendar_interval,
+                from_date=from_date,
+                to_date=to_date,
+                limiter=limiter,
+            )
+            frame = normalize_rolling_payload(payload, option_type, "ATM")
+            if not frame.empty:
+                parts.append(frame)
+        collected[option_type] = (
+            pd.concat(parts, ignore_index=True) if parts else pd.DataFrame(columns=list(OUTPUT_COLUMNS))
+        )
+
+    call_frame, put_frame = collected["CALL"], collected["PUT"]
+    trading_days = trading_days_from_frames([call_frame, put_frame])
+    if not trading_days:
+        raise RuntimeError(
+            "calendar pre-pass returned no bars at all, so trading days cannot be derived. "
+            "Check the date range, and that the Data API subscription is active."
+        )
+    expiry_map = build_expiry_map(trading_days)
+    log.info(
+        "derived %d trading days and %d weekly expiries (%s -> %s)",
+        len(trading_days),
+        len(set(expiry_map.values())),
+        trading_days[0].isoformat(),
+        trading_days[-1].isoformat(),
+    )
+    return trading_days, expiry_map, call_frame, put_frame
+
+
+def download_series(
+    dhan: Any,
+    args: argparse.Namespace,
+    defaults: ExpiredOptionsDefaults,
+    output_dir: Path,
+    strike_label: str,
+    option_type: str,
+    windows: Sequence[tuple[date, date]],
+    expiry_map: dict[date, date],
+    manifest: dict[str, Any],
+    manifest_path: Path,
+    limiter: RollingWindowRateLimiter | None,
+) -> int:
+    """Download one series end to end, resuming from the manifest where it can."""
+
+    key = f"{strike_label}_{option_type}"
+    csv_path = series_csv_path(output_dir, defaults, args, strike_label, option_type)
+    state: dict[str, Any] = {} if args.no_resume else manifest.get(key, {})
+
+    if state:
+        truncate_to(csv_path, int(state.get("bytes", 0)))
+    elif args.no_resume and csv_path.exists():
+        csv_path.unlink()
+
+    resume_after = state.get("last_to_date")
+    last_timestamp = state.get("last_timestamp")
+    rows_total = int(state.get("rows", 0))
+
+    for from_date, to_date in windows:
+        if resume_after and to_date <= date.fromisoformat(resume_after):
+            continue
+
+        payload = fetch_rolling_chunk(
+            dhan,
+            args=args,
+            strike_label=strike_label,
+            option_type=option_type,
+            interval=args.interval,
+            from_date=from_date,
+            to_date=to_date,
+            limiter=limiter,
+        )
+        frame = normalize_rolling_payload(payload, option_type, strike_label)
+        validate_options_frame(frame, from_date, to_date, key)
+        frame = label_with_expiry(frame, expiry_map)
+
+        written, size, newest = append_chunk(csv_path, frame, last_timestamp=last_timestamp)
+        rows_total += written
+        if newest is not None:
+            last_timestamp = newest
+
+        manifest[key] = {
+            "last_to_date": to_date.isoformat(),
+            "last_timestamp": last_timestamp,
+            "bytes": size,
+            "rows": rows_total,
+        }
+        save_manifest(manifest_path, manifest)
+
+    log.info("%-14s -> %-48s %8d rows", key, csv_path.name, rows_total)
+    return rows_total
+
+
+def run_expired_options_fetcher(defaults: ExpiredOptionsDefaults, argv: Sequence[str] | None = None) -> None:
+    """Entry point that every per-underlying wrapper calls."""
+
+    args = parse_args(defaults, argv)
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)-7s %(message)s",
+        datefmt="%H:%M:%S",
+    )
+    install_log_redaction()
+
+    problems = validate_args(args)
+    if problems:
+        raise ValueError("Invalid arguments:\n  - " + "\n  - ".join(problems))
+
+    start, end = resolve_date_range(args)
+    plan = describe_plan(args, start, end)
+    if args.dry_run:
+        print(f"[dry-run] {defaults.display_name} expired options plan:\n{plan}")
+        return
+    log.info("%s expired options download:\n%s", defaults.display_name, plan)
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = output_dir / MANIFEST_FILENAME
+    manifest: dict[str, Any] = {} if args.no_resume else load_manifest(manifest_path)
+
+    dhan = build_client(args)
+    limiter = RollingWindowRateLimiter(
+        per_second=max(1, int(args.requests_per_second)),
+        per_minute=max(1, int(args.requests_per_second * 60)),
+        # Generous on purpose. A downloader wants to WAIT for a slot; a live
+        # order would rather fail fast than send something stale.
+        max_wait_seconds=120.0,
+        label="Dhan expired-options",
+    )
+
+    if args.calendar_csv:
+        expiry_map = read_calendar_csv(Path(args.calendar_csv))
+        trading_days = sorted(expiry_map)
+        call_frame = pd.DataFrame(columns=list(OUTPUT_COLUMNS))
+        put_frame = pd.DataFrame(columns=list(OUTPUT_COLUMNS))
+        log.info("using supplied calendar %s (%d trading days)", args.calendar_csv, len(trading_days))
+    else:
+        trading_days, expiry_map, call_frame, put_frame = build_expiry_calendar(dhan, args, start, end, limiter)
+        write_calendar_csv(output_dir / CALENDAR_FILENAME, trading_days, expiry_map)
+        log.info("wrote %s", output_dir / CALENDAR_FILENAME)
+
+    windows = chunk_ranges(start, end, args.chunk_days)
+    option_types = parse_option_types(args.option_types)
+    grand_total = 0
+    for strike_label, option_type in series_plan(args.strike_range, option_types):
+        grand_total += download_series(
+            dhan,
+            args,
+            defaults,
+            output_dir,
+            strike_label,
+            option_type,
+            windows,
+            expiry_map,
+            manifest,
+            manifest_path,
+            limiter,
+        )
+
+    log.info("done: %d rows across %d series in %s", grand_total, len(manifest), output_dir)
+
+    if args.verify_expiries:
+        complaints = verify_expiries(call_frame, put_frame, sorted(set(expiry_map.values())))
+        if complaints:
+            log.warning("expiry verification raised %d concern(s):", len(complaints))
+            for complaint in complaints:
+                log.warning("  %s", complaint)
+        else:
+            log.info("expiry verification: every derived expiry behaved like one")
+
+
+def install_log_redaction() -> None:
+    """
+    Scrub secrets from logs, best-effort.
+
+    The repo-wide guard lives in Dependencies/. If it cannot be imported (a bare
+    checkout, say) the download is still safe to run -- this module never logs a
+    token -- so a missing helper must not stop the job.
+
+    Imported dynamically rather than with a normal statement for the same
+    module-identity reason as the block at the top of this file: naming
+    `Dependencies.secret_redaction` in an import statement would give mypy a
+    second name for a file it already knows as `secret_redaction`.
+    """
+    try:
+        redaction = importlib.import_module("Dependencies.secret_redaction")
+    except Exception:  # noqa: BLE001 - redaction is a hardening layer, not a dependency
+        log.debug("secret redaction helper unavailable; continuing without it")
+        return
+    redaction.install_redaction_filter(logging.getLogger(), redaction.environment_secrets(os.environ))

--- a/Data Extractors/expired_options_fetch_dhan_common.py
+++ b/Data Extractors/expired_options_fetch_dhan_common.py
@@ -313,6 +313,18 @@ def validate_args(args: argparse.Namespace) -> list[str]:
             problems.append(f"--option-types accepts CALL and PUT, got {option_type!r}")
     if not parse_option_types(args.option_types):
         problems.append("--option-types must name at least one of CALL,PUT")
+
+    # `expiry_calendar` derives WEEKLY expiries only. Downloading monthly
+    # contracts and then labelling them off the weekly calendar would give every
+    # bar an expiry date that is simply not its contract's -- silently wrong
+    # data, which is worse than a refusal. An operator with a real monthly
+    # calendar can still do it by supplying one.
+    if str(args.expiry_flag).upper() == "MONTH" and not args.calendar_csv:
+        problems.append(
+            "--expiry-flag MONTH has no derived calendar: expiry_calendar.py knows weekly "
+            "expiries only, so monthly bars would be labelled with weekly expiry dates. "
+            "Supply --calendar-csv with the monthly expiry dates, or use --expiry-flag WEEK."
+        )
     return problems
 
 
@@ -697,6 +709,11 @@ def label_with_expiry(frame: pd.DataFrame, expiry_map: dict[date, date]) -> pd.D
 # ---------------------------------------------------------------------------
 
 
+# Reserved manifest key describing the run the progress belongs to. Series keys
+# are "<STRIKE>_<TYPE>", so a dunder name cannot collide with one.
+RUN_SIGNATURE_KEY = "__run__"
+
+
 def load_manifest(path: Path) -> dict[str, Any]:
     """Read the resume manifest, treating any damage as 'start over'."""
 
@@ -706,6 +723,59 @@ def load_manifest(path: Path) -> dict[str, Any]:
     except (OSError, ValueError):
         return {}
     return payload if isinstance(payload, dict) else {}
+
+
+def run_signature(args: argparse.Namespace, start: date, end: date) -> dict[str, Any]:
+    """Identify the run that a manifest's progress belongs to.
+
+    Deliberately excludes `--strike-range` and `--option-types`: those only add
+    or drop whole series, and a series with no manifest entry simply starts
+    fresh. Everything here changes what a given series' rows MEAN, or where its
+    chunk boundaries fall.
+    """
+    return {
+        "start": start.isoformat(),
+        "interval": int(args.interval),
+        "chunk_days": int(args.chunk_days),
+        "expiry_flag": str(args.expiry_flag),
+        "expiry_code": int(args.expiry_code),
+        "security_id": int(args.security_id),
+        "exchange_segment": str(args.exchange_segment),
+        "instrument_type": str(args.instrument_type),
+    }
+
+
+def resumable_manifest(manifest: dict[str, Any], signature: dict[str, Any]) -> tuple[dict[str, Any], str | None]:
+    """
+    Decide whether stored progress may be resumed, and say why not.
+
+    The dangerous case is a manifest from a NARROWER or LATER run -- the
+    documented January smoke test, say, followed by the five-year backfill.
+    Every window ending on or before the stored `last_to_date` is skipped and
+    the writer only appends after `last_timestamp`, so the earlier years would
+    never be fetched and the command would report success over a dataset
+    missing most of its history.
+
+    Progress is therefore resumable only when it came from a run with the same
+    identity AND the same start date; a later `--end-date` extends it, which is
+    the normal case. Anything else starts over.
+
+    Returns ``(manifest_to_use, reason_it_was_discarded)``.
+    """
+    stored = manifest.get(RUN_SIGNATURE_KEY)
+    if not manifest:
+        return {}, None
+    if not isinstance(stored, dict):
+        return {}, "the existing manifest predates run signatures"
+
+    differing = [
+        f"{field}: {stored.get(field)!r} -> {value!r}"
+        for field, value in signature.items()
+        if stored.get(field) != value
+    ]
+    if differing:
+        return {}, "this run does not continue the stored one (" + "; ".join(differing) + ")"
+    return manifest, None
 
 
 def save_manifest(path: Path, manifest: dict[str, Any]) -> None:
@@ -999,13 +1069,33 @@ def build_client(args: argparse.Namespace) -> Any:
     return dhanhq(DhanContext(args.client_id, args.access_token))
 
 
+def read_atm_series(
+    output_dir: Path, defaults: ExpiredOptionsDefaults, args: argparse.Namespace
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """
+    Read back the ATM call and put files this run wrote, for verification.
+
+    Empty frames come back when a run downloaded only one side (or neither),
+    and `verify_expiries` reports that it could not check rather than passing
+    vacuously.
+    """
+    frames = []
+    for option_type in ("CALL", "PUT"):
+        path = series_csv_path(output_dir, defaults, args, "ATM", option_type)
+        if not path.exists():
+            frames.append(pd.DataFrame(columns=list(OUTPUT_COLUMNS)))
+            continue
+        frames.append(pd.read_csv(path, usecols=["timestamp", "close"], parse_dates=["timestamp"]))
+    return frames[0], frames[1]
+
+
 def build_expiry_calendar(
     dhan: Any,
     args: argparse.Namespace,
     start: date,
     end: date,
     limiter: RollingWindowRateLimiter | None,
-) -> tuple[list[date], dict[date, date], pd.DataFrame, pd.DataFrame]:
+) -> tuple[list[date], dict[date, date]]:
     """
     Learn the trading days from a cheap pre-pass, then derive the expiry map.
 
@@ -1044,16 +1134,23 @@ def build_expiry_calendar(
             "Check the date range, and that the Data API subscription is active."
         )
     # Short sessions stay trading days but cannot host an expiry -- see
-    # `full_session_days` and `expiry_calendar.weekly_expiry_dates`.
-    expiry_map = build_expiry_map(trading_days, full_sessions=full_session_days([call_frame, put_frame]))
+    # `full_session_days` and `expiry_calendar.weekly_expiry_dates`. The expiry
+    # INDEX must match the contracts being downloaded: labelling expiryCode=2
+    # bars with the near expiry would put every days_to_expiry a week out.
+    expiry_map = build_expiry_map(
+        trading_days,
+        full_sessions=full_session_days([call_frame, put_frame]),
+        expiry_index=int(args.expiry_code),
+    )
     log.info(
-        "derived %d trading days and %d weekly expiries (%s -> %s)",
+        "derived %d trading days and %d weekly expiries at expiryCode=%d (%s -> %s)",
         len(trading_days),
         len(set(expiry_map.values())),
+        int(args.expiry_code),
         trading_days[0].isoformat(),
         trading_days[-1].isoformat(),
     )
-    return trading_days, expiry_map, call_frame, put_frame
+    return trading_days, expiry_map
 
 
 def download_series(
@@ -1077,7 +1174,13 @@ def download_series(
 
     if state:
         truncate_to(csv_path, int(state.get("bytes", 0)))
-    elif args.no_resume and csv_path.exists():
+    elif csv_path.exists():
+        # No resume state, but a CSV is sitting there -- from --no-resume, or a
+        # manifest that was lost or damaged. Appending to it would duplicate
+        # every candle it already holds, because there is no last_timestamp to
+        # de-duplicate against. `load_manifest` says damage means starting over;
+        # this is what actually starts over.
+        log.info("no resume state for %s -- discarding the existing %s", key, csv_path.name)
         csv_path.unlink()
 
     resume_after = state.get("last_to_date")
@@ -1144,7 +1247,12 @@ def run_expired_options_fetcher(defaults: ExpiredOptionsDefaults, argv: Sequence
     output_dir = Path(args.output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
     manifest_path = output_dir / MANIFEST_FILENAME
+    signature = run_signature(args, start, end)
     manifest: dict[str, Any] = {} if args.no_resume else load_manifest(manifest_path)
+    manifest, discarded = resumable_manifest(manifest, signature)
+    if discarded:
+        log.warning("ignoring stored progress and starting over: %s", discarded)
+    manifest[RUN_SIGNATURE_KEY] = signature
 
     dhan = build_client(args)
     limiter = RollingWindowRateLimiter(
@@ -1159,11 +1267,9 @@ def run_expired_options_fetcher(defaults: ExpiredOptionsDefaults, argv: Sequence
     if args.calendar_csv:
         expiry_map = read_calendar_csv(Path(args.calendar_csv))
         trading_days = sorted(expiry_map)
-        call_frame = pd.DataFrame(columns=list(OUTPUT_COLUMNS))
-        put_frame = pd.DataFrame(columns=list(OUTPUT_COLUMNS))
         log.info("using supplied calendar %s (%d trading days)", args.calendar_csv, len(trading_days))
     else:
-        trading_days, expiry_map, call_frame, put_frame = build_expiry_calendar(dhan, args, start, end, limiter)
+        trading_days, expiry_map = build_expiry_calendar(dhan, args, start, end, limiter)
         write_calendar_csv(output_dir / CALENDAR_FILENAME, trading_days, expiry_map)
         log.info("wrote %s", output_dir / CALENDAR_FILENAME)
         warn_about_unlabelled_tail(trading_days, expiry_map, end)
@@ -1186,9 +1292,16 @@ def run_expired_options_fetcher(defaults: ExpiredOptionsDefaults, argv: Sequence
             limiter,
         )
 
-    log.info("done: %d rows across %d series in %s", grand_total, len(manifest), output_dir)
+    series_count = len(manifest) - 1  # the run signature is not a series
+    log.info("done: %d rows across %d series in %s", grand_total, series_count, output_dir)
 
     if args.verify_expiries:
+        # Verify against the ATM files that were just WRITTEN, not against the
+        # calendar pre-pass. That covers --calendar-csv (where there is no
+        # pre-pass at all, and verification used to report "no ATM data" and
+        # silently check nothing), and it checks the labelled data that actually
+        # shipped rather than an intermediate the operator never sees.
+        call_frame, put_frame = read_atm_series(output_dir, defaults, args)
         complaints = verify_expiries(call_frame, put_frame, sorted(set(expiry_map.values())))
         if complaints:
             log.warning("expiry verification raised %d concern(s):", len(complaints))

--- a/Data Extractors/expiry_calendar.py
+++ b/Data Extractors/expiry_calendar.py
@@ -85,6 +85,7 @@ def nominal_expiry_weekday(day: date, rules: Sequence[tuple[date, int]] | None =
 def weekly_expiry_dates(
     trading_days: Iterable[date],
     rules: Sequence[tuple[date, int]] | None = None,
+    full_sessions: Iterable[date] | None = None,
 ) -> list[date]:
     """
     Work out every weekly expiry date covered by ``trading_days``.
@@ -93,11 +94,25 @@ def weekly_expiry_dates(
 
     1. Take that week's Monday and ask the rule table for the nominal weekday.
     2. Step forward to the nominal date (e.g. Monday + 3 = Thursday).
-    3. Walk *backwards* to the most recent trading day on or before it.
+    3. Walk *backwards* to the most recent ELIGIBLE session on or before it.
 
-    Step 3 is what handles holidays, and it searches the whole trading-day list
-    rather than just that week -- so an expiry whose nominal day AND the days
-    before it were all holidays still rolls back correctly into the prior week.
+    Step 3 is what handles holidays, and it searches the whole list rather than
+    just that week -- so an expiry whose nominal day AND the days before it were
+    all holidays still rolls back correctly into the prior week.
+
+    ``full_sessions`` is the subset eligible to *be* an expiry, and defaults to
+    all of them. It exists because of Diwali. NSE runs a ~1-hour Muhurat session
+    on Diwali, which looks like an ordinary trading day in the data but cannot
+    host a weekly expiry -- so the exchange moves that week's expiry earlier.
+    Both occurrences in the five-year window were derived wrongly before this
+    parameter existed:
+
+        2021-11-04 (Thu, 61 bars)  -- real expiry was Wed 2021-11-03
+        2025-10-21 (Tue, 105 bars) -- real expiry was Mon 2025-10-20
+
+    Note the asymmetry: a Muhurat session cannot be an expiry, but it is still a
+    trading day that *has* one ahead of it, which is why `build_expiry_map`
+    still maps it.
 
     A week whose nominal expiry date falls after the last trading day we were
     given is skipped: that week has not finished yet, and inventing an expiry
@@ -105,6 +120,10 @@ def weekly_expiry_dates(
     """
     days = sorted(set(trading_days))
     if not days:
+        return []
+
+    eligible = sorted(set(full_sessions)) if full_sessions is not None else days
+    if not eligible:
         return []
 
     first, last = days[0], days[-1]
@@ -121,11 +140,11 @@ def weekly_expiry_dates(
         if nominal > last:
             break
 
-        # bisect_right gives the count of trading days <= nominal, so index-1 is
-        # the latest such day -- the holiday roll-back, for free.
-        position = bisect.bisect_right(days, nominal)
+        # bisect_right gives the count of eligible sessions <= nominal, so
+        # index-1 is the latest such day -- the holiday roll-back, for free.
+        position = bisect.bisect_right(eligible, nominal)
         if position > 0:
-            expiries.append(days[position - 1])
+            expiries.append(eligible[position - 1])
 
         monday += timedelta(days=7)
 
@@ -138,6 +157,7 @@ def weekly_expiry_dates(
 def build_expiry_map(
     trading_days: Iterable[date],
     rules: Sequence[tuple[date, int]] | None = None,
+    full_sessions: Iterable[date] | None = None,
 ) -> dict[date, date]:
     """
     Map every trading day to the near weekly expiry that was current on it.
@@ -147,11 +167,15 @@ def build_expiry_map(
     the API returns for ``expiryCode=1``. That makes expiry day map to itself
     and gives it ``days_to_expiry == 0``.
 
+    Every trading day is mapped, including a Diwali Muhurat session: such a day
+    cannot HOST an expiry (see `weekly_expiry_dates`) but it still has one
+    coming, and its bars deserve a label like any other.
+
     Trading days after the last derived expiry are left out entirely rather than
     guessed at -- the caller writes no expiry label for those bars.
     """
     days = sorted(set(trading_days))
-    expiries = weekly_expiry_dates(days, rules)
+    expiries = weekly_expiry_dates(days, rules, full_sessions)
     if not expiries:
         return {}
 

--- a/Data Extractors/expiry_calendar.py
+++ b/Data Extractors/expiry_calendar.py
@@ -1,0 +1,182 @@
+"""
+Derive NIFTY weekly option expiry dates from a list of trading days.
+
+Why this file exists
+--------------------
+DhanHQ's expired-options endpoint (`/charts/rollingoption`) answers in *relative*
+terms: you ask for "the ATM call of the near weekly expiry" and it hands back
+minute bars. What it never tells you is **which expiry** those bars belong to.
+
+For an intraday strategy that does not matter. For a positional option seller it
+matters enormously: "sell an option five days before expiry and hold it to
+settlement" is not a rule you can even express without knowing the expiry date.
+
+So we derive it. Two ingredients, and only two:
+
+1. **Which weekday NIFTY weeklies expire on.** This is a published exchange rule
+   that has changed once inside our five-year window (see the rule table below).
+2. **Which days the market was actually open.** We do not hard-code a holiday
+   list -- we read the trading days straight out of the downloaded data, so the
+   calendar can never disagree with the data it describes.
+
+The rule is then simply: a week's expiry is the last trading day on or before
+that week's nominal expiry weekday. If the nominal day was a holiday, the expiry
+rolls *backwards* to the previous trading day, which is exactly what NSE does.
+
+This module is deliberately pure -- no network, no files, no clock. Everything it
+knows arrives as arguments, which is what makes it testable and what makes the
+`--verify-expiries` cross-check in the fetcher meaningful.
+"""
+
+from __future__ import annotations
+
+import bisect
+from collections.abc import Iterable, Sequence
+from datetime import date, timedelta
+
+# Nominal expiry weekday, in `date.weekday()` terms: Monday=0 ... Sunday=6.
+#
+# Read this as "from this date onwards, NIFTY weeklies expire on this weekday".
+# Entries must stay sorted by date; `nominal_expiry_weekday` takes the last rule
+# whose start date has already arrived.
+#
+# History inside our 5-year window:
+#   - Thursday, as it had been for ~25 years.
+#   - Tuesday from 01-Sep-2025, when NSE moved index and stock derivatives off
+#     Thursday following SEBI's October 2024 circular. (BSE went the other way,
+#     to Thursday, which is why this table is NIFTY-specific.)
+#
+# NSE announced a switch to Monday in March 2025 and then deferred it; that one
+# never took effect and deliberately has no entry here.
+WEEKLY_EXPIRY_WEEKDAY_RULES: tuple[tuple[date, int], ...] = (
+    (date(2000, 1, 1), 3),  # Thursday
+    (date(2025, 9, 1), 1),  # Tuesday
+)
+
+
+class ExpiryCalendarError(ValueError):
+    """Raised when a calendar cannot be derived from the trading days given."""
+
+
+def nominal_expiry_weekday(day: date, rules: Sequence[tuple[date, int]] | None = None) -> int:
+    """
+    Return the weekday NIFTY weeklies nominally expire on, for a given date.
+
+    "Nominal" means *before* the holiday roll-back. On a normal week the nominal
+    day IS the expiry; on a week where that day is a holiday the real expiry is
+    earlier, and `weekly_expiry_dates` works that out.
+    """
+    table = WEEKLY_EXPIRY_WEEKDAY_RULES if rules is None else tuple(rules)
+    if not table:
+        raise ExpiryCalendarError("expiry weekday rule table is empty")
+
+    weekday = None
+    for start, candidate in table:
+        if day >= start:
+            weekday = candidate
+    if weekday is None:
+        raise ExpiryCalendarError(
+            f"no expiry weekday rule covers {day.isoformat()}; "
+            f"earliest rule starts {table[0][0].isoformat()}"
+        )
+    return weekday
+
+
+def weekly_expiry_dates(
+    trading_days: Iterable[date],
+    rules: Sequence[tuple[date, int]] | None = None,
+) -> list[date]:
+    """
+    Work out every weekly expiry date covered by ``trading_days``.
+
+    The algorithm, per calendar week:
+
+    1. Take that week's Monday and ask the rule table for the nominal weekday.
+    2. Step forward to the nominal date (e.g. Monday + 3 = Thursday).
+    3. Walk *backwards* to the most recent trading day on or before it.
+
+    Step 3 is what handles holidays, and it searches the whole trading-day list
+    rather than just that week -- so an expiry whose nominal day AND the days
+    before it were all holidays still rolls back correctly into the prior week.
+
+    A week whose nominal expiry date falls after the last trading day we were
+    given is skipped: that week has not finished yet, and inventing an expiry
+    for it would silently mislabel the most recent bars.
+    """
+    days = sorted(set(trading_days))
+    if not days:
+        return []
+
+    first, last = days[0], days[-1]
+    expiries: list[date] = []
+
+    # Start from the Monday of the first trading day's week and step a week at a
+    # time. Using Mondays (rather than the trading days themselves) means a week
+    # that is entirely holiday still gets considered.
+    monday = first - timedelta(days=first.weekday())
+    while monday <= last:
+        nominal = monday + timedelta(days=nominal_expiry_weekday(monday, rules))
+
+        # An unfinished week: no expiry has happened yet, so do not invent one.
+        if nominal > last:
+            break
+
+        # bisect_right gives the count of trading days <= nominal, so index-1 is
+        # the latest such day -- the holiday roll-back, for free.
+        position = bisect.bisect_right(days, nominal)
+        if position > 0:
+            expiries.append(days[position - 1])
+
+        monday += timedelta(days=7)
+
+    # Two adjacent weeks can roll back onto the same trading day when a run of
+    # holidays spans an expiry. Real contracts cannot share an expiry date, so
+    # collapse the duplicate rather than emit an impossible calendar.
+    return sorted(set(expiries))
+
+
+def build_expiry_map(
+    trading_days: Iterable[date],
+    rules: Sequence[tuple[date, int]] | None = None,
+) -> dict[date, date]:
+    """
+    Map every trading day to the near weekly expiry that was current on it.
+
+    "Current on it" includes the expiry day itself: on expiry Tuesday the near
+    weekly contract is the one expiring that afternoon, which is exactly what
+    the API returns for ``expiryCode=1``. That makes expiry day map to itself
+    and gives it ``days_to_expiry == 0``.
+
+    Trading days after the last derived expiry are left out entirely rather than
+    guessed at -- the caller writes no expiry label for those bars.
+    """
+    days = sorted(set(trading_days))
+    expiries = weekly_expiry_dates(days, rules)
+    if not expiries:
+        return {}
+
+    mapping: dict[date, date] = {}
+    for day in days:
+        position = bisect.bisect_left(expiries, day)
+        if position < len(expiries):
+            mapping[day] = expiries[position]
+    return mapping
+
+
+def trading_days_to_expiry(trading_days: Sequence[date], day: date, expiry: date) -> int:
+    """
+    Count the trading sessions left after ``day``, up to and including ``expiry``.
+
+    Expiry day itself returns 0. This is the number a theta-aware rule wants:
+    calendar days overstate the decay left across a long weekend.
+
+    ``trading_days`` must be sorted ascending; the fetcher passes the same list
+    the calendar was derived from.
+    """
+    if expiry < day:
+        raise ExpiryCalendarError(
+            f"expiry {expiry.isoformat()} precedes trade date {day.isoformat()}"
+        )
+    left = bisect.bisect_right(trading_days, day)
+    right = bisect.bisect_right(trading_days, expiry)
+    return max(right - left, 0)

--- a/Data Extractors/expiry_calendar.py
+++ b/Data Extractors/expiry_calendar.py
@@ -158,6 +158,7 @@ def build_expiry_map(
     trading_days: Iterable[date],
     rules: Sequence[tuple[date, int]] | None = None,
     full_sessions: Iterable[date] | None = None,
+    expiry_index: int = 1,
 ) -> dict[date, date]:
     """
     Map every trading day to the near weekly expiry that was current on it.
@@ -171,9 +172,17 @@ def build_expiry_map(
     cannot HOST an expiry (see `weekly_expiry_dates`) but it still has one
     coming, and its bars deserve a label like any other.
 
-    Trading days after the last derived expiry are left out entirely rather than
-    guessed at -- the caller writes no expiry label for those bars.
+    ``expiry_index`` mirrors the API's ``expiryCode``: 1 is the near expiry, 2
+    the next, and so on. It must match the contracts actually being downloaded
+    -- labelling ``expiryCode=2`` bars with the near expiry would put every
+    ``days_to_expiry`` a full week out and quietly wreck a positional backtest.
+
+    Trading days whose Nth expiry is not yet in the data are left out entirely
+    rather than guessed at -- the caller writes no expiry label for those bars.
     """
+    if expiry_index < 1:
+        raise ExpiryCalendarError(f"expiry_index is 1-based (1 = near expiry), got {expiry_index}")
+
     days = sorted(set(trading_days))
     expiries = weekly_expiry_dates(days, rules, full_sessions)
     if not expiries:
@@ -181,7 +190,7 @@ def build_expiry_map(
 
     mapping: dict[date, date] = {}
     for day in days:
-        position = bisect.bisect_left(expiries, day)
+        position = bisect.bisect_left(expiries, day) + (expiry_index - 1)
         if position < len(expiries):
             mapping[day] = expiries[position]
     return mapping

--- a/Data Extractors/index_1m_5y_data_fetch_dhan_common.py
+++ b/Data Extractors/index_1m_5y_data_fetch_dhan_common.py
@@ -21,6 +21,7 @@ High-level flow used by the wrapper scripts:
 import argparse
 import math
 import os
+import sys
 import tempfile
 import time
 from dataclasses import dataclass
@@ -30,6 +31,16 @@ from typing import TYPE_CHECKING, Literal
 
 import pandas as pd
 from dhanhq import DhanContext, dhanhq
+from dotenv import load_dotenv
+
+# `python algo.py fetch-data ...` launches this file as a SCRIPT, so Python puts
+# the script's own folder on sys.path -- not the repository root, and not the
+# working directory algo.py sets. Without this insert the `Dependencies.` import
+# below raises ModuleNotFoundError. The pytest suite never saw it because pytest
+# puts the rootdir on sys.path itself.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
 
 if TYPE_CHECKING:
     # mypy_path includes Dependencies/, where this module is known by its bare
@@ -40,6 +51,12 @@ else:
         MarketDataValidationError,
         validate_ohlc_frame,
     )
+
+# Credentials live in Dependencies/.env like everywhere else in this repo.
+# Without this the extractors could only see variables already exported in the
+# shell, which is why they silently refused to run. `override=False` keeps a
+# value the operator exported deliberately ahead of the file's.
+load_dotenv(dotenv_path=_REPO_ROOT / "Dependencies" / ".env", override=False)
 
 
 @dataclass(frozen=True)
@@ -94,7 +111,7 @@ def parse_args(defaults: IndexFetchDefaults):
     # - the CLIENT ID is an account identifier (not a secret), so it may come
     #   from the CLI flag, then the environment, then the wrapper default.
     # - the ACCESS TOKEN is a secret and is read from the environment ONLY
-    #   (DHAN_TOKEN_ID, e.g. loaded from Dependencies/.env). There is
+    #   (DHAN_ACCESS_TOKEN, loaded from Dependencies/.env above). There is
     #   deliberately no --access-token flag: a token typed on the command
     #   line would land in shell history and process listings.
     parser.add_argument(
@@ -143,7 +160,14 @@ def parse_args(defaults: IndexFetchDefaults):
     args = parser.parse_args()
     # Attach the token AFTER parsing so it can never be supplied (or leaked)
     # through the command line; downstream code keeps reading args.access_token.
-    args.access_token = os.getenv("DHAN_TOKEN_ID", defaults.default_access_token)
+    # DHAN_ACCESS_TOKEN is the key the rest of the repo uses and the one
+    # `algo.py setup-token` writes. DHAN_TOKEN_ID is accepted only so an
+    # operator who had exported the old name keeps working.
+    args.access_token = (
+        os.getenv("DHAN_ACCESS_TOKEN")
+        or os.getenv("DHAN_TOKEN_ID")
+        or defaults.default_access_token
+    )
     return args
 
 
@@ -483,9 +507,10 @@ def run_index_fetcher(defaults: IndexFetchDefaults) -> None:
 
     if not args.client_id or not args.access_token:
         raise ValueError(
-            "Missing credentials. Set DHAN_CLIENT_CODE and DHAN_TOKEN_ID in the "
-            "environment (e.g. Dependencies/.env). Only --client-id may be "
-            "overridden on the command line; the token is environment-only."
+            "Missing credentials. Set DHAN_CLIENT_CODE and DHAN_ACCESS_TOKEN in "
+            "Dependencies/.env (run `python algo.py setup-token` to refresh the "
+            "token). Only --client-id may be overridden on the command line; "
+            "the token is environment-only."
         )
 
     if args.chunk_days <= 0 or args.chunk_days > 90:

--- a/Data Extractors/nifty_expired_options_fetch_dhan.py
+++ b/Data Extractors/nifty_expired_options_fetch_dhan.py
@@ -1,0 +1,42 @@
+"""
+Download expired NIFTY weekly option history from DhanHQ.
+
+This is a thin wrapper. Everything that actually does the work -- paging, retry,
+expiry labelling, resumable writing -- lives in
+`expired_options_fetch_dhan_common.py`, exactly as the index fetchers keep their
+logic in `index_1m_5y_data_fetch_dhan_common.py`. All this file decides is which
+underlying to ask about and where the CSVs land.
+
+Typical use:
+
+    python algo.py fetch-expired-options --index nifty --dry-run
+    python algo.py fetch-expired-options --index nifty --lookback 5y --verify-expiries
+
+Credentials come from `Dependencies/.env` (`DHAN_CLIENT_CODE` and
+`DHAN_ACCESS_TOKEN`); the token is never a command-line flag. The endpoint needs
+an active DhanHQ Data API subscription.
+
+A word on what you get back, because it is easy to misread: the strikes are
+RELATIVE. `ATM+3` is whichever strike sat three above spot at the time, so it is
+not one contract over time. Re-key on the `strike_price` and `expiry_date`
+columns to rebuild fixed contracts. See the engine module's docstring and
+docs/adr/0015 before building a backtest on this.
+"""
+
+import os
+
+from expired_options_fetch_dhan_common import ExpiredOptionsDefaults, run_expired_options_fetcher
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+NIFTY_EXPIRED_OPTIONS_DEFAULTS = ExpiredOptionsDefaults(
+    display_name="NIFTY",
+    # 13 on the index side, the same ID the index fetchers and the live runner
+    # use (NIFTY_INDEX_SECURITY_ID). Note this is NOT the 26000 that appears as
+    # UNDERLYING_SECURITY_ID in the instrument master.
+    security_id=13,
+    default_output_dir=os.path.join(_REPO_ROOT, "Backtest Outputs", "expired_options", "nifty"),
+)
+
+if __name__ == "__main__":
+    run_expired_options_fetcher(NIFTY_EXPIRED_OPTIONS_DEFAULTS)

--- a/Dependencies/env.example
+++ b/Dependencies/env.example
@@ -50,6 +50,11 @@ DHAN_API_SECRET=
 # web console currently issues 24-hour tokens. Generate it OUTSIDE market
 # hours -- a token that dies mid-session can leave open intraday positions
 # that cannot be squared off through the API.
+#
+# The Data Extractors read DHAN_CLIENT_CODE and DHAN_ACCESS_TOKEN from this
+# file too, so a stale token shows up there as a DH-901 "invalid or expired"
+# on the first chunk. There is deliberately no --access-token flag on any
+# script: a token typed on a command line lands in shell history.
 DHAN_ACCESS_TOKEN=
 
 
@@ -934,6 +939,7 @@ SMA_CROSSOVER_TRADING_START_MINUTE=25
 SMA_CROSSOVER_SQUARE_OFF_HOUR=15
 SMA_CROSSOVER_SQUARE_OFF_MINUTE=15
 SMA_CROSSOVER_LOTS=1
+SMA_CROSSOVER_SIZE_MULTIPLIER=1
 SMA_CROSSOVER_STARTING_CAPITAL=600000
 SMA_CROSSOVER_DAILY_MAX_LOSS_PCT=0.03
 SMA_CROSSOVER_SHORT_WINDOW=9
@@ -1141,6 +1147,7 @@ SUPERTREND_PORT_TRADING_START_MINUTE=25
 SUPERTREND_PORT_SQUARE_OFF_HOUR=15
 SUPERTREND_PORT_SQUARE_OFF_MINUTE=15
 SUPERTREND_PORT_LOTS=1
+SUPERTREND_PORT_SIZE_MULTIPLIER=1
 SUPERTREND_PORT_STARTING_CAPITAL=600000
 SUPERTREND_PORT_DAILY_MAX_LOSS_PCT=0.03
 SUPERTREND_PORT_ATR_PERIOD=10

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Each subfolder has its own `Readme.md` with the details.
 | Command | What it does | Example |
 |---|---|---|
 | `fetch-data --index {nifty,banknifty,finnifty}` | Download 1-min OHLC for an index | `python algo.py fetch-data --index nifty --interval 5 --lookback 5y` |
+| `fetch-expired-options --index nifty` | Download expired option history (premium, OI, IV) — add `--dry-run` to see the call plan first | `python algo.py fetch-expired-options --index nifty --lookback 5y --verify-expiries` |
 | `backtest --strategy {renko,ema,heikin,cpr,profit-shooter,goldmine,money-machine}` | Backtest one strategy against a CSV | `python algo.py backtest --strategy renko --data "Backtest Outputs/nifty_renko_futures_5y_1min_data.csv"` |
 | `run` | Start the front-test master (paper by default; live per `.env`) | `python algo.py run` |
 | `setup-token` | One-time DhanHQ token setup (writes `.env`) | `python algo.py setup-token` |

--- a/Tests/Data Extractors/test_expired_options_fetch.py
+++ b/Tests/Data Extractors/test_expired_options_fetch.py
@@ -555,23 +555,27 @@ def test_reading_a_calendar_missing_its_columns_says_which(tmp_path):
         engine.read_calendar_csv(path)
 
 
+def two_session_frames(prior_close: float, expiry_close: float) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """One leg's last bar on the day before expiry, then on expiry day."""
+    frame = written_frame(["2025-01-08 15:29", "2025-01-09 15:29"])
+    frame.loc[0, "close"] = prior_close
+    frame.loc[1, "close"] = expiry_close
+    return frame, frame.copy()
+
+
 def test_verification_passes_when_the_straddle_collapses_on_expiry_day():
-    calls = written_frame(["2025-01-09 15:29"])
-    calls.loc[0, "close"] = 8.0
-    puts = written_frame(["2025-01-09 15:29"])
-    puts.loc[0, "close"] = 6.0
+    # 14 against 120 the session before -- a 0.12 ratio, the measured median.
+    calls, puts = two_session_frames(prior_close=60.0, expiry_close=7.0)
 
     assert engine.verify_expiries(calls, puts, [date(2025, 1, 9)]) == []
 
 
 def test_verification_flags_a_day_that_still_carries_time_value():
-    # A calendar that is off by a day looks exactly like this.
-    calls = written_frame(["2025-01-08 15:29"])
-    calls.loc[0, "close"] = 90.0
-    puts = written_frame(["2025-01-08 15:29"])
-    puts.loc[0, "close"] = 85.0
+    # A calendar off by a day looks exactly like this: the straddle barely moved.
+    calls, puts = two_session_frames(prior_close=60.0, expiry_close=58.0)
 
-    complaints = engine.verify_expiries(calls, puts, [date(2025, 1, 8)])
+    complaints = engine.verify_expiries(calls, puts, [date(2025, 1, 9)])
+
     assert len(complaints) == 1
     assert "may not be an expiry day" in complaints[0]
 
@@ -830,3 +834,156 @@ def test_atm_is_repicked_every_bar_so_one_file_holds_many_contracts():
     # And each is genuinely the nearest 50 to spot.
     for strike, spot in zip(frame["strike_price"], frame["spot"], strict=True):
         assert abs(strike - spot) <= 25.0
+
+
+# ---------------------------------------------------------------------------
+# Corrupt counters
+# ---------------------------------------------------------------------------
+
+
+def test_a_negative_volume_is_blanked_not_fatal():
+    """One corrupt bar must not destroy a 50-minute backfill.
+
+    The real one, from the 5-year run: 2025-08-14 15:02 on the ATM-1 put,
+    volume = -4253276221, between neighbours in the tens of millions. It killed
+    the job after 20 of 42 series.
+    """
+    stamps = [epoch("2025-08-14 15:01"), epoch("2025-08-14 15:02"), epoch("2025-08-14 15:03")]
+    payload = payload_for(
+        "pe", stamps,
+        open=[1.15, 1.15, 1.15], high=[1.15, 1.15, 1.15],
+        low=[1.15, 1.15, 1.15], close=[1.15, 1.15, 1.15],
+        volume=[41_000_000, -4_253_276_221, 41_800_000],
+        oi=[44_733_975, 44_733_975, 44_733_975],
+    )
+
+    frame = engine.normalize_rolling_payload(payload, "PUT", "ATM-1")
+
+    assert len(frame) == 3, "the bar itself is kept -- only the bad value goes"
+    assert pd.isna(frame["volume"].iloc[1])
+    assert frame["volume"].iloc[0] == 41_000_000
+    assert frame["volume"].iloc[2] == 41_800_000
+    # Everything else on that bar survives untouched.
+    assert frame["close"].iloc[1] == 1.15
+    assert frame["oi"].iloc[1] == 44_733_975
+
+    # And it now passes the validator that used to abort the run.
+    engine.validate_options_frame(frame, date(2025, 8, 14), date(2025, 8, 14), "ATM-1_PUT")
+
+
+def test_a_negative_volume_is_not_repaired_by_guesswork():
+    """-4253276221 + 2**32 == 41691075, which looks plausible. Resist it.
+
+    The value does not fit a clean int32 wrap, so the mechanism is inferred, and
+    a guessed bit-pattern is not a good enough reason to invent broker data.
+    Unknown is recorded as unknown.
+    """
+    stamps = [epoch("2025-08-14 15:02")]
+    payload = payload_for(
+        "pe", stamps,
+        open=[1.15], high=[1.15], low=[1.15], close=[1.15],
+        volume=[-4_253_276_221], oi=[44_733_975],
+    )
+
+    frame = engine.normalize_rolling_payload(payload, "PUT", "ATM-1")
+
+    assert pd.isna(frame["volume"].iloc[0])
+    assert frame["volume"].iloc[0] != 41_691_075
+
+
+def test_a_negative_open_interest_is_blanked_too():
+    stamps = [epoch("2025-08-14 15:02")]
+    payload = payload_for(
+        "pe", stamps, open=[1.15], high=[1.15], low=[1.15], close=[1.15],
+        volume=[100], oi=[-7],
+    )
+
+    frame = engine.normalize_rolling_payload(payload, "PUT", "ATM-1")
+    assert pd.isna(frame["oi"].iloc[0])
+
+
+def test_a_negative_price_still_aborts_the_chunk():
+    """Prices are what a backtest computes P&L from -- they are not blankable."""
+    frame = frame_from(
+        [{"timestamp": "2025-08-14 15:02", "open": 1.15, "high": 1.15, "low": -1.15,
+          "close": 1.15, "volume": 100, "oi": 100}]
+    )
+    with pytest.raises(engine.MarketDataValidationError):
+        engine.validate_options_frame(frame, date(2025, 8, 14), date(2025, 8, 14), "ATM-1_PUT")
+
+
+# ---------------------------------------------------------------------------
+# Short-session detection and the recalibrated verification
+# ---------------------------------------------------------------------------
+
+
+def session_frame(day: str, bars: int, close: float = 100.0) -> pd.DataFrame:
+    stamps = pd.date_range(f"{day} 09:15", periods=bars, freq="1min")
+    frame = pd.DataFrame({name: [close] * bars for name in engine.OUTPUT_COLUMNS})
+    frame["timestamp"] = stamps
+    return frame[list(engine.OUTPUT_COLUMNS)]
+
+
+def test_short_sessions_are_separated_from_normal_ones():
+    """Measured split over five years: normal 375-376 bars, special 60-107."""
+    frames = [
+        pd.concat(
+            [
+                session_frame("2025-10-16", 375),
+                session_frame("2025-10-17", 375),
+                session_frame("2025-10-20", 375),
+                session_frame("2025-10-21", 105),  # Diwali Muhurat
+            ],
+            ignore_index=True,
+        )
+    ]
+
+    full = engine.full_session_days(frames)
+
+    assert date(2025, 10, 21) not in full
+    assert len(full) == 3
+    # ... but it is still a trading day.
+    assert date(2025, 10, 21) in engine.trading_days_from_frames(frames)
+
+
+def test_full_session_detection_copes_with_no_data():
+    assert engine.full_session_days([]) == []
+    assert engine.full_session_days([pd.DataFrame()]) == []
+
+
+def test_verification_uses_the_collapse_ratio_not_an_absolute_level():
+    """An absolute ceiling flagged 38 of 261 real expiries and hid the 2 bad ones.
+
+    Because ATM is the nearest 50-point strike, an expiring straddle still holds
+    up to 25 points of intrinsic, so 40-50 is entirely normal. What identifies an
+    expiry is the COLLAPSE against the previous session.
+    """
+    calls = pd.concat([session_frame("2025-01-08", 1, close=60.0),
+                       session_frame("2025-01-09", 1, close=25.0)], ignore_index=True)
+    puts = pd.concat([session_frame("2025-01-08", 1, close=60.0),
+                      session_frame("2025-01-09", 1, close=20.0)], ignore_index=True)
+
+    # 45 on expiry day would have tripped the old 40-point ceiling; against 120
+    # the day before it is a 0.38 collapse, which is exactly what an expiry does.
+    assert engine.verify_expiries(calls, puts, [date(2025, 1, 9)]) == []
+
+
+def test_verification_flags_a_day_whose_straddle_barely_moved():
+    calls = pd.concat([session_frame("2025-01-08", 1, close=60.0),
+                       session_frame("2025-01-09", 1, close=55.0)], ignore_index=True)
+    puts = pd.concat([session_frame("2025-01-08", 1, close=60.0),
+                      session_frame("2025-01-09", 1, close=55.0)], ignore_index=True)
+
+    complaints = engine.verify_expiries(calls, puts, [date(2025, 1, 9)])
+
+    assert len(complaints) == 1
+    assert "may not be an expiry day" in complaints[0]
+    assert "ratio 0.92" in complaints[0]
+
+
+def test_verification_skips_an_expiry_with_nothing_before_it():
+    calls = session_frame("2025-01-09", 1, close=55.0)
+    puts = session_frame("2025-01-09", 1, close=55.0)
+
+    # No prior session in the data to compare against, so no verdict is possible.
+    assert engine.verify_expiries(calls, puts, [date(2025, 1, 9)]) == []

--- a/Tests/Data Extractors/test_expired_options_fetch.py
+++ b/Tests/Data Extractors/test_expired_options_fetch.py
@@ -1,0 +1,756 @@
+"""Tests for the expired-options download engine.
+
+Nothing here touches the network: the DhanHQ client is a `SimpleNamespace` duck,
+matching the style already used in `test_index_fetch_construction.py`.
+
+The cases worth their weight are the ones encoding something the API taught us
+the hard way -- expiryCode being 1-based, a `str` vs `dict` `remarks` meaning
+completely different things, and the parallel-array response shape.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import itertools
+import json
+import sys
+from datetime import date
+from pathlib import Path
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+# Tests/Data Extractors/<this file> -> the repository root is two levels up.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = _REPO_ROOT / "Data Extractors" / "expired_options_fetch_dhan_common.py"
+spec = importlib.util.spec_from_file_location("expired_options_fetch_dhan_common", MODULE_PATH)
+engine = importlib.util.module_from_spec(spec)
+sys.modules["expired_options_fetch_dhan_common"] = engine
+spec.loader.exec_module(engine)
+
+
+DEFAULTS = engine.ExpiredOptionsDefaults(
+    display_name="NIFTY",
+    security_id=13,
+    default_output_dir="out",
+)
+
+
+def make_args(**overrides):
+    """Parse a realistic argv, then apply overrides."""
+    argv = ["--client-id", "CLIENT123", *overrides.pop("argv", [])]
+    args = engine.parse_args(DEFAULTS, argv)
+    for key, value in overrides.items():
+        setattr(args, key, value)
+    return args
+
+
+def epoch(text: str) -> int:
+    """IST wall-clock string -> the epoch seconds the API would send."""
+    return int(pd.Timestamp(text, tz="Asia/Kolkata").timestamp())
+
+
+def payload_for(side: str, stamps: list[int], **fields):
+    """Build a response block in the API's column-per-field shape."""
+    block = {"timestamp": stamps}
+    for name in engine.REQUIRED_DATA_FIELDS:
+        block[name] = fields.get(name, [1.0] * len(stamps))
+    other = "pe" if side == "ce" else "ce"
+    return {side: block, other: None}
+
+
+# ---------------------------------------------------------------------------
+# The plan
+# ---------------------------------------------------------------------------
+
+
+def test_strike_labels_are_symmetric_around_atm():
+    assert engine.strike_labels(2) == ["ATM-2", "ATM-1", "ATM", "ATM+1", "ATM+2"]
+    assert engine.strike_labels(0) == ["ATM"]
+    assert len(engine.strike_labels(10)) == 21
+
+
+def test_series_plan_pairs_every_label_with_every_option_type():
+    plan = engine.series_plan(1, ["CALL", "PUT"])
+    assert len(plan) == 6
+    assert ("ATM", "CALL") in plan and ("ATM+1", "PUT") in plan
+
+
+def test_chunk_ranges_cover_the_whole_span_without_gaps():
+    windows = engine.chunk_ranges(date(2025, 1, 1), date(2025, 3, 31), 29)
+
+    assert windows[0][0] == date(2025, 1, 1)
+    # toDate is non-inclusive, so the last window ends one day past the range.
+    assert windows[-1][1] == date(2025, 4, 1)
+    for earlier, later in itertools.pairwise(windows):
+        assert earlier[1] == later[0], "windows must abut exactly"
+    assert all((end - start).days <= 29 for start, end in windows)
+
+
+def test_chunk_ranges_handles_a_single_day():
+    assert engine.chunk_ranges(date(2025, 1, 6), date(2025, 1, 6), 29) == [
+        (date(2025, 1, 6), date(2025, 1, 7))
+    ]
+
+
+def test_chunk_ranges_rejects_a_reversed_or_degenerate_range():
+    with pytest.raises(ValueError, match="is after end"):
+        engine.chunk_ranges(date(2025, 2, 1), date(2025, 1, 1), 29)
+    with pytest.raises(ValueError, match="chunk_days must be"):
+        engine.chunk_ranges(date(2025, 1, 1), date(2025, 2, 1), 0)
+
+
+def test_expiry_code_zero_is_rejected_because_the_api_reads_it_as_absent():
+    # The live API answers expiryCode=0 with "DH-905 expiryCode is required",
+    # so 1 is the near expiry here even though Dhan's annexure says otherwise.
+    assert DEFAULTS.expiry_code == 1
+    problems = engine.validate_args(make_args(expiry_code=0))
+    assert any("expiry-code" in p for p in problems), problems
+
+
+def test_validate_args_reports_every_problem_at_once():
+    problems = engine.validate_args(
+        make_args(chunk_days=99, strike_range=25, requests_per_second=0, option_types="CALL,BOTH")
+    )
+    joined = " ".join(problems)
+    assert "--chunk-days" in joined
+    assert "--strike-range" in joined
+    assert "--requests-per-second" in joined
+    assert "BOTH" in joined
+
+
+def test_valid_args_produce_no_complaints():
+    assert engine.validate_args(make_args()) == []
+
+
+def test_describe_plan_counts_every_call_including_the_calendar_pass():
+    args = make_args(strike_range=1, chunk_days=29, calendar_csv="")
+    text = engine.describe_plan(args, date(2025, 1, 1), date(2025, 1, 10))
+
+    # 3 labels x 2 types x 1 window, plus 2 calendar calls.
+    assert "TOTAL API CALLS: 8" in text
+    assert "series         : 6 files" in text
+
+
+def test_series_csv_path_names_the_file_after_the_series():
+    args = make_args()
+    path = engine.series_csv_path(Path("out"), DEFAULTS, args, "ATM+3", "CALL")
+    assert path.name == "nifty_1m_WEEK_ATM+3_CALL.csv"
+
+
+# ---------------------------------------------------------------------------
+# Envelope handling
+# ---------------------------------------------------------------------------
+
+
+def test_dict_remarks_is_a_real_refusal_and_is_not_retried():
+    remarks = {"error_code": "DH-905", "error_type": "Input_Exception", "error_message": "bad field"}
+    assert engine.classify_failure(remarks) == "fatal"
+
+
+def test_str_remarks_is_indeterminate_and_is_retried():
+    # The SDK stringifies transport errors into the same envelope shape as a
+    # server refusal. A read is safe to repeat, so this one retries.
+    assert engine.classify_failure("HTTPSConnectionPool: read timed out") == "retryable"
+
+
+def test_a_rate_limit_refusal_is_retried_even_though_it_is_structured():
+    remarks = {"error_code": "DH-908", "error_message": "Rate Limit exceeded"}
+    assert engine.classify_failure(remarks) == "retryable"
+
+
+def test_empty_window_is_recognised_from_either_remarks_shape():
+    assert engine.is_empty_window({"error_message": "No Data available"})
+    assert engine.is_empty_window("no records found")
+    assert not engine.is_empty_window({"error_message": "Invalid_Authentication"})
+
+
+def test_extract_payload_unwraps_the_doubled_data_key():
+    inner = {"ce": {"timestamp": [1]}, "pe": None}
+    assert engine.extract_payload({"data": inner}) is inner
+    # A flat body (should Dhan ever stop double-wrapping) still works.
+    assert engine.extract_payload(inner) is inner
+    assert engine.extract_payload({"unrelated": 1}) is None
+    assert engine.extract_payload("") is None
+
+
+# ---------------------------------------------------------------------------
+# Fetching
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_retries_a_transport_failure_then_succeeds():
+    stamps = [epoch("2025-01-06 09:15")]
+    calls = []
+    responses = [
+        {"status": "failure", "remarks": "read timed out", "data": ""},
+        {"status": "success", "remarks": "", "data": {"data": payload_for("ce", stamps)}},
+    ]
+
+    def fake(**kwargs):
+        calls.append(kwargs)
+        return responses[len(calls) - 1]
+
+    slept = []
+    payload = engine.fetch_rolling_chunk(
+        SimpleNamespace(expired_options_data=fake),
+        args=make_args(max_retries=3),
+        strike_label="ATM",
+        option_type="CALL",
+        interval=1,
+        from_date=date(2025, 1, 6),
+        to_date=date(2025, 1, 7),
+        sleeper=slept.append,
+    )
+
+    assert len(calls) == 2
+    assert slept == [1.0]
+    assert payload is not None and "ce" in payload
+    assert calls[0]["expiry_code"] == 1
+    assert calls[0]["strike"] == "ATM"
+    assert set(calls[0]["required_data"]) == set(engine.REQUIRED_DATA_FIELDS)
+
+
+def test_fetch_does_not_retry_a_structured_refusal():
+    calls = []
+
+    def fake(**kwargs):
+        calls.append(kwargs)
+        return {"status": "failure", "remarks": {"error_code": "DH-905"}, "data": ""}
+
+    with pytest.raises(RuntimeError, match="API refused"):
+        engine.fetch_rolling_chunk(
+            SimpleNamespace(expired_options_data=fake),
+            args=make_args(max_retries=3),
+            strike_label="ATM",
+            option_type="CALL",
+            interval=1,
+            from_date=date(2025, 1, 6),
+            to_date=date(2025, 1, 7),
+            sleeper=lambda _s: None,
+        )
+
+    assert len(calls) == 1, "a refusal must not be repeated"
+
+
+def test_fetch_returns_none_for_a_window_that_simply_has_no_data():
+    fake = SimpleNamespace(
+        expired_options_data=lambda **_k: {"status": "failure", "remarks": {"error_message": "No Data"}, "data": ""}
+    )
+    assert (
+        engine.fetch_rolling_chunk(
+            fake,
+            args=make_args(),
+            strike_label="ATM-10",
+            option_type="PUT",
+            interval=1,
+            from_date=date(2025, 1, 6),
+            to_date=date(2025, 1, 7),
+            sleeper=lambda _s: None,
+        )
+        is None
+    )
+
+
+def test_fetch_gives_up_after_the_retry_budget():
+    fake = SimpleNamespace(expired_options_data=lambda **_k: {"status": "failure", "remarks": "timeout", "data": ""})
+    with pytest.raises(RuntimeError, match="API failed 3x"):
+        engine.fetch_rolling_chunk(
+            fake,
+            args=make_args(max_retries=2),
+            strike_label="ATM",
+            option_type="CALL",
+            interval=1,
+            from_date=date(2025, 1, 6),
+            to_date=date(2025, 1, 7),
+            sleeper=lambda _s: None,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Normalisation
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_builds_ist_rows_from_the_parallel_arrays():
+    stamps = [epoch("2025-01-06 09:15"), epoch("2025-01-06 09:16")]
+    payload = payload_for(
+        "ce", stamps, close=[142.5, 143.8], strike=[21500.0, 21500.0], spot=[21503.2, 21510.0], oi=[1250, 1300]
+    )
+
+    frame = engine.normalize_rolling_payload(payload, "CALL", "ATM+3")
+
+    assert list(frame.columns) == list(engine.OUTPUT_COLUMNS)
+    assert len(frame) == 2
+    assert str(frame["timestamp"].iloc[0]) == "2025-01-06 09:15:00"
+    assert frame["strike_price"].iloc[0] == 21500.0
+    assert frame["spot"].iloc[1] == 21510.0
+    assert frame["strike_label"].iloc[0] == "ATM+3"
+    assert frame["option_type"].iloc[0] == "CALL"
+
+
+def test_normalize_reads_the_pe_block_for_a_put():
+    stamps = [epoch("2025-01-06 09:15")]
+    payload = payload_for("pe", stamps, close=[88.0])
+
+    assert engine.normalize_rolling_payload(payload, "PUT", "ATM").iloc[0]["close"] == 88.0
+    # The CE side is null in that same payload, so a CALL request finds nothing.
+    assert engine.normalize_rolling_payload(payload, "CALL", "ATM").empty
+
+
+def test_normalize_refuses_to_zip_misaligned_arrays():
+    # A short field would silently pair prices with the wrong timestamps.
+    payload = {"ce": {"timestamp": [1, 2, 3], "close": [10.0, 11.0]}, "pe": None}
+    with pytest.raises(engine.MarketDataValidationError, match="has 2 values for 3 timestamps"):
+        engine.normalize_rolling_payload(payload, "CALL", "ATM")
+
+
+def test_normalize_tolerates_a_field_the_server_left_empty():
+    stamps = [epoch("2025-01-06 09:15")]
+    block = {"timestamp": stamps, "close": [10.0], "open": [10.0], "high": [10.0], "low": [10.0], "iv": []}
+    frame = engine.normalize_rolling_payload({"ce": block, "pe": None}, "CALL", "ATM")
+
+    assert len(frame) == 1
+    assert pd.isna(frame["iv"].iloc[0])
+
+
+def test_normalize_handles_empty_and_missing_payloads():
+    assert engine.normalize_rolling_payload(None, "CALL", "ATM").empty
+    assert engine.normalize_rolling_payload({"ce": None, "pe": None}, "CALL", "ATM").empty
+    assert engine.normalize_rolling_payload({"ce": {"timestamp": []}, "pe": None}, "CALL", "ATM").empty
+
+
+def test_normalize_rejects_a_chunk_mixing_epoch_units():
+    stamps = [epoch("2025-01-06 09:15"), epoch("2025-01-06 09:16") * 1000]
+    with pytest.raises(engine.MarketDataValidationError, match="mixes epoch units"):
+        engine.normalize_rolling_payload(payload_for("ce", stamps), "CALL", "ATM")
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def frame_from(rows):
+    frame = pd.DataFrame(rows)
+    frame["timestamp"] = pd.to_datetime(frame["timestamp"])
+    return frame
+
+
+def test_validation_accepts_a_zero_priced_deep_otm_candle():
+    # market_data_health.validate_ohlc_frame would reject this outright, which
+    # is why this module has its own validator.
+    frame = frame_from(
+        [{"timestamp": "2025-01-06 09:15", "open": 0.0, "high": 0.05, "low": 0.0, "close": 0.05,
+          "volume": 0, "oi": 0}]
+    )
+    engine.validate_options_frame(frame, date(2025, 1, 6), date(2025, 1, 7), "ATM-10_PUT")
+
+
+def test_validation_rejects_a_candle_outside_the_requested_window():
+    frame = frame_from(
+        [{"timestamp": "2025-01-09 09:15", "open": 1.0, "high": 1.0, "low": 1.0, "close": 1.0,
+          "volume": 1, "oi": 1}]
+    )
+    with pytest.raises(engine.MarketDataValidationError, match="outside the requested window"):
+        engine.validate_options_frame(frame, date(2025, 1, 6), date(2025, 1, 7), "ATM_CALL")
+
+
+def test_validation_rejects_duplicate_and_unsorted_timestamps():
+    one_bar = {
+        "timestamp": "2025-01-06 09:15", "open": 1.0, "high": 1.0, "low": 1.0,
+        "close": 1.0, "volume": 1, "oi": 1,
+    }
+    dupe = frame_from([one_bar, dict(one_bar)])
+    with pytest.raises(engine.MarketDataValidationError, match="duplicate timestamps"):
+        engine.validate_options_frame(dupe, date(2025, 1, 6), date(2025, 1, 7), "ATM_CALL")
+
+    backwards = frame_from(
+        [
+            {"timestamp": "2025-01-06 09:16", "open": 1.0, "high": 1.0, "low": 1.0, "close": 1.0, "volume": 1, "oi": 1},
+            {"timestamp": "2025-01-06 09:15", "open": 1.0, "high": 1.0, "low": 1.0, "close": 1.0, "volume": 1, "oi": 1},
+        ]
+    )
+    with pytest.raises(engine.MarketDataValidationError, match="not ascending"):
+        engine.validate_options_frame(backwards, date(2025, 1, 6), date(2025, 1, 7), "ATM_CALL")
+
+
+def test_validation_rejects_impossible_candle_geometry_and_negatives():
+    inverted = frame_from(
+        [{"timestamp": "2025-01-06 09:15", "open": 5.0, "high": 1.0, "low": 9.0, "close": 5.0,
+          "volume": 1, "oi": 1}]
+    )
+    with pytest.raises(engine.MarketDataValidationError, match="high < low"):
+        engine.validate_options_frame(inverted, date(2025, 1, 6), date(2025, 1, 7), "ATM_CALL")
+
+    negative = frame_from(
+        [{"timestamp": "2025-01-06 09:15", "open": 1.0, "high": 1.0, "low": 1.0, "close": 1.0,
+          "volume": -5, "oi": 1}]
+    )
+    with pytest.raises(engine.MarketDataValidationError, match="negative volume"):
+        engine.validate_options_frame(negative, date(2025, 1, 6), date(2025, 1, 7), "ATM_CALL")
+
+
+def test_validation_says_nothing_about_an_empty_chunk():
+    engine.validate_options_frame(pd.DataFrame(), date(2025, 1, 6), date(2025, 1, 7), "ATM_CALL")
+
+
+# ---------------------------------------------------------------------------
+# Expiry labelling
+# ---------------------------------------------------------------------------
+
+
+def test_labelling_attaches_expiry_and_drops_what_it_cannot_label():
+    frame = frame_from(
+        [
+            {"timestamp": "2025-01-06 09:15", "open": 1.0, "high": 1.0, "low": 1.0, "close": 1.0,
+             "volume": 1, "oi": 1},
+            {"timestamp": "2025-01-20 09:15", "open": 1.0, "high": 1.0, "low": 1.0, "close": 1.0,
+             "volume": 1, "oi": 1},
+        ]
+    )
+    frame["expiry_date"] = pd.NA
+    frame["days_to_expiry"] = pd.NA
+
+    labelled = engine.label_with_expiry(frame, {date(2025, 1, 6): date(2025, 1, 9)})
+
+    # The 20-Jan bar has no mapping, and an unlabelled bar is worse than none.
+    assert len(labelled) == 1
+    assert labelled["expiry_date"].iloc[0] == "2025-01-09"
+    assert labelled["days_to_expiry"].iloc[0] == 3
+
+
+def test_labelling_leaves_an_empty_frame_alone():
+    assert engine.label_with_expiry(pd.DataFrame(), {}).empty
+
+
+# ---------------------------------------------------------------------------
+# Resumable writing
+# ---------------------------------------------------------------------------
+
+
+def written_frame(stamps: list[str]) -> pd.DataFrame:
+    """A frame shaped exactly like one the engine would write.
+
+    Built column-first so that an EMPTY stamps list still carries the full
+    column set. An empty frame with no columns at all is not something the
+    engine ever hands to `append_chunk`, so testing against one proves nothing.
+    """
+    frame = pd.DataFrame({name: [1.0] * len(stamps) for name in engine.OUTPUT_COLUMNS})
+    frame["timestamp"] = pd.to_datetime(pd.Series(stamps, dtype="object"))
+    return frame[list(engine.OUTPUT_COLUMNS)]
+
+
+def test_append_writes_one_header_and_then_only_new_rows(tmp_path):
+    target = tmp_path / "series.csv"
+
+    rows, size, newest = engine.append_chunk(
+        target, written_frame(["2025-01-06 09:15", "2025-01-06 09:16"]), last_timestamp=None
+    )
+    assert rows == 2 and size > 0 and newest == "2025-01-06 09:16:00"
+
+    rows, _size, newest = engine.append_chunk(
+        target, written_frame(["2025-01-06 09:16", "2025-01-06 09:17"]), last_timestamp=newest
+    )
+    # The overlapping boundary bar is dropped, not duplicated.
+    assert rows == 1 and newest == "2025-01-06 09:17:00"
+
+    text = target.read_text(encoding="utf-8")
+    assert text.count("timestamp,open") == 1
+    assert text.count("2025-01-06 09:16:00") == 1
+
+
+def test_append_of_an_empty_chunk_is_a_no_op(tmp_path):
+    target = tmp_path / "series.csv"
+    rows, size, newest = engine.append_chunk(target, written_frame([]), last_timestamp="2025-01-06 09:15:00")
+
+    assert (rows, size, newest) == (0, 0, "2025-01-06 09:15:00")
+    assert not target.exists()
+
+
+def test_truncate_discards_a_half_written_chunk(tmp_path):
+    target = tmp_path / "series.csv"
+    # Bytes, not text. On Windows a text-mode write turns each \n into \r\n, so
+    # a byte offset computed from the text would not match the file on disk --
+    # and byte offsets agreeing with the file is the entire point of truncation.
+    target.write_bytes(b"header\ngood\nPARTIAL")
+    good_length = len(b"header\ngood\n")
+
+    engine.truncate_to(target, good_length)
+
+    assert target.read_bytes() == b"header\ngood\n"
+
+
+def test_truncate_leaves_a_shorter_or_missing_file_alone(tmp_path):
+    target = tmp_path / "series.csv"
+    target.write_text("short", encoding="utf-8")
+    engine.truncate_to(target, 9999)
+    assert target.read_text(encoding="utf-8") == "short"
+
+    engine.truncate_to(tmp_path / "absent.csv", 10)  # must not raise
+
+
+def test_manifest_round_trips_and_treats_damage_as_start_over(tmp_path):
+    path = tmp_path / "_manifest.json"
+    assert engine.load_manifest(path) == {}
+
+    engine.save_manifest(path, {"ATM_CALL": {"rows": 5, "bytes": 120}})
+    assert engine.load_manifest(path)["ATM_CALL"]["rows"] == 5
+    assert json.loads(path.read_text(encoding="utf-8"))["ATM_CALL"]["bytes"] == 120
+
+    path.write_text("{ this is not json", encoding="utf-8")
+    assert engine.load_manifest(path) == {}
+
+
+# ---------------------------------------------------------------------------
+# Calendar plumbing and verification
+# ---------------------------------------------------------------------------
+
+
+def test_trading_days_are_read_out_of_the_downloaded_frames():
+    frame = written_frame(["2025-01-06 09:15", "2025-01-06 15:29", "2025-01-07 09:15"])
+    assert engine.trading_days_from_frames([frame]) == [date(2025, 1, 6), date(2025, 1, 7)]
+    assert engine.trading_days_from_frames([pd.DataFrame()]) == []
+
+
+def test_calendar_csv_round_trips(tmp_path):
+    days = [date(2025, 1, 6), date(2025, 1, 7), date(2025, 1, 9)]
+    expiry_map = dict.fromkeys(days, date(2025, 1, 9))
+    path = tmp_path / engine.CALENDAR_FILENAME
+
+    frame = engine.write_calendar_csv(path, days, expiry_map)
+    assert list(frame.columns) == list(engine.CALENDAR_COLUMNS)
+    assert frame["days_to_expiry"].tolist() == [3, 2, 0]
+    assert frame["trading_days_to_expiry"].tolist() == [2, 1, 0]
+
+    assert engine.read_calendar_csv(path) == expiry_map
+
+
+def test_reading_a_calendar_missing_its_columns_says_which(tmp_path):
+    path = tmp_path / "bad.csv"
+    path.write_text("trade_date\n2025-01-06\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="weekly_expiry_date"):
+        engine.read_calendar_csv(path)
+
+
+def test_verification_passes_when_the_straddle_collapses_on_expiry_day():
+    calls = written_frame(["2025-01-09 15:29"])
+    calls.loc[0, "close"] = 8.0
+    puts = written_frame(["2025-01-09 15:29"])
+    puts.loc[0, "close"] = 6.0
+
+    assert engine.verify_expiries(calls, puts, [date(2025, 1, 9)]) == []
+
+
+def test_verification_flags_a_day_that_still_carries_time_value():
+    # A calendar that is off by a day looks exactly like this.
+    calls = written_frame(["2025-01-08 15:29"])
+    calls.loc[0, "close"] = 90.0
+    puts = written_frame(["2025-01-08 15:29"])
+    puts.loc[0, "close"] = 85.0
+
+    complaints = engine.verify_expiries(calls, puts, [date(2025, 1, 8)])
+    assert len(complaints) == 1
+    assert "may not be an expiry day" in complaints[0]
+
+
+def test_verification_reports_a_derived_expiry_with_no_data_at_all():
+    calls = puts = written_frame(["2025-01-09 15:29"])
+    complaints = engine.verify_expiries(calls, puts, [date(2025, 1, 16)])
+    assert "has no ATM close" in complaints[0]
+
+    assert engine.verify_expiries(pd.DataFrame(), pd.DataFrame(), [date(2025, 1, 9)]) == [
+        "no ATM data available to verify expiries against"
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Credentials
+# ---------------------------------------------------------------------------
+
+
+def test_token_is_environment_only_and_never_a_command_line_flag(monkeypatch):
+    monkeypatch.setenv("DHAN_ACCESS_TOKEN", "env-only-token")
+    monkeypatch.delenv("DHAN_TOKEN_ID", raising=False)
+
+    assert engine.parse_args(DEFAULTS, ["--client-id", "C1"]).access_token == "env-only-token"
+
+    with pytest.raises(SystemExit):
+        engine.parse_args(DEFAULTS, ["--access-token", "cli-token"])
+
+
+def test_build_client_refuses_to_start_without_credentials(monkeypatch):
+    monkeypatch.delenv("DHAN_ACCESS_TOKEN", raising=False)
+    monkeypatch.delenv("DHAN_TOKEN_ID", raising=False)
+    args = engine.parse_args(DEFAULTS, ["--client-id", "C1"])
+
+    with pytest.raises(ValueError, match="Missing credentials"):
+        engine.build_client(args)
+
+
+# ---------------------------------------------------------------------------
+# Downloading one series, and resuming it
+# ---------------------------------------------------------------------------
+
+
+def one_day_client(close_by_day: dict[str, float]):
+    """A fake client that serves one bar at 09:15 for each day it is asked about."""
+
+    def fake(**kwargs):
+        start = date.fromisoformat(kwargs["from_date"])
+        end = date.fromisoformat(kwargs["to_date"])
+        stamps, closes = [], []
+        for day, close in close_by_day.items():
+            when = date.fromisoformat(day)
+            if start <= when < end:
+                stamps.append(epoch(f"{day} 09:15"))
+                closes.append(close)
+        if not stamps:
+            return {"status": "failure", "remarks": {"error_message": "No Data"}, "data": ""}
+        # Flat candles (o == h == l == c). Anything else here would trip the
+        # engine's own geometry check, which is the correct behaviour but not
+        # what these tests are about.
+        block = payload_for("ce", stamps, close=closes, open=closes, high=closes, low=closes)
+        return {"status": "success", "remarks": "", "data": {"data": block}}
+
+    return SimpleNamespace(expired_options_data=fake)
+
+
+EXPIRY_MAP = {
+    date(2025, 1, 6): date(2025, 1, 9),
+    date(2025, 1, 7): date(2025, 1, 9),
+    date(2025, 1, 8): date(2025, 1, 9),
+    date(2025, 1, 9): date(2025, 1, 9),
+}
+
+
+def test_download_series_writes_rows_and_records_its_progress(tmp_path):
+    client = one_day_client({"2025-01-06": 100.0, "2025-01-08": 120.0})
+    manifest: dict = {}
+    manifest_path = tmp_path / engine.MANIFEST_FILENAME
+    windows = [(date(2025, 1, 6), date(2025, 1, 8)), (date(2025, 1, 8), date(2025, 1, 10))]
+
+    rows = engine.download_series(
+        client, make_args(), DEFAULTS, tmp_path, "ATM", "CALL",
+        windows, EXPIRY_MAP, manifest, manifest_path, None,
+    )
+
+    assert rows == 2
+    written = pd.read_csv(tmp_path / "nifty_1m_WEEK_ATM_CALL.csv")
+    assert written["close"].tolist() == [100.0, 120.0]
+    assert written["expiry_date"].tolist() == ["2025-01-09", "2025-01-09"]
+    assert written["days_to_expiry"].tolist() == [3, 1]
+
+    # The manifest must survive on disk, not just in memory: it is what a
+    # restarted run reads.
+    assert engine.load_manifest(manifest_path)["ATM_CALL"]["rows"] == 2
+
+
+def test_download_series_resumes_without_refetching_finished_windows(tmp_path):
+    windows = [(date(2025, 1, 6), date(2025, 1, 8)), (date(2025, 1, 8), date(2025, 1, 10))]
+    calls: list = []
+
+    def counting_client(**kwargs):
+        calls.append(kwargs["from_date"])
+        return one_day_client({"2025-01-08": 120.0}).expired_options_data(**kwargs)
+
+    # First window already done, per the manifest.
+    csv_path = tmp_path / "nifty_1m_WEEK_ATM_CALL.csv"
+    header = ",".join(engine.OUTPUT_COLUMNS) + "\n"
+    first_row = "2025-01-06 09:15:00,1,1,1,100.0,1,1,1,21500,21500,ATM,CALL,2025-01-09,3\n"
+    csv_path.write_bytes((header + first_row).encode("utf-8"))
+    manifest = {
+        "ATM_CALL": {
+            "last_to_date": "2025-01-08",
+            "last_timestamp": "2025-01-06 09:15:00",
+            "bytes": csv_path.stat().st_size,
+            "rows": 1,
+        }
+    }
+
+    rows = engine.download_series(
+        SimpleNamespace(expired_options_data=counting_client),
+        make_args(), DEFAULTS, tmp_path, "ATM", "CALL",
+        windows, EXPIRY_MAP, manifest, tmp_path / engine.MANIFEST_FILENAME, None,
+    )
+
+    assert calls == ["2025-01-08"], "the finished window must not be requested again"
+    assert rows == 2, "the resumed count continues from the manifest, not from zero"
+    written = pd.read_csv(csv_path)
+    assert written["close"].tolist() == [100.0, 120.0]
+
+
+def test_download_series_discards_a_chunk_left_half_written_by_a_crash(tmp_path):
+    csv_path = tmp_path / "nifty_1m_WEEK_ATM_CALL.csv"
+    header = ",".join(engine.OUTPUT_COLUMNS) + "\n"
+    first_row = "2025-01-06 09:15:00,1,1,1,100.0,1,1,1,21500,21500,ATM,CALL,2025-01-09,3\n"
+    good_bytes = len((header + first_row).encode("utf-8"))
+    # Simulate the crash: bytes on disk that the manifest never acknowledged.
+    csv_path.write_bytes((header + first_row + "2025-01-07 09:15:00,1,1,1,GARB").encode("utf-8"))
+
+    manifest = {
+        "ATM_CALL": {
+            "last_to_date": "2025-01-08",
+            "last_timestamp": "2025-01-06 09:15:00",
+            "bytes": good_bytes,
+            "rows": 1,
+        }
+    }
+
+    engine.download_series(
+        one_day_client({"2025-01-08": 120.0}),
+        make_args(), DEFAULTS, tmp_path, "ATM", "CALL",
+        [(date(2025, 1, 8), date(2025, 1, 10))], EXPIRY_MAP, manifest,
+        tmp_path / engine.MANIFEST_FILENAME, None,
+    )
+
+    written = pd.read_csv(csv_path)
+    assert written["close"].tolist() == [100.0, 120.0], "the torn row must be gone"
+
+
+def test_no_resume_starts_the_series_from_scratch(tmp_path):
+    csv_path = tmp_path / "nifty_1m_WEEK_ATM_CALL.csv"
+    csv_path.write_bytes(b"stale contents that must not survive\n")
+    manifest = {"ATM_CALL": {"last_to_date": "2025-01-08", "last_timestamp": None, "bytes": 5, "rows": 99}}
+
+    rows = engine.download_series(
+        one_day_client({"2025-01-06": 100.0}),
+        make_args(no_resume=True), DEFAULTS, tmp_path, "ATM", "CALL",
+        [(date(2025, 1, 6), date(2025, 1, 8))], EXPIRY_MAP, manifest,
+        tmp_path / engine.MANIFEST_FILENAME, None,
+    )
+
+    assert rows == 1
+    assert "stale contents" not in csv_path.read_text(encoding="utf-8")
+
+
+def test_dry_run_prints_the_plan_and_makes_no_calls(tmp_path, capsys, monkeypatch):
+    monkeypatch.setenv("DHAN_ACCESS_TOKEN", "token")
+    monkeypatch.setattr(
+        engine, "build_client", lambda _a: pytest.fail("--dry-run must not build a client")
+    )
+
+    engine.run_expired_options_fetcher(
+        DEFAULTS,
+        [
+            "--client-id", "C1",
+            "--start-date", "2025-01-06", "--end-date", "2025-01-10",
+            "--strike-range", "1", "--output-dir", str(tmp_path), "--dry-run",
+        ],
+    )
+
+    printed = capsys.readouterr().out
+    assert "TOTAL API CALLS: 8" in printed
+    assert not list(tmp_path.iterdir()), "--dry-run must not write anything"
+
+
+def test_bad_arguments_stop_the_run_before_any_network_call(tmp_path, monkeypatch):
+    monkeypatch.setenv("DHAN_ACCESS_TOKEN", "token")
+    monkeypatch.setattr(engine, "build_client", lambda _a: pytest.fail("must not reach the client"))
+
+    with pytest.raises(ValueError, match="Invalid arguments"):
+        engine.run_expired_options_fetcher(
+            DEFAULTS,
+            ["--client-id", "C1", "--strike-range", "99", "--output-dir", str(tmp_path)],
+        )

--- a/Tests/Data Extractors/test_expired_options_fetch.py
+++ b/Tests/Data Extractors/test_expired_options_fetch.py
@@ -14,7 +14,7 @@ import importlib.util
 import itertools
 import json
 import sys
-from datetime import date
+from datetime import date, timedelta
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -77,20 +77,41 @@ def test_series_plan_pairs_every_label_with_every_option_type():
     assert ("ATM", "CALL") in plan and ("ATM+1", "PUT") in plan
 
 
-def test_chunk_ranges_cover_the_whole_span_without_gaps():
+def test_chunk_ranges_tile_the_span_inclusively_without_gaps_or_overlap():
     windows = engine.chunk_ranges(date(2025, 1, 1), date(2025, 3, 31), 29)
 
+    # Both ends inclusive: the API serves toDate, whatever the docs say.
     assert windows[0][0] == date(2025, 1, 1)
-    # toDate is non-inclusive, so the last window ends one day past the range.
-    assert windows[-1][1] == date(2025, 4, 1)
+    assert windows[-1][1] == date(2025, 3, 31)
     for earlier, later in itertools.pairwise(windows):
-        assert earlier[1] == later[0], "windows must abut exactly"
-    assert all((end - start).days <= 29 for start, end in windows)
+        assert later[0] == earlier[1] + timedelta(days=1), "windows must abut, not overlap"
+    # An inclusive 29-day window spans 29 days, a day under Dhan's 30-day cap.
+    assert all((end - start).days + 1 <= 29 for start, end in windows)
+
+
+def test_chunk_ranges_do_not_overlap_on_a_trading_day():
+    """The bug this pins cost a live run.
+
+    Half-open windows made chunk N end on the same date chunk N+1 began. Because
+    toDate is inclusive, that boundary day came back in BOTH chunks, and the
+    trailing bars tripped the out-of-window guard:
+
+        ATM_CALL: 375 candle(s) outside the requested window
+        2025-01-06 -> 2025-01-17, first 2025-01-17 09:15:00
+
+    A five-day smoke run missed it only because its boundary fell on a Saturday.
+    """
+    windows = engine.chunk_ranges(date(2025, 1, 6), date(2025, 2, 28), 10)
+    covered = [d for start, end in windows for d in pd.date_range(start, end).date]
+
+    assert len(covered) == len(set(covered)), "no date may appear in two windows"
+    assert covered == sorted(covered)
+    assert covered[0] == date(2025, 1, 6) and covered[-1] == date(2025, 2, 28)
 
 
 def test_chunk_ranges_handles_a_single_day():
     assert engine.chunk_ranges(date(2025, 1, 6), date(2025, 1, 6), 29) == [
-        (date(2025, 1, 6), date(2025, 1, 7))
+        (date(2025, 1, 6), date(2025, 1, 6))
     ]
 
 
@@ -754,3 +775,58 @@ def test_bad_arguments_stop_the_run_before_any_network_call(tmp_path, monkeypatc
             DEFAULTS,
             ["--client-id", "C1", "--strike-range", "99", "--output-dir", str(tmp_path)],
         )
+
+
+# ---------------------------------------------------------------------------
+# The unlabelled tail
+# ---------------------------------------------------------------------------
+
+
+def test_sessions_after_the_last_expiry_are_reported_not_silently_dropped():
+    # The live smoke run ended on Friday 10-Jan-2025, one day past the Thursday
+    # expiry. All 375 of that Friday's bars were correctly discarded -- and said
+    # nothing about it, which is silent data loss. A 5-year backfill ending
+    # today loses the whole current part-week the same way.
+    trading_days = [date(2025, 1, 6), date(2025, 1, 7), date(2025, 1, 8), date(2025, 1, 9), date(2025, 1, 10)]
+    expiry_map = dict.fromkeys(trading_days[:4], date(2025, 1, 9))
+
+    message = engine.warn_about_unlabelled_tail(trading_days, expiry_map, date(2025, 1, 10))
+
+    assert message is not None
+    assert "1 session(s)" in message
+    assert "2025-01-10" in message
+    assert "--end-date" in message, "the message must say how to keep those bars"
+
+
+def test_a_range_ending_on_an_expiry_reports_nothing():
+    trading_days = [date(2025, 1, 6), date(2025, 1, 7), date(2025, 1, 8), date(2025, 1, 9)]
+    expiry_map = dict.fromkeys(trading_days, date(2025, 1, 9))
+
+    assert engine.warn_about_unlabelled_tail(trading_days, expiry_map, date(2025, 1, 9)) is None
+
+
+def test_atm_is_repicked_every_bar_so_one_file_holds_many_contracts():
+    """Measured against the live API, and the reason strike_price is mandatory.
+
+    On 06-Jan-2025 the ATM call series switched strike 69 times inside the one
+    session. This pins the shape that makes that survivable: the actual strike
+    travels on every row, so a re-key can recover real contracts.
+    """
+    stamps = [epoch("2025-01-06 09:15"), epoch("2025-01-06 09:16"), epoch("2025-01-06 09:17")]
+    payload = payload_for(
+        "ce", stamps,
+        close=[139.05, 158.0, 134.15],
+        open=[139.05, 158.0, 134.15],
+        high=[139.05, 158.0, 134.15],
+        low=[139.05, 158.0, 134.15],
+        strike=[24050.0, 24000.0, 24050.0],
+        spot=[24039.65, 24019.0, 24034.05],
+    )
+
+    frame = engine.normalize_rolling_payload(payload, "CALL", "ATM")
+
+    assert frame["strike_price"].tolist() == [24050.0, 24000.0, 24050.0]
+    assert frame["strike_price"].nunique() == 2, "one label, two contracts, three minutes"
+    # And each is genuinely the nearest 50 to spot.
+    for strike, spot in zip(frame["strike_price"], frame["spot"], strict=True):
+        assert abs(strike - spot) <= 25.0

--- a/Tests/Data Extractors/test_expired_options_fetch.py
+++ b/Tests/Data Extractors/test_expired_options_fetch.py
@@ -987,3 +987,147 @@ def test_verification_skips_an_expiry_with_nothing_before_it():
 
     # No prior session in the data to compare against, so no verdict is possible.
     assert engine.verify_expiries(calls, puts, [date(2025, 1, 9)]) == []
+
+
+# ---------------------------------------------------------------------------
+# Resume safety: a manifest only resumes the run it came from
+# ---------------------------------------------------------------------------
+
+
+def test_a_manifest_from_a_narrower_later_run_is_discarded():
+    """The documented smoke test, then the backfill, used to lose four years.
+
+    A January-2025 smoke run leaves last_to_date=2025-01-10. The five-year
+    backfill then skips every window ending on or before that, and the writer
+    only appends after last_timestamp -- so 2021-2024 is never fetched and the
+    command reports success over a dataset missing most of its history.
+    """
+    smoke = engine.run_signature(make_args(), date(2025, 1, 6), date(2025, 1, 10))
+    manifest = {engine.RUN_SIGNATURE_KEY: smoke, "ATM_CALL": {"last_to_date": "2025-01-10", "rows": 1500}}
+
+    backfill = engine.run_signature(make_args(), date(2021, 9, 6), date(2026, 9, 1))
+    kept, reason = engine.resumable_manifest(manifest, backfill)
+
+    assert kept == {}, "stored progress must not be reused across a different range"
+    assert reason is not None and "start" in reason
+
+
+def test_a_manifest_resumes_when_the_run_only_extends_forward():
+    signature = engine.run_signature(make_args(), date(2021, 9, 6), date(2026, 1, 1))
+    manifest = {engine.RUN_SIGNATURE_KEY: signature, "ATM_CALL": {"rows": 10}}
+
+    # Same start, later end -- the normal "carry on where I stopped" case.
+    later = engine.run_signature(make_args(), date(2021, 9, 6), date(2026, 9, 1))
+    kept, reason = engine.resumable_manifest(manifest, later)
+
+    assert reason is None
+    assert kept["ATM_CALL"]["rows"] == 10
+
+
+def test_a_manifest_is_discarded_when_the_contract_identity_changes():
+    base = engine.run_signature(make_args(), date(2021, 9, 6), date(2026, 9, 1))
+    manifest = {engine.RUN_SIGNATURE_KEY: base, "ATM_CALL": {"rows": 10}}
+
+    # Same dates, different contracts: those rows mean something else entirely.
+    other = engine.run_signature(make_args(expiry_code=2), date(2021, 9, 6), date(2026, 9, 1))
+    kept, reason = engine.resumable_manifest(manifest, other)
+
+    assert kept == {}
+    assert reason is not None and "expiry_code" in reason
+
+
+def test_a_manifest_without_a_signature_is_discarded():
+    kept, reason = engine.resumable_manifest(
+        {"ATM_CALL": {"rows": 10}}, engine.run_signature(make_args(), date(2021, 9, 6), date(2026, 9, 1))
+    )
+    assert kept == {}
+    assert reason is not None and "predates" in reason
+
+
+def test_an_empty_manifest_is_not_reported_as_discarded():
+    kept, reason = engine.resumable_manifest({}, engine.run_signature(make_args(), date(2025, 1, 6), date(2025, 1, 10)))
+    assert (kept, reason) == ({}, None)
+
+
+def test_strike_range_and_option_types_do_not_invalidate_progress():
+    """Widening the strike band only ADDS series; each new one starts fresh."""
+    narrow = engine.run_signature(make_args(strike_range=1), date(2021, 9, 6), date(2026, 9, 1))
+    wide = engine.run_signature(
+        make_args(strike_range=10, option_types="CALL"), date(2021, 9, 6), date(2026, 9, 1)
+    )
+    assert narrow == wide
+
+
+# ---------------------------------------------------------------------------
+# A stale CSV with no resume state
+# ---------------------------------------------------------------------------
+
+
+def test_a_stale_csv_is_discarded_when_the_manifest_is_gone(tmp_path):
+    """A lost or damaged manifest used to duplicate every existing candle.
+
+    `load_manifest` documents damage as "start over", but download_series kept
+    the CSV and appended with no last_timestamp to de-duplicate against.
+    """
+    csv_path = tmp_path / "nifty_1m_WEEK_ATM_CALL.csv"
+    header = ",".join(engine.OUTPUT_COLUMNS) + "\n"
+    row = "2025-01-06 09:15:00,1,1,1,100.0,1,1,1,21500,21500,ATM,CALL,2025-01-09,3\n"
+    csv_path.write_bytes((header + row).encode("utf-8"))
+
+    engine.download_series(
+        one_day_client({"2025-01-06": 100.0}),
+        make_args(), DEFAULTS, tmp_path, "ATM", "CALL",
+        [(date(2025, 1, 6), date(2025, 1, 7))], EXPIRY_MAP, {},  # empty manifest
+        tmp_path / engine.MANIFEST_FILENAME, None,
+    )
+
+    written = pd.read_csv(csv_path)
+    assert len(written) == 1, "the orphaned row must be discarded, not duplicated"
+    assert written["timestamp"].tolist() == ["2025-01-06 09:15:00"]
+
+
+# ---------------------------------------------------------------------------
+# Labelling must match the contracts actually downloaded
+# ---------------------------------------------------------------------------
+
+
+def test_month_expiries_are_refused_rather_than_labelled_from_the_weekly_calendar():
+    """Monthly bars carrying weekly expiry dates would be silently wrong."""
+    problems = engine.validate_args(make_args(expiry_flag="MONTH", calendar_csv=""))
+
+    assert any("MONTH" in p for p in problems), problems
+    assert any("--calendar-csv" in p for p in problems), problems
+
+
+def test_month_expiries_are_allowed_with_an_operator_supplied_calendar():
+    assert engine.validate_args(make_args(expiry_flag="MONTH", calendar_csv="cal.csv")) == []
+
+
+# ---------------------------------------------------------------------------
+# Verification reads what was actually written
+# ---------------------------------------------------------------------------
+
+
+def test_verification_reads_the_atm_files_that_were_written(tmp_path):
+    """With --calendar-csv there is no pre-pass, so verification used to check
+    nothing at all and report "no ATM data available"."""
+    args = make_args()
+    for option_type, close in (("CALL", 7.0), ("PUT", 6.0)):
+        frame = written_frame(["2025-01-08 15:29", "2025-01-09 15:29"])
+        frame.loc[0, "close"] = 60.0
+        frame.loc[1, "close"] = close
+        frame.to_csv(engine.series_csv_path(tmp_path, DEFAULTS, args, "ATM", option_type), index=False)
+
+    calls, puts = engine.read_atm_series(tmp_path, DEFAULTS, args)
+
+    assert not calls.empty and not puts.empty
+    assert engine.verify_expiries(calls, puts, [date(2025, 1, 9)]) == []
+
+
+def test_verification_says_so_when_the_atm_files_are_absent(tmp_path):
+    calls, puts = engine.read_atm_series(tmp_path, DEFAULTS, make_args())
+
+    assert calls.empty and puts.empty
+    assert engine.verify_expiries(calls, puts, [date(2025, 1, 9)]) == [
+        "no ATM data available to verify expiries against"
+    ]

--- a/Tests/Data Extractors/test_expiry_calendar.py
+++ b/Tests/Data Extractors/test_expiry_calendar.py
@@ -1,0 +1,157 @@
+"""Tests for the derived NIFTY weekly expiry calendar.
+
+The API this feeds returns no expiry date, so the whole positional use case
+rests on this derivation being right. These tests pin the two things that can
+realistically go wrong: the holiday roll-back, and the 01-Sep-2025 change of
+expiry weekday.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+
+import pytest
+
+# Tests/Data Extractors/<this file> -> the repository root is two levels up.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = _REPO_ROOT / "Data Extractors" / "expiry_calendar.py"
+spec = importlib.util.spec_from_file_location("expiry_calendar", MODULE_PATH)
+calendar = importlib.util.module_from_spec(spec)
+sys.modules["expiry_calendar"] = calendar
+spec.loader.exec_module(calendar)
+
+
+def weekdays(start: date, days: int, holidays: set[date] | None = None) -> list[date]:
+    """Mon-Fri sessions from `start`, minus any holidays given."""
+    skip = holidays or set()
+    out = []
+    for offset in range(days):
+        day = start + timedelta(days=offset)
+        if day.weekday() < 5 and day not in skip:
+            out.append(day)
+    return out
+
+
+def test_nominal_weekday_is_thursday_before_the_rule_change():
+    assert calendar.nominal_expiry_weekday(date(2023, 6, 14)) == 3
+    assert calendar.nominal_expiry_weekday(date(2025, 8, 31)) == 3
+
+
+def test_nominal_weekday_is_tuesday_from_01_sep_2025():
+    # NSE moved NIFTY weeklies off Thursday effective 01-Sep-2025.
+    assert calendar.nominal_expiry_weekday(date(2025, 9, 1)) == 1
+    assert calendar.nominal_expiry_weekday(date(2026, 3, 2)) == 1
+
+
+def test_nominal_weekday_rejects_a_date_before_every_rule():
+    with pytest.raises(calendar.ExpiryCalendarError, match="no expiry weekday rule"):
+        calendar.nominal_expiry_weekday(date(1990, 1, 1), rules=[(date(2000, 1, 1), 3)])
+
+
+def test_nominal_weekday_rejects_an_empty_rule_table():
+    with pytest.raises(calendar.ExpiryCalendarError, match="rule table is empty"):
+        calendar.nominal_expiry_weekday(date(2025, 1, 1), rules=[])
+
+
+def test_expiries_land_on_thursdays_in_the_thursday_era():
+    days = weekdays(date(2025, 1, 1), 60)
+    expiries = calendar.weekly_expiry_dates(days)
+
+    assert expiries, "expected at least one expiry"
+    assert all(e.weekday() == 3 for e in expiries), [str(e) for e in expiries]
+
+
+def test_a_holiday_on_the_nominal_day_rolls_the_expiry_back_one_session():
+    # 2025-01-16 is a Thursday; knock it out and the expiry must move to the
+    # Wednesday, not forward to the Friday.
+    days = weekdays(date(2025, 1, 1), 60, holidays={date(2025, 1, 16)})
+    expiries = calendar.weekly_expiry_dates(days)
+
+    assert date(2025, 1, 15) in expiries
+    assert date(2025, 1, 16) not in expiries
+    assert date(2025, 1, 17) not in expiries
+
+
+def test_a_run_of_holidays_rolls_back_across_the_week_boundary():
+    # Wipe out Mon-Thu of one week entirely. The roll-back must keep walking
+    # backwards into the previous week rather than give up or skip forward.
+    dead = {date(2025, 1, 13), date(2025, 1, 14), date(2025, 1, 15), date(2025, 1, 16)}
+    days = weekdays(date(2025, 1, 1), 60, holidays=dead)
+    expiries = calendar.weekly_expiry_dates(days)
+
+    assert date(2025, 1, 10) in expiries  # the previous Friday
+    assert not (dead & set(expiries))
+
+
+def test_the_thursday_to_tuesday_transition_is_reproduced_exactly():
+    days = weekdays(date(2025, 8, 11), 42)
+    expiries = calendar.weekly_expiry_dates(days)
+
+    # Last Thursday expiry, then straight to Tuesdays.
+    assert date(2025, 8, 28) in expiries
+    assert date(2025, 9, 2) in expiries
+    assert date(2025, 9, 9) in expiries
+    before = [e for e in expiries if e < date(2025, 9, 1)]
+    after = [e for e in expiries if e >= date(2025, 9, 1)]
+    assert all(e.weekday() == 3 for e in before), [str(e) for e in before]
+    assert all(e.weekday() == 1 for e in after), [str(e) for e in after]
+
+
+def test_an_unfinished_week_gets_no_invented_expiry():
+    # Data stops on Monday 2025-01-06. That week's Thursday has not happened,
+    # so labelling those bars with an expiry would be a fabrication.
+    days = weekdays(date(2025, 1, 1), 6)
+    expiries = calendar.weekly_expiry_dates(days)
+
+    assert date(2025, 1, 2) in expiries
+    assert max(expiries) == date(2025, 1, 2)
+
+
+def test_no_trading_days_yields_no_expiries():
+    assert calendar.weekly_expiry_dates([]) == []
+    assert calendar.build_expiry_map([]) == {}
+
+
+def test_expiry_map_points_expiry_day_at_itself():
+    days = weekdays(date(2025, 1, 1), 30)
+    mapping = calendar.build_expiry_map(days)
+
+    assert mapping[date(2025, 1, 9)] == date(2025, 1, 9)
+    assert mapping[date(2025, 1, 6)] == date(2025, 1, 9)
+    assert mapping[date(2025, 1, 10)] == date(2025, 1, 16)
+
+
+def test_expiry_map_omits_days_past_the_last_derived_expiry():
+    days = weekdays(date(2025, 1, 1), 10)
+    mapping = calendar.build_expiry_map(days)
+    last_expiry = max(calendar.weekly_expiry_dates(days))
+
+    assert all(day <= last_expiry for day in mapping)
+    assert any(day > last_expiry for day in days), "test needs a day past the last expiry"
+
+
+def test_trading_days_to_expiry_counts_sessions_not_calendar_days():
+    days = weekdays(date(2025, 1, 1), 30)
+
+    # Thu 09-Jan expiry, seen from Fri 03-Jan: Mon/Tue/Wed/Thu = 4 sessions,
+    # while the calendar gap is 6 days.
+    assert calendar.trading_days_to_expiry(days, date(2025, 1, 3), date(2025, 1, 9)) == 4
+    assert (date(2025, 1, 9) - date(2025, 1, 3)).days == 6
+    # Expiry day itself has nothing left.
+    assert calendar.trading_days_to_expiry(days, date(2025, 1, 9), date(2025, 1, 9)) == 0
+
+
+def test_trading_days_to_expiry_rejects_an_expiry_in_the_past():
+    days = weekdays(date(2025, 1, 1), 30)
+    with pytest.raises(calendar.ExpiryCalendarError, match="precedes trade date"):
+        calendar.trading_days_to_expiry(days, date(2025, 1, 9), date(2025, 1, 2))
+
+
+def test_a_custom_rule_table_overrides_the_shipped_one():
+    days = weekdays(date(2025, 1, 1), 30)
+    fridays = calendar.weekly_expiry_dates(days, rules=[(date(2000, 1, 1), 4)])
+
+    assert all(e.weekday() == 4 for e in fridays), [str(e) for e in fridays]

--- a/Tests/Data Extractors/test_expiry_calendar.py
+++ b/Tests/Data Extractors/test_expiry_calendar.py
@@ -155,3 +155,58 @@ def test_a_custom_rule_table_overrides_the_shipped_one():
     fridays = calendar.weekly_expiry_dates(days, rules=[(date(2000, 1, 1), 4)])
 
     assert all(e.weekday() == 4 for e in fridays), [str(e) for e in fridays]
+
+
+# ---------------------------------------------------------------------------
+# Special (Muhurat) sessions
+# ---------------------------------------------------------------------------
+
+
+def test_a_muhurat_session_cannot_be_an_expiry():
+    """The real 2025 Diwali week, which the first full backfill got wrong.
+
+    Tuesday 21-Oct-2025 was Diwali: a ~1 hour Muhurat session, so NSE moved that
+    week's expiry back to Monday the 20th. Treating it as an ordinary trading
+    day put the expiry on the 21st and mislabelled the whole week.
+    """
+    week = [date(2025, 10, 16), date(2025, 10, 17), date(2025, 10, 20), date(2025, 10, 21)]
+    full = [d for d in week if d != date(2025, 10, 21)]
+
+    naive = calendar.weekly_expiry_dates(week)
+    fixed = calendar.weekly_expiry_dates(week, full_sessions=full)
+
+    assert date(2025, 10, 21) in naive, "this is the bug being pinned"
+    assert date(2025, 10, 21) not in fixed
+    assert date(2025, 10, 20) in fixed
+
+
+def test_the_2021_diwali_week_lands_on_the_wednesday():
+    # Thursday 04-Nov-2021 was Diwali; the expiry was Wednesday the 3rd.
+    week = [date(2021, 11, 1), date(2021, 11, 2), date(2021, 11, 3), date(2021, 11, 4)]
+    full = [d for d in week if d != date(2021, 11, 4)]
+
+    assert date(2021, 11, 3) in calendar.weekly_expiry_dates(week, full_sessions=full)
+    assert date(2021, 11, 4) not in calendar.weekly_expiry_dates(week, full_sessions=full)
+
+
+def test_a_muhurat_session_is_still_a_trading_day_with_an_expiry_ahead():
+    """It cannot HOST an expiry, but its bars still deserve a label."""
+    days = [date(2025, 10, 16), date(2025, 10, 17), date(2025, 10, 20), date(2025, 10, 21),
+            date(2025, 10, 23), date(2025, 10, 24), date(2025, 10, 27), date(2025, 10, 28)]
+    full = [d for d in days if d != date(2025, 10, 21)]
+
+    mapping = calendar.build_expiry_map(days, full_sessions=full)
+
+    assert mapping[date(2025, 10, 20)] == date(2025, 10, 20), "Monday hosts the expiry"
+    # The Muhurat session belongs to the NEXT weekly expiry, not the past one.
+    assert mapping[date(2025, 10, 21)] == date(2025, 10, 28)
+
+
+def test_full_sessions_defaults_to_every_trading_day():
+    days = [date(2025, 1, 6), date(2025, 1, 7), date(2025, 1, 8), date(2025, 1, 9)]
+    assert calendar.weekly_expiry_dates(days) == calendar.weekly_expiry_dates(days, full_sessions=days)
+
+
+def test_no_eligible_sessions_yields_no_expiries():
+    days = [date(2025, 1, 6), date(2025, 1, 9)]
+    assert calendar.weekly_expiry_dates(days, full_sessions=[]) == []

--- a/Tests/Data Extractors/test_expiry_calendar.py
+++ b/Tests/Data Extractors/test_expiry_calendar.py
@@ -210,3 +210,48 @@ def test_full_sessions_defaults_to_every_trading_day():
 def test_no_eligible_sessions_yields_no_expiries():
     days = [date(2025, 1, 6), date(2025, 1, 9)]
     assert calendar.weekly_expiry_dates(days, full_sessions=[]) == []
+
+
+# ---------------------------------------------------------------------------
+# expiry_index: the label must match the contract that was downloaded
+# ---------------------------------------------------------------------------
+
+
+def test_expiry_index_two_labels_the_next_expiry_not_the_near_one():
+    """`--expiry-code 2` downloads next-week contracts.
+
+    Labelling those with the near expiry puts every days_to_expiry a full week
+    short, which for a positional backtest is not a rounding error -- it is the
+    wrong contract.
+    """
+    days = weekdays(date(2025, 1, 1), 30)
+
+    near = calendar.build_expiry_map(days)
+    following = calendar.build_expiry_map(days, expiry_index=2)
+
+    assert near[date(2025, 1, 6)] == date(2025, 1, 9)
+    assert following[date(2025, 1, 6)] == date(2025, 1, 16)
+    assert (following[date(2025, 1, 6)] - near[date(2025, 1, 6)]).days == 7
+
+
+def test_expiry_index_defaults_to_the_near_expiry():
+    days = weekdays(date(2025, 1, 1), 30)
+    assert calendar.build_expiry_map(days) == calendar.build_expiry_map(days, expiry_index=1)
+
+
+def test_expiry_index_drops_days_whose_nth_expiry_is_not_in_the_data():
+    days = weekdays(date(2025, 1, 1), 30)
+
+    near = calendar.build_expiry_map(days, expiry_index=1)
+    far = calendar.build_expiry_map(days, expiry_index=3)
+
+    # Every day needs three expiries ahead of it now, so the tail falls away
+    # rather than being labelled with an expiry that is not in the range.
+    assert len(far) < len(near)
+    assert max(far) < max(near)
+
+
+def test_expiry_index_must_be_one_based():
+    days = weekdays(date(2025, 1, 1), 30)
+    with pytest.raises(calendar.ExpiryCalendarError, match="1-based"):
+        calendar.build_expiry_map(days, expiry_index=0)

--- a/Tests/Data Extractors/test_index_fetch_construction.py
+++ b/Tests/Data Extractors/test_index_fetch_construction.py
@@ -10,6 +10,8 @@ without touching the network.
 from __future__ import annotations
 
 import importlib.util
+import os
+import subprocess  # nosec B404 - launching the wrapper as a script IS what this test asserts
 import sys
 from datetime import date, datetime
 from pathlib import Path
@@ -66,7 +68,11 @@ def test_access_token_is_environment_only_never_a_cli_flag(monkeypatch):
         security_id="13",
         default_output="out.csv",
     )
-    monkeypatch.setenv("DHAN_TOKEN_ID", "env-only-token")
+    # Hermetic: the engine now load_dotenv()s Dependencies/.env at import, so
+    # every key this assertion depends on is pinned here. Leaving one unset
+    # would let a real token decide the result -- and print it on failure.
+    monkeypatch.setenv("DHAN_ACCESS_TOKEN", "env-only-token")
+    monkeypatch.delenv("DHAN_TOKEN_ID", raising=False)
     monkeypatch.setattr(sys, "argv", ["fetcher"])
 
     args = fetcher.parse_args(defaults)
@@ -143,3 +149,64 @@ def test_atomic_csv_replace_commits_complete_file(tmp_path):
     fetcher.atomic_write_csv(pd.DataFrame({"close": [101.0]}), target)
 
     assert "101.0" in target.read_text(encoding="utf-8")
+
+
+def test_wrapper_runs_as_a_script_the_way_algo_py_launches_it():
+    """`algo.py fetch-data` runs the wrapper as a script, not as an import.
+
+    Python then puts the SCRIPT's folder on sys.path -- not the repository root,
+    and not the cwd algo.py sets -- so the engine's `from Dependencies....`
+    import used to die with ModuleNotFoundError before argparse ever ran. This
+    test reproduces that exact launch and asserts the module imports.
+
+    `--help` exits 0 without credentials or network, which is enough: the old
+    failure happened at import time, well before argument parsing.
+    """
+    wrapper = _REPO_ROOT / "Data Extractors" / "nifty_1m_5y_data_fetch_dhan.py"
+
+    # Strip PYTHONPATH so a developer's own path setup cannot mask the bug, and
+    # clear the credential keys so nothing here depends on a populated .env.
+    env = {k: v for k, v in os.environ.items() if k != "PYTHONPATH"}
+    env.pop("DHAN_CLIENT_CODE", None)
+    env.pop("DHAN_ACCESS_TOKEN", None)
+    env.pop("DHAN_TOKEN_ID", None)
+
+    # nosec B603 - argv is [sys.executable, <a path built from __file__>, "--help"];
+    # nothing here comes from user input, and no shell is involved.
+    completed = subprocess.run(  # nosec B603
+        [sys.executable, str(wrapper), "--help"],
+        cwd=str(_REPO_ROOT),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+
+    assert "ModuleNotFoundError" not in completed.stderr, completed.stderr
+    assert completed.returncode == 0, completed.stderr
+    assert "--lookback" in completed.stdout
+
+
+def test_token_is_read_from_dhan_access_token_with_legacy_fallback(monkeypatch):
+    """DHAN_ACCESS_TOKEN is the repo-wide key and must win.
+
+    The engine used to read DHAN_TOKEN_ID only -- a name documented nowhere and
+    present in no .env -- so credentials could never load. DHAN_TOKEN_ID stays
+    accepted so an operator who exported the old name is not broken.
+    """
+    defaults = fetcher.IndexFetchDefaults(
+        display_name="NIFTY", security_id="13", default_output="out.csv"
+    )
+    monkeypatch.setattr(sys, "argv", ["prog"])
+    monkeypatch.setenv("DHAN_CLIENT_CODE", "CLIENT123")
+
+    monkeypatch.setenv("DHAN_ACCESS_TOKEN", "primary-token")
+    monkeypatch.setenv("DHAN_TOKEN_ID", "legacy-token")
+    assert fetcher.parse_args(defaults).access_token == "primary-token"
+
+    monkeypatch.delenv("DHAN_ACCESS_TOKEN")
+    assert fetcher.parse_args(defaults).access_token == "legacy-token"
+
+    monkeypatch.delenv("DHAN_TOKEN_ID")
+    assert fetcher.parse_args(defaults).access_token == ""

--- a/algo.py
+++ b/algo.py
@@ -87,6 +87,14 @@ INDEX_SCRIPTS = {
     "finnifty": "Data Extractors/finnifty_1m_5y_data_fetch_dhan.py",
 }
 
+# `fetch-expired-options --index <key>`
+# Separate from INDEX_SCRIPTS on purpose: these download expired OPTION
+# contracts (premium, OI, IV) rather than the index itself, and they take a
+# different flag set.
+EXPIRED_OPTIONS_SCRIPTS = {
+    "nifty": "Data Extractors/nifty_expired_options_fetch_dhan.py",
+}
+
 # `backtest --strategy <key>`
 BACKTEST_SCRIPTS = {
     "renko": "My Backtest Files (For Reference)/renko_strategy_backtest.py",
@@ -157,6 +165,17 @@ def build_parser() -> argparse.ArgumentParser:
              "--start-date, --end-date, --output, ...) pass through to the fetcher.",
     )
 
+    fetch_options = sub.add_parser(
+        "fetch-expired-options",
+        help="Download expired index-option history (premium, OI, IV) from DhanHQ.",
+    )
+    fetch_options.add_argument(
+        "--index", required=True, choices=sorted(EXPIRED_OPTIONS_SCRIPTS),
+        help="Which underlying to download. All other flags (--strike-range, "
+             "--expiry-flag, --lookback, --dry-run, --verify-expiries, ...) pass "
+             "through to the fetcher.",
+    )
+
     backtest = sub.add_parser(
         "backtest",
         help="Run one strategy's backtest against a historical-data CSV.",
@@ -216,6 +235,8 @@ def main(argv=None) -> int:
 
     if args.command == "fetch-data":
         return _run(INDEX_SCRIPTS[args.index], forwarded)
+    if args.command == "fetch-expired-options":
+        return _run(EXPIRED_OPTIONS_SCRIPTS[args.index], forwarded)
     if args.command == "backtest":
         return _run(BACKTEST_SCRIPTS[args.strategy], forwarded)
     if args.command == "run":

--- a/docs/README.md
+++ b/docs/README.md
@@ -59,6 +59,7 @@ component folder's own `Readme.md`.
 | [0012](adr/0012-crash-durable-session-state.md) | Per-trade P&L and open positions persisted during the session |
 | [0013](adr/0013-codeql-false-positive-triage.md) | Five CodeQL alerts dismissed as false positives, not patched |
 | [0014](adr/0014-tiered-rename-of-spaced-filenames.md) | Spaced filenames renamed in reviewable tiers, master last (supersedes 0009) |
+| [0015](adr/0015-rolling-relative-strike-expired-options.md) | Expired-options history kept in rolling relative-strike form, expiry date derived |
 
 ## Keeping these documents honest
 

--- a/docs/adr/0015-rolling-relative-strike-expired-options.md
+++ b/docs/adr/0015-rolling-relative-strike-expired-options.md
@@ -36,6 +36,39 @@ next. Dhan's annexure documents `0 = current expiry`, but that table describes
 `/charts/historical`; this endpoint reads a zero as a missing field. Following
 the annexure would have produced a run that failed on every single call.
 
+### What the smoke run established
+
+A live 8-call run over 06–10 Jan 2025 settled the rest, and corrected the
+documentation on one point that had already produced a bug:
+
+| Question | Answer |
+|---|---|
+| `securityId` | **13** with `NSE_FNO` + `OPTIDX` — the index-side ID, not the `26000` in the instrument master. |
+| Response envelope | Doubled: `resp["data"]["data"]["ce"]`. |
+| `toDate` | **Inclusive**, *not* "non-inclusive" as documented. 06→08 Jan returns three sessions ending on the 8th. |
+| ATM cadence | Re-picked **every bar**, not daily (see below). |
+| Field coverage | All nine fields fully populated — 1500/1500 rows for volume, OI and IV. |
+
+The `toDate` correction was not cosmetic. Half-open chunk windows made adjacent
+chunks overlap by a day, and the trailing bars then tripped the out-of-window
+guard: `375 candle(s) outside the requested window 2025-01-06 -> 2025-01-17`.
+The five-day smoke run had passed only because its boundary landed on a
+Saturday. Windows now tile the range inclusively, with no overlap and no gap.
+
+Two further observations, both upstream characteristics rather than defects:
+
+- **Deep-OTM options really do print at the 0.05 tick floor** — the ATM call
+  closed at exactly 0.05 on expiry day. This is the concrete reason
+  `validate_ohlc_frame`, which rejects non-positive prices, is unsuitable.
+- **Session length is not always 375 bars.** 20-Jan-2025 carries a 15:30 print
+  on top of the usual 09:15–15:29, giving 376. A rule that assumes "the last bar
+  is 15:29" will be wrong on such days.
+
+The expiry derivation checks out against the prices: the ATM straddle's closing
+value across that week ran 377.75 → 233.15 → 136.75 → **23.50** on the derived
+expiry (Thursday 09-Jan), a wide margin either side of the 40-point ceiling
+`--verify-expiries` uses.
+
 ## Decision
 
 ### 1. Store the data in the rolling, relative-strike form the API returns
@@ -45,12 +78,19 @@ a contract. There is no security ID for an expired contract, and
 `Dependencies/all_instrument *.csv` holds only live ones, so there is nothing to
 map to. We keep the API's own shape: one CSV per `(strike label, option type)`.
 
-The cost is that a rolling label **is not a tradeable instrument** — `ATM+3 CE`
-on Monday and on Wednesday are different contracts if spot moved. We therefore
-always request the `strike` field and write it as `strike_price`, alongside
-`spot`. Re-keying on `(expiry_date, strike_price, option_type)` reconstructs
-fixed contracts; `strike_label` and `option_type` are written on every row,
-redundantly, so that reconstruction is a concat plus a groupby.
+The cost is that a rolling label **is not a tradeable instrument**, and the
+smoke run showed the churn is much faster than "day to day" — it is **minute to
+minute**. On 06-Jan-2025 the `ATM` call series switched strike **69 times in one
+session**, and a single four-session `ATM` file held **13 distinct contracts**.
+The rule is the nearest 50-point strike to spot, re-evaluated every bar:
+`strike_price` matched the nearest 50 to `spot` on 1500 of 1500 rows, never more
+than 25 points away.
+
+We therefore always request the `strike` field and write it as `strike_price`,
+alongside `spot`. Re-keying on `(expiry_date, strike_price, option_type)`
+reconstructs fixed contracts; `strike_label` and `option_type` are written on
+every row, redundantly, so that reconstruction is a concat plus a groupby.
+Without `strike_price` the dataset would be worthless for anything positional.
 
 ### 2. Derive the expiry date, because the API does not return one
 
@@ -94,6 +134,11 @@ available.
   positional seller this is the single most likely source of a falsely
   optimistic result.
 - **Expiry dates are inferred, not sourced.** Verified, but not authoritative.
+- **The tail of a range is dropped.** Sessions after the last expiry inside the
+  requested window cannot be labelled, so they are discarded — a backfill ending
+  today loses the current part-week. `warn_about_unlabelled_tail` says so
+  explicitly at the start of a run; extend `--end-date` past the next expiry to
+  keep them.
 - **No bid/ask.** Slippage and spread still cannot be modelled from this data,
   exactly as with the index feed.
 

--- a/docs/adr/0015-rolling-relative-strike-expired-options.md
+++ b/docs/adr/0015-rolling-relative-strike-expired-options.md
@@ -63,6 +63,16 @@ Two further observations, both upstream characteristics rather than defects:
 - **Session length is not always 375 bars.** 20-Jan-2025 carries a 15:30 print
   on top of the usual 09:15–15:29, giving 376. A rule that assumes "the last bar
   is 15:29" will be wrong on such days.
+- **Volume is occasionally corrupt, and not randomly.** 26 bars in ~19.4 million
+  carried a large negative volume. Every one fell on an expiry day, most at
+  14:15 exactly — the busiest minutes of the busiest session, consistent with a
+  counter overflowing upstream. Those values are blanked to `NA`, never
+  repaired: the first one looked like a lost top bit (`+2**32` gave a plausible
+  41,691,075), but applying that to later ones produced ~1.1 billion, roughly
+  25× a normal day. The pattern was a coincidence, and had we trusted it we
+  would have written fabricated volume into two-thirds of the affected bars.
+  Practical consequence: **treat volume as unreliable on expiry-day afternoons**.
+  OHLC, OI, IV and spot on those same bars are unaffected.
 
 The expiry derivation checks out against the prices: the ATM straddle's closing
 value across that week ran 377.75 → 233.15 → 136.75 → **23.50** on the derived
@@ -110,11 +120,33 @@ it labels means the two can never disagree.
 ### 3. Verify that derivation against the prices
 
 `--verify-expiries` checks each derived expiry against the ATM straddle's last
-close: on a real expiry afternoon it collapses, one session earlier it still
-carries a day of time value. This is a smell test aimed at the failure mode that
-matters — a calendar off by a day, or one that missed a rule change.
-`--calendar-csv` overrides derivation entirely when an authoritative calendar is
-available.
+close: on a real expiry afternoon it collapses against the previous session's.
+This is a smell test aimed at the failure mode that matters — a calendar off by
+a day, or one that missed a rule change. `--calendar-csv` overrides derivation
+entirely when an authoritative calendar is available.
+
+**It paid for itself on the first full backfill**, catching a real bug — see
+below. Two calibration notes, both learned there:
+
+- The test is a **ratio**, not an absolute level. An absolute 40-point ceiling
+  was tried first and flagged 38 of 261 genuine expiries, because ATM is the
+  nearest 50-point strike and an expiring straddle still holds up to 25 points
+  of intrinsic. That noise hid the two real failures completely. Measured across
+  five years the ratio is decisive: median 0.12, p90 0.35, while the bad dates
+  came in at 0.53 and above.
+- A **short session cannot host an expiry.** NSE runs a ~1-hour Diwali Muhurat
+  session that appears in the data as an ordinary trading day, and moves that
+  week's expiry earlier. Both occurrences in the window were derived wrongly
+  until `full_session_days` separated them:
+
+  | Derived | Bars | Actual expiry |
+  |---|---|---|
+  | 2021-11-04 (Thu) | 61 | 2021-11-03 (Wed) |
+  | 2025-10-21 (Tue) | 105 | 2025-10-20 (Mon) |
+
+  Six short sessions exist in the five years (60–107 bars against a normal
+  375–376), so the split is unambiguous. A Muhurat session stays a trading day
+  and still gets an expiry label — it just cannot *be* one.
 
 ## Consequences
 

--- a/docs/adr/0015-rolling-relative-strike-expired-options.md
+++ b/docs/adr/0015-rolling-relative-strike-expired-options.md
@@ -1,0 +1,108 @@
+# ADR-0015: Take expired-options history in rolling relative-strike form, and derive the expiry date
+
+**Status:** Accepted
+**Date:** 2026-09-05
+**Deciders:** repository owner
+
+## Context
+
+Every backtest in this repository runs on NIFTY **index** 1-minute bars. Option
+P&L is therefore simulated rather than observed, and
+[`data-and-backtesting.md`](../lld/data-and-backtesting.md) §7 has long recorded
+the consequences: no volume, no open interest, no implied volatility, and no way
+to check a fill against a premium that actually printed.
+
+DhanHQ closed that gap in API v2.3 (08 Sep 2025) with
+`POST /v2/charts/rollingoption`: five years of minute-level expired-options data
+carrying OHLC, volume, OI, IV, strike and spot. The pinned `dhanhq==2.2.0`
+already exposes it as `expired_options_data()`, so no dependency moved.
+
+The immediate motivation is a rule-based **positional option-selling** strategy,
+which is precisely the use case the endpoint's shape complicates.
+
+### What a live probe established
+
+Documentation and third-party wrappers disagreed on `expiryCode`, so it was
+resolved against the live API on 2026-09-05. Input validation runs before
+authentication, which made the answer legible even with an expired token:
+
+| Request | Response |
+|---|---|
+| `expiryCode: 0` | `DH-905 Input_Exception: "expiryCode is required"` |
+| `expiryCode: 1` | passed input validation, reached the auth check |
+
+So **`expiryCode` on this endpoint is 1-based**: 1 is the near expiry, 2 the
+next. Dhan's annexure documents `0 = current expiry`, but that table describes
+`/charts/historical`; this endpoint reads a zero as a missing field. Following
+the annexure would have produced a run that failed on every single call.
+
+## Decision
+
+### 1. Store the data in the rolling, relative-strike form the API returns
+
+The endpoint is addressed by `ATM`, `ATM±1` … `ATM±10` and `CALL`/`PUT`, not by
+a contract. There is no security ID for an expired contract, and
+`Dependencies/all_instrument *.csv` holds only live ones, so there is nothing to
+map to. We keep the API's own shape: one CSV per `(strike label, option type)`.
+
+The cost is that a rolling label **is not a tradeable instrument** — `ATM+3 CE`
+on Monday and on Wednesday are different contracts if spot moved. We therefore
+always request the `strike` field and write it as `strike_price`, alongside
+`spot`. Re-keying on `(expiry_date, strike_price, option_type)` reconstructs
+fixed contracts; `strike_label` and `option_type` are written on every row,
+redundantly, so that reconstruction is a concat plus a groupby.
+
+### 2. Derive the expiry date, because the API does not return one
+
+Without it, "sell five days out and hold to settlement" cannot even be
+expressed. `Data Extractors/expiry_calendar.py` derives it from two inputs:
+
+- a **rule table** of nominal expiry weekdays — Thursday, then Tuesday from
+  01-Sep-2025, when NSE moved index derivatives off Thursday following SEBI's
+  October 2024 circular; and
+- the **trading days present in the downloaded data itself**, from a cheap
+  hourly ATM pre-pass, rather than a hard-coded holiday list.
+
+A week's expiry is the last trading day on or before its nominal weekday, which
+gives NSE's holiday roll-back for free. Deriving the calendar from the same data
+it labels means the two can never disagree.
+
+### 3. Verify that derivation against the prices
+
+`--verify-expiries` checks each derived expiry against the ATM straddle's last
+close: on a real expiry afternoon it collapses, one session earlier it still
+carries a day of time value. This is a smell test aimed at the failure mode that
+matters — a calendar off by a day, or one that missed a rule change.
+`--calendar-csv` overrides derivation entirely when an authoritative calendar is
+available.
+
+## Consequences
+
+**Good**
+
+- Backtests can read real premium, OI and IV instead of modelling them.
+- The relative-strike shape is a natural fit for the existing ATM/OTM1 workers.
+- No new dependency; a full five-year NIFTY backfill is ~2,772 calls.
+- The download is resumable at chunk granularity, which matters on a machine
+  that has hung mid-session before ([ADR-0012](0012-crash-durable-session-state.md)).
+
+**Bad, and permanent**
+
+- **±10 strikes is a ±500-point band** at NIFTY's 50-point spacing. A contract
+  whose strike drifts further than that from spot stops appearing. A backtest
+  must not read that silence as "the option expired worthless" — for a
+  positional seller this is the single most likely source of a falsely
+  optimistic result.
+- **Expiry dates are inferred, not sourced.** Verified, but not authoritative.
+- **No bid/ask.** Slippage and spread still cannot be modelled from this data,
+  exactly as with the index feed.
+
+**Deliberately not done**
+
+- No conversion to fixed-strike contract files. The re-key is a few lines
+  against data whose real behaviour we can now observe, and building it on an
+  unverified expiry calendar would bake in any error the calendar has.
+- `validate_ohlc_frame` is **not** reused. It rejects any non-positive price,
+  which is correct for an index and wrong for a deep-OTM option printing at the
+  0.05 tick floor, and it knows nothing of OI, IV, strike or spot. The engine
+  carries its own validator instead.

--- a/docs/lld/data-and-backtesting.md
+++ b/docs/lld/data-and-backtesting.md
@@ -48,6 +48,42 @@ the extractor engine) infer the unit and then **assert it is consistent across
 the response** — a frame with mixed units would otherwise produce candles
 decades apart with no obvious symptom.
 
+### 2.2 Expired options
+
+```
+ Data Extractors/
+   expired_options_fetch_dhan_common.py     ← the engine
+   expiry_calendar.py                       ← pure expiry derivation
+   nifty_expired_options_fetch_dhan.py      ← thin wrapper
+```
+
+```bash
+python algo.py fetch-expired-options --index nifty --dry-run
+python algo.py fetch-expired-options --index nifty --lookback 5y --verify-expiries
+```
+
+Real expired NIFTY option bars — OHLC **plus volume, open interest, implied
+volatility, the actual strike and the spot** — via `POST /v2/charts/rollingoption`
+(`dhanhq.expired_options_data`). Five years, minute resolution. Output is one CSV
+per `(strike label, option type)` under
+`Backtest Outputs/expired_options/nifty/`, alongside a
+`_weekly_expiry_calendar.csv` and a `_manifest.json`.
+
+Three properties worth knowing before using it, all covered by
+[ADR-0015](../adr/0015-rolling-relative-strike-expired-options.md):
+
+- **Strikes are relative, not contracts.** `ATM+3` is whichever strike sat three
+  above spot at the time. Re-key on `strike_price` and `expiry_date` to rebuild
+  a fixed contract; never treat `strike_label` as an instrument.
+- **±10 strikes is a ±500-point band.** A contract that drifts further from spot
+  stops appearing. Silence is missing data, not a worthless option.
+- **`expiryCode` is 1-based here** (1 = near), unlike the annexure's table for
+  `/charts/historical`. A zero is rejected as a missing field.
+
+The download is resumable per chunk: `_manifest.json` records each series' byte
+length, and a restart trims any chunk a crash left half-written before carrying
+on. Pacing goes through the shared `RollingWindowRateLimiter`.
+
 ---
 
 ## 3. Backtesting
@@ -118,6 +154,13 @@ whose size or logic changed.
 engine's construction and request-building. Its module path anchor points back
 at the **source** `Data Extractors/` folder.
 
+`test_expired_options_fetch.py` and `test_expiry_calendar.py` cover the
+expired-options engine and its calendar. Neither touches the network — the
+DhanHQ client is a `SimpleNamespace` duck. The cases that earn their keep encode
+what the API taught us: `expiryCode` being 1-based, a `str` vs `dict` `remarks`
+meaning two completely different things, the parallel-array response shape, the
+holiday roll-back, and the 01-Sep-2025 Thursday→Tuesday change.
+
 The backtests themselves are not tested — they are reference scripts, not
 runtime code. `compileall` is their only gate.
 
@@ -130,5 +173,10 @@ runtime code. `compileall` is their only gate.
 - **Backtests do not model the spread gate, sizing rejections, or partial fills.**
   A backtest is an idea filter, not a P&L forecast. The paper-trading phase is
   what exercises the execution path.
-- **No volume** in the source data, so volume-derived indicators are proxies here
-  too — the same limitation the live feed has.
+- **No volume** in the *index* source data, so volume-derived indicators are
+  proxies there — the same limitation the live feed has. The expired-options
+  data of §2.2 does carry real volume, OI and IV; it is the one dataset here
+  that does not need the proxy.
+- **The expired-options set has no bid/ask** either, so spread and slippage
+  still cannot be modelled from it, and its ±500-point strike band means a
+  drifted contract goes missing rather than reading as worthless (§2.2).

--- a/docs/lld/data-and-backtesting.md
+++ b/docs/lld/data-and-backtesting.md
@@ -80,7 +80,11 @@ Three properties worth knowing before using it, all covered by
   window cannot be labelled, so a backfill ending today loses the current
   part-week. The run warns about it; extend `--end-date` past the next expiry.
 - **A session is usually 375 bars, but not always** — 20-Jan-2025 has a 15:30
-  print as well, giving 376. Do not assume the last bar is 15:29.
+  print as well, giving 376, and the six Diwali/special sessions run 60–107.
+  Do not assume the last bar is 15:29.
+- **Volume is unreliable on expiry-day afternoons.** 26 bars in 19.4M carried a
+  corrupt negative volume, every one on an expiry day and most at 14:15; they
+  are blanked to `NA`. OHLC, OI, IV and spot on those bars are fine.
 - **±10 strikes is a ±500-point band.** A contract that drifts further from spot
   stops appearing. Silence is missing data, not a worthless option.
 - **`expiryCode` is 1-based here** (1 = near), unlike the annexure's table for

--- a/docs/lld/data-and-backtesting.md
+++ b/docs/lld/data-and-backtesting.md
@@ -72,9 +72,15 @@ per `(strike label, option type)` under
 Three properties worth knowing before using it, all covered by
 [ADR-0015](../adr/0015-rolling-relative-strike-expired-options.md):
 
-- **Strikes are relative, not contracts.** `ATM+3` is whichever strike sat three
-  above spot at the time. Re-key on `strike_price` and `expiry_date` to rebuild
-  a fixed contract; never treat `strike_label` as an instrument.
+- **Strikes are relative, not contracts, and re-pick every bar.** Measured: the
+  `ATM` call switched strike 69 times in one session, and a four-session `ATM`
+  file held 13 distinct contracts. Re-key on `strike_price` and `expiry_date` to
+  rebuild a fixed contract; never treat `strike_label` as an instrument.
+- **The tail of a range is dropped.** Sessions after the last expiry inside the
+  window cannot be labelled, so a backfill ending today loses the current
+  part-week. The run warns about it; extend `--end-date` past the next expiry.
+- **A session is usually 375 bars, but not always** — 20-Jan-2025 has a 15:30
+  print as well, giving 376. Do not assume the last bar is 15:29.
 - **±10 strikes is a ±500-point band.** A contract that drifts further from spot
   stops appearing. Silence is missing data, not a worthless option.
 - **`expiryCode` is 1-based here** (1 = near), unlike the annexure's table for

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,10 @@ files = [
     "Data Extractors/nifty_1m_5y_data_fetch_dhan.py",
     "Data Extractors/banknifty_1m_5y_data_fetch_dhan.py",
     "Data Extractors/finnifty_1m_5y_data_fetch_dhan.py",
+    # The expired-options extractor, typed from the start.
+    "Data Extractors/expiry_calendar.py",
+    "Data Extractors/expired_options_fetch_dhan_common.py",
+    "Data Extractors/nifty_expired_options_fetch_dhan.py",
     "Dependencies/broker_contract.py",
     "Dependencies/check_env_config.py",
     "Dependencies/diagnostic_preflight.py",
@@ -188,9 +192,11 @@ files = [
     "Signal Generators/SL Hunting AI Agent/sl_hunting_tools.py",
 ]
 # Sibling imports (sl_hunting_agent -> sl_hunting_knowledge, shoonya_execution
-# -> NorenApi, logic modules -> *_strategy_common) resolve through these roots.
+# -> NorenApi, expired_options_fetch_dhan_common -> expiry_calendar, logic
+# modules -> *_strategy_common) resolve through these roots.
 mypy_path = [
     "Dependencies",
+    "Data Extractors",
     "Signal Generators",
     "Signal Generators/CPR Strategy",
     "Signal Generators/CPR AI Agent",


### PR DESCRIPTION
## What and why

Every backtest in this repo runs on NIFTY **index** bars, so option P&L is simulated rather than observed — `docs/lld/data-and-backtesting.md` §7 has long recorded the consequences: no volume, no OI, no IV, and no way to check a fill against a premium that actually printed.

DhanHQ closed that gap in API v2.3 with `POST /v2/charts/rollingoption`: five years of minute-level expired-options data carrying OHLC, volume, OI, IV, strike and spot. **The pinned `dhanhq==2.2.0` already exposes it** as `expired_options_data()`, so `requirements.txt` is untouched.

The motivating use case is a framework-independent, rule-based **positional option-selling** backtest — which is exactly the case the endpoint's shape complicates, hence the design notes below.

```bash
python algo.py fetch-expired-options --index nifty --dry-run
python algo.py fetch-expired-options --index nifty --lookback 5y --verify-expiries
```

A full 5-year NIFTY backfill is 42 series × 63 windows plus a 126-call calendar pass — **2,772 calls**, roughly 45–90 min at 2 req/s.

## Three things a reviewer should know

**1. `expiryCode` is 1-based on this endpoint.** Dhan's annexure documents `0 = current expiry`, but that table describes `/charts/historical`. This one answers a zero with `DH-905 Input_Exception: "expiryCode is required"` — it reads zero as a missing field. Established against the live API, where input validation runs *before* authentication and so answered even with an expired token. Following the annexure would have failed on every single call.

**2. Strikes are relative, not contracts.** You address `ATM±n`; no security ID exists for an expired contract, and `all_instrument *.csv` holds only live ones. So `ATM+3 CE` on Monday and Wednesday are different contracts if spot moved. We always request `strike` and write it as `strike_price` alongside `spot`, and carry `strike_label`/`option_type` on every row, so re-keying on `(expiry_date, strike_price, option_type)` rebuilds fixed contracts.

**3. The response carries no expiry date, so we derive it.** `expiry_calendar.py` combines a rule table of nominal expiry weekdays (Thursday, then Tuesday from 01-Sep-2025 per SEBI's Oct-2024 circular) with the trading days the downloaded data itself reveals — no hard-coded holiday list, so the calendar cannot disagree with the bars it labels. It reproduces the real transition exactly: last Thursday 28-Aug-2025, first Tuesday 02-Sep-2025. `--verify-expiries` then cross-checks each derived expiry against the ATM straddle's collapse; `--calendar-csv` overrides derivation entirely.

Full reasoning in [ADR-0015](docs/adr/0015-rolling-relative-strike-expired-options.md).

## Also in here: `algo.py fetch-data` was broken

Found while exploring, fixed in its own commit. It died at import with `ModuleNotFoundError: No module named 'Dependencies'` — `algo.py` sets `cwd=REPO_ROOT`, but `python <script>` puts the *script's* folder on `sys.path`. pytest hid it by inserting the rootdir. Two more defects kept credentials from loading at all: it read `DHAN_TOKEN_ID` (a key in neither `env.example` nor `.env`) and never called `load_dotenv`.

A third commit closes a template gap `check-env` reported: two size-multiplier keys the code reads were missing from `env.example`. No behaviour change — both are `1`, the default — but the gap made a genuine typo indistinguishable from them. `check-env` is now clean at 609/609.

## Limits, deliberately documented rather than engineered around

- **ATM±10 is a ±500-point band.** A contract drifting further from spot stops appearing. A backtest must not read that silence as "expired worthless" — for a positional seller this is the likeliest source of a falsely optimistic result.
- **Expiry dates are inferred, not authoritative.** Verified against prices, not sourced from NSE.
- **No bid/ask**, so spread and slippage still cannot be modelled.
- `validate_ohlc_frame` is **not** reused: it rejects any non-positive price, correct for an index and wrong for a deep-OTM option at the 0.05 tick floor, and it knows nothing of OI/IV/strike/spot. The engine carries its own validator.

## Verification

| Gate | Result |
|---|---|
| `unittest` master / market-data-health | 547 OK / 28 OK |
| `pytest` Signal Generators + Dependencies + Data Extractors | 1322 passed |
| ruff · mypy (77 files) · bandit · compileall · pre-commit | all clean |
| Coverage | 72.8% total; new engine 84.2%, calendar 98.6% |
| `algo.py check-env` | clean, 609/609 |

No test touches the network — the DhanHQ client is a `SimpleNamespace` duck. Nothing here is imported by `nifty_multi_strategy_master.py`; no live-trading path changes.

**Not yet verified against the live API.** The Dhan token is expired, so four things remain assumptions, each handled defensively: `securityId` 13 vs 26000, the doubled `data` key (both shapes accepted), `toDate` exclusivity (chunk boundaries de-duplicate on timestamp), and whether ATM is re-picked daily or intraday. After `python algo.py setup-token`, this 8-call smoke test settles all four:

```bash
python algo.py fetch-expired-options --index nifty --start-date 2025-01-06 --end-date 2025-01-10 --strike-range 1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
