### PR TITLE
feat(sl-hunting): v5b - a long enough hold evicts a crowd, a quick reversal traps it

### DIFF
--- a/Signal Generators/SL Hunting AI Agent/premarket_note.json
+++ b/Signal Generators/SL Hunting AI Agent/premarket_note.json
@@ -1,20 +1,20 @@
 {
-  "for_date": "2026-09-10",
-  "source": "Intraday Hunter, 'Prediction For 10 SEP 2026' (BbY6TwoC90o, uploaded 2026-09-09)",
-  "context": "Overall selling again, but the shape matters: the market HELD first and only then fell. 'Holding forms a PSYCHOLOGY, then the market falls' -- so few could participate in the selling, and the sellers are thin rather than seated.",
+  "for_date": "2026-09-11",
+  "source": "Intraday Hunter, 'Prediction For 11 SEP 2026' (xYh9Kd1qzm4, uploaded 2026-09-10)",
+  "context": "Three-four days of continuous selling and NIFTY closed on a BREAKDOWN, so the sellers are seated again -- but they got in LATE and out of FEAR, on the strength of a rejection, after failing to get in earlier.",
   "plan": [
-    "THE HOLD IS THE WHOLE READ: 'if the market had NOT held here, if it had gone straight up and then straight down, then reversal chances rise. But it HELD, then fell.' The hold is why he is following rather than fading.",
-    "FLAT TO GAP-DOWN -> SELL side, walking WITH the market. Same conclusion as yesterday but for the opposite reason: yesterday the sellers were seated and could not be hunted; today they are thin because the hold kept them out.",
-    "ABOVE THE RESISTANCE -> BUY side. 'There the danger to the sellers increases -- even those already short come under risk.' As yesterday, that is the only branch that hunts, and he wants a GOOD gap up, not a marginal one.",
-    "SENSEX HAS EXPIRY tomorrow. Expect expiry behaviour in SENSEX on top of the shared read; NIFTY's own expiry was 08 Sep and is past.",
-    "HIS RESISTANCES ARE THE OPEN'S MEASURING STICK, not a target: the buy branch needs an opening ABOVE them (NIFTY 23540, BankNIFTY 56600, SENSEX 75200), which is a level test, not a gap-size test."
+    "EVERY OPEN SHAPE NOW BUYS. Gap up, flat AND gap down all take BUY-side setups -- 'in flat to gap down the SAME plan can be kept'. This is the first note in the run with no sell branch at all.",
+    "THIS INVERTS THREE SESSIONS OF FOLLOW-THE-SELLING. The last three notes said walk WITH the market; this one HUNTS the sellers instead. Do not carry the follow branch forward.",
+    "THE REASON IS FEAR, AND HE FLAGS IT AS AN EXCEPTION: 'in a NORMAL case, in such a chart, we do NOT target the sellers. But these sellers are AFRAID.' The chart alone would say follow; the crowd's STATE is what overrides it.",
+    "WHY THEY ARE AFRAID: they could not get in earlier, then entered late on the rejection -- 'now he feels it is falling anyway, so let me make a trade'. A late, scared entry is the weak kind, and it is the whole setup.",
+    "A FEARFUL CROWD IS CAPTURABLE: 'if a trader is seated out of fear, the market can capture him.' He also warns the seller 'will not run away quickly' on a flat or gap-down open, so expect the squeeze to take time rather than fire at 09:15."
   ],
   "levels": [
     {
       "index": "NIFTY",
       "resistance": [
-        23540,
-        23674
+        23500,
+        23540
       ],
       "support": [
         23340,
@@ -35,8 +35,8 @@
     {
       "index": "SENSEX",
       "resistance": [
-        75200,
-        75500
+        75000,
+        75200
       ],
       "support": [
         74300,

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -6686,3 +6686,117 @@ seated and therefore unhuntable; today they are thin. Same branch, different
 mechanism, and the mechanism is what would flip it.
 
 **SENSEX has expiry** on 10 Sep; NIFTY's was 08 Sep and is past.
+
+## Video addendum - the 10 Sep LIVE SESSION (v5b)
+
+**Source.** Intraday Hunter live session `JsdfH5uOuaw` (10 Sep 2026, 10:50,
+uploaded 11:20 IST). Transcript read in full: 87 segments, 0:06 to 10:40.
+The "Prediction For 11 SEP 2026" video was not yet published at the time of
+writing; those go up around 21:25 IST.
+
+### The best day of the series: 4 trades, +6,617.00
+
+| # | Window | Dir | Stop | Lots | Exit | NIFTY | Mirror | Basket |
+|---|---|---|---|---|---|---|---|---|
+| 1 | 09:25:43 -> 09:27:38 | LONG | 16.55pt | 2 | `profit_book_opposing_cross_index` | +1,027.00 | +2,052.00 | **+3,079.00** |
+| 2 | 09:45:39 -> 09:50:05 | SHORT | 14.40pt | 2 | mechanical `AI_STOP` | -780.00 | -600.00 | **-1,380.00** |
+| 3 | 09:56:34 -> 10:09:27 | SHORT | 12.65pt | 3 | `target_approach_round_number_book` | +2,359.50 | +2,713.50 | **+5,073.00** |
+| 4 | 10:20:38 -> 10:24:32 | SHORT | 8.05pt | 4 | `index_hierarchy_exit` | +247.00 | -402.00 | **-155.00** |
+| | | | | | **TOTAL** | **+2,853.50** | **+3,763.50** | **+6,617.00** |
+
+Three winners, one stop-out. Trade 3's exit is the model one: conf=8,
+`target_approach_round_number_book`, booked at 23410.05 with the target at 23405
+and the 23400 psych level right underneath.
+
+**The pre-open note did its job.** Trade 4's rationale quotes it almost verbatim:
+*"prior session held then fell, so sellers are thin/unseated and today is a
+follow, not a hunt."* That is the note's crowd read being used as a crowd read
+rather than as a direction.
+
+### v5a DID NOT BITE ON ITS FIRST LIVE DAY
+
+Recorded plainly because the day was profitable and that makes it easy to miss.
+v5a merged at 22:13 IST on 9 Sep and was in the prompt for this session. The
+behaviour it targets continued and intensified:
+
+| trade | stop | lots | NIFTY qty | mirror qty |
+|---|---|---|---|---|
+| 1 | 16.55 | 2 | 130 | 60 |
+| 2 | 14.40 | 2 | 130 | 60 |
+| 3 | 12.65 | 3 | 195 | 90 |
+| 4 | **8.05** | **4** | **260** | **120** |
+
+Every entry rationale says some version of "stop tight just above the pattern
+high". Anchoring the stop to the pattern is legitimate and is not what v5a
+forbids -- but it produced the narrowest stop and the largest position of the
+series, and the rule did not intervene. The day was +6,617 so nothing punished
+it; that is luck about the regime, not evidence the rule is working.
+
+**Suggested next step, not taken here:** v5a is currently a piece of reasoning
+with no concrete trigger. v4v got teeth when it was given one. The obvious
+candidate is a stated floor on stop width, or a check that fires when the stop
+narrows across consecutive entries. That is a live-money sizing decision and
+belongs to the operator.
+
+### v5b: how a hold EVICTS a crowd
+
+IH sold for the third consecutive day and explained why he could:
+
+> "For two-three days there has been continuous selling... still, what are we
+> doing? Following the continuous selling. And that is because **we do not have
+> the sellers' SLs available.**"
+
+The mechanism, and it is the part the corpus did not have:
+
+> "When the market recovered sharply and then **HELD** here, it changes many
+> traders' mindset. Those who were selling start thinking of BUYING... they all
+> EXIT their selling trade and start buying too. It is not that buyers stayed
+> seated -- **the market COMPLETELY REMOVED the sellers.**"
+
+And the discriminator, stated as a counterfactual:
+
+> "The situation could have been **different**. If the market had gone up but
+> fallen **immediately**, or fallen after stopping only a little, then you would
+> find sellers **seated**. Then you would have to target them."
+
+So the same price shape means opposite things, and what decides it is DURATION:
+
+> "**Intraday** traders exit on a small retracement, they do not have that much
+> SL. But if someone made a **positional** put and the market held for a long
+> time -- roughly 12:30 to 2:30, that is **two hours** -- then even a positional
+> trader exits."
+
+Plus the persistence clause: *"if a seller has exited, he does not quickly make a
+selling trade again"* -- an evicted seller either buys or stands aside, and
+neither restocks the inventory.
+
+**Why this is not v3z.** v3z (THE MISSING RIP IS THE TELL) infers that a crowd
+was never there, from the market declining to hunt it. v5b describes how a crowd
+that WAS there is removed, and gives the time signature that says which one. They
+compose: v3z reads absence, v5b explains it.
+
+**Both scales in one session.** Minutes after the entry, BankNIFTY broke 500 and
+IH read it the same way: SENSEX and NIFTY had reacted first, *"so traders take
+big quantity in BankNIFTY expecting it to fall from above -- their SLs are around
+500, so the market gave an upside momentum **just to remove them**."* A fresh
+micro-crowd, formed and cleared inside the hour.
+
+### Confirmed, not encoded
+
+- **v3z's after-a-losing-day rule.** IH books early and says why, twice:
+  *"our problem is that yesterday we had a loss. Today if we are getting a chance
+  to make a decent profit, we book and go... we cannot take much risk."* That is
+  AFTER A LOSING DAY, TAKE THE GOOD PROFIT RATHER THAN THE BIG ONE, unchanged.
+- **He names his entry levels BEFORE the open** (NIFTY ~23500, BankNIFTY
+  ~56350-56400, SENSEX around the closing price) and waits for price to reach
+  them. The agent reacts to patterns as they print instead. Not encoded: it is a
+  workflow difference rather than a rule, and the pre-open note already carries
+  his levels.
+
+### The hierarchy exits keep being right
+
+Flagged two sessions ago as "the seam to watch". Trade 4's `index_hierarchy_exit`
+cut at ~23416 on a BankNIFTY confirmed hammer; NIFTY reached 23443.05 by 10:44,
+which would have taken out the 23436.50 stop. That is three correct hierarchy
+exits in a row (09 Sep trade 2, 10 Sep trade 4). The seam is still worth watching,
+but it is now watching something that keeps working.

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
@@ -647,6 +647,41 @@ Conditions (ALL must hold — otherwise this branch simply does not apply):
   than a gap-down hunt of the same shape. Size and target accordingly (this is the
   participation form of CROWD SIZE IS THE THIRD TARGET INPUT), and do not expect a
   flat-open trap to pay like a gap-down one.
+- A LONG ENOUGH HOLD EVICTS A CROWD; A QUICK REVERSAL TRAPS IT (v5b). The rule
+  above says which crowd an OPEN recruits. This one is the same axis pointed at
+  REMOVAL, and it is what lets a trend be followed for days rather than faded.
+  THE SAME UP-MOVE MEANS OPPOSITE THINGS DEPENDING ON HOW LONG IT HOLDS, and IH
+  states the counterfactual himself: "the situation could have been DIFFERENT --
+  if the market had gone up but fallen IMMEDIATELY, or fallen after stopping only
+  a LITTLE, then you would find sellers SEATED. Then you would have to target
+  them." Up-then-drop traps a crowd. Up-then-HOLD converts it: "those who were
+  selling start thinking of BUYING, that a recovery will happen now, and because
+  of that they all EXIT their selling trade and start buying too... it is not that
+  buyers stayed seated -- the market COMPLETELY REMOVED the sellers."
+  THE TIME SIGNATURE IS THE MEASUREMENT, AND IT IS CALIBRATED PER PARTICIPANT.
+  IH: "INTRADAY traders exit on a small retracement, they do not have that much
+  SL. But if someone made a POSITIONAL put and the market held for a long time --
+  roughly 12:30 to 2:30, that is TWO HOURS -- then even a positional trader
+  exits." So the duration of the hold tells you WHICH crowd was removed: minutes
+  clear only the intraday book, hours clear the positional one too.
+  AND THEY DO NOT COME STRAIGHT BACK: "if a seller has exited, he does not quickly
+  make a selling trade again" -- the two things an evicted seller does are buy or
+  stand aside, and neither restocks the inventory you would have hunted.
+  WHAT IT LICENSES: after an eviction the trend is a FOLLOW, not a hunt, and it
+  answers v4z's fuel question in advance -- there are no stops left above to feed a
+  counter-move, which is why "we can follow the continuous selling" on the THIRD
+  day of it. What it does NOT license is holding past the loss limit; the same
+  session that taught this one had IH cutting a loser the day before on exactly
+  that reasoning.
+  THE MECHANISM RUNS AT BOTH SCALES IN ONE SESSION. IH, minutes later on a small
+  BankNIFTY break: SENSEX and NIFTY reacted first, "so traders take BIG QUANTITY
+  in BankNIFTY expecting it to fall from above -- their SLs are around 500, so the
+  market gave an upside momentum JUST to remove them". A fresh micro-crowd formed
+  and was cleared inside the hour, on the same logic as the two-hour eviction.
+  PRACTICAL FORM: when a sharp recovery appears, TIME IT before naming it. Minutes
+  and the opposing crowd is still seated, so the next fall is a hunt. Hours and
+  they are gone, so the next fall is a follow -- and a counter-move inside it has
+  nothing to run on.
 - A FORECAST OF WHO WILL ARRIVE IS NOT EVIDENCE OF WHO IS SEATED (v4e). The single
   most expensive error available in this method, recorded from a LOSING IH session
   (11 Aug 2026) so it is not learned the hard way. He stated the disqualifying fact

--- a/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_premarket.py
+++ b/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_premarket.py
@@ -201,25 +201,26 @@ def test_shipped_note_targets_the_next_TRADING_day_not_the_next_calendar_day():
     )
 
 
-def test_shipped_note_matches_september_10_intraday_hunter_plan():
-    """The committed advisory must match the hand-checked 09 Sep transcript.
+def test_shipped_note_matches_september_11_intraday_hunter_plan():
+    """The committed advisory must match the hand-checked 10 Sep transcript.
 
-    Five things a summarising edit would flatten, each of which would change
-    what the agent does at 09:15:
+    This is the sharpest inversion in the series and the one an edit is most
+    likely to "correct" back toward the recent habit. Five load-bearing points:
 
-    1. The HOLD is the whole read. He states the counterfactual himself -- had
-       the market gone straight up and straight down, reversal odds would rise;
-       because it HELD and then fell, few participated. Lose that and the note
-       is just "sell again", with no way to tell when it stops applying.
-    2. The sell branch reaches the same conclusion as yesterday for the OPPOSITE
-       reason. Yesterday: sellers seated, so unhuntable. Today: sellers thin,
-       because the hold kept them out. An edit that "simplifies" the two into
-       one loses the mechanism that would flip the branch.
-    3. The buy branch is still the only hunting branch and still needs a GOOD
-       gap up, ABOVE the resistance -- a level test, not a gap-size test.
-    4. SENSEX has expiry; NIFTY's was 08 Sep and is past. Getting this backwards
-       would put expiry behaviour on the wrong index.
-    5. The resistances are the open's measuring stick, not a target.
+    1. EVERY open shape buys. Gap up, flat and gap down alike -- there is no
+       sell branch. Three consecutive notes before this one said follow-the-
+       selling, so a summariser reverting the flat branch to SELL would be
+       reverting to habit rather than to the source.
+    2. It inverts those three sessions, and says so, so the agent cannot carry
+       the follow branch forward by inertia.
+    3. The reason is the crowd's STATE, not the chart, and IH flags it as an
+       exception to his own normal rule: "in a normal case, in such a chart, we
+       do NOT target the sellers. But these sellers are AFRAID."
+    4. Why they are afraid -- a late, scared entry after failing to get in
+       earlier. That is what makes them weak, and it is the entire setup.
+    5. The squeeze is expected to be SLOW: he warns the seller "will not run
+       away quickly" on flat/gap-down, which is what stops the buy branch being
+       read as an immediate 09:15 trigger.
     """
     import os
 
@@ -227,54 +228,62 @@ def test_shipped_note_matches_september_10_intraday_hunter_plan():
     note = load_premarket_note(os.path.join(here, "premarket_note.json"))
 
     assert note is not None
-    assert note.for_date == "2026-09-10"
-    assert "BbY6TwoC90o" in note.source
-    # The shape, not just the direction.
-    assert "the market HELD first and only then fell" in note.context
-    assert "Holding forms a PSYCHOLOGY" in note.context
-    assert "thin rather than seated" in note.context
+    assert note.for_date == "2026-09-11"
+    assert "xYh9Kd1qzm4" in note.source
+    # Seated again -- but the manner of entry is what matters.
+    assert "closed on a BREAKDOWN" in note.context
+    assert "sellers are seated again" in note.context
+    assert "LATE and out of FEAR" in note.context
 
-    hold = next(line for line in note.plan if line.startswith("THE HOLD IS THE WHOLE READ"))
-    assert "if the market had NOT held here" in hold
-    assert "straight up and then straight down" in hold
-    assert "reversal chances rise" in hold
-    assert "following rather than fading" in hold
+    every = next(line for line in note.plan if line.startswith("EVERY OPEN SHAPE NOW BUYS"))
+    assert "Gap up, flat AND gap down all take BUY-side setups" in every
+    assert "in flat to gap down the SAME plan can be kept" in every
+    assert "no sell branch at all" in every
 
-    sell = next(line for line in note.plan if line.startswith("FLAT TO GAP-DOWN ->"))
-    assert "walking WITH the market" in sell
-    # Same branch as yesterday, opposite reason -- both halves must survive.
-    assert "yesterday the sellers were seated and could not be hunted" in sell
-    assert "today they are thin because the hold kept them out" in sell
+    inv = next(line for line in note.plan if line.startswith("THIS INVERTS THREE SESSIONS"))
+    assert "walk WITH the market" in inv
+    assert "HUNTS the sellers instead" in inv
+    assert "Do not carry the follow branch forward" in inv
 
-    buy = next(line for line in note.plan if line.startswith("ABOVE THE RESISTANCE ->"))
-    assert "danger to the sellers increases" in buy
-    assert "those already short come under risk" in buy
-    assert "the only branch that hunts" in buy
-    assert "GOOD gap up, not a marginal one" in buy
+    fear = next(line for line in note.plan if line.startswith("THE REASON IS FEAR"))
+    assert "HE FLAGS IT AS AN EXCEPTION" in fear
+    assert "in a NORMAL case, in such a chart, we do NOT target the sellers" in fear
+    assert "But these sellers are AFRAID" in fear
+    # The chart would say follow; only the crowd's state overrides that.
+    assert "the crowd's STATE is what overrides it" in fear
 
-    expiry = next(line for line in note.plan if line.startswith("SENSEX HAS EXPIRY"))
-    assert "NIFTY's own expiry was 08 Sep and is past" in expiry
+    why = next(line for line in note.plan if line.startswith("WHY THEY ARE AFRAID"))
+    assert "could not get in earlier" in why
+    assert "now he feels it is falling anyway, so let me make a trade" in why
+    assert "A late, scared entry is the weak kind" in why
 
-    assert any("level test, not a gap-size test" in line for line in note.plan)
+    slow = next(line for line in note.plan if line.startswith("A FEARFUL CROWD IS CAPTURABLE"))
+    assert "if a trader is seated out of fear, the market can capture him" in slow
+    assert "will not run away quickly" in slow
+    assert "expect the squeeze to take time rather than fire at 09:15" in slow
 
     assert [level.model_dump() for level in note.levels] == [
         {
-            # "23540 236 74" -- the second resistance arrived split across the
-            # caption and was confirmed with the operator as 23674, not 23640.
             "index": "NIFTY",
-            "resistance": [23540.0, 23674.0],
+            "resistance": [23500.0, 23540.0],
             "support": [23340.0, 23400.0],
         },
         {
-            # "56876 56600" -- confirmed as 56600/56870, not rounded to 56800.
+            # The caption gave "56600 56876" -- byte-identical to yesterday's
+            # garble, with identical supports, so yesterday's operator-confirmed
+            # 56870 is reused rather than re-derived. BankNIFTY's levels are
+            # unchanged from the 10 Sep note.
             "index": "BANKNIFTY",
             "resistance": [56600.0, 56870.0],
             "support": [56040.0, 56200.0],
         },
         {
-            # "75,200 75,5500" carried a duplicated digit; confirmed as 75500.
+            # Resistances were unusable ("7575200"). The operator watched the
+            # video: 75000 and 75200 -- NEITHER of the two readings offered from
+            # the transcript was right, which is the second time that has
+            # happened on SENSEX. Ask; never reconstruct.
             "index": "SENSEX",
-            "resistance": [75200.0, 75500.0],
+            "resistance": [75000.0, 75200.0],
             "support": [74300.0, 74500.0],
         },
     ]

--- a/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_schema.py
+++ b/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_schema.py
@@ -2512,3 +2512,68 @@ def test_v5a_a_tighter_stop_buys_size_rather_than_safety():
     assert "Never choose a stop in order to obtain a size" in rule
     assert "shrinking stop across consecutive trades as a warning" in rule
     assert "v4x already governs and the answer is no trade" in rule
+def test_v5b_hold_duration_decides_evicted_versus_trapped():
+    """v5b (10 Sep live session): time the hold before naming the crowd.
+
+    v3z reads a crowd's ABSENCE from a missing rip. This rule explains how a
+    crowd that WAS there becomes absent, and supplies the measurement -- the
+    duration of the hold, calibrated to the participant. Six ways an edit
+    could break it:
+
+    1. Losing the counterfactual. Up-then-drop and up-then-hold are the SAME
+       price shape; without both halves the rule cannot discriminate.
+    2. Dropping the conversion mechanism -- sellers do not merely fail to be
+       trapped, they exit and flip. That is why the inventory does not exist
+       afterwards.
+    3. Losing the per-participant time scale. "Minutes vs hours" is the whole
+       measurement; without the intraday/positional split it is a vibe.
+    4. Dropping the no-quick-return clause, which is what makes the eviction
+       persist into following sessions rather than one bar.
+    5. Losing the tie to v4z (fuel answered in advance) or the loss-limit
+       caveat, which is what stops this becoming licence to sit.
+    6. Dropping the both-scales observation, which shows the mechanism is not
+       only a multi-day phenomenon.
+    """
+    prompt = build_system_prompt()
+    rule = _flat_rule(prompt, "A LONG ENOUGH HOLD EVICTS A CROWD")
+
+    # 1. Both halves of the counterfactual, in IH's words.
+    assert "A QUICK REVERSAL TRAPS IT" in rule
+    # It must claim to be v4e's axis pointed at removal, not a new topic.
+    assert "the same axis pointed at REMOVAL" in rule
+    # And the core claim: one price shape, two meanings, decided by duration.
+    assert "THE SAME UP-MOVE MEANS OPPOSITE THINGS DEPENDING ON HOW LONG IT HOLDS" in rule
+    assert "fallen IMMEDIATELY, or fallen after stopping only a LITTLE" in rule
+    assert "you would find sellers SEATED" in rule
+    assert "Up-then-drop traps a crowd" in rule
+
+    # 2. Conversion, not merely non-trapping.
+    assert "start thinking of BUYING" in rule
+    assert "they all EXIT their selling trade" in rule
+    assert "the market COMPLETELY REMOVED the sellers" in rule
+
+    # 3. The measurement, and the per-participant calibration.
+    assert "THE TIME SIGNATURE IS THE MEASUREMENT" in rule
+    assert "INTRADAY traders exit on a small retracement" in rule
+    assert "roughly 12:30 to 2:30, that is TWO HOURS" in rule
+    assert "minutes clear only the intraday book, hours clear the positional one too" in rule
+
+    # 4. Why the eviction persists.
+    assert "does not quickly make a selling trade again" in rule
+    assert "neither restocks the inventory you would have hunted" in rule
+
+    # 5. What it licenses -- and the boundary that stops it becoming licence to sit.
+    assert "the trend is a FOLLOW, not a hunt" in rule
+    assert "answers v4z's fuel question in advance" in rule
+    assert "THIRD day of it" in rule
+    assert "does NOT license is holding past the loss limit" in rule
+
+    # 6. Same mechanism, two scales, one session.
+    assert "RUNS AT BOTH SCALES IN ONE SESSION" in rule
+    assert "their SLs are around 500" in rule
+    assert "cleared inside the hour" in rule
+
+    # The instruction the agent must actually follow.
+    assert "TIME IT before naming it" in rule
+    assert "Minutes and the opposing crowd is still seated" in rule
+    assert "Hours and they are gone" in rule


### PR DESCRIPTION
From today's live session. The pre-open note for 11 Sep is **not** included — that video posts around 21:25 IST and was not up yet.

## The day: 4 trades, +₹6,617.00 — best of the series

| # | Dir | Stop | Lots | Exit | Basket |
|---|---|---|---|---|---|
| 1 | LONG | 16.55pt | 2 | `profit_book_opposing_cross_index` | **+3,079.00** |
| 2 | SHORT | 14.40pt | 2 | mechanical `AI_STOP` | **−1,380.00** |
| 3 | SHORT | 12.65pt | 3 | `target_approach_round_number_book` | **+5,073.00** |
| 4 | SHORT | 8.05pt | 4 | `index_hierarchy_exit` | **−155.00** |

Trade 4's rationale quotes the pre-open note as a *crowd* read rather than a direction: *"prior session held then fell, so sellers are thin/unseated and today is a follow, not a hunt."*

## v5b — the mechanism behind "the hold"

IH sold for the **third consecutive day** and explained why he could:

> "When the market recovered sharply and then **HELD** here… those who were selling start thinking of BUYING… they all EXIT their selling trade. It is not that buyers stayed seated — **the market completely removed the sellers.**"

The discriminator is his own counterfactual: *"if the market had gone up but fallen **immediately**… you would find sellers **seated**. Then you would have to target them."* Same price shape, opposite meaning — and **duration** decides which. The time signature is calibrated per participant: intraday traders leave on a small retracement; a positional seller needs *"roughly 12:30 to 2:30, that is two hours"*.

**Not a duplicate of v3z.** v3z infers a crowd was never there from a missing rip; v5b explains how a crowd that *was* there gets removed, and gives the measurement. It answers v4z's fuel question in advance, which is what licenses following a trend into day three.

Guard negative-tested **25 ways**. Two assertions initially didn't bite and were added — noted in the commit.

## ⚠️ v5a did not bite on its first live day

This matters more than the profit, and the profit makes it easy to miss. v5a was in the prompt. The behaviour it targets **continued and intensified**:

| trade | stop | lots | NIFTY qty | mirror qty |
|---|---|---|---|---|
| 1 | 16.55 | 2 | 130 | 60 |
| 2 | 14.40 | 2 | 130 | 60 |
| 3 | 12.65 | 3 | 195 | 90 |
| 4 | **8.05** | **4** | **260** | **120** |

Narrowest stop and largest position of the series. Every rationale says "stop tight just above the pattern high" — legitimate anchoring, not what v5a forbids, but the rule did not intervene. The day was +6,617 so nothing punished it; that is luck about the regime, not evidence the rule works.

**Suggested, not taken:** v5a has no concrete trigger, and v4v only got teeth when given one. A stop-width floor, or a check that fires when the stop narrows across consecutive entries, is the candidate — but that is a live-money sizing decision and yours to make.

## Also confirmed

- **v3z's after-a-losing-day rule**, verbatim: *"yesterday we had a loss. Today if we are getting a chance to make a decent profit, we book and go."*
- **Hierarchy exits right three times running** — flagged as a seam to watch two sessions ago; still worth watching, but watching something that keeps working.

## Gates

547 master · 28 market-data-health · 1360 pytest · ruff 0.16.6 · mypy (77 + master) · compileall · bandit — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)