### PR TITLE
chore(sl-hunting): pre-open note for 09 SEP 2026

### DIFF
--- a/Signal Generators/SL Hunting AI Agent/premarket_note.json
+++ b/Signal Generators/SL Hunting AI Agent/premarket_note.json
@@ -1,47 +1,46 @@
 {
-  "for_date": "2026-09-08",
-  "source": "Intraday Hunter, 'Prediction For 08 SEP 2026' (mfCrKdkHlig, uploaded 2026-09-07)",
-  "context": "All three indices had continuous, good selling today. The sellers are in good profit but did NOT hold in size -- 'put premiums become very high, so the trader would not have held the put trade'. BankNIFTY never crossed its round number.",
+  "for_date": "2026-09-09",
+  "source": "Intraday Hunter, 'Prediction For 09 SEP 2026' (bwqMeOc-b8I, uploaded 2026-09-08)",
+  "context": "Continuous selling in all three indices, so this time the sellers ARE seated -- 'sellers may be in the market here'. But whoever is short has an SL, so they only come under threat on a gap up.",
   "plan": [
-    "SELL ON EVERY OPEN SHAPE. Flat, gap-down AND gap-up all take sell-side setups. The only thing that cancels the plan is a SUDDEN BIG POSITIVE MOMENTUM right at the open: 'that we cannot do anything about'.",
-    "THIS IS THE FIRST ONE-DIRECTION NOTE IN THE SERIES -- there is no buy branch to switch to. If the big-positive-momentum exception fires, the answer is NO TRADE, never a long.",
-    "THE SELLERS ARE IN PROFIT BUT NOT SEATED IN SIZE, because the high put premiums stopped them holding. Being right is not the same as being positioned: there is no big short crowd here to squeeze.",
-    "HE ASKS WHETHER THE FOLLOW CONTINUES, not whether it reverses: 'we cannot directly say the market will go up tomorrow -- we have to see whether we can CONTINUE to follow, or whether the market makes a trap'.",
-    "BANKNIFTY DID NOT CROSS ITS ROUND NUMBER 57000, so 'even if someone made a trade they would not have held it' -- the same un-seated read as NIFTY and SENSEX.",
-    "TOMORROW IS NIFTY EXPIRY. Expect expiry behaviour in NIFTY on top of the shared read."
+    "A SEATED CROWD IS ONLY A TARGET WHEN THE OPEN THREATENS IT: 'if we get flat or gap-down we CANNOT make those sellers our target. If we get a GAP UP, then THEY will see risk.' The open decides whether the shorts are prey or company.",
+    "GAP UP -> BUY side, and in NIFTY it must be ABOVE THE RESISTANCE. This is the only branch that hunts anyone: what you would be taking are the seated shorts' stops.",
+    "FLAT TO GAP-DOWN -> SELL side, walking WITH the market. Explicitly NOT a hunt -- 'do not target them DIRECTLY' -- you are joining the seated shorts, not squeezing them.",
+    "THIS INVERTS YESTERDAY'S CROWD READ WITHOUT CHANGING THE DIRECTION. Yesterday the sellers were in profit but NOT seated (high put premiums stopped them holding); today he says they ARE seated. Same sell branch, a different reason.",
+    "SENSEX'S OLD SUPPORTS ARE NOW ITS RESISTANCES: 75800 and 75950 were yesterday's support pair. Measure the open against those, not against yesterday's ceiling."
   ],
   "levels": [
     {
       "index": "NIFTY",
       "resistance": [
-        23860,
-        23940
+        23670,
+        23720
       ],
       "support": [
-        23660,
-        23720
+        23480,
+        23540
       ]
     },
     {
       "index": "BANKNIFTY",
       "resistance": [
-        57280,
-        57570
+        57100,
+        57870
       ],
       "support": [
-        56800,
-        57000
+        56370,
+        56500
       ]
     },
     {
       "index": "SENSEX",
       "resistance": [
-        76200,
-        76370
-      ],
-      "support": [
         75800,
         75950
+      ],
+      "support": [
+        75200,
+        75310
       ]
     }
   ]

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -6505,3 +6505,80 @@ here, put premiums become very high, so the trader would not have HELD the put
 trade."* Being right is not the same as being positioned.
 
 Tomorrow is **NIFTY expiry**.
+
+## Video addendum - the 8 Sep LIVE SESSION and the 9 Sep prediction (v4z)
+
+**Sources.** Both transcripts read in full:
+
+| Video | Id | Length | Uploaded (IST) | Segments |
+|---|---|---|---|---|
+| Live session, Tuesday 8 Sep (NIFTY expiry) | `NitY2pWf3p0` | 12:47 | 8 Sep 12:41 | 97 (0:02-12:42) |
+| Prediction For 09 SEP 2026 | `bwqMeOc-b8I` | 1:55 | 8 Sep 21:25 | 13 (0:06-1:44) |
+
+### The day, and the first session run under v4y
+
+NIFTY opened 23737.40, fell to ~23670 by 09:30, then chopped 23660-23700 all
+morning. IH entered puts AT the open, followed continuously, and booked his
+target after roughly two hours. The agent took two trades and finished -70.25.
+
+| # | Window | Entry | Exit reason | NIFTY | Mirror | Basket |
+|---|---|---|---|---|---|---|
+| 1 | 09:45:13 -> 09:50:32 | 23670.60, stop 23695.00 | `premise_invalidation_bullish_reversal_cluster` | -393.25 | -393.00 | **-786.25** |
+| 2 | 10:18:42 -> 10:31:36 | 23704.10, stop 23722.00 | `basket_book_stall_reversal` | +65.00 | +651.00 | **+716.00** |
+| | | | **TOTAL** | **-328.25** | **+258.00** | **-70.25** |
+
+**Trade 2 is v4y working, and it should be recorded as such.** It shorted the
+23700.30 spike at 23704.10 - within four points of the top - and booked using the
+completed-hunt test in its own words: *"target zone 23657 already tapped 10:05 and
+sharply rejected to 23717; NIFTY chopping 6+ candles unable to make new low."*
+That is the reasoning v4y and v4q were written for, applied unprompted.
+
+### Trade 1 is the gap, and IH narrates the exact minute
+
+Both watched the same bounce. The agent called it a bullish reversal cluster on
+both indices - morning star plus bullish doji with two-bar follow-through on
+NIFTY, hammer plus bullish engulfing on BankNIFTY - and cut, noting it was "only
+~8pts from its 23695 stop". IH, on the same move:
+
+> "This much is all it should be, the market will not go higher than this...
+> to change the mindset of the traders who were coming in, the market suddenly
+> pulled an upside momentum. **That is, the sellers' SLs are not available here.**
+> See when the problem happens? When in this chart the sellers' SLs WERE
+> available - then this upside momentum becomes dangerous, it creates more SLs
+> then rises, creates more SLs then rises."
+
+Spot at the agent's exit was about 23679. By 10:03 it was **23660.55**, below the
+entry. The cluster died in ten minutes.
+
+That is v4z: a counter-move compounds only when there are stops on YOUR side above
+it to harvest. IH also says why the seats were empty, and both reasons are
+readable from the session's own history - the market had already given its
+retracement and was holding round-number support, and the continuous fall had
+driven put premiums so high that "the trader does make the trade, but NOT in big
+quantity".
+
+### Recorded, not encoded
+
+- **He is NOT hunting on a continuation day, deliberately.** *"In SL hunting it is
+  not that we don't follow continuously. If retail sellers have not come in, the
+  chart can be followed continuously... if some traders are sitting in profit, we
+  don't make them our target either."* Plus a timing model for retail: they sell
+  after "selling, selling, retracement, then fall", not during clean continuation.
+  This is the same seated-crowd logic v4e/v4f/v3y already carry, restated.
+- **Strike selection.** He always sizes around AT THE MONEY: deep ITM gives better
+  momentum but ties up capital and spoils the risk-reward; OTM pays more when
+  momentum comes but "when momentum takes time, OTM hurts more". The agent already
+  trades ATM, so this confirms rather than changes anything.
+- **Option buyers pay rent.** *"If time is taking too long and you are in option
+  BUYING then you should get out. An option SELLER can try, because he can
+  withstand a retracement."* Already covered by v4j and v4g's time rules.
+- **Chop days punish over-trading specifically.** *"In such a market the problem is
+  bigger for traders who overtrade... you will lose more than you profit."*
+
+### Operator constraints, settled
+
+Two things flagged in earlier addenda are **deliberate** and should not be raised
+again: the 11:00 worker cutoff is sized to the operator's Claude Pro 5-hour limit,
+and `SL_HUNTING_RISK_BUDGET` exists so no single trade can lose an unbounded
+amount - so v4x's "if the re-derived stop cannot be sized, take NO trade" is the
+intended outcome of that budget, not a workaround for it.

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
@@ -2181,6 +2181,41 @@ you size or place the NIFTY trade. Advisory, not a hard gate.
   This never overrides the stop, the daily max loss, or premise-invalidation, and
   it does not license sitting through a genuine turn. It refuses exactly one move:
   ending a trade on a counter-move too small to be the turn it is being called.
+- A COUNTER-MOVE IS ONLY DANGEROUS WHEN IT HAS FUEL, AND THE FUEL IS YOUR OWN
+  SIDE'S STOPS SITTING ABOVE IT (v4z). The rule above measures a counter-move
+  AFTER it prints; this one asks whether it can grow at all, which is answerable
+  the moment it starts. The two compose: a counter-move with no fuel cannot
+  become the big one v4y is looking for.
+  THE MECHANISM. You are short. The move against you is up. What makes an up-move
+  compound is other SHORTS above you, because stopping them out puts buy orders
+  into the book, which lifts price, which stops out more of them. IH, watching a
+  sharp bounce inside his winning short: "this much is all it should be, the
+  market will not go higher than this... to change the mindset of the traders who
+  were coming in, the market suddenly pulled an upside momentum. THAT IS, THE
+  SELLERS' SLs ARE NOT AVAILABLE HERE. See when the problem happens? When in this
+  chart the sellers' SLs WERE available -- then this upside momentum becomes
+  DANGEROUS, it creates more SLs then rises, creates more SLs then rises."
+  So the question is never "how convincing is this reversal pattern?" but "WHOSE
+  STOPS WOULD IT EAT ON THE WAY UP?" With nobody seated on your side above you,
+  the move has nothing to trigger; it is aimed at the traders arriving NOW, and
+  it dies. He was explicit about why the seats were empty that day: the market
+  had already given its retracement earlier and was holding round-number support,
+  and the continuous fall had driven put premiums so high that "the trader does
+  make the trade, but NOT in big quantity". Both are readable from the session's
+  own history rather than guessed.
+  MEASURED ON THIS BOOK (2026-09-08), and the same session got it both wrong and
+  right, which is what makes it teachable. A short opened 09:45:13 from 23670.60
+  was cut 09:50:32 on a "premise-invalidation bullish reversal cluster" -- morning
+  star plus bullish doji with two-bar follow-through on NIFTY, hammer plus bullish
+  engulfing on BankNIFTY. Spot at that exit was about 23679. By 10:03 it was
+  23660.55, BELOW the entry: the cluster died in ten minutes. Cost -786.25, and IH
+  sat through the very same move. The second trade then did it correctly, shorting
+  the 23700.30 spike at 23704.10 and booking +716.00.
+  WHAT THIS DOES NOT SAY. It is not "ignore reversal patterns", and it does not
+  weaken v4u -- a confirmed reversal on the leading index still matters. It adds
+  one question before acting on one: a pattern with no crowd underneath it to feed
+  on is a shakeout aimed at you, not a turn. And it never overrides the stop, the
+  daily max loss, or premise-invalidation by a level.
 - INDEX HIERARCHY ON THE WAY OUT — the indices are NOT equal when a position is
   going against you (v3y). NIFTY and Sensex drifting against the trade is
   TOLERABLE; that is handleable noise and does not by itself end the trade.

--- a/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_premarket.py
+++ b/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_premarket.py
@@ -201,26 +201,25 @@ def test_shipped_note_targets_the_next_TRADING_day_not_the_next_calendar_day():
     )
 
 
-def test_shipped_note_matches_september_8_intraday_hunter_plan():
-    """The committed advisory must match the hand-checked 07 Sep transcript.
+def test_shipped_note_matches_september_9_intraday_hunter_plan():
+    """The committed advisory must match the hand-checked 08 Sep transcript.
 
-    Six things a summarising edit would flatten, each of which would change what
-    the agent does at 09:15:
+    Five things a summarising edit would flatten, each of which would change
+    what the agent does at 09:15:
 
-    1. EVERY open shape sells -- flat, gap-down and gap-up alike. Every previous
-       note in this series branched by open shape, so an edit that "restores"
-       a buy branch would be reverting to a habit rather than to the source.
-    2. The one exception is a SUDDEN BIG POSITIVE MOMENTUM at the open, and its
-       consequence is NO TRADE, not a long. There is no buy branch to fall to.
-    3. The sellers are in profit but NOT seated in size, because high put
-       premiums stopped them holding. That is the opposite of the obvious read
-       after a one-way down day, and it is what stops the note being taken as
-       "a big short crowd is there to squeeze".
-    4. He frames the question as whether the FOLLOW continues, not whether the
-       market reverses.
-    5. BankNIFTY never crossed its round number, which is why nobody held there
-       either.
-    6. Tomorrow is NIFTY expiry.
+    1. The crowd IS seated this time, and the whole note turns on the fact that
+       a seated crowd is only a TARGET when the open threatens it. Flat or
+       gap-down cannot threaten shorts, so those branches join them instead.
+       Collapse that and the note reads as "sell because sellers are there",
+       which is the opposite of the SL-hunting premise.
+    2. The gap-up branch is the ONLY hunting branch, and in NIFTY it needs the
+       open to be ABOVE THE RESISTANCE, not merely green.
+    3. The flat/gap-down branch is explicitly NOT a hunt -- "do not target them
+       DIRECTLY". Reading it as one would invent a squeeze that is not there.
+    4. The crowd read INVERTS yesterday's while the direction stays the same.
+       Yesterday: sellers in profit but not seated. Today: seated. An edit that
+       "reconciles" the two by dropping one would lose the reason.
+    5. SENSEX's old supports (75800/75950) are now its resistances.
     """
     import os
 
@@ -228,57 +227,57 @@ def test_shipped_note_matches_september_8_intraday_hunter_plan():
     note = load_premarket_note(os.path.join(here, "premarket_note.json"))
 
     assert note is not None
-    assert note.for_date == "2026-09-08"
-    assert "mfCrKdkHlig" in note.source
-    # The crowd read, and the mechanism that makes it counter-intuitive.
-    assert "continuous, good selling" in note.context
-    assert "did NOT hold in size" in note.context
-    assert "put premiums become very high" in note.context
+    assert note.for_date == "2026-09-09"
+    assert "bwqMeOc-b8I" in note.source
+    # Seated this time -- and the reason they are still not automatically prey.
+    assert "the sellers ARE seated" in note.context
+    assert "whoever is short has an SL" in note.context
+    assert "only come under threat on a gap up" in note.context
 
-    every = next(line for line in note.plan if line.startswith("SELL ON EVERY OPEN SHAPE"))
-    assert "Flat, gap-down AND gap-up all take sell-side setups" in every
-    assert "SUDDEN BIG POSITIVE MOMENTUM right at the open" in every
-    assert "that we cannot do anything about" in every
+    seated = next(line for line in note.plan if line.startswith("A SEATED CROWD IS ONLY A TARGET"))
+    assert "CANNOT make those sellers our target" in seated
+    assert "If we get a GAP UP, then THEY will see risk" in seated
+    assert "whether the shorts are prey or company" in seated
 
-    one_way = next(line for line in note.plan if line.startswith("THIS IS THE FIRST ONE-DIRECTION"))
-    assert "there is no buy branch to switch to" in one_way
-    # The exception must resolve to standing aside, never to flipping long.
-    assert "the answer is NO TRADE, never a long" in one_way
+    up = next(line for line in note.plan if line.startswith("GAP UP ->"))
+    assert "BUY side" in up
+    assert "ABOVE THE RESISTANCE" in up
+    assert "the only branch that hunts anyone" in up
 
-    crowd = next(line for line in note.plan if line.startswith("THE SELLERS ARE IN PROFIT"))
-    assert "NOT SEATED IN SIZE" in crowd
-    assert "high put premiums stopped them holding" in crowd
-    assert "Being right is not the same as being positioned" in crowd
-    assert "no big short crowd here to squeeze" in crowd
+    down = next(line for line in note.plan if line.startswith("FLAT TO GAP-DOWN ->"))
+    assert "SELL side, walking WITH the market" in down
+    assert "Explicitly NOT a hunt" in down
+    assert "do not target them DIRECTLY" in down
+    assert "joining the seated shorts, not squeezing them" in down
 
-    follow = next(line for line in note.plan if line.startswith("HE ASKS WHETHER THE FOLLOW"))
-    assert "not whether it reverses" in follow
-    assert "cannot directly say the market will go up tomorrow" in follow
-    assert "whether we can CONTINUE to follow" in follow
+    inv = next(line for line in note.plan if line.startswith("THIS INVERTS YESTERDAY'S CROWD READ"))
+    assert "WITHOUT CHANGING THE DIRECTION" in inv
+    assert "in profit but NOT seated" in inv
+    assert "today he says they ARE seated" in inv
 
-    assert any("ROUND NUMBER 57000" in line for line in note.plan)
-    assert any("TOMORROW IS NIFTY EXPIRY" in line for line in note.plan)
+    assert any("75800 and 75950 were yesterday's support" in line for line in note.plan)
 
     assert [level.model_dump() for level in note.levels] == [
         {
-            # "23720 2360" -- the second support came through truncated and was
-            # confirmed with the operator as 23660, not the rounder 23600.
             "index": "NIFTY",
-            "resistance": [23860.0, 23940.0],
-            "support": [23660.0, 23720.0],
+            "resistance": [23670.0, 23720.0],
+            "support": [23480.0, 23540.0],
         },
         {
-            # Both BankNIFTY sides were garbled: resistances as "57284 57570"
-            # and supports as the unusable seven-digit "5756800". Confirmed as
-            # 57280/57570 and 56800/57000 -- 57000 being the round number he
-            # says the market failed to cross. Do NOT reconstruct from caption.
+            # "57100 57876" -- the second resistance came through mangled and
+            # was confirmed with the operator as 57870, not the rounder 57800.
             "index": "BANKNIFTY",
-            "resistance": [57280.0, 57570.0],
-            "support": [56800.0, 57000.0],
+            "resistance": [57100.0, 57870.0],
+            "support": [56370.0, 56500.0],
         },
         {
+            # Supports were unusable in the caption ("7530 750"). The operator
+            # listened to the video and gave 75310/75200 -- NEITHER of the two
+            # readings offered from the transcript was right, which is why these
+            # get asked rather than reconstructed. Note the resistances here are
+            # yesterday's support pair, unchanged in value and flipped in role.
             "index": "SENSEX",
-            "resistance": [76200.0, 76370.0],
-            "support": [75800.0, 75950.0],
+            "resistance": [75800.0, 75950.0],
+            "support": [75200.0, 75310.0],
         },
     ]

--- a/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_schema.py
+++ b/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_schema.py
@@ -2382,3 +2382,68 @@ def test_v4y_retracement_size_decides_turn_versus_continuation():
     assert "never overrides the stop, the daily max loss, or premise-invalidation" in rule
     assert "does not license sitting through a genuine turn" in rule
     assert "too small to be the turn it is being called" in rule
+def test_v4z_a_counter_move_needs_fuel_to_be_dangerous():
+    """v4z (08 Sep live session + this book): whose stops would it eat?
+
+    v4y measures a counter-move after it prints. This one asks whether it can
+    grow at all. Six ways an edit could break it:
+
+    1. Losing the direction of the mechanism. The fuel is YOUR OWN side's stops
+       above you -- other shorts, whose stop-outs are buy orders. Flip that and
+       the test points at the wrong crowd.
+    2. Turning it into "ignore reversal patterns". It adds a question before
+       acting on a pattern; it does not delete v4u.
+    3. Dropping IH's compounding description -- creates SLs, rises, creates more
+       -- which is the only thing that explains why a fuelled move is different
+       in kind rather than just bigger.
+    4. Losing the two readable reasons the seats were empty that day (the
+       retracement already given at round-number support, and premiums too high
+       for size). Without them the test is unanswerable in the moment.
+    5. Dropping the measured pair. The SAME session got it wrong at 09:50 and
+       right at 10:18, which is what makes it teachable rather than a scolding.
+    6. Losing the override clause.
+    """
+    prompt = build_system_prompt()
+    rule = _flat_rule(prompt, "A COUNTER-MOVE IS ONLY DANGEROUS WHEN IT HAS FUEL")
+
+    # 1. Direction of the mechanism, and how it compounds.
+    assert "THE FUEL IS YOUR OWN SIDE'S STOPS SITTING ABOVE IT" in rule
+    assert "other SHORTS above you" in rule
+    assert "stopping them out puts buy orders into the book" in rule
+    # The compounding half of the sentence, not just the first link.
+    assert "which lifts price, which stops out more of them" in rule
+
+    # It composes with v4y rather than replacing it.
+    assert "measures a counter-move AFTER it prints" in rule
+    assert "a counter-move with no fuel cannot become the big one" in rule
+
+    # 3. IH's words, including the compounding loop.
+    assert "THE SELLERS' SLs ARE NOT AVAILABLE HERE" in rule
+    assert "creates more SLs then rises" in rule
+    assert "the market will not go higher than this" in rule
+
+    # The question the agent must actually ask.
+    assert "WHOSE STOPS WOULD IT EAT ON THE WAY UP?" in rule
+    assert 'the question is never "how convincing is this reversal pattern?"' in rule
+    assert "aimed at the traders arriving NOW" in rule
+
+    # 4. Why the seats were empty -- both readable from the session itself.
+    assert "already given its retracement earlier and was holding round-number support" in rule
+    assert "but NOT in big quantity" in rule
+
+    # 5. The measured pair, wrong then right, in one session.
+    assert "MEASURED ON THIS BOOK (2026-09-08)" in rule
+    assert "09:45:13 from 23670.60" in rule
+    assert "premise-invalidation bullish reversal cluster" in rule
+    assert "By 10:03 it was" in rule
+    assert "23660.55, BELOW the entry" in rule
+    assert "cluster died in ten minutes" in rule
+    assert "-786.25" in rule
+    assert "IH sat through the very same move" in rule
+    assert "booking +716.00" in rule
+
+    # 2 and 6. Scope: it does not delete v4u, and cannot outrank hard risk.
+    assert "It is not \"ignore reversal patterns\"" in rule
+    assert "does not weaken v4u" in rule
+    assert "a shakeout aimed at you, not a turn" in rule
+    assert "never overrides the stop, the daily max loss, or premise-invalidation" in rule


### PR DESCRIPTION
Today's note, ahead of the 09:15 open.

**The crowd is seated this time** — after three sessions of continuous selling, the inverse of yesterday's read. The note turns on a distinction the agent has not been given this plainly: **a seated crowd is only a target when the open threatens it.**

> "If we get flat or gap-down we CANNOT make those sellers our target. If we get a GAP UP, then THEY will see risk."

| Open | Branch | Hunt? |
|---|---|---|
| Gap up (NIFTY: above the resistance) | BUY | **Yes** — the shorts' stops |
| Flat to gap-down | SELL, walking with the market | **No** — "do not target them DIRECTLY" |

The flattening risk is reading it as "sellers are seated, so sell", which inverts the premise: on the sell branch the seated crowd is company, not prey.

SENSEX's old supports (75800/75950) are now its resistances — same values, flipped role.

**Levels:** two captions garbled. BankNIFTY's second resistance "57876" → confirmed 57870. SENSEX supports were unusable ("7530 750") and the operator listened to the video: **75310 / 75200** — neither reading I offered was right, which is why these get asked rather than reconstructed.

Negative-tested **22 ways**, all caught. Gates: 547 master · 28 market-data-health · 1357 pytest · ruff 0.16.6 · mypy (77 + master) · compileall · bandit — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)