### PR TITLE
feat(sl-hunting): v5c - a big retracement recruits the crowd that gets hunted next

### DIFF
--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_doc.md
@@ -6800,3 +6800,115 @@ cut at ~23416 on a BankNIFTY confirmed hammer; NIFTY reached 23443.05 by 10:44,
 which would have taken out the 23436.50 stop. That is three correct hierarchy
 exits in a row (09 Sep trade 2, 10 Sep trade 4). The seam is still worth watching,
 but it is now watching something that keeps working.
+
+## Video addendum - the 11 Sep LIVE SESSION (v5c)
+
+**Source.** Intraday Hunter live session `SW6rxOEMJkQ` (11 Sep 2026, 12:20,
+uploaded 11:38 IST). Transcript read in full: 99 segments, 0:02 to 12:15.
+
+### The day: 3 trades, +3,370.75, all LONG
+
+NIFTY gapped down 210 points to 23268.05, chopped to a 23245.35 low by 09:41,
+then ran to 23307.75 by 10:22.
+
+| # | Window | Stop | Lots | Exit | NIFTY | Mirror | Basket |
+|---|---|---|---|---|---|---|---|
+| 1 | 09:19:33 -> 09:41:34 | 23.30pt | 1 | `premise_invalidation_bearish_cluster` | -338.00 | +1,597.50 | **+1,259.50** |
+| 2 | 09:59:35 -> 10:10:38 | 23.10pt | 1 | `book_before_round_number` (conf 8) | +672.75 | +795.00 | **+1,467.75** |
+| 3 | 10:18:03 -> 10:26:52 | 10.85pt | 3 | `profit_book_reversal_cluster` | +643.50 | *skipped* | **+643.50** |
+| | | | | **TOTAL** | **+978.25** | **+2,392.50** | **+3,370.75** |
+
+**The inverted note worked.** All three entries are LONG, and each rationale
+cites the buy branch explicitly -- "pre-open note explicitly hunts the late
+sellers", "matches the pre-open note's buy branch". After three sessions of
+follow-the-selling, the agent flipped when the note flipped.
+
+**v5a bit, partially.** Trades 1 and 2 used 23.30 and 23.10-point stops and took
+ONE lot each -- the widest stops since 04 Sep, and a clear break from the
+16.55 -> 8.05 slide of the previous session. Trade 3 then went back to 10.85 and
+3 lots. Two out of three is real movement, not noise, but the rule is not yet
+decisive.
+
+### Trade 1 is v5c, and it is the same failure in a new costume
+
+Cut at 23245.35 on a "confirmed bearish reversal cluster" with the NIFTY leg at
+-299. **That price is the session low.** NIFTY ran 62 points from there, and the
+agent re-entered the same direction twice more to catch part of what it had just
+left.
+
+IH, in the same session, held through exactly that dip -- "we are NOT going to
+exit here, even if the loss grows a bit" -- and explains why the dip was
+expected:
+
+> "I tell you again and again: a market that falls after a **small** retracement,
+> let it fall. But falling after a **big** retracement becomes DIFFICULT for the
+> market... when such a big retracement happens and then the market falls,
+> **EVERYONE will sell there**."
+
+And he narrates the loop as it runs:
+
+> "This candle formed only to give **greed**. What will the trader see? Selling
+> happened, retracement happened, suddenly it fell. As premiums rise he will make
+> a put trade -- and targeting exactly them, the market goes up again. Then it
+> repeats the same."
+
+So the dip is not noise to be endured, it is the mechanism that manufactures the
+crowd the trade is aiming at. The agent closed at the exact moment its own
+premise was being built.
+
+**v5c pairs with v5b deliberately.** Same counter-move, two axes: v5b times it and
+finds an eviction, v5c sizes it and finds a recruitment. Both preconditions are
+in the rule because IH states both -- sentiment already negative, and the
+session's lower point not crossed, which is a v4v-style level test and the thing
+that ends the setup.
+
+### A real defect worth a separate look: the BNF mirror race
+
+Trade 3 opened 3 lots of NIFTY with **no BankNIFTY mirror**:
+
+```
+10:18:01,349  MarketDataFetcher  Published frame | LastCandle=10:18:00
+10:18:03,251  sl-hunting-sdk-call  dynamic sizing: ... lots=3 qty=195
+10:18:03,517  sl-hunting-sdk-call  ENTRY LONG  NIFTY-Sep2026-23300-CE  Qty=195
+10:18:05,563  sl-hunting-sdk-call  WARNING  BNF mirror skipped: no BankNIFTY close seen yet this session.
+10:18:13,810  sl-hunting-inference  decision took 60.6s
+```
+
+The message is wrong and the cause is a race. `_open_bnf_mirror` skips when
+`self._last_bnf_close <= 0`, and the decision loop sets `self._last_bnf_close =
+0.0` at the top of EVERY cycle, repopulating it only from a BankNIFTY bar that is
+timestamp-aligned with NIFTY. The 60.6s inference began around 10:17:13; its
+order tool fired at 10:18:03, by which time the 10:18 bar's cycle had already
+reset the field. A BankNIFTY close had certainly been seen this session -- two
+mirrors were placed on it at 09:19 and 09:59.
+
+Consequences, in order of importance:
+
+1. The documented invariant "every NIFTY entry is mechanically MIRRORED" silently
+   did not hold, and the only trace is one WARNING. Exposure was LOWER, not
+   higher, so this is not dangerous -- but it is not the configured strategy.
+2. The log line sends an operator hunting a session-wide feed failure that did
+   not happen. It should say "no ALIGNED BankNIFTY close on this bar".
+
+**Frequency, corrected.** This exact message has fired TWICE in the whole log
+(2026-08-11 and 2026-09-11). A grep for "BNF mirror skipped" returns twelve lines,
+but the other ten are different reasons (eight "no LTP for BANKNIFTY-...", two
+"NIFTY entry is paper fallback"). It is a rare race, not a recurring one.
+
+Not fixed here: it is live-order-path code and this session's task was the
+knowledge rule. The candidate fix is to stop resetting `_last_bnf_close`
+unconditionally, or to capture it at decision time and pass it to the order tool.
+
+### Confirmed, not encoded
+
+- **v4d, pre-committing the adverse move.** IH, before entering against the
+  opening trend: "there's risk that we're working OPPOSITE to the market's trend
+  per the opening... **we're assuming roughly 1.5 lakh of loss could happen**."
+- **v3z's two-sided flow.** "A few buyers can still come, a few sellers can come,
+  so liquidity remains. But when only ONE type of trader starts coming, the market
+  cannot work there for long."
+- **He abandoned his own pre-open plan's REASON while keeping its direction**:
+  "in the analysis we had planned to target these sellers, but that condition is
+  no longer visible because the gap down is quite large -- per the NEW chart,
+  buying chances are forming anyway." The note's conclusion survived; its stated
+  mechanism did not. Worth remembering when a note and the tape disagree on WHY.

--- a/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
+++ b/Signal Generators/SL Hunting AI Agent/sl_hunting_knowledge.py
@@ -682,6 +682,46 @@ Conditions (ALL must hold — otherwise this branch simply does not apply):
   and the opposing crowd is still seated, so the next fall is a hunt. Hours and
   they are gone, so the next fall is a follow -- and a counter-move inside it has
   nothing to run on.
+- A BIG RETRACEMENT RECRUITS THE CROWD THAT GETS HUNTED NEXT (v5c). The twin of
+  the rule above and its opposite sign: a long HOLD evicts a crowd, a big
+  RETRACEMENT manufactures one. Both are read off the counter-move; v5b measures
+  its duration, this one measures its SIZE.
+  IH says it as a rule and repeats it: "I tell you again and again -- a market
+  that falls after a SMALL retracement, let it fall. But falling after a BIG
+  retracement becomes DIFFICULT for the market." The reason is who each shape
+  recruits. After a small one the trader cannot even tell a retracement happened,
+  so nobody is added and the fall continues. After a big one, "when such a big
+  retracement happens and THEN the market falls, EVERYONE will sell there" -- a
+  fresh intraday seller crowd forms at a visibly good price, and the market then
+  goes UP through their stops.
+  HE NARRATES THE RECRUITMENT LOOP WHILE IT RUNS: "this candle formed only to give
+  GREED. What will the trader see? Selling happened, retracement happened, suddenly
+  it fell. As premiums rise he will make a put trade -- and targeting exactly them,
+  the market goes up again. Then it repeats the same." And afterwards: "when the
+  market was going down slowly it was because it had to ADD sellers... when the
+  market eats all their SLs, see how fast the momentum comes."
+  TWO CONDITIONS, AND BOTH MUST HOLD:
+  * THE SENTIMENT MUST ALREADY BE NEGATIVE. "The condition is that the sentiment
+    must also be that way" -- his was, after several days of selling. On a fresh
+    or two-sided chart a big retracement recruits nobody in particular.
+  * THE SESSION'S LOWER POINT MUST NOT BE CROSSED. This is the premise-ending
+    level, named in advance: "if the market crosses this lower point, then only
+    sellers are going to come and nobody will buy, so the market cannot work in
+    such a zone" -- and "after a breakdown the market takes TIME making a trap".
+    Cross it and the setup is over; that is a level test in the sense of v4v, not
+    a feeling.
+  MEASURED ON THIS BOOK (2026-09-11), and it is the same failure in a new costume.
+  A long was opened 09:19:33 from 23256.10 into a 210-point gap down and cut
+  09:41:34 on a "confirmed bearish reversal cluster" with the NIFTY leg at -299.
+  Spot at that exit was 23245.35 -- THE SESSION LOW. NIFTY then ran to 23307.75 by
+  10:22, sixty-two points, and the agent re-entered the same direction twice more
+  to catch part of it. The dip it cut into was the seller-recruitment event the
+  whole setup depends on: the trade was closed at the exact moment its premise was
+  being manufactured.
+  WHAT IT DOES NOT SAY: this is not permission to sit through a breakdown. IH names
+  the two exits himself -- "if a breakdown appears... or the loss goes far outside
+  the LOSS LIMIT, in that condition we have to exit". The lower point and the loss
+  limit both still bind.
 - A FORECAST OF WHO WILL ARRIVE IS NOT EVIDENCE OF WHO IS SEATED (v4e). The single
   most expensive error available in this method, recorded from a LOSING IH session
   (11 Aug 2026) so it is not learned the hard way. He stated the disqualifying fact

--- a/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_schema.py
+++ b/Tests/Signal Generators/SL Hunting AI Agent/test_sl_hunting_schema.py
@@ -2577,3 +2577,64 @@ def test_v5b_hold_duration_decides_evicted_versus_trapped():
     assert "TIME IT before naming it" in rule
     assert "Minutes and the opposing crowd is still seated" in rule
     assert "Hours and they are gone" in rule
+def test_v5c_a_big_retracement_recruits_the_next_crowd():
+    """v5c (11 Sep live session + this book): measure the counter-move's SIZE.
+
+    Paired with v5b deliberately -- same counter-move, two axes. v5b times it
+    and finds an eviction; v5c sizes it and finds a recruitment. Six ways an
+    edit could break it:
+
+    1. Losing the pairing, or the small-versus-big contrast. "Let it fall" after
+       a small one and "difficult to fall" after a big one are the whole rule.
+    2. Dropping WHY size matters -- after a small retracement nobody can tell it
+       happened, so nobody is recruited. Without that the rule is superstition.
+    3. Losing the recruitment loop, which is what makes the dip predictable
+       rather than merely survivable.
+    4. Dropping either precondition. Negative sentiment and an unbroken lower
+       point are both required; an edit keeping only one turns a conditional
+       setup into a standing bias.
+    5. Losing the measured trade, including that the exit was AT the session low
+       and that the move afterwards was 62 points.
+    6. Losing the breakdown/loss-limit exits, which is what stops this being
+       read as permission to sit.
+    """
+    prompt = build_system_prompt()
+    rule = _flat_rule(prompt, "A BIG RETRACEMENT RECRUITS THE CROWD THAT GETS HUNTED NEXT")
+
+    # 1. The pairing with v5b, and the two-sided contrast.
+    assert "a long HOLD evicts a crowd, a big RETRACEMENT manufactures one" in rule
+    assert "v5b measures its duration, this one measures its SIZE" in rule
+    assert "falls after a SMALL retracement, let it fall" in rule
+    assert "falling after a BIG retracement becomes DIFFICULT for the market" in rule
+
+    # 2. Why size is the thing that matters.
+    assert "cannot even tell a retracement happened" in rule
+    assert "EVERYONE will sell there" in rule
+    assert "goes UP through their stops" in rule
+
+    # 3. The loop, narrated while it ran.
+    assert "this candle formed only to give GREED" in rule
+    assert "As premiums rise he will make a put trade" in rule
+    assert "when the market eats all their SLs, see how fast the momentum comes" in rule
+
+    # 4. Both preconditions -- and that they are REQUIRED, not decoration.
+    assert "TWO CONDITIONS, AND BOTH MUST HOLD" in rule
+    assert "THE SENTIMENT MUST ALREADY BE NEGATIVE" in rule
+    assert "On a fresh or two-sided chart a big retracement recruits nobody" in rule
+    assert "THE SESSION'S LOWER POINT MUST NOT BE CROSSED" in rule
+    assert "only sellers are going to come and nobody will buy" in rule
+    assert "after a breakdown the market takes TIME making a trap" in rule
+    assert "a level test in the sense of v4v" in rule
+
+    # 5. The measured trade -- cut at the low, and what followed.
+    assert "MEASURED ON THIS BOOK (2026-09-11)" in rule
+    assert "210-point gap down" in rule
+    assert "confirmed bearish reversal cluster" in rule
+    assert "23245.35 -- THE SESSION LOW" in rule
+    assert "23307.75 by 10:22, sixty-two points" in rule
+    assert "closed at the exact moment its premise was being manufactured" in rule
+
+    # 6. The two exits that still bind.
+    assert "not permission to sit through a breakdown" in rule
+    assert "the loss goes far outside the LOSS LIMIT" in rule
+    assert "The lower point and the loss limit both still bind" in rule


### PR DESCRIPTION
From today's live session. No pre-open note here — the "Prediction For 12 SEP" video posts around 21:25 IST and was not up yet.

## The day: 3 trades, +₹3,370.75, all LONG

NIFTY gapped down 210 points to 23268.05, bottomed at 23245.35 by 09:41, then ran to 23307.75 by 10:22.

| # | Stop | Lots | Exit | Basket |
|---|---|---|---|---|
| 1 | 23.30pt | 1 | `premise_invalidation_bearish_cluster` | **+1,259.50** |
| 2 | 23.10pt | 1 | `book_before_round_number` (conf 8) | **+1,467.75** |
| 3 | 10.85pt | 3 | `profit_book_reversal_cluster` | **+643.50** |

**The inverted note worked** — all three entries LONG, each citing its buy branch. The agent flipped when the note flipped, after three sessions of follow-the-selling.

**v5a bit, partially.** Trades 1 and 2 took 23.30 and 23.10-point stops at **one lot each** — the widest since 04 Sep and a clean break from yesterday's 16.55 → 8.05 slide. Trade 3 reverted to 10.85 and 3 lots. Two of three is movement, not noise.

## v5c — the twin of v5b

Same counter-move, two axes: v5b **times** it and finds an eviction; v5c **sizes** it and finds a recruitment.

> "I tell you again and again — a market that falls after a **small** retracement, let it fall. But falling after a **big** retracement becomes DIFFICULT for the market… when such a big retracement happens and then the market falls, **everyone will sell there**."

After a small retracement nobody can tell one happened, so nobody is recruited. After a big one a fresh seller crowd forms at a visibly good price — and the market goes up through their stops. Both of his preconditions are in the rule: sentiment already negative, and the session's **lower point** not crossed (a v4v-style level test), plus his two exits verbatim so it cannot read as permission to sit.

**Trade 1 is the measured case.** Cut at **23245.35 — the session low** — on a bearish reversal cluster, then re-entered the same direction twice to catch part of the 62-point move it had just left. The dip it cut into *was* the recruitment event its own premise depended on.

Guard negative-tested **26 ways**. One assertion initially didn't bite (nothing covered "TWO CONDITIONS, AND BOTH MUST HOLD", so both preconditions could have been demoted to scenery) — added and re-verified.

## ⚠️ A real defect, not fixed here

Trade 3 opened **3 NIFTY lots with no BankNIFTY mirror**. `_open_bnf_mirror` skips when `_last_bnf_close <= 0`, and the decision loop resets that field to `0.0` at the top of every cycle. The 60.6s inference began ~10:17:13 and its order tool fired at 10:18:03 — after the 10:18 bar had already reset it. So the documented *"every NIFTY entry is mechanically MIRRORED"* invariant silently did not hold, and the log blames a session-wide feed failure that never happened.

Exposure was **lower**, not higher, so it is not dangerous. It has fired **twice in the whole log** (11 Aug, 11 Sep) — a grep returns twelve lines but ten are different skip reasons. Candidate fix: stop resetting `_last_bnf_close` unconditionally, or capture it at decision time and pass it to the order tool. Live-order-path code, so I left it alone.

## Note on running the master suite locally

`test_the_dashboard_is_off_by_default` asserts the **live** value of a `.env` knob rather than the code default, so it fails for any operator who has switched the dashboard on — as you now have. Pre-existing, unrelated to this change, and CI passes because CI has no `.env`. Locally: `DASHBOARD_ENABLED=false python -m unittest Tests.test_nifty_multi_strategy_master`. Happy to make the test independent of the environment if you want it.

## Gates

591 master · 28 market-data-health · 1438 pytest · ruff 0.16.6 · mypy (79 + master) · compileall · bandit — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)