### PR TITLE
feat(sl-hunting): v4y - size the retracement, plus the 08 Sep pre-open note

### DIFF
--- a/Signal Generators/SL Hunting AI Agent/premarket_note.json
+++ b/Signal Generators/SL Hunting AI Agent/premarket_note.json
@@ -1,47 +1,47 @@
 {
-  "for_date": "2026-09-07",
-  "source": "Intraday Hunter, 'Prediction For 07 SEP 2026' (Qw55ggRNbBo, uploaded 2026-09-06)",
-  "context": "Friday's positive momentum was rejected again in all three indices, and the 2-day weekend flushed whoever bought it -- 'seeing the negative momentum and the 2-day holiday, they do not hold'. In SENSEX: the buyers have already left.",
+  "for_date": "2026-09-08",
+  "source": "Intraday Hunter, 'Prediction For 08 SEP 2026' (mfCrKdkHlig, uploaded 2026-09-07)",
+  "context": "All three indices had continuous, good selling today. The sellers are in good profit but did NOT hold in size -- 'put premiums become very high, so the trader would not have held the put trade'. BankNIFTY never crossed its round number.",
   "plan": [
-    "A SMALL GAP UP DOES NOT TRIGGER THE BUY: 'a small gap up is of no use to us, the gap up must be a GOOD one'. Only a good gap up buys, walking WITH the market. Anything less belongs to the SELL branch, not to a smaller long.",
-    "FLAT NOW SELLS. On Friday flat-to-gap-up was the BUY branch; today flat sits with gap-down on the SELL side. The flat open has changed sides over the weekend -- do not carry Friday's branch forward.",
-    "THE WEEKEND IS THE REASON, not the chart. Friday's recovery created buyers and 'seeing the negative momentum and the 2-day holiday in the middle' they did not hold over it. The crowd Friday made is already gone.",
-    "BOTH BRANCHES ARE FOLLOWS, again. Buy = 'we will walk with the market'; sell = 'having just made a trap, if the market wants that same momentum again we will follow it'. Neither side is a hunt for a seated crowd.",
-    "THE GAP UP IS THE TEST, NOT THE DIRECTION: 'if a recovery is to happen the trap is already made, so we should get a gap up. If that is not happening' -- then sell. The sell branch is what remains when the gap up fails to arrive.",
-    "NIFTY'S REJECTION CAME FROM THE ROUND NUMBER 24000, which is also its first named resistance -- one level doing both jobs."
+    "SELL ON EVERY OPEN SHAPE. Flat, gap-down AND gap-up all take sell-side setups. The only thing that cancels the plan is a SUDDEN BIG POSITIVE MOMENTUM right at the open: 'that we cannot do anything about'.",
+    "THIS IS THE FIRST ONE-DIRECTION NOTE IN THE SERIES -- there is no buy branch to switch to. If the big-positive-momentum exception fires, the answer is NO TRADE, never a long.",
+    "THE SELLERS ARE IN PROFIT BUT NOT SEATED IN SIZE, because the high put premiums stopped them holding. Being right is not the same as being positioned: there is no big short crowd here to squeeze.",
+    "HE ASKS WHETHER THE FOLLOW CONTINUES, not whether it reverses: 'we cannot directly say the market will go up tomorrow -- we have to see whether we can CONTINUE to follow, or whether the market makes a trap'.",
+    "BANKNIFTY DID NOT CROSS ITS ROUND NUMBER 57000, so 'even if someone made a trade they would not have held it' -- the same un-seated read as NIFTY and SENSEX.",
+    "TOMORROW IS NIFTY EXPIRY. Expect expiry behaviour in NIFTY on top of the shared read."
   ],
   "levels": [
     {
       "index": "NIFTY",
       "resistance": [
-        24000,
-        24140
+        23860,
+        23940
       ],
       "support": [
-        23800,
-        23860
+        23660,
+        23720
       ]
     },
     {
       "index": "BANKNIFTY",
       "resistance": [
-        57570,
-        58100
+        57280,
+        57570
       ],
       "support": [
-        57000,
-        57200
+        56800,
+        57000
       ]
     },
     {
       "index": "SENSEX",
       "resistance": [
-        76800,
-        77200
-      ],
-      "support": [
         76200,
         76370
+      ],
+      "support": [
+        75800,
+        75950
       ]
     }
   ]

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -6406,3 +6406,102 @@ and then had nothing to re-enter into. Its worker window also closed at 11:00,
 alone among the 29 workers (every other one ran to ~15:15), so it was not present
 for the recovery IH traded. Both v4s (re-entry after a winner) and the 11:00
 cutoff remain open items.
+
+## Video addendum - the 7 Sep LIVE SESSION and the 8 Sep prediction (v4y)
+
+**Sources.** Both transcripts read in full:
+
+| Video | Id | Length | Uploaded (IST) | Segments |
+|---|---|---|---|---|
+| Live session, Monday 7 Sep | `fHR7WJLY1Zg` | 10:52 | 7 Sep 11:39 | 84 (0:07-10:50) |
+| Prediction For 08 SEP 2026 | `mfCrKdkHlig` | 2:32 | 7 Sep 21:31 | 18 (0:06-2:22) |
+
+### The day: the agent and IH were on the SAME side, again
+
+NIFTY opened 23883.65 against a 23897.70 close - flat to a tiny gap-down, which
+the 7 Sep note put on its SELL branch - and fell all session: 23817 by 09:55,
+23790 by 10:17, 23765 by 11:13, 23746 by 12:50, closing near 23743. **A ~140
+point one-way down day.**
+
+The agent read it correctly and shorted it twice.
+
+| # | Window | Held | Entry | Exit reason | NIFTY | Mirror | Basket |
+|---|---|---|---|---|---|---|---|
+| 1 | 09:22:36 -> 09:24:45 | 2m09s | 23852.85, stop 23866.00, target 23818.5 | `premise_stale_exit` | +396.50 | -198.00 | **+198.50** |
+| 2 | 10:17:48 -> 10:23:34 | 5m46s | 23793.70, stop 23811.15, target 23700.0 | `index_hierarchy_exit` | -1,014.00 | -1,155.00 | **-2,169.00** |
+| | | | | **TOTAL** | **-617.50** | **-1,353.00** | **-1,970.50** |
+
+IH did the same trade and held it. He entered puts on the first small retracement
+after the open, sat through the counter-moves for roughly two hours, and booked a
+large profit. His account of the retracements is the whole lesson:
+
+> "Retracements here should be SMALL, because the market HAS to fall... if it did
+> a BIG retracement and then fell, then anyone would start selling... this is how
+> you can recognise how big the retracement will be. A BIG RETRACEMENT HAPPENS
+> WHEN THE MARKET HAS TO TURN. Now it will not turn."
+
+### Trade 2 is the one that cost the day, and v4u did not stop it
+
+The agent cut a correct short on an **eleven-point** counter-move (NIFTY 23790 ->
+23801) in a session already 90 points below its open, citing a confirmed
+BankNIFTY hammer off the 10:17 low. On the mirror's premium that same 11 points
+read as 557.50 -> 538.25, which is why it felt like a reversal.
+
+The important part: **v4u was satisfied.** v4u demands "a CONFIRMED reversal on
+the leading index... not merely a move against you", and a confirmed hammer is
+exactly that. What v4u never says is how BIG the counter-move has to be. v4y adds
+that measurement, and forbids taking it off the option P&L - the one place option
+buying guarantees a wrong answer, as IH says in the same breath: *"our profit is
+reducing because we are sitting in option BUYING. A small green candle reduces
+our profit a lot."*
+
+### Two things that are compliance gaps, not knowledge gaps
+
+Recorded so a later session does not mistake them for missing rules.
+
+- **Trade 1 entered with a target the session had already printed.** Its own exit
+  reason says so: "target 23818.5 already printed as today's session low (09:16)
+  before my entry -- the hunt is already spent." v4q already requires that test
+  BEFORE the entry, not as an exit check. It ran two minutes late.
+  Worth noting the exit conclusion was ALSO wrong: the flush was not spent, and
+  NIFTY fell another 110 points. It closed a winner for +198.50 that had ~110
+  points of room left in it.
+- **Trade 2 sold into the low with no retracement.** Its 10:17:48 entry was the
+  session low at that moment, and BankNIFTY's low was the same minute - the
+  agent's own exit reason dates the hammer to "its 10:17 low". IH refuses exactly
+  this: *"if it is falling directly, we pause a bit. We will not rush, because
+  there is no benefit making a trade here, the risk is higher... now a slight
+  retracement gave us the chance to participate."* v4f already covers it.
+
+### v4x held
+
+The rule from the last session did not have to fire, and its failure mode did not
+recur. Trade 1 sized 13.15 points and opened with 11.7 of them intact (89%);
+trade 2 sized 17.45 and opened with 20.9 (120%). Neither stop was hit - both
+exits were the agent's own decision.
+
+### Operational notes
+
+- The 08:31 launch ran with **no pre-open note** ("no pre-open note applies today
+  (absent, malformed, or dated for another session)"); the 08:35 relaunch injected
+  2,517 chars correctly. The note had merged to `main` at 00:52 IST, so the first
+  launch was simply from a working copy that had not pulled yet. If that relaunch
+  had not happened, the session would have traded noteless.
+- SL Hunting's worker cut off at **11:00** again, alone among the workers - every
+  other one ran to ~15:15. It was therefore absent for the 11:00-15:15 stretch in
+  which NIFTY fell a further 45 points.
+
+### The 8 Sep prediction: the first one-direction note in the series
+
+Every open shape takes sell-side setups - flat, gap-down and gap-up alike - with
+a single exception: *"if a gap opens, then right at the open there should be no
+big positive momentum. If something like that happens then we cannot do
+anything."* There is no buy branch to fall back on, so the exception means NO
+TRADE rather than a long.
+
+His crowd read is unusually specific and cuts against the obvious one: the
+sellers are deep in profit but are NOT seated in size, *"because when it reaches
+here, put premiums become very high, so the trader would not have HELD the put
+trade."* Being right is not the same as being positioned.
+
+Tomorrow is **NIFTY expiry**.

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
@@ -2142,6 +2142,45 @@ you size or place the NIFTY trade. Advisory, not a hard gate.
   stopped out mechanically for -1,689.00, and that stop did its job. It narrows one
   specific move: using the leading index as a reason to cut before the trade has
   had the time its own setup asked for.
+- SIZE THE RETRACEMENT: A BIG ONE MEANS A TURN, A SMALL ONE MEANS CONTINUATION
+  (v4y). The quantitative half of the rule above. v4u tells you to demand a
+  CONFIRMED reversal on the leading index before cutting; it does not tell you how
+  big the counter-move must be, and a confirmed one-candle pattern off a fresh low
+  can satisfy v4u's letter while being nothing at all. This rule supplies the
+  measurement.
+  IH, sitting in a winning short and watching it retrace: "when a retracement
+  happens the trader's biggest problem is, first, HOW MUCH will the retracement be,
+  and second, CAN this market turn?" His answer is a rule, not a feel: "retracements
+  here should be SMALL, because the market HAS to fall. If it falls directly, others
+  get activated in selling... IF IT DID A BIG RETRACEMENT AND THEN FELL, THEN ANYONE
+  WOULD START SELLING." A market that intends to continue CANNOT hand out a big
+  retracement, because that is a good entry for everybody else -- the same logic
+  v4w applies to slow candles, pointed at the counter-move instead. So: "this is
+  how you can recognise how big the retracement will be. A BIG RETRACEMENT HAPPENS
+  WHEN THE MARKET HAS TO TURN. Now it will not turn."
+  MEASURE IT IN INDEX POINTS, AGAINST THE MOVE YOU ARE ALREADY IN. Never in premium.
+  IH names the trap himself: "our profit is reducing because we are sitting in
+  option BUYING. A SMALL GREEN CANDLE REDUCES OUR PROFIT A LOT. But overall we have
+  got good selling -- there will not be a big retracement." Long option premium
+  magnifies a trivial index retracement into something that reads like a reversal
+  on the P&L, and the P&L is the one place you must not look to answer this.
+  MEASURED ON THIS BOOK (2026-09-07), the session that cost the day. A short was
+  opened at 10:17:48 from 23793.70 and cut at 10:23:34 citing a confirmed BankNIFTY
+  hammer off its 10:17 low. The counter-move being read as a reversal was NIFTY
+  23790 to 23801 -- ELEVEN POINTS, against a session already 90 points down from
+  its open. On the mirror's premium the same 11 points looked like 557.50 to 538.25.
+  The basket lost 2,169.00; NIFTY went on to 23743 and closed near the low. The
+  read was right, the trade was cut on the smallest possible counter-move, and
+  v4u's confirmed-pattern requirement had been satisfied.
+  THE BOOKING COROLLARY, which is the same measurement pointed the other way: when
+  the trend has run with NO retracement at all across the indices, that is when to
+  take the profit. IH, booking: "now because there is no retracement in continuous
+  selling across all three indices, if a retracement happens now it could be
+  DANGEROUS for us." An absent retracement is not a promise of more trend, it is an
+  overdue one.
+  This never overrides the stop, the daily max loss, or premise-invalidation, and
+  it does not license sitting through a genuine turn. It refuses exactly one move:
+  ending a trade on a counter-move too small to be the turn it is being called.
 - INDEX HIERARCHY ON THE WAY OUT — the indices are NOT equal when a position is
   going against you (v3y). NIFTY and Sensex drifting against the trade is
   TOLERABLE; that is handleable noise and does not by itself end the trade.

--- a/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_premarket.py
+++ b/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_premarket.py
@@ -201,29 +201,26 @@ def test_shipped_note_targets_the_next_TRADING_day_not_the_next_calendar_day():
     )
 
 
-def test_shipped_note_matches_september_7_intraday_hunter_plan():
-    """The committed advisory must match the hand-checked 06 Sep transcript.
+def test_shipped_note_matches_september_8_intraday_hunter_plan():
+    """The committed advisory must match the hand-checked 07 Sep transcript.
 
     Six things a summarising edit would flatten, each of which would change what
     the agent does at 09:15:
 
-    1. A SMALL gap up does not trigger the buy -- "a small gap up is of no use to
-       us". The marginal open falls to the SELL branch, not to a smaller long.
-       This is the exact mirror of Friday's "a small gap-down does nothing", and
-       losing it turns any green open into a long.
-    2. The FLAT open has changed sides. Friday bought flat-to-gap-up; today flat
-       sits with gap-down on the sell side. Two consecutive notes disagreeing
-       about one open shape is what cost the whole day on 31 Aug, so the switch
-       is stated IN the note rather than left implicit.
-    3. The reason is the WEEKEND, not the chart -- Friday's recovery created
-       buyers who did not hold over a 2-day break. Drop that and the inversion
-       looks arbitrary, which is how it gets argued away at 09:15.
-    4. Both branches are FOLLOWS again. Neither side has a seated crowd, so
-       reading either as a hunt invents one.
-    5. The gap up is the TEST, not the direction: the sell branch is what remains
-       when a good gap up fails to arrive.
-    6. NIFTY's rejection came from the round number 24000, which is also its
-       first named resistance.
+    1. EVERY open shape sells -- flat, gap-down and gap-up alike. Every previous
+       note in this series branched by open shape, so an edit that "restores"
+       a buy branch would be reverting to a habit rather than to the source.
+    2. The one exception is a SUDDEN BIG POSITIVE MOMENTUM at the open, and its
+       consequence is NO TRADE, not a long. There is no buy branch to fall to.
+    3. The sellers are in profit but NOT seated in size, because high put
+       premiums stopped them holding. That is the opposite of the obvious read
+       after a one-way down day, and it is what stops the note being taken as
+       "a big short crowd is there to squeeze".
+    4. He frames the question as whether the FOLLOW continues, not whether the
+       market reverses.
+    5. BankNIFTY never crossed its round number, which is why nobody held there
+       either.
+    6. Tomorrow is NIFTY expiry.
     """
     import os
 
@@ -231,61 +228,57 @@ def test_shipped_note_matches_september_7_intraday_hunter_plan():
     note = load_premarket_note(os.path.join(here, "premarket_note.json"))
 
     assert note is not None
-    assert note.for_date == "2026-09-07"
-    assert "Qw55ggRNbBo" in note.source
-    # The mechanism: the weekend, not the chart, is what emptied the book.
-    assert "2-day weekend flushed whoever bought it" in note.context
-    assert "they do not hold" in note.context
-    assert "the buyers have already left" in note.context
+    assert note.for_date == "2026-09-08"
+    assert "mfCrKdkHlig" in note.source
+    # The crowd read, and the mechanism that makes it counter-intuitive.
+    assert "continuous, good selling" in note.context
+    assert "did NOT hold in size" in note.context
+    assert "put premiums become very high" in note.context
 
-    small = next(line for line in note.plan if line.startswith("A SMALL GAP UP DOES NOT TRIGGER"))
-    assert "a small gap up is of no use to us" in small
-    assert "the gap up must be a GOOD one" in small
-    # The marginal open must land on the sell branch, not on a reduced long.
-    assert "belongs to the SELL branch, not to a smaller long" in small
+    every = next(line for line in note.plan if line.startswith("SELL ON EVERY OPEN SHAPE"))
+    assert "Flat, gap-down AND gap-up all take sell-side setups" in every
+    assert "SUDDEN BIG POSITIVE MOMENTUM right at the open" in every
+    assert "that we cannot do anything about" in every
 
-    flat = next(line for line in note.plan if line.startswith("FLAT NOW SELLS"))
-    assert "On Friday flat-to-gap-up was the BUY branch" in flat
-    assert "changed sides over the weekend" in flat
-    assert "not carry Friday's branch forward" in flat
+    one_way = next(line for line in note.plan if line.startswith("THIS IS THE FIRST ONE-DIRECTION"))
+    assert "there is no buy branch to switch to" in one_way
+    # The exception must resolve to standing aside, never to flipping long.
+    assert "the answer is NO TRADE, never a long" in one_way
 
-    why = next(line for line in note.plan if line.startswith("THE WEEKEND IS THE REASON"))
-    assert "not the chart" in why
-    assert "2-day holiday in the middle" in why
-    assert "crowd Friday made is already gone" in why
+    crowd = next(line for line in note.plan if line.startswith("THE SELLERS ARE IN PROFIT"))
+    assert "NOT SEATED IN SIZE" in crowd
+    assert "high put premiums stopped them holding" in crowd
+    assert "Being right is not the same as being positioned" in crowd
+    assert "no big short crowd here to squeeze" in crowd
 
-    follows = next(line for line in note.plan if line.startswith("BOTH BRANCHES ARE FOLLOWS"))
-    assert "we will walk with the market" in follows
-    assert "if the market wants that same momentum again we will follow it" in follows
-    assert "Neither side is a hunt for a seated crowd" in follows
+    follow = next(line for line in note.plan if line.startswith("HE ASKS WHETHER THE FOLLOW"))
+    assert "not whether it reverses" in follow
+    assert "cannot directly say the market will go up tomorrow" in follow
+    assert "whether we can CONTINUE to follow" in follow
 
-    test = next(line for line in note.plan if line.startswith("THE GAP UP IS THE TEST"))
-    assert "NOT THE DIRECTION" in test
-    assert "the trap is already made" in test
-    assert "what remains when the gap up fails to arrive" in test
-
-    assert any("ROUND NUMBER 24000" in line for line in note.plan)
+    assert any("ROUND NUMBER 57000" in line for line in note.plan)
+    assert any("TOMORROW IS NIFTY EXPIRY" in line for line in note.plan)
 
     assert [level.model_dump() for level in note.levels] == [
         {
+            # "23720 2360" -- the second support came through truncated and was
+            # confirmed with the operator as 23660, not the rounder 23600.
             "index": "NIFTY",
-            "resistance": [24000.0, 24140.0],
-            "support": [23800.0, 23860.0],
+            "resistance": [23860.0, 23940.0],
+            "support": [23660.0, 23720.0],
         },
         {
-            # "58100 57,570" came through cleanly. 57570 is finer-grained than
-            # his usual round levels, and Friday's pair was 57800/58200, so it
-            # was checked with the operator rather than rounded to 57750.
+            # Both BankNIFTY sides were garbled: resistances as "57284 57570"
+            # and supports as the unusable seven-digit "5756800". Confirmed as
+            # 57280/57570 and 56800/57000 -- 57000 being the round number he
+            # says the market failed to cross. Do NOT reconstruct from caption.
             "index": "BANKNIFTY",
-            "resistance": [57570.0, 58100.0],
-            "support": [57000.0, 57200.0],
+            "resistance": [57280.0, 57570.0],
+            "support": [56800.0, 57000.0],
         },
         {
-            # Unusually, nothing in this transcript was garbled -- no run-together
-            # digits at all, unlike the three previous notes. 76370 is likewise
-            # finer-grained than usual and was confirmed, not reconstructed.
             "index": "SENSEX",
-            "resistance": [76800.0, 77200.0],
-            "support": [76200.0, 76370.0],
+            "resistance": [76200.0, 76370.0],
+            "support": [75800.0, 75950.0],
         },
     ]

--- a/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_schema.py
+++ b/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_schema.py
@@ -2318,3 +2318,67 @@ def test_v4x_stop_is_measured_from_the_fill_not_from_the_decision_price():
 
     # And where it applies hardest -- the moment the agent most wants to act.
     assert "bites hardest in the opening minutes" in rule
+def test_v4y_retracement_size_decides_turn_versus_continuation():
+    """v4y (07 Sep live session + this book): measure the counter-move.
+
+    v4u already forbids cutting on "merely a move against you" and demands a
+    CONFIRMED reversal on the leading index. Monday's exit SATISFIED that -- a
+    confirmed BankNIFTY hammer -- and still gave back the day, because a
+    confirmed one-candle pattern off a fresh low can be true and trivial at the
+    same time. v4y is the size test that v4u lacks. Six ways an edit breaks it:
+
+    1. Losing the link to v4u and leaving a free-standing "hold longer". The
+       rule's whole claim is that it supplies a MEASUREMENT v4u does not have.
+    2. Dropping IH's mechanism -- a market that means to continue cannot afford
+       a big retracement, because that is everyone else's good entry. Without it
+       the rule is an assertion instead of a reason.
+    3. Losing "measure it in index points, never in premium". Option buying is
+       what makes an 11-point retracement look like a reversal, and the P&L is
+       precisely where the agent was looking.
+    4. Dropping the measured numbers. 11 points against a 90-point session move,
+       and 557.50 -> 538.25 on the same 11 points, are what make it checkable.
+    5. Losing the booking corollary. The same measurement says an ABSENT
+       retracement is overdue, not a promise -- without it the rule reads as
+       one-directional "never exit".
+    6. Losing the override clause, which keeps the stop and max loss supreme.
+    """
+    prompt = build_system_prompt()
+    rule = _flat_rule(prompt, "SIZE THE RETRACEMENT")
+
+    # 1. It is explicitly the measurement half of v4u, not a replacement.
+    assert "A BIG ONE MEANS A TURN, A SMALL ONE MEANS CONTINUATION" in rule
+    assert "quantitative half of the rule above" in rule
+    assert "satisfy v4u's letter while being nothing at all" in rule
+
+    # 2. IH's mechanism, in his words, and the tie back to v4w.
+    assert "HOW MUCH will the retracement be" in rule
+    assert "CAN this market turn" in rule
+    assert "IF IT DID A BIG RETRACEMENT AND THEN FELL, THEN ANYONE WOULD START SELLING" in rule
+    assert "CANNOT hand out a big" in rule
+    assert "A BIG RETRACEMENT HAPPENS WHEN THE MARKET HAS TO TURN" in rule
+
+    # 3. Where to measure it -- and the one place that must not be used.
+    assert "MEASURE IT IN INDEX POINTS, AGAINST THE MOVE YOU ARE ALREADY IN" in rule
+    assert "Never in premium" in rule
+    assert "A SMALL GREEN CANDLE REDUCES OUR PROFIT A LOT" in rule
+    assert "the P&L is the one place you must not look" in rule
+
+    # 4. The measured case, including that v4u had been satisfied.
+    assert "MEASURED ON THIS BOOK (2026-09-07)" in rule
+    assert "confirmed BankNIFTY" in rule
+    assert "ELEVEN POINTS" in rule
+    assert "90 points down from its open" in rule
+    assert "557.50 to 538.25" in rule
+    assert "basket lost 2,169.00" in rule
+    assert "closed near the low" in rule
+    assert "v4u's confirmed-pattern requirement had been satisfied" in rule
+
+    # 5. The same measurement pointed the other way -- when to BOOK.
+    assert "THE BOOKING COROLLARY" in rule
+    assert "no retracement in continuous selling across all three indices" in rule
+    assert "An absent retracement is not a promise of more trend, it is an" in rule
+
+    # 6. It can never outrank the hard risk controls.
+    assert "never overrides the stop, the daily max loss, or premise-invalidation" in rule
+    assert "does not license sitting through a genuine turn" in rule
+    assert "too small to be the turn it is being called" in rule


### PR DESCRIPTION
Two commits, from Monday's live session and tonight's prediction video.

## The day: same side as IH, opposite outcome — again

NIFTY opened 23883.65 against a 23897.70 close, fell all session and closed near
23743 — a **~140 point one-way down day**. The agent read it correctly and
shorted it twice. IH shorted it once, held ~2 hours, booked large.

| # | Window | Held | Entry | Exit reason | Basket |
|---|---|---|---|---|---|
| 1 | 09:22:36 → 09:24:45 | 2m09s | 23852.85, stop 23866.00, tgt 23818.5 | `premise_stale_exit` | **+198.50** |
| 2 | 10:17:48 → 10:23:34 | 5m46s | 23793.70, stop 23811.15, tgt 23700.0 | `index_hierarchy_exit` | **−2,169.00** |
| | | | | **TOTAL** | **−1,970.50** |

## 1. v4y — size the retracement before calling it a turn

Trade 2 was cut on an **eleven-point** counter-move (NIFTY 23790 → 23801) in a
session already 90 points below its open, citing a confirmed BankNIFTY hammer off
the 10:17 low. On the mirror's premium those 11 points read as 557.50 → 538.25 —
which is why it felt like a reversal. NIFTY then fell another 50 points.

**What makes this a rule and not a telling-off: v4u was satisfied.** v4u demands
"a CONFIRMED reversal on the leading index… not merely a move against you", and a
confirmed hammer is exactly that. v4u never says how *big* the counter-move must
be, so a one-candle pattern off a fresh low can meet its letter and mean nothing.

IH states the missing half as a rule:

> "Retracements here should be SMALL, because the market HAS to fall… if it did a
> BIG retracement and then fell, then anyone would start selling… **A BIG
> RETRACEMENT HAPPENS WHEN THE MARKET HAS TO TURN.** Now it will not turn."

A market that means to continue cannot afford a big retracement — that is
everyone else's good entry. It is v4w's logic pointed at the counter-move.

And measure it in **index points, never premium**. IH names that trap in the same
breath: *"our profit is reducing because we are sitting in option BUYING. A small
green candle reduces our profit a lot."* The P&L is the one place option buying
guarantees a wrong answer, and it is where the agent was looking.

The booking corollary is the same measurement reversed: when the trend has run
with **no** retracement across the indices, that is when to book — the first real
one is overdue. Never outranks the stop, max loss, or premise-invalidation.

Guard negative-tested **23 ways**, all caught.

### Recorded as compliance gaps, not new rules

- Trade 1 entered with a target the session had **already printed** — its own exit
  says so. v4q already requires that test *before* entry. Its exit conclusion was
  also wrong: it closed a +198.50 winner that still had ~110 points in it.
- Trade 2 **sold into the session low** with no retracement. v4f covers it, and IH
  refuses it explicitly: *"if it is falling directly, we pause a bit. We will not
  rush… the risk is higher here."*

**v4x held** — trade 1 opened with 89% of its sized stop intact, trade 2 with
120%. Neither stop was hit; both exits were the agent's own decision.

## 2. Pre-open note for 08 SEP 2026

**The first one-direction note in the series.** Flat, gap-down *and* gap-up all
take sell-side setups. The only exception is a sudden big positive momentum at
the open — and with no buy branch to fall back to, that means **no trade**, never
a long.

His crowd read cuts against the obvious: after a one-way down day the sellers are
deep in profit but are **not seated in size**, *"because put premiums become very
high, so the trader would not have held the put trade"*. Tomorrow is **NIFTY
expiry**.

Three garbled levels were confirmed with the operator rather than reconstructed
(NIFTY 23660; BankNIFTY 57280/57570 and 56800/57000), each recorded in a test
comment. Negative-tested **23 ways**, including flipping the gap-up branch to a
buy — all caught.

## Gates

547 master · 28 market-data-health · 1256 pytest · ruff · mypy (74 files + the
master) · compileall · bandit · coverage policy — all clean.

> Built in an isolated worktree off `main`, because the primary checkout has
> unrelated in-flight work on `feat/expired-options-data-extractor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
