### PR TITLE
fix(sl-hunting): stop the per-bar reset that left an entry unmirrored

### DIFF
--- a/Tests/test_nifty_multi_strategy_master.py
+++ b/Tests/test_nifty_multi_strategy_master.py
@@ -5558,6 +5558,47 @@ class TestSLHuntingBnfMirror(unittest.TestCase):
         self.assertTrue(worker.enter_position("LONG", 24300.0, 24290.0, 24400.0))
         self.assertFalse(worker._mirror_pos.active)
 
+    def test_a_failed_banknifty_bar_does_not_erase_the_close_the_mirror_needs(self):
+        """An ENTER that lands after a later bar's BankNIFTY fetch failed must
+        still mirror.
+
+        The agent's inference runs on its own thread with a 90-second deadline,
+        so the order tool for bar N can fire AFTER bar N+1 has already begun.
+        `process_strategy_frame` must therefore not destroy the last aligned
+        BankNIFTY close it recorded: doing so leaves the NIFTY leg unmirrored,
+        which is exactly what the entry-evaluation guard above it exists to
+        prevent ("a flat worker must not create an unmirrored NIFTY position").
+
+        Measured on 2026-09-11 at 10:18:03, where a 3-lot NIFTY entry opened
+        with no mirror and the log blamed a session-wide feed failure that had
+        not happened -- two mirrors had already been placed that morning.
+        """
+        worker, _ = self._make_worker()
+        worker._use_bnf = True
+        aligned_close = worker._last_bnf_close
+        self.assertGreater(aligned_close, 0.0)
+
+        # The next bar's BankNIFTY fetch fails. The worker is flat, so this bar
+        # returns early without evaluating an entry -- but the in-flight
+        # inference from the PREVIOUS bar can still fire its order tool.
+        worker.broker.fetch_index_1m_ohlc.side_effect = RuntimeError("BNF feed hiccup")
+        # The worker is flat, so the 10:30 entry cutoff would otherwise return
+        # before the BankNIFTY block is reached at all.
+        with patch.object(master_file, "is_after_time", return_value=False):
+            worker.process_strategy_frame(
+                pd.DataFrame(
+                    {
+                        "timestamp": [pd.Timestamp("2026-09-11 10:18:00")],
+                        "open": [24300.0], "high": [24305.0],
+                        "low": [24295.0], "close": [24300.0],
+                    }
+                )
+            )
+
+        self.assertEqual(worker._last_bnf_close, aligned_close)
+        self.assertTrue(worker.enter_position("LONG", 24300.0, 24290.0, 24400.0))
+        self.assertTrue(worker._mirror_pos.active)
+
     def test_mirror_disabled_flag_trades_nifty_only(self):
         worker, _ = self._make_worker()
         worker._mirror_enabled = False

--- a/nifty_multi_strategy_master.py
+++ b/nifty_multi_strategy_master.py
@@ -16280,7 +16280,14 @@ if SL_HUNTING_AVAILABLE:
             bnf_candles = None
             bnf_ready = not self._use_bnf
             if self._use_bnf:
-                self._last_bnf_close = 0.0
+                # NOT reset per bar, deliberately. Inference runs on its own
+                # thread with a 90s deadline, so the order tool for bar N can
+                # fire AFTER bar N+1 has started; clearing the close here left
+                # that entry unmirrored, which is the very thing the
+                # entry-evaluation guard below exists to prevent. Staleness is
+                # already bounded by that guard (a FLAT worker never evaluates
+                # an entry without aligned BankNIFTY data) plus the deadline,
+                # so the value can only ever be a bar or two old.
                 try:
                     bnf_1m = self.broker.fetch_index_1m_ohlc(
                         BANKNIFTY_INDEX_SECURITY_ID,


### PR DESCRIPTION
Intended as an addendum to #164, but that had already merged at 11:38 — so it is its own PR. One deleted line plus the comment explaining it.

## What happened

Yesterday's session opened **3 NIFTY lots with no BankNIFTY mirror** and logged `BNF mirror skipped: no BankNIFTY close seen yet this session` — which was false. Two mirrors had already been placed that morning.

## Root cause: a cross-bar race, not a feed failure

`process_strategy_frame` set `self._last_bnf_close = 0.0` at the top of **every** decision cycle and repopulated it only from a timestamp-aligned BankNIFTY bar. Inference runs on its own thread with a 90-second deadline, so the order tool for bar N can fire after bar N+1 has begun:

```
10:18:01,349  Published frame | LastCandle=10:18:00
10:18:03,251  dynamic sizing: ... lots=3 qty=195
10:18:03,517  ENTRY LONG  NIFTY-Sep2026-23300-CE  Qty=195
10:18:05,563  WARNING  BNF mirror skipped: no BankNIFTY close seen yet...
10:18:13,810  decision took 60.6s        <- inference began ~10:17:13
```

## Why it matters more than the wrong log line

The guard immediately below that block states the invariant in its own comment — *"a flat worker must not create an unmirrored NIFTY position from a stale/missing BankNIFTY confirmation"* — and refuses to even evaluate an entry when aligned data is missing.

The race walked straight past it: the bar that **decided** had aligned data and passed the guard, and the reset then destroyed the close before that decision's order landed. A documented safety invariant was being violated silently, with one WARNING as the only trace.

## The fix

Delete the per-bar reset. The field then means what its declaration comment always said — *"latest BankNIFTY close seen this session"* — and the log message becomes accurate, because `0.0` now genuinely means none has ever been seen.

Staleness stays bounded by the two things already doing that work: the entry-evaluation guard (a flat worker never evaluates an entry without aligned data, so an ENTER can only originate on a good bar) and the 90s deadline (so the close is at most a bar or two old — well inside one BankNIFTY strike interval for an ATM pick).

**Considered and rejected:** threading the decision-time close through to the order tool. Semantically exact, but it changes the executor signature on the live order path for a bounded imprecision this already removes.

## TDD — and the first attempt did not reproduce

Written against the real `process_strategy_frame`, the test **passed immediately**: a flat worker returns at the 10:30 entry cutoff, evaluated against the wall clock, before the BankNIFTY block is reached. Patching `is_after_time` to `False` made it fail for the right reason — `AssertionError: 0.0 != 57910.0` — before the fix, and pass after.

`test_mirror_skipped_without_bnf_spot` still passes, so a genuinely never-seen close still skips the mirror. All 52 tests in `TestSLHuntingBnfMirror` are green.

## Gates

592 master · 28 market-data-health · 1437 pytest · ruff 0.16.6 · mypy (79 + master) · compileall · bandit · coverage policy — all clean.

> The master suite needs `DASHBOARD_ENABLED=false` on the operator's machine for the unrelated `test_the_dashboard_is_off_by_default`, which asserts the live `.env` value rather than the code default. Untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)