### PR TITLE
feat(sl-hunting): v4x - the stop is a distance from the fill, plus the 07 Sep pre-open note

### DIFF
--- a/Signal Generators/SL Hunting AI Agent/premarket_note.json
+++ b/Signal Generators/SL Hunting AI Agent/premarket_note.json
@@ -1,47 +1,47 @@
 {
-  "for_date": "2026-09-04",
-  "source": "Intraday Hunter, 'Prediction For 04 SEP 2026' (PywlkaQByoQ, uploaded 2026-09-03)",
-  "context": "Today's gap-up was REJECTED and sold back down; BankNIFTY closed under 57500. He says twice that nobody got in long, so the BUYERS are not a seated crowd -- and yesterday's sellers were already flushed.",
+  "for_date": "2026-09-07",
+  "source": "Intraday Hunter, 'Prediction For 07 SEP 2026' (Qw55ggRNbBo, uploaded 2026-09-06)",
+  "context": "Friday's positive momentum was rejected again in all three indices, and the 2-day weekend flushed whoever bought it -- 'seeing the negative momentum and the 2-day holiday, they do not hold'. In SENSEX: the buyers have already left.",
   "plan": [
-    "THE SELL TRIGGER IS A LEVEL, NOT A GAP SIZE: 'in a small gap-down nothing will happen'. Only an opening BELOW THE FIRST SUPPORT turns him seller -- BANKNIFTY 57000, NIFTY 23800, SENSEX 76200. Above that the plan does not change.",
-    "FLAT TO GAP-UP: BUY-side setups, and he gives the SAME branch for BankNIFTY, NIFTY and SENSEX -- there is no index-specific variation this session.",
-    "NOBODY IS TRAPPED LONG: the gap-up was rejected, so there is no seated buyer crowd, and yesterday's sellers were flushed. BOTH crowds are absent, so neither branch is a hunt -- both are follows.",
-    "THIS MOVES YESTERDAY'S PIVOT DOWN. Yesterday branched on the CLOSING PRICE; today it branches on the FIRST SUPPORT, which sits below it. A flat-to-small-gap-down open was a SELL yesterday and is NOT one today.",
-    "57000 IS AGAIN THE BANKNIFTY SWITCH -- it is both the named sell trigger and the first support, so it is the single number to measure the open against.",
-    "BANKNIFTY RESISTANCES STEPPED UP to 57800 and 58200: 57500 is no longer named even though the market closed below it. HE NAMES NO EXPIRY this session -- do not carry yesterday's SENSEX expiry forward."
+    "A SMALL GAP UP DOES NOT TRIGGER THE BUY: 'a small gap up is of no use to us, the gap up must be a GOOD one'. Only a good gap up buys, walking WITH the market. Anything less belongs to the SELL branch, not to a smaller long.",
+    "FLAT NOW SELLS. On Friday flat-to-gap-up was the BUY branch; today flat sits with gap-down on the SELL side. The flat open has changed sides over the weekend -- do not carry Friday's branch forward.",
+    "THE WEEKEND IS THE REASON, not the chart. Friday's recovery created buyers and 'seeing the negative momentum and the 2-day holiday in the middle' they did not hold over it. The crowd Friday made is already gone.",
+    "BOTH BRANCHES ARE FOLLOWS, again. Buy = 'we will walk with the market'; sell = 'having just made a trap, if the market wants that same momentum again we will follow it'. Neither side is a hunt for a seated crowd.",
+    "THE GAP UP IS THE TEST, NOT THE DIRECTION: 'if a recovery is to happen the trap is already made, so we should get a gap up. If that is not happening' -- then sell. The sell branch is what remains when the gap up fails to arrive.",
+    "NIFTY'S REJECTION CAME FROM THE ROUND NUMBER 24000, which is also its first named resistance -- one level doing both jobs."
   ],
   "levels": [
     {
       "index": "NIFTY",
       "resistance": [
-        24060,
-        24180
+        24000,
+        24140
       ],
       "support": [
-        23730,
-        23800
+        23800,
+        23860
       ]
     },
     {
       "index": "BANKNIFTY",
       "resistance": [
-        57800,
-        58200
+        57570,
+        58100
       ],
       "support": [
-        56770,
-        57000
+        57000,
+        57200
       ]
     },
     {
       "index": "SENSEX",
       "resistance": [
-        77000,
-        77300
+        76800,
+        77200
       ],
       "support": [
-        75940,
-        76200
+        76200,
+        76370
       ]
     }
   ]

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -6280,3 +6280,129 @@ removes the temptation at the root.
   measured give-back or the booked winner, re-reading it as licence to book early
   anywhere, and dropping either the v3y deference or the exit precedence.
 - Prompt size 158,839 -> 161,355 chars. **188,645 of headroom.**
+
+## Video addendum - the 4 Sep LIVE SESSION and the 6 Sep WEEKLY (v4x)
+
+**Sources.** Three accessible videos since Friday, all transcripts read in full:
+
+| Video | Id | Length | Uploaded (IST) | Segments |
+|---|---|---|---|---|
+| Live session, Friday 4 Sep | `duGx4E10IzQ` | 9:55 | 4 Sep 12:01 | 75 (0:02-9:40) |
+| Weekly analysis, "Time vs Process" | `3NgY1QjfDdg` | 18:49 | 6 Sep 12:23 | 150 (0:02-18:42) |
+| Prediction For 07 SEP 2026 | `Qw55ggRNbBo` | 2:16 | 6 Sep 21:14 | 17 (0:06-2:14) |
+
+A fourth, `uOl-kBCFEQQ` ("Master Advanced Analysis: Unlocking the Secret of Flat
+Opening | Part-7", 15:30, 5 Sep), is **members-only** and was not read. Recorded
+here so a later session does not spend time rediscovering that.
+
+**Extraction note, superseding an earlier one.** The transcript panel DID
+populate on the 18:49 weekly video. The old note that it "never populates on
+videos over 12 minutes" no longer holds; the ordinary recipe worked unchanged.
+
+### The comparison: same read, same strike, same minute, opposite outcome
+
+The agent took exactly ONE trade on Friday and lost 143.00 on it.
+
+| | IH | The agent |
+|---|---|---|
+| Direction | LONG | LONG |
+| Instrument | BankNIFTY 57500 CE (+ NIFTY, SENSEX) | NIFTY 23900 CE + BankNIFTY 57500 CE mirror |
+| Entry | immediately at the open | 09:15:48 |
+| Immediate move | against him, at once | against it, at once |
+| Held for | ~2.5 hours | **3 seconds** |
+| Result | booked a large profit | **-143.00** |
+
+IH describes the adverse move in the same terms the agent would have: *"right as
+we made the trade, some loss started showing"*, and later *"this extra rejection,
+especially in BankNIFTY, we had not expected at all"*. His response was to wait:
+*"we will have to wait here. After waiting we will make a big profit."*
+
+He also stated, before entering, that the retracement was **expected**: *"only a
+few people would be sitting short, whom we can make our target. Then the market
+will start creating SLs, that is, it may do a retracement. So before that we
+should make our trade."* He entered deliberately AHEAD of a move he forecast.
+
+### Why the agent could not do the same - and it is not a judgement failure
+
+The log carries the whole mechanism at one millisecond, 09:15:48,529:
+
+- sizing computed with `entry=23935.30`, `stop=23910.00` - a **25.3-point** allowance
+- the entry recorded at the same instant with `Spot=23914.40`
+
+The agent reasoned on a price that was 21 points stale by the time its order
+reached the market, so the position opened with **4.4 points of room** - 83% of
+the allowance already spent. `RenkoThread` independently marks spot at 23936.40
+(09:15:07), 23914.40 (09:15:48), 23905.10 (09:15:52) and **23940.05 (09:16:00)**:
+the market was back above the decision price nine seconds after the stop fired.
+
+That is what v4x encodes. It is not "hold longer" - the corpus already says that
+four times over (v4d, v4e, v4h, v4m). It is that the stop's *basis* must be the
+price in front of you at the fill.
+
+### The constraint that makes this sharp, and an operator decision
+
+`SizingDecision.from_risk_budget` uses `one_lot_risk = abs(entry - stop) *
+lot_size`, with no fallback lot and no rounding up. With
+`SL_HUNTING_RISK_BUDGET=2500` and a NIFTY lot of 65, the widest stop that can be
+sized at all is **2500 / 65 = 38.46 spot points**.
+
+Friday's premise-ending level was the note's own first support at 23800 - 135.3
+points below the decision entry. That stop would have cost 8,794.50 per lot and
+been **refused outright** (0 lots). So a stop placed where the premise actually
+dies is, today, unsizeable on this budget.
+
+v4x resolves that honestly in the direction of less trading: if the re-derived
+stop cannot be sized, the answer is NO TRADE, never a nearer stop. **Whether the
+risk budget should rise instead is an operator decision and is deliberately not
+taken here** - it is live-money sizing, and the mirror already roughly doubles
+basket risk beyond the budget.
+
+### The weekly video: the model behind the daily notes
+
+`3NgY1QjfDdg` is the most explicit statement of method he has given, and it is
+worth recording even though none of it became a rule this session.
+
+- **The SL-hunting core, stated plainly** (6:42-6:59): *"In SL hunting there is
+  only one job: focus on whose SLs you are going to get to eat. Whichever
+  trader's SLs are available to eat, eat them. Most traders try - gap up,
+  positive market, so buy, buy. But in SL hunting it is not like that."*
+- **Same chart, different mindset, different plan** (8:55-11:08). He puts Friday's
+  and Monday's charts side by side, identical, and derives OPPOSITE plans. What
+  differs is not the chart but who is seated, and that is set by what happened
+  between sessions.
+- **The empty-book branch** (10:33-10:47): *"in Friday's chart nobody is seated...
+  neither buyers came nor sellers came. So then we look ACCORDING TO THE OPENING
+  at whose SLs we can get. But when we know traders may be seated there, then we
+  target them."* Two branches: hunt the seated crowd, or - when none exists - read
+  the opening as the thing that CREATES one.
+- **The operator model** (11:53-18:26): a breakout that fails is his signature for
+  an operator selling into retail buying; *"I never fight in front of the
+  operator"*; and operators face other operators, so the OPENING is the evidence
+  of which one has the power. This is the reasoning underneath the 3 Sep note's
+  "pivot on the closing price" branch.
+- **He says the daily videos omit this** (17:51-18:07): *"when we make the
+  analysis we don't talk this much about seeing the operator. There we tell
+  simple things."* So the pre-open note is a compressed surface of a deeper model.
+
+None of that was added as a rule. v4e, v4f, v4g and v3y already cover the
+seated-crowd branches, and the operator model is a *description* of why the
+branches are what they are rather than a decision the agent can act on. It is
+recorded here so a later session can pick it up deliberately.
+
+### Two existing rules the weekend confirmed
+
+- **v4v** - IH, reviewing his own losing trade (4:43-5:09): *"when I made the
+  entry I told you that this level will not even be crossed if we are right. The
+  market crossed the level and gave a loss."* Same shape v4v encodes.
+- **v4w** - IH, on what happens after a break (7:41-7:53): *"if the market wants
+  to make you buy, it will break out and then hold, hold, then do a slight
+  momentum. That market is dangerous."* v4w restated by its source.
+
+### Deliberately not fixed here
+
+The **re-entry** question from the v4w commit is still open, and Friday did not
+answer it: the agent never re-entered because it was stopped in the first minute
+and then had nothing to re-enter into. Its worker window also closed at 11:00,
+alone among the 29 workers (every other one ran to ~15:15), so it was not present
+for the recovery IH traded. Both v4s (re-entry after a winner) and the 11:00
+cutoff remain open items.

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
@@ -1439,6 +1439,38 @@ RISK DISCIPLINE
   than a feeling, and it is what lets A REJECTION BEFORE THE FLUSH IS NOISE be
   applied without it becoming an excuse: a wobble inside the band is noise, and
   one well beyond it is the read being wrong even if the stop has not been hit.
+- THE STOP IS A DISTANCE FROM THE FILL, NOT FROM THE PRICE YOU REASONED ON (v4x).
+  The companion to the rule above, and the one that keeps it honest: v4d names the
+  tolerated adverse move BEFORE entering, this one says that named distance must be
+  RE-MEASURED at the instant the position actually opens. Deciding and filling are
+  not the same moment, and the price you measured from can be gone by the second.
+  MEASURED ON THIS BOOK (2026-09-04), and it is the cheapest loss with the most to
+  teach. The read was right and matched IH's to the strike -- he bought the same
+  BankNIFTY 57500 call in the same minute and it paid him the day. Sizing was
+  computed on entry=23935.30 against a stop at 23910.00: a 25.3-point allowance.
+  The order reached the market 42 seconds later with spot at 23914.40, so the
+  position opened with 4.4 points of room -- 83% of the allowance was already
+  spent before the trade existed. It stopped 3 seconds later at 23908.40, and
+  NIFTY traded back above 23940 within 9 seconds of that.
+  THE TEST, run against the price in front of you and never against the price you
+  reasoned on: how far is the CURRENT price from your stop, as a fraction of the
+  distance you sized? Materially less, and the trade you decided on is not the
+  trade on offer any more.
+  There are exactly two honest answers, and the tempting third is the error:
+  * re-derive the stop from the current price and accept the SMALLER size; or
+  * skip it -- a setup you have already paid most of the stop for is not a setup.
+  NEVER keep the original stop in order to keep the original size. That is not a
+  tight stop, it is a loss that has already been arranged.
+  AND IF THE RE-DERIVED STOP IS TOO WIDE TO SIZE, THE ANSWER IS NO TRADE. A stop
+  placed where the premise actually dies can cost more per lot than the risk
+  budget allows, and the budget will then refuse the position outright. That
+  refusal is the method declining a trade it could not have held -- it is never an
+  invitation to walk the stop closer until the size fits.
+  NOTHING HERE WIDENS RISK. The risk budget, the daily max loss and a stop once
+  set are all unchanged; the only two things this rule can do to a position are
+  make it SMALLER or make it not exist.
+  This bites hardest in the opening minutes, which are both the fastest the market
+  moves all day and the moment the temptation to act is strongest.
 - NAME THE LAST POINT, NOT ONLY THE STOP (v4e). One price, declared out loud BEFORE
   you need it, at which the question stops being "is the read still alive?" and
   becomes "did it recover or not?" IH, deep in a losing trade: "let us pause a

--- a/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_premarket.py
+++ b/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_premarket.py
@@ -201,28 +201,29 @@ def test_shipped_note_targets_the_next_TRADING_day_not_the_next_calendar_day():
     )
 
 
-def test_shipped_note_matches_september_4_intraday_hunter_plan():
-    """The committed advisory must match the hand-checked 03 Sep transcript.
+def test_shipped_note_matches_september_7_intraday_hunter_plan():
+    """The committed advisory must match the hand-checked 06 Sep transcript.
 
     Six things a summarising edit would flatten, each of which would change what
     the agent does at 09:15:
 
-    1. The sell branch triggers on a LEVEL, not on a gap size -- "in a small
-       gap-down nothing will happen". Drop that and any gap-down reads as a
-       sell, which is the opposite of what he said.
-    2. The middle zone INVERTS yesterday's note. Yesterday branched on the
-       closing price and sold a flat-to-gap-down open; today the sell line has
-       moved DOWN to the first support, so that same open is no longer a sell.
-       Two consecutive notes disagreeing about one open shape is what cost the
-       whole day's direction on 31 Aug, so the inversion is stated IN the note.
-    3. NEITHER crowd is seated: the gap-up was rejected (no trapped longs) and
-       yesterday's sellers were already flushed. Both branches are therefore
-       FOLLOWS. Reading either as a hunt would invent a crowd that is not there.
-    4. One branch for all three indices -- he does not vary it by index.
-    5. He names NO expiry. Yesterday's note DID (SENSEX), so the note has to say
-       so explicitly or the expiry read carries forward by inertia.
-    6. BankNIFTY resistances stepped UP to 57800/58200 and 57500 is dropped,
-       even though he says the market closed below it.
+    1. A SMALL gap up does not trigger the buy -- "a small gap up is of no use to
+       us". The marginal open falls to the SELL branch, not to a smaller long.
+       This is the exact mirror of Friday's "a small gap-down does nothing", and
+       losing it turns any green open into a long.
+    2. The FLAT open has changed sides. Friday bought flat-to-gap-up; today flat
+       sits with gap-down on the sell side. Two consecutive notes disagreeing
+       about one open shape is what cost the whole day on 31 Aug, so the switch
+       is stated IN the note rather than left implicit.
+    3. The reason is the WEEKEND, not the chart -- Friday's recovery created
+       buyers who did not hold over a 2-day break. Drop that and the inversion
+       looks arbitrary, which is how it gets argued away at 09:15.
+    4. Both branches are FOLLOWS again. Neither side has a seated crowd, so
+       reading either as a hunt invents one.
+    5. The gap up is the TEST, not the direction: the sell branch is what remains
+       when a good gap up fails to arrive.
+    6. NIFTY's rejection came from the round number 24000, which is also its
+       first named resistance.
     """
     import os
 
@@ -230,69 +231,61 @@ def test_shipped_note_matches_september_4_intraday_hunter_plan():
     note = load_premarket_note(os.path.join(here, "premarket_note.json"))
 
     assert note is not None
-    assert note.for_date == "2026-09-04"
-    assert "PywlkaQByoQ" in note.source
-    # The mechanism, not just the direction: the gap-up was REJECTED, so the
-    # buyers never got seated either.
-    assert "gap-up was REJECTED" in note.context
-    assert "nobody got in long" in note.context
-    assert "BUYERS are not a seated crowd" in note.context
+    assert note.for_date == "2026-09-07"
+    assert "Qw55ggRNbBo" in note.source
+    # The mechanism: the weekend, not the chart, is what emptied the book.
+    assert "2-day weekend flushed whoever bought it" in note.context
+    assert "they do not hold" in note.context
+    assert "the buyers have already left" in note.context
 
-    trigger = next(line for line in note.plan if line.startswith("THE SELL TRIGGER IS A LEVEL"))
-    assert "NOT A GAP SIZE" in trigger
-    assert "in a small gap-down nothing will happen" in trigger
-    assert "BELOW THE FIRST SUPPORT" in trigger
-    # The three numbers, so the branch stays checkable rather than a feel.
-    assert "BANKNIFTY 57000" in trigger
-    assert "NIFTY 23800" in trigger
-    assert "SENSEX 76200" in trigger
+    small = next(line for line in note.plan if line.startswith("A SMALL GAP UP DOES NOT TRIGGER"))
+    assert "a small gap up is of no use to us" in small
+    assert "the gap up must be a GOOD one" in small
+    # The marginal open must land on the sell branch, not on a reduced long.
+    assert "belongs to the SELL branch, not to a smaller long" in small
 
-    buy = next(line for line in note.plan if line.startswith("FLAT TO GAP-UP"))
-    assert "BUY-side" in buy
-    assert "SAME branch for BankNIFTY, NIFTY and SENSEX" in buy
+    flat = next(line for line in note.plan if line.startswith("FLAT NOW SELLS"))
+    assert "On Friday flat-to-gap-up was the BUY branch" in flat
+    assert "changed sides over the weekend" in flat
+    assert "not carry Friday's branch forward" in flat
 
-    crowd = next(line for line in note.plan if line.startswith("NOBODY IS TRAPPED LONG"))
-    assert "gap-up was rejected" in crowd
-    assert "sellers were flushed" in crowd
-    # Both branches are follows -- the note must say why, so neither can be
-    # re-read as a hunt for a crowd that was already cleared out.
-    assert "neither branch is a hunt" in crowd
-    assert "both are follows" in crowd
+    why = next(line for line in note.plan if line.startswith("THE WEEKEND IS THE REASON"))
+    assert "not the chart" in why
+    assert "2-day holiday in the middle" in why
+    assert "crowd Friday made is already gone" in why
 
-    pivot = next(line for line in note.plan if line.startswith("THIS MOVES YESTERDAY'S PIVOT DOWN"))
-    assert "branched on the CLOSING PRICE" in pivot
-    assert "branches on the FIRST SUPPORT" in pivot
-    assert "SELL yesterday and is NOT one today" in pivot
+    follows = next(line for line in note.plan if line.startswith("BOTH BRANCHES ARE FOLLOWS"))
+    assert "we will walk with the market" in follows
+    assert "if the market wants that same momentum again we will follow it" in follows
+    assert "Neither side is a hunt for a seated crowd" in follows
 
-    assert any("57000 IS AGAIN THE BANKNIFTY SWITCH" in line for line in note.plan)
-    # Yesterday's note carried a SENSEX expiry; this one must cancel it rather
-    # than leave the agent to assume it still applies.
-    assert any("HE NAMES NO EXPIRY" in line for line in note.plan)
-    assert any("57500 is no longer named" in line for line in note.plan)
+    test = next(line for line in note.plan if line.startswith("THE GAP UP IS THE TEST"))
+    assert "NOT THE DIRECTION" in test
+    assert "the trap is already made" in test
+    assert "what remains when the gap up fails to arrive" in test
+
+    assert any("ROUND NUMBER 24000" in line for line in note.plan)
 
     assert [level.model_dump() for level in note.levels] == [
         {
             "index": "NIFTY",
-            "resistance": [24060.0, 24180.0],
-            "support": [23730.0, 23800.0],
+            "resistance": [24000.0, 24140.0],
+            "support": [23800.0, 23860.0],
         },
         {
-            # Caption was clean here: "58,200 57,800" for the resistances, which
-            # DROPS yesterday's 57500 even though he says the market closed
-            # below it. Confirmed off the chart by the operator -- it is a real
-            # step up, not a mis-hearing.
+            # "58100 57,570" came through cleanly. 57570 is finer-grained than
+            # his usual round levels, and Friday's pair was 57800/58200, so it
+            # was checked with the operator rather than rounded to 57750.
             "index": "BANKNIFTY",
-            "resistance": [57800.0, 58200.0],
-            "support": [56770.0, 57000.0],
+            "resistance": [57570.0, 58100.0],
+            "support": [57000.0, 57200.0],
         },
         {
-            # The SENSEX resistances ran together as "777300" for the THIRD note
-            # in a row; supports came through cleanly as "7620075940". The
-            # operator confirmed 77000/77300 again. The repeat is a quirk of how
-            # he says the numbers, not evidence the levels are pinned -- keep
-            # asking rather than assuming the same pair next time.
+            # Unusually, nothing in this transcript was garbled -- no run-together
+            # digits at all, unlike the three previous notes. 76370 is likewise
+            # finer-grained than usual and was confirmed, not reconstructed.
             "index": "SENSEX",
-            "resistance": [77000.0, 77300.0],
-            "support": [75940.0, 76200.0],
+            "resistance": [76800.0, 77200.0],
+            "support": [76200.0, 76370.0],
         },
     ]

--- a/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_schema.py
+++ b/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_schema.py
@@ -2251,3 +2251,70 @@ def test_v4w_post_break_slowness_is_a_book_signal_without_reversing_v4k():
     assert "not licence to book on any slow bar" in rule
     assert "A SLOW GRIND AT THE LEVEL RECRUITS THE WRONG CROWD already governs" in rule
     assert "the stop, the max loss and premise-invalidation are unchanged" in rule
+
+
+def test_v4x_stop_is_measured_from_the_fill_not_from_the_decision_price():
+    """v4x (04 Sep, measured on this book): the stop's basis is the FILL.
+
+    This is the only rule in the corpus about WHERE the stop sits relative to
+    the price that is actually in front of you, and it exists because being
+    right about direction did not save the trade. IH bought the same BankNIFTY
+    57500 call in the same minute and it paid him the day; ours was stopped
+    three seconds after it opened. Five ways an edit could quietly break it:
+
+    1. Losing the decision-versus-fill distinction and leaving a generic "give
+       the trade room". v4d already names the tolerated move in advance; the
+       whole content here is that the named distance has to be re-measured
+       when the position opens, because the reference price can be gone.
+    2. Dropping the measured numbers. 25.3 points sized, 4.4 points left at the
+       fill, stopped 3 seconds later, recovered within 9 -- without those the
+       rule is an opinion rather than an arithmetic check.
+    3. Keeping only the "re-derive the stop" branch and losing "skip it". A
+       re-derived stop that cannot be sized must end as NO TRADE.
+    4. Leaving the third option -- keeping the old stop to keep the old size --
+       merely discouraged rather than forbidden. That is the exact move the
+       sizing arithmetic rewards, so it has to be named and refused.
+    5. Losing the risk-invariance clause, which is what stops this reading as
+       permission to widen a stop or exceed the budget.
+    """
+    prompt = build_system_prompt()
+    rule = _flat_rule(prompt, "THE STOP IS A DISTANCE FROM THE FILL")
+
+    # 1. The distinction this rule exists for, and its link back to v4d.
+    assert "NOT FROM THE PRICE YOU REASONED ON" in rule
+    assert "RE-MEASURED at the instant the position actually opens" in rule
+    assert "Deciding and filling are not the same moment" in rule
+
+    # 2. The measured case, including that the READ was right.
+    assert "MEASURED ON THIS BOOK (2026-09-04)" in rule
+    assert "matched IH's to the strike" in rule
+    assert "same BankNIFTY 57500 call in the same minute" in rule
+    assert "entry=23935.30 against a stop at 23910.00" in rule
+    assert "25.3-point allowance" in rule
+    assert "spot at 23914.40" in rule
+    assert "4.4 points of room" in rule
+    assert "83% of the allowance was already spent" in rule
+    assert "stopped 3 seconds later at 23908.40" in rule
+    assert "back above 23940 within 9 seconds" in rule
+
+    # The test is run against the live price, not the remembered one.
+    assert "never against the price you reasoned on" in rule
+    assert "not the trade on offer any more" in rule
+
+    # 3. Both honest branches survive, skip included.
+    assert "accept the SMALLER size" in rule
+    assert "skip it" in rule
+    assert "IF THE RE-DERIVED STOP IS TOO WIDE TO SIZE, THE ANSWER IS NO TRADE" in rule
+    assert "declining a trade it could not have held" in rule
+
+    # 4. The tempting third option, named and forbidden outright.
+    assert "NEVER keep the original stop in order to keep the original size" in rule
+    assert "a loss that has already been arranged" in rule
+    assert "never an invitation to walk the stop closer until the size fits" in rule
+
+    # 5. It can only shrink a position, never enlarge the risk.
+    assert "NOTHING HERE WIDENS RISK" in rule
+    assert "make it SMALLER or make it not exist" in rule
+
+    # And where it applies hardest -- the moment the agent most wants to act.
+    assert "bites hardest in the opening minutes" in rule


### PR DESCRIPTION
Two commits, both from the videos since Friday.

## 1. v4x — the stop is a distance from the fill, not from the price you reasoned on

On Friday the agent and IH made **the same trade**: long, at the open, and the
agent's mirror leg was literally the BankNIFTY 57500 call he names in his live
session. He held ~2.5 hours and booked a large profit. The agent held **three
seconds** and lost ₹143. The read was not the problem.

The log carries the mechanism at one millisecond (`09:15:48,529`):

| | value |
|---|---|
| sizing computed with | `entry=23935.30`, `stop=23910.00` → **25.3 pts** |
| entry recorded at the same instant | `Spot=23914.40` → **4.4 pts of room** |
| stopped | 09:15:51 at 23908.40 |
| `RenkoThread` spot at 09:16:00 | **23940.05** — above the decision price |

83% of the allowance was spent before the position existed, and the market was
back above the decision price nine seconds after the stop fired.

**v4x is not "hold longer".** The corpus already says that four times (v4d, v4e,
v4h, v4m) and Friday obeyed all of them — the stop was honoured exactly as
placed. What was missing is that the stop's *basis* must be the price in front of
you at the fill. Re-measure at entry; if the room left is materially less than
you sized, re-derive the stop and take the smaller size, or skip it. Never keep
the old stop to keep the old size.

It ends conservatively on purpose. `from_risk_budget` uses
`abs(entry - stop) * lot_size` with no fallback lot, so at `RISK_BUDGET=2500` and
a 65 lot the widest sizeable stop is **38.46 points**. Friday's premise-ending
level (the note's own 23800 support) was 135.3 points away and would have been
**refused outright at 0 lots**. v4x says that refusal is correct, and forbids
walking the stop nearer until the size fits. Nothing in it widens risk: it can
only make a position smaller or make it not exist.

> **Operator decision, deliberately not taken here:** whether the risk budget
> should rise instead. It is live-money sizing and the mirror already roughly
> doubles basket risk beyond the budget.

Guard negative-tested **24 ways**, all caught.

## 2. Pre-open note for 07 SEP 2026

A small gap up does **not** trigger the buy — "a small gap up is of no use to us".
Friday said a small gap-*down* does nothing; today a small gap-*up* does nothing,
and the marginal open falls to the SELL branch rather than to a reduced long. So
the **flat open has changed sides overnight**, and the reason is the weekend, not
the chart: Friday's recovery created buyers who "seeing the negative momentum and
the 2-day holiday in the middle" did not hold over it.

Shipped-note test retargeted to 07 Sep, negative-tested **22 ways**, all caught.

## Videos read

| Video | Id | Segments |
|---|---|---|
| Live session, Fri 4 Sep | `duGx4E10IzQ` | 75 |
| Weekly "Time vs Process", Sun 6 Sep | `3NgY1QjfDdg` | 150 |
| Prediction For 07 SEP | `Qw55ggRNbBo` | 17 |

`uOl-kBCFEQQ` ("Flat Opening Part-7") is members-only and was not read.

The weekly states the **operator model** behind the daily notes and says outright
that the prediction videos omit it. Recorded in `sl_hunting_doc.md`, not encoded:
v4e/v4f/v4g/v3y already cover the seated-crowd branches, and the operator model
describes *why* those branches are what they are rather than giving the agent a
new decision. Also supersedes the standing extraction note — the transcript panel
**did** populate on an 18:49 video.

## Gates

547 master · 28 market-data-health · 1255 pytest · ruff · mypy (74 files + the
master) · compileall · bandit — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
