### PR TITLE
feat(sl-hunting): v5a - the stop is a size dial, plus the 10 Sep pre-open note

### DIFF
--- a/Signal Generators/SL Hunting AI Agent/premarket_note.json
+++ b/Signal Generators/SL Hunting AI Agent/premarket_note.json
@@ -1,46 +1,46 @@
 {
-  "for_date": "2026-09-09",
-  "source": "Intraday Hunter, 'Prediction For 09 SEP 2026' (bwqMeOc-b8I, uploaded 2026-09-08)",
-  "context": "Continuous selling in all three indices, so this time the sellers ARE seated -- 'sellers may be in the market here'. But whoever is short has an SL, so they only come under threat on a gap up.",
+  "for_date": "2026-09-10",
+  "source": "Intraday Hunter, 'Prediction For 10 SEP 2026' (BbY6TwoC90o, uploaded 2026-09-09)",
+  "context": "Overall selling again, but the shape matters: the market HELD first and only then fell. 'Holding forms a PSYCHOLOGY, then the market falls' -- so few could participate in the selling, and the sellers are thin rather than seated.",
   "plan": [
-    "A SEATED CROWD IS ONLY A TARGET WHEN THE OPEN THREATENS IT: 'if we get flat or gap-down we CANNOT make those sellers our target. If we get a GAP UP, then THEY will see risk.' The open decides whether the shorts are prey or company.",
-    "GAP UP -> BUY side, and in NIFTY it must be ABOVE THE RESISTANCE. This is the only branch that hunts anyone: what you would be taking are the seated shorts' stops.",
-    "FLAT TO GAP-DOWN -> SELL side, walking WITH the market. Explicitly NOT a hunt -- 'do not target them DIRECTLY' -- you are joining the seated shorts, not squeezing them.",
-    "THIS INVERTS YESTERDAY'S CROWD READ WITHOUT CHANGING THE DIRECTION. Yesterday the sellers were in profit but NOT seated (high put premiums stopped them holding); today he says they ARE seated. Same sell branch, a different reason.",
-    "SENSEX'S OLD SUPPORTS ARE NOW ITS RESISTANCES: 75800 and 75950 were yesterday's support pair. Measure the open against those, not against yesterday's ceiling."
+    "THE HOLD IS THE WHOLE READ: 'if the market had NOT held here, if it had gone straight up and then straight down, then reversal chances rise. But it HELD, then fell.' The hold is why he is following rather than fading.",
+    "FLAT TO GAP-DOWN -> SELL side, walking WITH the market. Same conclusion as yesterday but for the opposite reason: yesterday the sellers were seated and could not be hunted; today they are thin because the hold kept them out.",
+    "ABOVE THE RESISTANCE -> BUY side. 'There the danger to the sellers increases -- even those already short come under risk.' As yesterday, that is the only branch that hunts, and he wants a GOOD gap up, not a marginal one.",
+    "SENSEX HAS EXPIRY tomorrow. Expect expiry behaviour in SENSEX on top of the shared read; NIFTY's own expiry was 08 Sep and is past.",
+    "HIS RESISTANCES ARE THE OPEN'S MEASURING STICK, not a target: the buy branch needs an opening ABOVE them (NIFTY 23540, BankNIFTY 56600, SENSEX 75200), which is a level test, not a gap-size test."
   ],
   "levels": [
     {
       "index": "NIFTY",
       "resistance": [
-        23670,
-        23720
+        23540,
+        23674
       ],
       "support": [
-        23480,
-        23540
+        23340,
+        23400
       ]
     },
     {
       "index": "BANKNIFTY",
       "resistance": [
-        57100,
-        57870
+        56600,
+        56870
       ],
       "support": [
-        56370,
-        56500
+        56040,
+        56200
       ]
     },
     {
       "index": "SENSEX",
       "resistance": [
-        75800,
-        75950
+        75200,
+        75500
       ],
       "support": [
-        75200,
-        75310
+        74300,
+        74500
       ]
     }
   ]

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -6582,3 +6582,107 @@ again: the 11:00 worker cutoff is sized to the operator's Claude Pro 5-hour limi
 and `SL_HUNTING_RISK_BUDGET` exists so no single trade can lose an unbounded
 amount - so v4x's "if the re-derived stop cannot be sized, take NO trade" is the
 intended outcome of that budget, not a workaround for it.
+
+## Video addendum - the 9 Sep LIVE SESSION and the 10 Sep prediction (v5a)
+
+**Sources.** Both transcripts read in full:
+
+| Video | Id | Length | Uploaded (IST) | Segments |
+|---|---|---|---|---|
+| Live session, Wednesday 9 Sep | `6ZCIGnuRZpE` | 11:31 | 9 Sep 11:38 | 92 (0:02-11:29) |
+| Prediction For 10 SEP 2026 | `BbY6TwoC90o` | 2:13 | 9 Sep 21:25 | 17 (0:06-2:04) |
+
+### IH LOST TODAY, and that is the most useful thing in the video
+
+He is not a benchmark that always wins, and this session is the counter-example
+to v4z. He read the fuel correctly and still had to cut:
+
+> "The market shouldn't go up, because **no SLs are available nearby**. No
+> psychology is forming that would take it up. But if it IS going up, we have a
+> LIMIT... I feel fear when I can SEE SLs available, or when something forms per
+> the mindset. There's nothing like that -- but the market is going up, the loss
+> is growing, **so we'll have to exit. There's no other way.**"
+
+And the discipline that ended it:
+
+> "We cannot wait OUTSIDE the loss limit... if it keeps crossing the LIMIT again
+> and again, you should exit. **Don't build the habit of just sitting and
+> sitting.** If we keep sitting like this, the market can give a very big loss --
+> if not today then someday."
+
+**CALIBRATION ON v4z, and it should be read WITH the rule rather than against it.**
+v4z says an unfuelled counter-move dies. Today it did not, for the man who wrote
+the reasoning. The absence of fuel raises the odds; it does not remove the need
+for the loss limit, which is exactly what v4z's own override clause and v4h
+already say. What today adds is the demonstration: being right about the fuel and
+still losing is a NORMAL outcome, not evidence the read was wrong.
+
+### The day: 2 trades, -1,701.50
+
+NIFTY gapped down to 23519.45, chopped 23474-23545 all morning, closed ~23470.
+
+| # | Window | Entry | Stop | Lots | Exit | Basket |
+|---|---|---|---|---|---|---|
+| 1 | 09:24:48 -> 09:26:19 | 23500.60 | 23518.00 (15.15pt) | 2 | mechanical `AI_STOP` at 23519.30 | **-1,202.00** |
+| 2 | 09:50:37 -> 09:58:35 | 23497.90 | 23510.00 (11.85pt) | 3 | `index_hierarchy_reversal_exit` | **-499.50** |
+
+**Trade 2's exit was RIGHT and should be recorded as such.** It cut at ~23494;
+NIFTY fell to 23474.85 by 10:09 and then rallied to 23545.55 by 10:25, which
+would have taken out the 23510 stop for a larger loss. The BankNIFTY hammer it
+cited was an early read on a real turn.
+
+But its rationale contains the sentence worth watching: *"Per the index
+hierarchy, a confirmed reversal on the leading index disqualifies the short
+basket **even though NIFTY's own pullback is small**."* It saw v4y's measurement,
+named it, and overrode it with the hierarchy. It was right this time. The corpus
+should not be edited on one correct call, but if hierarchy-over-size becomes the
+habit, that is the seam to watch.
+
+### Trade 1 is v5a
+
+Stopped ninety-one seconds after entry, on a 15.15-point stop, in the bounce that
+follows a large gap down. The direction was right - NIFTY reached 23474.85 by
+10:09 - and the session's opening bounce topped at 23524.20, so a ~24-point stop
+would have survived it and bought ONE lot instead of two.
+
+IH describes that exact bounce, in advance, in the same session:
+
+> "The gap down is quite good, so **let's WAIT a bit**, because the momentums are
+> sharp. If such selling comes in a gap down, nobody will buy - everyone starts
+> selling... **If the market fell straight, RANDOM SELLERS also get activated, and
+> when it flushes them, sometimes the market makes a bigger positive momentum.**
+> Greed will definitely come here, but we must not be greedy."
+
+That is now the SECOND time he has said wait-for-the-retracement on a directional
+open (7 Sep was the first), and the second time the agent has been hurt by not
+waiting. It stays recorded rather than encoded only because v4f already covers it;
+if it recurs a third time, encode it.
+
+### The sizing arithmetic behind v5a
+
+Nineteen sizing decisions are now in the log, and the relationship is exact:
+
+| stop (pts) | one-lot risk | lots | NIFTY qty | mirror qty |
+|---|---|---|---|---|
+| 25.30 | 1,644.50 | 1 | 65 | 30 |
+| 17.90 | 1,163.50 | 2 | 130 | 60 |
+| 15.15 | 984.75 | 2 | 130 | 60 |
+| 11.85 | 770.25 | 3 | 195 | 90 |
+| 7.65 | 497.25 | **5 (cap)** | 325 | 150 |
+
+Same 2500 budget throughout. The stop is not setting risk, it is setting size -
+and the BankNIFTY mirror, which is equal-LOT and outside the budget entirely,
+scales with it: about 15,350 of premium at a 24.40-point stop on 08 Sep, about
+46,845 at an 11.85-point stop on 09 Sep.
+
+### The 10 Sep prediction: the HOLD is the read
+
+Same sell branch as yesterday, opposite reason. He gives the counterfactual
+himself: *"if the market had NOT held here, if it had gone straight up and then
+straight down, then reversal chances rise. But it HELD, then fell"* - and
+*"holding forms a PSYCHOLOGY, then the market falls"*. Because it held, few could
+participate, so the sellers are THIN rather than seated. Yesterday they were
+seated and therefore unhuntable; today they are thin. Same branch, different
+mechanism, and the mechanism is what would flip it.
+
+**SENSEX has expiry** on 10 Sep; NIFTY's was 08 Sep and is past.

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
@@ -1471,6 +1471,38 @@ RISK DISCIPLINE
   make it SMALLER or make it not exist.
   This bites hardest in the opening minutes, which are both the fastest the market
   moves all day and the moment the temptation to act is strongest.
+- A TIGHTER STOP IS NOT LESS RISK, IT IS MORE SIZE (v5a). The completion of the
+  rule above, and the direction it does not cover. v4x handles a stop too WIDE to
+  size; this one handles the far more tempting move of making it narrow.
+  THE ARITHMETIC, because it is not visible from inside a decision. The host sizes
+  every entry as one_lot_risk = |entry - stop| * lot_size, then takes
+  lots = min(max_lots, floor(budget / one_lot_risk)). The rupee risk on the NIFTY
+  leg is therefore held CONSTANT by construction, whatever stop you choose. What
+  the stop actually sets is the QUANTITY. MEASURED ACROSS 19 SIZING DECISIONS on
+  this book: a 25.30-point stop bought 1 lot, and a 7.65-point stop bought 5 -- the
+  cap -- out of the same 2500 budget.
+  THREE THINGS SCALE WITH QUANTITY AND NOT WITH THE STOP YOU PLANNED:
+  * THE BANKNIFTY MIRROR IS EQUAL-LOT AND SITS OUTSIDE THE BUDGET. 2026-09-08's
+    24.40-point stop took 30 mirror lots-worth at 511.65, about 15,350 of premium;
+    2026-09-09's 11.85-point stop took 90 at 520.50, about 46,845. Tightening the
+    stop by twelve points TRIPLED the exposure the budget does not measure.
+  * Slippage and any gap through the stop are charged per unit, so they grow with
+    quantity while the planned loss does not.
+  * The PROBABILITY the stop is hit rises as it tightens. A constant rupee loss
+    suffered more often is not a smaller loss.
+  So a tight stop is leverage wearing the costume of caution, and the budget will
+  not object, because the number it watches has not moved.
+  MEASURED ON THIS BOOK (2026-09-09), the first trade. A short was opened at
+  09:24:48 from 23500.60 with the stop 15.15 points away, which bought 2 lots, and
+  the mechanical AI_STOP fired NINETY-ONE SECONDS later at 23519.30 for -1,202.00.
+  The direction was right: NIFTY reached 23474.85 by 10:09. The session's opening
+  bounce topped at 23524.20, so a stop placed above it -- about 24 points, which
+  would have bought ONE lot -- would have survived the move that ended the trade.
+  PRACTICAL FORM: choose the stop THE PREMISE REQUIRES, then accept whatever size
+  falls out of it. Never choose a stop in order to obtain a size, and treat a
+  shrinking stop across consecutive trades as a warning that this is happening. If
+  the premise-width stop sizes to zero lots, v4x already governs and the answer is
+  no trade.
 - NAME THE LAST POINT, NOT ONLY THE STOP (v4e). One price, declared out loud BEFORE
   you need it, at which the question stops being "is the read still alive?" and
   becomes "did it recover or not?" IH, deep in a losing trade: "let us pause a

--- a/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_premarket.py
+++ b/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_premarket.py
@@ -201,25 +201,25 @@ def test_shipped_note_targets_the_next_TRADING_day_not_the_next_calendar_day():
     )
 
 
-def test_shipped_note_matches_september_9_intraday_hunter_plan():
-    """The committed advisory must match the hand-checked 08 Sep transcript.
+def test_shipped_note_matches_september_10_intraday_hunter_plan():
+    """The committed advisory must match the hand-checked 09 Sep transcript.
 
     Five things a summarising edit would flatten, each of which would change
     what the agent does at 09:15:
 
-    1. The crowd IS seated this time, and the whole note turns on the fact that
-       a seated crowd is only a TARGET when the open threatens it. Flat or
-       gap-down cannot threaten shorts, so those branches join them instead.
-       Collapse that and the note reads as "sell because sellers are there",
-       which is the opposite of the SL-hunting premise.
-    2. The gap-up branch is the ONLY hunting branch, and in NIFTY it needs the
-       open to be ABOVE THE RESISTANCE, not merely green.
-    3. The flat/gap-down branch is explicitly NOT a hunt -- "do not target them
-       DIRECTLY". Reading it as one would invent a squeeze that is not there.
-    4. The crowd read INVERTS yesterday's while the direction stays the same.
-       Yesterday: sellers in profit but not seated. Today: seated. An edit that
-       "reconciles" the two by dropping one would lose the reason.
-    5. SENSEX's old supports (75800/75950) are now its resistances.
+    1. The HOLD is the whole read. He states the counterfactual himself -- had
+       the market gone straight up and straight down, reversal odds would rise;
+       because it HELD and then fell, few participated. Lose that and the note
+       is just "sell again", with no way to tell when it stops applying.
+    2. The sell branch reaches the same conclusion as yesterday for the OPPOSITE
+       reason. Yesterday: sellers seated, so unhuntable. Today: sellers thin,
+       because the hold kept them out. An edit that "simplifies" the two into
+       one loses the mechanism that would flip the branch.
+    3. The buy branch is still the only hunting branch and still needs a GOOD
+       gap up, ABOVE the resistance -- a level test, not a gap-size test.
+    4. SENSEX has expiry; NIFTY's was 08 Sep and is past. Getting this backwards
+       would put expiry behaviour on the wrong index.
+    5. The resistances are the open's measuring stick, not a target.
     """
     import os
 
@@ -227,57 +227,54 @@ def test_shipped_note_matches_september_9_intraday_hunter_plan():
     note = load_premarket_note(os.path.join(here, "premarket_note.json"))
 
     assert note is not None
-    assert note.for_date == "2026-09-09"
-    assert "bwqMeOc-b8I" in note.source
-    # Seated this time -- and the reason they are still not automatically prey.
-    assert "the sellers ARE seated" in note.context
-    assert "whoever is short has an SL" in note.context
-    assert "only come under threat on a gap up" in note.context
+    assert note.for_date == "2026-09-10"
+    assert "BbY6TwoC90o" in note.source
+    # The shape, not just the direction.
+    assert "the market HELD first and only then fell" in note.context
+    assert "Holding forms a PSYCHOLOGY" in note.context
+    assert "thin rather than seated" in note.context
 
-    seated = next(line for line in note.plan if line.startswith("A SEATED CROWD IS ONLY A TARGET"))
-    assert "CANNOT make those sellers our target" in seated
-    assert "If we get a GAP UP, then THEY will see risk" in seated
-    assert "whether the shorts are prey or company" in seated
+    hold = next(line for line in note.plan if line.startswith("THE HOLD IS THE WHOLE READ"))
+    assert "if the market had NOT held here" in hold
+    assert "straight up and then straight down" in hold
+    assert "reversal chances rise" in hold
+    assert "following rather than fading" in hold
 
-    up = next(line for line in note.plan if line.startswith("GAP UP ->"))
-    assert "BUY side" in up
-    assert "ABOVE THE RESISTANCE" in up
-    assert "the only branch that hunts anyone" in up
+    sell = next(line for line in note.plan if line.startswith("FLAT TO GAP-DOWN ->"))
+    assert "walking WITH the market" in sell
+    # Same branch as yesterday, opposite reason -- both halves must survive.
+    assert "yesterday the sellers were seated and could not be hunted" in sell
+    assert "today they are thin because the hold kept them out" in sell
 
-    down = next(line for line in note.plan if line.startswith("FLAT TO GAP-DOWN ->"))
-    assert "SELL side, walking WITH the market" in down
-    assert "Explicitly NOT a hunt" in down
-    assert "do not target them DIRECTLY" in down
-    assert "joining the seated shorts, not squeezing them" in down
+    buy = next(line for line in note.plan if line.startswith("ABOVE THE RESISTANCE ->"))
+    assert "danger to the sellers increases" in buy
+    assert "those already short come under risk" in buy
+    assert "the only branch that hunts" in buy
+    assert "GOOD gap up, not a marginal one" in buy
 
-    inv = next(line for line in note.plan if line.startswith("THIS INVERTS YESTERDAY'S CROWD READ"))
-    assert "WITHOUT CHANGING THE DIRECTION" in inv
-    assert "in profit but NOT seated" in inv
-    assert "today he says they ARE seated" in inv
+    expiry = next(line for line in note.plan if line.startswith("SENSEX HAS EXPIRY"))
+    assert "NIFTY's own expiry was 08 Sep and is past" in expiry
 
-    assert any("75800 and 75950 were yesterday's support" in line for line in note.plan)
+    assert any("level test, not a gap-size test" in line for line in note.plan)
 
     assert [level.model_dump() for level in note.levels] == [
         {
+            # "23540 236 74" -- the second resistance arrived split across the
+            # caption and was confirmed with the operator as 23674, not 23640.
             "index": "NIFTY",
-            "resistance": [23670.0, 23720.0],
-            "support": [23480.0, 23540.0],
+            "resistance": [23540.0, 23674.0],
+            "support": [23340.0, 23400.0],
         },
         {
-            # "57100 57876" -- the second resistance came through mangled and
-            # was confirmed with the operator as 57870, not the rounder 57800.
+            # "56876 56600" -- confirmed as 56600/56870, not rounded to 56800.
             "index": "BANKNIFTY",
-            "resistance": [57100.0, 57870.0],
-            "support": [56370.0, 56500.0],
+            "resistance": [56600.0, 56870.0],
+            "support": [56040.0, 56200.0],
         },
         {
-            # Supports were unusable in the caption ("7530 750"). The operator
-            # listened to the video and gave 75310/75200 -- NEITHER of the two
-            # readings offered from the transcript was right, which is why these
-            # get asked rather than reconstructed. Note the resistances here are
-            # yesterday's support pair, unchanged in value and flipped in role.
+            # "75,200 75,5500" carried a duplicated digit; confirmed as 75500.
             "index": "SENSEX",
-            "resistance": [75800.0, 75950.0],
-            "support": [75200.0, 75310.0],
+            "resistance": [75200.0, 75500.0],
+            "support": [74300.0, 74500.0],
         },
     ]

--- a/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_schema.py
+++ b/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_schema.py
@@ -2447,3 +2447,68 @@ def test_v4z_a_counter_move_needs_fuel_to_be_dangerous():
     assert "does not weaken v4u" in rule
     assert "a shakeout aimed at you, not a turn" in rule
     assert "never overrides the stop, the daily max loss, or premise-invalidation" in rule
+def test_v5a_a_tighter_stop_buys_size_rather_than_safety():
+    """v5a (09 Sep, measured on this book): the stop is a size dial.
+
+    The agent cannot derive this from inside a decision -- the sizing maths runs
+    in the host, and the number the budget watches does not move when the stop
+    narrows. Six ways an edit could break it:
+
+    1. Losing the arithmetic. Without one_lot_risk and the floor(), the claim
+       that rupee risk is held constant is an assertion rather than a mechanism.
+    2. Dropping the 25.30 -> 1 lot and 7.65 -> 5 lots endpoints, which are what
+       make the size effect concrete rather than directional.
+    3. Losing the MIRROR consequence. That leg is equal-lot and outside the
+       budget, so it is where tightening actually costs money; an edit that
+       keeps only "more quantity" loses the part that bites.
+    4. Dropping either of the other two quantity-scaled costs (per-unit
+       slippage, and a constant loss suffered more OFTEN).
+    5. Losing the measured trade, including that the DIRECTION was right and a
+       premise-width stop would have survived. Without it the rule reads as
+       "use wider stops", which is not what it says.
+    6. Losing the practical form -- stop first, size second, never the reverse.
+    """
+    prompt = build_system_prompt()
+    rule = _flat_rule(prompt, "A TIGHTER STOP IS NOT LESS RISK")
+
+    # 1. The mechanism, and its relationship to v4x.
+    assert "IT IS MORE SIZE" in rule
+    assert "v4x handles a stop too WIDE to size" in rule
+    # It must claim to cover the OTHER direction, not restate v4x.
+    assert "the direction it does not cover" in rule
+    assert "one_lot_risk = |entry - stop| * lot_size" in rule
+    assert "lots = min(max_lots, floor(budget / one_lot_risk))" in rule
+    assert "held CONSTANT by construction" in rule
+    assert "What the stop actually sets is the QUANTITY" in rule
+
+    # 2. The measured endpoints, same budget.
+    assert "MEASURED ACROSS 19 SIZING DECISIONS" in rule
+    assert "25.30-point stop bought 1 lot" in rule
+    assert "7.65-point stop bought 5" in rule
+
+    # 3. The mirror -- equal-lot, outside the budget, where it actually costs.
+    assert "THE BANKNIFTY MIRROR IS EQUAL-LOT AND SITS OUTSIDE THE BUDGET" in rule
+    assert "about 15,350 of premium" in rule
+    assert "about 46,845" in rule
+    assert "TRIPLED the exposure the budget does not measure" in rule
+
+    # 4. The other two costs that scale with quantity.
+    assert "charged per unit" in rule
+    assert "PROBABILITY the stop is hit rises as it tightens" in rule
+    assert "A constant rupee loss suffered more often is not a smaller loss" in rule
+    assert "leverage wearing the costume of caution" in rule
+
+    # 5. The measured trade, including that the read was right.
+    assert "MEASURED ON THIS BOOK (2026-09-09)" in rule
+    assert "15.15 points away, which bought 2 lots" in rule
+    assert "NINETY-ONE SECONDS later at 23519.30" in rule
+    assert "-1,202.00" in rule
+    assert "The direction was right" in rule
+    assert "NIFTY reached 23474.85 by 10:09" in rule
+    assert "would have bought ONE lot -- would have survived" in rule
+
+    # 6. Stop first, size second -- and the tie back to v4x for the other end.
+    assert "choose the stop THE PREMISE REQUIRES" in rule
+    assert "Never choose a stop in order to obtain a size" in rule
+    assert "shrinking stop across consecutive trades as a warning" in rule
+    assert "v4x already governs and the answer is no trade" in rule


### PR DESCRIPTION
Two commits, from today's session and tonight's prediction video.

## The day: 2 trades, −₹1,701.50

NIFTY gapped down to 23519.45, chopped 23474–23545, closed ~23470.

| # | Window | Entry | Stop | Lots | Exit | Basket |
|---|---|---|---|---|---|---|
| 1 | 09:24:48 → 09:26:19 | 23500.60 | 15.15pt | 2 | mechanical `AI_STOP` | **−1,202.00** |
| 2 | 09:50:37 → 09:58:35 | 23497.90 | 11.85pt | 3 | `index_hierarchy_reversal_exit` | **−499.50** |

**Trade 2 was right** and the addendum records it as such — it cut at ~23494 before the rally to 23545.55 that would have taken out its stop.

## 1. v5a — a tighter stop is not less risk, it is more size

Trade 1 died **91 seconds** after entry. The direction was right (NIFTY hit 23474.85 by 10:09), and the opening bounce topped at 23524.20 — so a ~24-point stop would have survived it.

The reason it was not placed there is arithmetic invisible from inside a decision:

```
one_lot_risk = |entry - stop| * lot_size
lots         = min(max_lots, floor(budget / one_lot_risk))
```

Rupee risk on the NIFTY leg is **constant by construction**. What the stop sets is **quantity**. Nineteen sizing decisions are now logged and the relationship is exact:

| stop (pts) | lots | NIFTY qty | mirror qty |
|---|---|---|---|
| 25.30 | 1 | 65 | 30 |
| 15.15 | 2 | 130 | 60 |
| 11.85 | 3 | 195 | 90 |
| 7.65 | **5 (cap)** | 325 | 150 |

Same ₹2500 budget throughout — and the agent's stops have been narrowing (25.30 → 15.15 → 11.85).

Three things scale with quantity, not with the planned stop: **the BankNIFTY mirror is equal-lot and outside the budget entirely** (≈₹15,350 of premium at a 24.40pt stop on 08 Sep vs ≈₹46,845 at 11.85pt today — and today the mirror lost −850.50 while the NIFTY leg *made* +351.00); per-unit slippage; and the probability of being stopped at all.

v4x governs the too-wide direction; this is the other one.

Guard negative-tested **24 ways**. One assertion initially failed to bite and was tightened — noted in the commit rather than reported as a clean pass.

## 2. Pre-open note for 10 SEP 2026

**The hold is the read.** Same sell branch as yesterday, opposite reason: *"if the market had NOT held here… reversal chances rise. But it HELD, then fell"* — so few participated and the sellers are **thin** rather than seated. Yesterday they were seated and unhuntable; today thin. The mechanism is what would flip the branch.

**SENSEX has expiry**; NIFTY's was 08 Sep and is past. All three resistance pairs were garbled and confirmed with the operator. Negative-tested **22 ways**, all caught.

## Worth your attention: IH lost today

He read the fuel exactly as v4z prescribes — *"no SLs are available nearby… I feel fear when I can SEE SLs available; there's nothing like that"* — and still cut: *"the market is going up, the loss is growing, so we'll have to exit."* That is **calibration on v4z, not against it**: being right about the fuel and still losing is a normal outcome, and the loss limit is what ends the trade. Recorded in the addendum, no rule changed.

## Gates

547 master · 28 market-data-health · 1359 pytest · ruff 0.16.6 · mypy (77 + master) · compileall · bandit — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)