### PR TITLE
feat(dashboard): CPR, VWAP and a stochastic sub-pane, with a 1m/5m toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,7 @@ htmlcov/
 # per-session working record, not product documentation. docs/ itself is the
 # committed architecture set (hld/, lld/, adr/) -- only this subtree is ignored.
 docs/superpowers/
+
+# Git worktrees for isolated feature work. Never tracked: a worktree is a
+# second checkout of this same repository, not content that belongs in it.
+.worktrees/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,8 +82,19 @@ One process, cooperating threads:
   (broker fallback), or `SessionStateStore.snapshot()` on a tick; a test asserts all
   three. `DASHBOARD_BIND_HOST` is a module constant with deliberately NO `.env` knob.
   Stopped LAST, after the session is flat and results are published. Pure shaping in
-  `Dependencies/dashboard_snapshot.py`, transport in `dashboard_server.py`, the collector
-  in the master beside `_worker_session_state_snapshot`; see `docs/adr/0016`.
+  `Dependencies/dashboard_snapshot.py`, chart indicators in `dashboard_indicators.py`,
+  transport in `dashboard_server.py`, the collector in the master beside
+  `_worker_session_state_snapshot`; see `docs/adr/0016`.
+  The chart carries CPR, a session VWAP and a stochastic %K/%D sub-pane, with a 1m/5m
+  toggle (both timeframes ride in ONE `/api/chart` payload, so switching needs no
+  fetch). VWAP and the stochastic are the strategies' OWN objects, reached through
+  `load_module` under BARE names so `sys.modules` returns the already-loaded instance
+  rather than a second copy. CPR is the one deliberate divergence and is labelled
+  CHART-ONLY everywhere: it reads the prior session 09:15-15:15 inclusive (high, low
+  AND close) while CPR / CPR Algo 3 / CPR AI keep using the full session and its last
+  intraday close -- those strategies are untouched, only the input WINDOW differs, and
+  a test feeds an untruncated session through both to prove the algebra has not forked.
+  See `docs/adr/0017`.
 - Each entry/exit is published to a `queue.Queue` consumed by a single `TelegramMessageWorker`
   (best-effort alerts; never blocks trading). That same `publish_trade_event` choke point also
   mirrors every event into the **crash-durable session state** (`Dependencies/session_state.py`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,8 +82,19 @@ One process, cooperating threads:
   (broker fallback), or `SessionStateStore.snapshot()` on a tick; a test asserts all
   three. `DASHBOARD_BIND_HOST` is a module constant with deliberately NO `.env` knob.
   Stopped LAST, after the session is flat and results are published. Pure shaping in
-  `Dependencies/dashboard_snapshot.py`, transport in `dashboard_server.py`, the collector
-  in the master beside `_worker_session_state_snapshot`; see `docs/adr/0016`.
+  `Dependencies/dashboard_snapshot.py`, chart indicators in `dashboard_indicators.py`,
+  transport in `dashboard_server.py`, the collector in the master beside
+  `_worker_session_state_snapshot`; see `docs/adr/0016`.
+  The chart carries CPR, a session VWAP and a stochastic %K/%D sub-pane, with a 1m/5m
+  toggle (both timeframes ride in ONE `/api/chart` payload, so switching needs no
+  fetch). VWAP and the stochastic are the strategies' OWN objects, reached through
+  `load_module` under BARE names so `sys.modules` returns the already-loaded instance
+  rather than a second copy. CPR is the one deliberate divergence and is labelled
+  CHART-ONLY everywhere: it reads the prior session 09:15-15:15 inclusive (high, low
+  AND close) while CPR / CPR Algo 3 / CPR AI keep using the full session and its last
+  intraday close -- those strategies are untouched, only the input WINDOW differs, and
+  a test feeds an untruncated session through both to prove the algebra has not forked.
+  See `docs/adr/0017`.
 - Each entry/exit is published to a `queue.Queue` consumed by a single `TelegramMessageWorker`
   (best-effort alerts; never blocks trading). That same `publish_trade_event` choke point also
   mirrors every event into the **crash-durable session state** (`Dependencies/session_state.py`,

--- a/Dependencies/dashboard_assets/dashboard.css
+++ b/Dependencies/dashboard_assets/dashboard.css
@@ -107,7 +107,63 @@ main { padding: 12px; display: flex; flex-direction: column; gap: 12px; }
 .columns .wide { flex: 3 1 560px; }
 .columns .narrow { flex: 2 1 380px; }
 
-.chart-pane #chart { height: 40vh; min-height: 260px; }
+/* Taller than it was (40vh), and taller still than it looks: the stochastic
+ * sub-pane lives INSIDE this box, so the price pane only grows if the total
+ * grows by more than the sub-pane takes. At 1080p this is ~626px, of which
+ * ~110px is the oscillator, leaving ~510px of price against the old 432px.
+ * `clamp` stops a 4K monitor pushing the tables below the fold, and the drag
+ * handle lets the operator settle it themselves -- `autoSize: true` on the
+ * chart follows the element. */
+.chart-pane #chart {
+  height: clamp(340px, 58vh, 760px);
+  min-height: 340px;
+  resize: vertical;
+  overflow: hidden;
+}
+
+.chart-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 6px 16px;
+}
+.chart-head h2 { margin-bottom: 6px; }
+
+.chart-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px 12px;
+  margin-bottom: 6px;
+  font-size: 11px;
+  color: var(--muted);
+}
+.chart-controls label {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+  user-select: none;
+}
+.chart-controls input[type="checkbox"] { accent-color: var(--accent); margin: 0; }
+
+.tf-switch { display: inline-flex; border: 1px solid var(--line); border-radius: 3px; overflow: hidden; }
+.tf-switch .tf {
+  padding: 2px 9px;
+  border: 0;
+  background: var(--panel-2);
+  color: var(--muted);
+  font: inherit;
+  font-family: var(--mono);
+  cursor: pointer;
+}
+.tf-switch .tf.active { background: var(--accent); color: #0e1116; font-weight: 600; }
+.tf-switch .tf:not(.active):hover { color: var(--text); }
+
+/* The CPR provenance line: the actual numbers the levels came from, so the
+ * 15:15 close is visible rather than merely promised. */
+.provenance { margin: 6px 2px 0; font-size: 11px; color: var(--muted); }
 
 /* Wide tables scroll inside their own pane; the page body never scrolls
  * sideways. */

--- a/Dependencies/dashboard_assets/dashboard.js
+++ b/Dependencies/dashboard_assets/dashboard.js
@@ -16,9 +16,13 @@
   const REFRESH_FALLBACK_SECONDS = 1.0;
   const HIDDEN_TAB_SECONDS = 5.0;
   const RETRY_SECONDS = 5.0;
-  /* Two quiet polls in a row is normal jitter; more than this many means the
-   * builder thread has stopped producing new documents. */
-  const STALE_POLLS = 5;
+  /* How long the document may go unchanged before the page says so. Measured
+   * in TIME, not in polls: a poll count silently assumes this tab polls no
+   * faster than the runner publishes, and a count of consecutive 304s says
+   * nothing about how long they took. Five refresh intervals of real silence
+   * is a stopped builder; anything shorter is jitter. */
+  const STALE_AFTER_INTERVALS = 5;
+  const STALE_FLOOR_SECONDS = 5.0;
 
   const el = (id) => document.getElementById(id);
   const nodes = {
@@ -52,7 +56,15 @@
 
   let etag = null;
   let pollSeconds = REFRESH_FALLBACK_SECONDS;
-  let unchangedPolls = 0;
+  let lastFreshAt = Date.now();
+  /* Exactly one pending timer and one in-flight request at any moment. Without
+   * these, every return to the tab started an ADDITIONAL poll chain: the old
+   * timer was never cancelled, so N tab-switches meant N concurrent loops all
+   * polling a server that publishes once per interval. Most of those requests
+   * then got a 304, which the page read as "the runner has gone quiet" and
+   * flashed a staleness banner that cleared on the next publish. */
+  let pollTimer = null;
+  let pollInFlight = false;
   let chart = null;
   let candleSeries = null;
   let seriesVersion = -1;
@@ -340,24 +352,35 @@
     renderChart(doc);
   }
 
+  function schedulePoll(delaySeconds) {
+    /* Cancelling first is what keeps this to ONE loop. */
+    if (pollTimer !== null) clearTimeout(pollTimer);
+    pollTimer = setTimeout(poll, delaySeconds * 1000);
+  }
+
   async function poll() {
+    /* A request is already out; it will schedule the next one when it lands. */
+    if (pollInFlight) return;
+    pollInFlight = true;
     let delay = pollSeconds;
     try {
       const headers = etag ? { "If-None-Match": etag } : {};
       const response = await fetch("/api/state", { headers, cache: "no-store" });
 
       if (response.status === 304) {
-        /* The document is byte-identical, including its clock -- so the
-         * builder thread has stopped producing. Say so rather than quietly
-         * showing numbers that are no longer being refreshed. */
-        unchangedPolls += 1;
-        if (unchangedPolls >= STALE_POLLS) {
+        /* Byte-identical, including the document's own clock -- so nothing has
+         * been published since THIS tab's last 200. (Other tabs cannot cause
+         * this: each keeps its own ETag, so every tab gets a 200 on every new
+         * version.) One 304 just means we polled inside a publish gap; only
+         * sustained silence means the builder has actually stopped. */
+        const quietFor = (Date.now() - lastFreshAt) / 1000;
+        if (quietFor >= Math.max(STALE_FLOOR_SECONDS, pollSeconds * STALE_AFTER_INTERVALS)) {
           setLiveness("stale", "The runner has not published an update recently; " +
             "these numbers are frozen. Trading is unaffected.");
         }
       } else if (response.ok) {
         etag = response.headers.get("ETag");
-        unchangedPolls = 0;
+        lastFreshAt = Date.now();
         const doc = await response.json();
         if (doc.poll_seconds) pollSeconds = doc.poll_seconds;
         render(doc);
@@ -374,13 +397,15 @@
       delay = RETRY_SECONDS;
     }
 
+    pollInFlight = false;
     if (document.visibilityState === "hidden") delay = Math.max(delay, HIDDEN_TAB_SECONDS);
-    setTimeout(poll, delay * 1000);
+    schedulePoll(delay);
   }
 
   document.addEventListener("visibilitychange", () => {
-    if (document.visibilityState === "visible") poll();
+    /* Bring the NEXT poll forward rather than starting a second loop. */
+    if (document.visibilityState === "visible") schedulePoll(0);
   });
 
-  poll();
+  schedulePoll(0);
 })();

--- a/Dependencies/dashboard_assets/dashboard.js
+++ b/Dependencies/dashboard_assets/dashboard.js
@@ -52,6 +52,12 @@
     sessionStateNote: el("session-state-note"),
     chart: el("chart"),
     chartEmpty: el("chart-empty"),
+    chartTitle: el("chart-title"),
+    cprProvenance: el("cpr-provenance"),
+    vwapLabel: el("vwap-label"),
+    vwapFootnote: el("vwap-footnote"),
+    tf1: el("tf-1"),
+    tf5: el("tf-5"),
   };
 
   let etag = null;
@@ -67,7 +73,24 @@
   let pollInFlight = false;
   let chart = null;
   let candleSeries = null;
+  let vwapSeries = null;
+  let kSeries = null;
+  let dSeries = null;
   let seriesVersion = -1;
+  /* The last `/api/chart` response, holding BOTH timeframes. Keeping it means
+   * the timeframe toggle redraws from memory instead of issuing a request
+   * that could fail and leave a blank chart. */
+  let chartPayload = null;
+  let cprLines = [];
+  let cprSignature = null;
+  /* Which timeframe the series currently hold. Switching changes both the bar
+   * spacing and the span, so the visible range has to be refit -- but ONLY
+   * then, never on the once-a-minute refresh, or the operator's zoom would be
+   * yanked back every minute. */
+  let renderedTimeframe = null;
+  /* Set whenever the visible range needs refitting, cleared once a fit has
+   * actually landed. See `requestFit`. */
+  let pendingFit = false;
 
   /* ------------------------------------------------------------ formatting */
   const DASH = '<span class="dash">—</span>';
@@ -276,6 +299,49 @@
   }
 
   /* ----------------------------------------------------------------- chart */
+  /* ----------------------------------------------------------------- chart */
+  /* Indicator visibility and the timeframe are per-browser preferences, held
+   * in a VERSIONED key so a future rename falls back to defaults instead of
+   * silently hiding a line. Every access is wrapped: a private window, cleared
+   * site data or a corrupt value must not take the page down with it. */
+  const PREFS_KEY = "algoDashboard.chart.v1";
+  const PREF_DEFAULTS = { tf: "1", cpr: true, cprRS1: false, cprRS3: false, vwap: true, stoch: true };
+
+  function loadPrefs() {
+    try {
+      const stored = JSON.parse(localStorage.getItem(PREFS_KEY) || "{}");
+      return { ...PREF_DEFAULTS, ...(stored && typeof stored === "object" ? stored : {}) };
+    } catch (error) {
+      return { ...PREF_DEFAULTS };
+    }
+  }
+
+  function savePrefs() {
+    try {
+      localStorage.setItem(PREFS_KEY, JSON.stringify(prefs));
+    } catch (error) {
+      /* A preference that cannot be remembered is not worth an error. */
+    }
+  }
+
+  const prefs = loadPrefs();
+
+  /* CPR groups. `core` is on by default; the ladders are opt-in because
+   * eleven horizontal lines over candles is not a chart, it is a net. */
+  const CPR_LEVELS = [
+    { key: "pivot", group: "core", title: "P",  color: "#e8b13a", dashed: false },
+    { key: "bc",    group: "core", title: "BC", color: "#8b94a3", dashed: true },
+    { key: "tc",    group: "core", title: "TC", color: "#8b94a3", dashed: true },
+    { key: "r1",    group: "rs1",  title: "R1", color: "#ef5f5f", dashed: true },
+    { key: "r2",    group: "rs1",  title: "R2", color: "#ef5f5f", dashed: true },
+    { key: "s1",    group: "rs1",  title: "S1", color: "#35c46b", dashed: true },
+    { key: "s2",    group: "rs1",  title: "S2", color: "#35c46b", dashed: true },
+    { key: "r3",    group: "rs3",  title: "R3", color: "#8a3b3b", dashed: true },
+    { key: "r4",    group: "rs3",  title: "R4", color: "#8a3b3b", dashed: true },
+    { key: "s3",    group: "rs3",  title: "S3", color: "#2c6b45", dashed: true },
+    { key: "s4",    group: "rs3",  title: "S4", color: "#2c6b45", dashed: true },
+  ];
+
   function ensureChart() {
     if (chart || typeof LightweightCharts === "undefined") return;
     chart = LightweightCharts.createChart(nodes.chart, {
@@ -285,6 +351,13 @@
         /* Left enabled deliberately: the vendored library is Apache-2.0 and
          * this is its attribution. See vendor/NOTICE-lightweight-charts.md. */
         attributionLogo: true,
+        /* The library's own separator defaults are light-theme greys
+         * (#E0E3EB) and would draw a bright bar across this panel. */
+        panes: {
+          enableResize: true,
+          separatorColor: "#2c333d",
+          separatorHoverColor: "rgba(91, 157, 217, 0.35)",
+        },
       },
       grid: {
         vertLines: { color: "#232932" },
@@ -295,11 +368,192 @@
       crosshair: { mode: LightweightCharts.CrosshairMode.Normal },
       autoSize: true,
     });
+
     candleSeries = chart.addSeries(LightweightCharts.CandlestickSeries, {
       upColor: "#35c46b", downColor: "#ef5f5f",
       borderUpColor: "#35c46b", borderDownColor: "#ef5f5f",
       wickUpColor: "#35c46b", wickDownColor: "#ef5f5f",
-    });
+    }, 0);
+
+    vwapSeries = chart.addSeries(LightweightCharts.LineSeries, {
+      color: "#e8b13a", lineWidth: 1, priceLineVisible: false,
+      lastValueVisible: false, title: "VWAP*", visible: prefs.vwap,
+    }, 0);
+
+    /* Pane 1: the oscillator. v5 takes the pane index as addSeries' third
+     * argument and creates the pane on demand. */
+    kSeries = chart.addSeries(LightweightCharts.LineSeries, {
+      color: "#5b9dd9", lineWidth: 1, priceLineVisible: false, title: "%K",
+    }, 1);
+    dSeries = chart.addSeries(LightweightCharts.LineSeries, {
+      color: "#e8b13a", lineWidth: 1, priceLineVisible: false, title: "%D",
+    }, 1);
+    for (const level of [80, 20]) {
+      kSeries.createPriceLine({
+        price: level, color: "#39414d", lineWidth: 1,
+        lineStyle: LightweightCharts.LineStyle.Dotted, axisLabelVisible: true,
+      });
+    }
+    applyStochVisibility();
+
+    /* Fitting the visible range requires the container to HAVE a width. On a
+     * first paint -- or in a tab that is still hidden -- it can be zero, and
+     * fitting against a zero-width box silently does nothing while leaving a
+     * nonsense bar spacing behind, which draws every candle squeezed into a
+     * few pixels at the right edge. Observing the element means the fit
+     * happens exactly when layout gives it a size, however late that is. */
+    try {
+      new ResizeObserver(() => applyPendingFit()).observe(nodes.chart);
+    } catch (error) {
+      /* No ResizeObserver: the per-render retry below still covers it. */
+    }
+  }
+
+  function requestFit() {
+    pendingFit = true;
+    applyPendingFit();
+  }
+
+  function applyPendingFit() {
+    if (!pendingFit || !chart) return;
+    if (!nodes.chart.clientWidth) return;  // not laid out yet; try again later
+    chart.timeScale().fitContent();
+    pendingFit = false;
+  }
+
+  const STOCH_PANE_HEIGHT = 110;
+
+  function applyStochVisibility() {
+    if (!kSeries) return;
+    kSeries.applyOptions({ visible: prefs.stoch });
+    dSeries.applyOptions({ visible: prefs.stoch });
+    /* Hiding the lines is not enough: the pane itself keeps its height and
+     * the price chart stays short, which is the opposite of what turning the
+     * oscillator off is for. Collapse it so the candles get the room back. */
+    try {
+      chart.panes()[1].setHeight(prefs.stoch ? STOCH_PANE_HEIGHT : 1);
+    } catch (error) {
+      /* Pane sizing is cosmetic; never let it stop the chart drawing. */
+    }
+  }
+
+  /* Indicator columns arrive as bare numbers zipped against bars[i].time --
+   * ~9 bytes a point instead of ~36 for {time, value} objects. */
+  function pointsFrom(bars, values) {
+    const points = [];
+    for (let index = 0; index < bars.length; index += 1) {
+      const value = values ? values[index] : null;
+      if (value !== null && value !== undefined) {
+        points.push({ time: bars[index].time, value });
+      }
+    }
+    return points;
+  }
+
+  function renderCprLines(cpr) {
+    if (!candleSeries) return;
+    const signature = JSON.stringify([
+      cpr && cpr.available ? cpr.pivot : null, prefs.cpr, prefs.cprRS1, prefs.cprRS3,
+    ]);
+    if (signature === cprSignature) return;
+    cprSignature = signature;
+
+    for (const handle of cprLines) candleSeries.removePriceLine(handle);
+    cprLines = [];
+    if (!cpr || !cpr.available || !prefs.cpr) return;
+
+    for (const level of CPR_LEVELS) {
+      const on = level.group === "core"
+        || (level.group === "rs1" && prefs.cprRS1)
+        || (level.group === "rs3" && prefs.cprRS3);
+      const price = cpr[level.key];
+      if (!on || price === null || price === undefined) continue;
+      cprLines.push(candleSeries.createPriceLine({
+        price,
+        color: level.color,
+        lineWidth: 1,
+        lineStyle: level.dashed ? LightweightCharts.LineStyle.Dashed : LightweightCharts.LineStyle.Solid,
+        axisLabelVisible: true,
+        /* The "(chart)" suffix travels with a screenshot of just the chart,
+         * where none of the page's other captions would. */
+        title: `${level.title} (chart)`,
+      }));
+    }
+  }
+
+  function renderCprProvenance(cpr) {
+    if (!cpr || !cpr.available) {
+      nodes.cprProvenance.hidden = false;
+      nodes.cprProvenance.textContent = cpr && cpr.unavailable_reason
+        ? `CPR unavailable — ${cpr.unavailable_reason}.`
+        : "";
+      nodes.cprProvenance.hidden = !nodes.cprProvenance.textContent;
+      return;
+    }
+    /* Built from the payload's OWN inputs, not a fixed string: the operator
+     * can see the 15:15 close rather than take it on trust, and can see how
+     * far it sits from the figure the strategies actually trade. */
+    const parts = [
+      `Prior ${cpr.prior_session_date} ${cpr.window}`,
+      `${cpr.bars_used} bars`,
+      `H ${cpr.prev_high} L ${cpr.prev_low} C ${cpr.prev_close}`,
+      `pivot ${cpr.pivot} (chart)`,
+    ];
+    if (cpr.strategies_pivot !== null && cpr.strategies_pivot !== undefined) {
+      parts.push(`strategies ${cpr.strategies_pivot} (full session)`);
+    }
+    if (cpr.partial) parts.push("partial prior session");
+    if (cpr.width) parts.push(cpr.width);
+    nodes.cprProvenance.textContent = parts.join(" · ");
+    nodes.cprProvenance.hidden = false;
+  }
+
+  function applyTimeframe() {
+    if (!chartPayload || !candleSeries) return;
+    const block = chartPayload.timeframes[prefs.tf] || chartPayload.timeframes["1"];
+    if (!block) return;
+
+    candleSeries.setData(block.bars || []);
+    vwapSeries.setData(pointsFrom(block.bars || [], block.vwap));
+    kSeries.setData(pointsFrom(block.bars || [], block.stoch_k));
+    dSeries.setData(pointsFrom(block.bars || [], block.stoch_d));
+
+    if (renderedTimeframe !== prefs.tf) {
+      renderedTimeframe = prefs.tf;
+      /* 75 five-minute bars cover a different span from 375 one-minute ones,
+       * so without a refit the new candles sit outside the old visible range
+       * and the pane looks empty apart from the price lines.
+       *
+       * Deferred to the next PAINT, not called inline: on a first load the
+       * container can still have zero width, and fitting against a zero-width
+       * box silently does nothing and leaves the stale range behind. A hidden
+       * tab does not run animation frames at all, so this also waits, by
+       * itself, until the tab is actually shown. */
+      requestFit();
+    }
+
+    const minutes = block.minutes || 1;
+    nodes.chartTitle.textContent =
+      `NIFTY · ${minutes} minute${minutes === 1 ? "" : "s"} · CPR from prior session `
+      + `${(chartPayload.cpr && chartPayload.cpr.window) || "09:15-15:15"} (chart only)`;
+    renderCprLines(chartPayload.cpr);
+    renderCprProvenance(chartPayload.cpr);
+
+    const vwapMeta = (chartPayload.indicators || {}).vwap || {};
+    nodes.vwapLabel.title = vwapMeta.note || "";
+    nodes.vwapFootnote.hidden = vwapMeta.is_proxy === false;
+  }
+
+  function setTimeframe(value) {
+    prefs.tf = value;
+    savePrefs();
+    nodes.tf1.classList.toggle("active", value === "1");
+    nodes.tf5.classList.toggle("active", value === "5");
+    nodes.tf1.setAttribute("aria-pressed", String(value === "1"));
+    nodes.tf5.setAttribute("aria-pressed", String(value === "5"));
+    /* Switching redraws from the payload the browser ALREADY holds: no fetch,
+     * so the toggle has no way to fail. */
+    applyTimeframe();
   }
 
   async function renderChart(doc) {
@@ -311,24 +565,29 @@
     ensureChart();
     if (!candleSeries) return;
 
-    /* The full candle array is refetched only when a new MINUTE closed --
-     * roughly 375 times a session rather than once per poll. In between, the
-     * forming candle is updated in place, which is what makes the chart move
-     * tick-by-tick under MARKET_DATA_SOURCE=WEBSOCKET for ~120 bytes a poll. */
+    /* The arrays are refetched only when a new MINUTE closed -- roughly 375
+     * times a session rather than once per poll. In between, the forming
+     * candle is updated in place, which is what makes the chart move
+     * tick-by-tick under MARKET_DATA_SOURCE=WEBSOCKET for a few hundred bytes. */
     if (info.series_version !== seriesVersion) {
       try {
         const response = await fetch("/api/chart", { cache: "no-store" });
         if (response.ok) {
-          const payload = await response.json();
-          candleSeries.setData(payload.bars || []);
+          chartPayload = await response.json();
           seriesVersion = info.series_version;
+          applyTimeframe();
         }
       } catch (error) {
         /* Leave the previous series on screen; the next poll retries. */
         return;
       }
     }
-    candleSeries.update(info.last_bar);
+
+    /* Only the forming candle moves between minutes. Indicators are computed
+     * on COMPLETED bars, so they deliberately have no point here. */
+    const forming = prefs.tf === "5" ? info.last_bar_5m : info.last_bar;
+    if (forming) candleSeries.update(forming);
+    applyPendingFit();
   }
 
   /* ------------------------------------------------------------------ poll */
@@ -401,6 +660,27 @@
     if (document.visibilityState === "hidden") delay = Math.max(delay, HIDDEN_TAB_SECONDS);
     schedulePoll(delay);
   }
+
+  /* Controls. Each checkbox flips visibility rather than re-setting data, so
+   * toggling never costs a redraw of the series it keeps. */
+  nodes.tf1.addEventListener("click", () => setTimeframe("1"));
+  nodes.tf5.addEventListener("click", () => setTimeframe("5"));
+
+  for (const [id, key] of [
+    ["ind-cpr", "cpr"], ["ind-cpr-rs1", "cprRS1"], ["ind-cpr-rs3", "cprRS3"],
+    ["ind-vwap", "vwap"], ["ind-stoch", "stoch"],
+  ]) {
+    const box = el(id);
+    box.checked = Boolean(prefs[key]);
+    box.addEventListener("change", () => {
+      prefs[key] = box.checked;
+      savePrefs();
+      if (key === "vwap" && vwapSeries) vwapSeries.applyOptions({ visible: prefs.vwap });
+      else if (key === "stoch") applyStochVisibility();
+      else if (chartPayload) renderCprLines(chartPayload.cpr);
+    });
+  }
+  setTimeframe(prefs.tf === "5" ? "5" : "1");
 
   document.addEventListener("visibilitychange", () => {
     /* Bring the NEXT poll forward rather than starting a second loop. */

--- a/Dependencies/dashboard_assets/index.html
+++ b/Dependencies/dashboard_assets/index.html
@@ -36,9 +36,26 @@
 
 <main>
   <section class="pane chart-pane">
-    <h2>NIFTY · 1 minute</h2>
+    <div class="chart-head">
+      <h2 id="chart-title">NIFTY · 1 minute</h2>
+      <div class="chart-controls">
+        <div class="tf-switch" role="group" aria-label="Chart timeframe">
+          <button type="button" id="tf-1" class="tf active" aria-pressed="true">1m</button>
+          <button type="button" id="tf-5" class="tf" aria-pressed="false">5m</button>
+        </div>
+        <label title="Pivot, BC and TC from the prior session 09:15-15:15">
+          <input type="checkbox" id="ind-cpr" checked> CPR
+          <span class="flag warn" id="cpr-chip">CHART-ONLY</span>
+        </label>
+        <label><input type="checkbox" id="ind-cpr-rs1"> R1/R2 · S1/S2</label>
+        <label><input type="checkbox" id="ind-cpr-rs3"> R3/R4 · S3/S4</label>
+        <label id="vwap-label"><input type="checkbox" id="ind-vwap" checked> VWAP*</label>
+        <label><input type="checkbox" id="ind-stoch" checked> Stochastic</label>
+      </div>
+    </div>
     <div id="chart"></div>
     <p class="empty" id="chart-empty">Waiting for the first candle…</p>
+    <p class="provenance mono" id="cpr-provenance" hidden></p>
   </section>
 
   <div class="columns">
@@ -94,6 +111,7 @@
 <footer>
   <span>Informational only — the broker is the authority on what is open.</span>
   <span class="muted">Read-only · loopback · GET only</span>
+  <span class="muted" id="vwap-footnote">* VWAP is an equal-weight proxy — the index feed carries no volume.</span>
   <span class="muted">Charts by TradingView Lightweight Charts™ — Apache-2.0</span>
 </footer>
 

--- a/Dependencies/dashboard_indicators.py
+++ b/Dependencies/dashboard_indicators.py
@@ -1,0 +1,528 @@
+"""Chart indicator shaping for the read-only monitoring dashboard.
+
+The dashboard's chart shows candles; this module turns the same 1-minute frame
+into the things an operator needs to read them against: CPR levels, a session
+VWAP, a stochastic oscillator, and a 5-minute view of all three.
+
+Same three rules as `dashboard_snapshot.py`:
+
+1. **Pure.** pandas is allowed; threads, sockets, disk, the clock and `.env`
+   are not. Every function is a transformation of its arguments. The module
+   must never call `_env_*` or `os.getenv` -- configuration is read in the
+   master, the only place `check_env_config` audits against `env.example`.
+2. **Never invent a number.** Anything that cannot be derived honestly comes
+   back as `None`, and the page draws nothing there. `render_document_bytes`
+   serializes with `allow_nan=False`, so a stray NaN would raise inside the
+   renderer and freeze the whole dashboard on its last good document -- every
+   value crossing this boundary goes through `finite_or_none` first.
+3. **Reporting only.** Nothing here feeds risk, sizing or execution.
+
+**Indicators are computed on COMPLETED bars.** The forming candle is drawn as a
+candle but carries no indicator point, which is both cheaper and truer: the
+strategies themselves evaluate closed candles only.
+
+**The maths is not reimplemented here.** `stochastic` and `attach_session_vwap`
+are injected by the caller as the very objects the live strategies use, so a
+line on the chart cannot drift from the figure a strategy traded on. The one
+exception is CPR, and it is a deliberate one -- see `chart_cpr`.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import date, time
+
+import pandas as pd
+
+#: The prior session is read from this window rather than the whole day. The
+#: operator's reason: an index close is settled by the closing auction, so the
+#: last prints of the day are the least trustworthy input to a pivot. The bar
+#: labelled 15:15 is INCLUDED -- "the 3:15 candle close" means that candle's
+#: close. Deliberately a constant, not a knob: it is a charting convention, and
+#: a `.env` key here would escape the config audit this module is excluded from.
+CPR_SESSION_START: time = time(9, 15)
+CPR_SESSION_END: time = time(15, 15)
+
+#: Epoch for the bar timestamps. Integer-dividing a Timedelta is independent of
+#: the frame's datetime RESOLUTION -- pandas 3 defaults to microseconds, so the
+#: obvious `astype("int64") // 10**9` silently yields values a thousand times
+#: too small and draws the whole session in 1970.
+_EPOCH = pd.Timestamp("1970-01-01")
+
+_OHLC = ("open", "high", "low", "close")
+
+
+# ---------------------------------------------------------------------------
+# Guards
+# ---------------------------------------------------------------------------
+def finite_or_none(value: object) -> float | None:
+    """A real number, or None. Rejects NaN and infinity; never raises.
+
+    The gate in front of `allow_nan=False`. NaN arrives routinely and
+    legitimately -- an indicator's warm-up window, a session with too few bars
+    -- so this is a normal path, not an error path.
+    """
+
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        return None
+    number = float(value)
+    return number if math.isfinite(number) else None
+
+
+def round_or_none(value: object, digits: int = 2) -> float | None:
+    """`finite_or_none`, rounded for the wire."""
+
+    number = finite_or_none(value)
+    return None if number is None else round(number, digits)
+
+
+def _series_values(series: pd.Series[float], digits: int = 2) -> list[float | None]:
+    """A JSON-ready column: rounded floats with None wherever the value is not real."""
+
+    return [round_or_none(value, digits) for value in series.tolist()]
+
+
+# ---------------------------------------------------------------------------
+# Bars
+# ---------------------------------------------------------------------------
+def bar_records(frame: pd.DataFrame) -> list[dict]:
+    """Serialize an OHLC frame into the shape the charting library expects.
+
+    Produces exactly what the master's `_bar_record` produces for one row, and
+    a test asserts that equivalence bar for bar. It exists because the
+    row-at-a-time version costs ~39 ms for 375 bars against a 1000 ms build
+    budget, where this costs ~1.6 ms.
+
+    The timestamps are naive IST wall-clock and are labelled UTC on purpose:
+    lightweight-charts renders every timestamp as UTC and has no timezone
+    setting, so this makes the axis read 09:15, 09:16 ... as the exchange clock
+    does. Localizing to IST instead would draw the session starting at 03:45.
+    """
+
+    if frame.empty:
+        return []
+    seconds = (frame["timestamp"] - _EPOCH) // pd.Timedelta(seconds=1)
+    return [
+        {
+            "time": int(stamp),
+            "open": round(float(open_), 2),
+            "high": round(float(high), 2),
+            "low": round(float(low), 2),
+            "close": round(float(close), 2),
+        }
+        for stamp, open_, high, low, close in zip(
+            seconds, frame["open"], frame["high"], frame["low"], frame["close"], strict=True
+        )
+    ]
+
+
+def forming_bucket(
+    frame: pd.DataFrame, *, timeframe_minutes: int
+) -> tuple[dict | None, pd.Timestamp | None]:
+    """The in-progress higher-timeframe bar, aggregated from its finished minutes.
+
+    `resample_ohlc_from_1m` deliberately DISCARDS incomplete buckets, because
+    that is the guarantee the 5-minute strategies stand on. The chart still
+    wants to show the bar as it forms, so it is built here instead and
+    concatenated afterwards -- the resampler is never weakened to produce it.
+
+    Returns `(bar record, bucket start)`, or `(None, None)` when the newest
+    minute happens to complete a bucket exactly and nothing is forming.
+    """
+
+    if frame.empty or int(timeframe_minutes) <= 1:
+        return None, None
+    newest = pd.Timestamp(frame["timestamp"].iloc[-1])
+    anchor = newest.floor(f"{int(timeframe_minutes)}min")
+    partial = frame.loc[frame["timestamp"] >= anchor]
+    if partial.empty or len(partial) >= int(timeframe_minutes):
+        # A full bucket is the resampler's business, not ours.
+        return None, None
+    record = {
+        "time": int((anchor - _EPOCH) // pd.Timedelta(seconds=1)),
+        "open": round(float(partial["open"].iloc[0]), 2),
+        "high": round(float(partial["high"].max()), 2),
+        "low": round(float(partial["low"].min()), 2),
+        "close": round(float(partial["close"].iloc[-1]), 2),
+    }
+    return record, anchor
+
+
+# ---------------------------------------------------------------------------
+# CPR
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True)
+class PriorSession:
+    """The slice of the previous trading day the chart's CPR is built from."""
+
+    session_date: date | None
+    frame: pd.DataFrame
+    first_bar: str | None
+    last_bar: str | None
+    bars_used: int
+    #: True when the slice does not reach back to the session open, so the
+    #: high and low may understate the day. Shown, not hidden.
+    partial: bool
+
+
+@dataclass(frozen=True)
+class ChartCpr:
+    """Daily CPR levels for the chart. NOT the levels the strategies trade on."""
+
+    available: bool
+    prior_session_date: str | None = None
+    window: str | None = None
+    last_bar: str | None = None
+    bars_used: int = 0
+    partial: bool = False
+    prev_high: float | None = None
+    prev_low: float | None = None
+    prev_close: float | None = None
+    pivot: float | None = None
+    bc: float | None = None
+    tc: float | None = None
+    r1: float | None = None
+    r2: float | None = None
+    r3: float | None = None
+    r4: float | None = None
+    s1: float | None = None
+    s2: float | None = None
+    s3: float | None = None
+    s4: float | None = None
+    width: str | None = None
+    #: The pivot the live strategies see, from the FULL prior session. Carried
+    #: purely so the page can print both numbers side by side; nothing computes
+    #: with it.
+    strategies_pivot: float | None = None
+    unavailable_reason: str | None = None
+
+    def as_dict(self) -> dict[str, object]:
+        """JSON-ready form; the page reads these key names directly."""
+
+        return {
+            "available": self.available,
+            "chart_only": True,
+            "prior_session_date": self.prior_session_date,
+            "window": self.window,
+            "last_bar": self.last_bar,
+            "bars_used": self.bars_used,
+            "partial": self.partial,
+            "prev_high": self.prev_high,
+            "prev_low": self.prev_low,
+            "prev_close": self.prev_close,
+            "pivot": self.pivot,
+            "bc": self.bc,
+            "tc": self.tc,
+            "r1": self.r1,
+            "r2": self.r2,
+            "r3": self.r3,
+            "r4": self.r4,
+            "s1": self.s1,
+            "s2": self.s2,
+            "s3": self.s3,
+            "s4": self.s4,
+            "width": self.width,
+            "strategies_pivot": self.strategies_pivot,
+            "unavailable_reason": self.unavailable_reason,
+            "caveat": (
+                "Chart CPR reads the prior session 09:15-15:15 -- high, low AND close. "
+                "The live CPR, CPR Algo 3 and CPR AI strategies use the full session and "
+                "its last intraday close, so their levels differ slightly. These lines are "
+                "for the eye only and move nothing."
+            ),
+        }
+
+
+def prior_session_window(
+    frame: pd.DataFrame,
+    *,
+    session_start: time = CPR_SESSION_START,
+    session_end: time = CPR_SESSION_END,
+) -> PriorSession:
+    """Slice the previous AVAILABLE session down to its `start..end` window.
+
+    "Previous available" rather than "yesterday" so a weekend or a holiday
+    resolves to whatever traded last -- the same day `_add_daily_cpr`'s
+    `groupby(...).shift(1)` picks, which is what keeps the two implementations
+    talking about the same session.
+    """
+
+    empty = PriorSession(None, frame.iloc[0:0], None, None, 0, False)
+    if frame.empty or "timestamp" not in frame.columns:
+        return empty
+
+    dates = frame["timestamp"].dt.date
+    today = dates.iloc[-1]
+    earlier = [value for value in dates.unique() if value < today]
+    if not earlier:
+        return empty
+
+    prior_date = max(earlier)
+    day = frame.loc[dates == prior_date]
+    clock = day["timestamp"].dt.time
+    window = day.loc[(clock >= session_start) & (clock <= session_end)]
+    if window.empty:
+        return PriorSession(prior_date, window, None, None, 0, False)
+
+    stamps = window["timestamp"]
+    return PriorSession(
+        session_date=prior_date,
+        frame=window,
+        first_bar=stamps.iloc[0].strftime("%H:%M"),
+        last_bar=stamps.iloc[-1].strftime("%H:%M"),
+        bars_used=len(window),
+        # Measured against the session START, not against the day's own first
+        # bar: comparing the slice to the day it was sliced from can never
+        # detect anything, because a truncated frame truncates both. A prior
+        # session whose history does not reach 09:15 may understate the high
+        # and low, so the page says so rather than quietly drawing it.
+        partial=stamps.iloc[0].time() > session_start,
+    )
+
+
+def pivot_levels(high: float, low: float, close: float) -> dict[str, float]:
+    """Standard CPR / floor-pivot algebra.
+
+    Transcribed from `Signal Generators/CPR Strategy/cpr_strategy_logic.py`
+    rather than re-derived, so the chart and the strategies can only ever
+    differ in their INPUT WINDOW. A test feeds an untruncated prior session
+    through both and asserts the levels match.
+    """
+
+    pivot = (high + low + close) / 3.0
+    bc = (high + low) / 2.0
+    tc = 2.0 * pivot - bc
+    r1 = 2.0 * pivot - low
+    r2 = pivot + high - low
+    r3 = high + 2.0 * (pivot - low)
+    s1 = 2.0 * pivot - high
+    s2 = pivot - (high - low)
+    s3 = low - 2.0 * (high - pivot)
+    return {
+        "pivot": pivot,
+        "bc": bc,
+        "tc": tc,
+        "r1": r1,
+        "r2": r2,
+        "r3": r3,
+        "r4": r3 + high - low,
+        "s1": s1,
+        "s2": s2,
+        "s3": s3,
+        "s4": s3 - (high - low),
+    }
+
+
+def chart_cpr(
+    frame: pd.DataFrame,
+    *,
+    session_start: time = CPR_SESSION_START,
+    session_end: time = CPR_SESSION_END,
+    width_classifier: Callable[[float, float, float], str] | None = None,
+) -> ChartCpr:
+    """CPR levels for the chart, from a prior session truncated at 15:15.
+
+    Every failure is `available=False` with a stated reason and every level
+    `None` -- never a zero, and never today's own bars, either of which would
+    draw a confident line in the wrong place.
+    """
+
+    prior = prior_session_window(frame, session_start=session_start, session_end=session_end)
+    if prior.session_date is None:
+        return ChartCpr(False, unavailable_reason="no prior session in the loaded history")
+    if prior.frame.empty:
+        return ChartCpr(
+            False,
+            prior_session_date=prior.session_date.isoformat(),
+            unavailable_reason=f"prior session has no bars between {session_start:%H:%M} and {session_end:%H:%M}",
+        )
+
+    high = finite_or_none(prior.frame["high"].max())
+    low = finite_or_none(prior.frame["low"].min())
+    close = finite_or_none(prior.frame["close"].iloc[-1])
+    if high is None or low is None or close is None:
+        return ChartCpr(
+            False,
+            prior_session_date=prior.session_date.isoformat(),
+            unavailable_reason="prior session high, low or close is not a finite number",
+        )
+
+    levels = pivot_levels(high, low, close)
+
+    # The same algebra on the UNTRUNCATED session: what the live strategies
+    # see. Carried so the page can show both figures instead of merely warning
+    # that they differ.
+    whole_day = frame.loc[frame["timestamp"].dt.date == prior.session_date]
+    strategies_pivot = None
+    if not whole_day.empty:
+        full_high = finite_or_none(whole_day["high"].max())
+        full_low = finite_or_none(whole_day["low"].min())
+        full_close = finite_or_none(whole_day["close"].iloc[-1])
+        if None not in (full_high, full_low, full_close):
+            strategies_pivot = round_or_none(
+                pivot_levels(full_high, full_low, full_close)["pivot"]  # type: ignore[arg-type]
+            )
+
+    width = None
+    if width_classifier is not None:
+        try:
+            width = str(width_classifier(high, low, close))
+        except Exception:  # noqa: BLE001 - a label must never break the chart
+            width = None
+
+    return ChartCpr(
+        available=True,
+        prior_session_date=prior.session_date.isoformat(),
+        window=f"{prior.first_bar}-{prior.last_bar}",
+        last_bar=prior.last_bar,
+        bars_used=prior.bars_used,
+        partial=prior.partial,
+        prev_high=round_or_none(high),
+        prev_low=round_or_none(low),
+        prev_close=round_or_none(close),
+        width=width,
+        strategies_pivot=strategies_pivot,
+        # Spelled out rather than splatted: a `**dict` hides which level is
+        # which from both the reader and the type checker.
+        pivot=round_or_none(levels["pivot"]),
+        bc=round_or_none(levels["bc"]),
+        tc=round_or_none(levels["tc"]),
+        r1=round_or_none(levels["r1"]),
+        r2=round_or_none(levels["r2"]),
+        r3=round_or_none(levels["r3"]),
+        r4=round_or_none(levels["r4"]),
+        s1=round_or_none(levels["s1"]),
+        s2=round_or_none(levels["s2"]),
+        s3=round_or_none(levels["s3"]),
+        s4=round_or_none(levels["s4"]),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Series
+# ---------------------------------------------------------------------------
+def session_vwap_values(
+    frame: pd.DataFrame,
+    *,
+    attach_session_date: Callable[[pd.DataFrame], pd.DataFrame],
+    attach_session_vwap: Callable[[pd.DataFrame], pd.DataFrame],
+) -> tuple[list[float | None], bool]:
+    """Session VWAP for every bar, plus whether it is the equal-weight proxy.
+
+    Both callables are injected rather than imported: they are the SAME objects
+    the Regime Adaptive strategy uses, so the drawn line cannot drift from the
+    traded one, and no fourth copy of the VWAP formula enters the repository.
+
+    The index feed carries no volume, so in live running this is always the
+    proxy -- the expanding mean of `(H+L+C)/3` since the session open. The page
+    must say so; `is_proxy` is how it knows.
+    """
+
+    if frame.empty:
+        return [], True
+    enriched = attach_session_vwap(attach_session_date(frame))
+    values = _series_values(enriched["vwap"])
+    proxy_column = enriched.get("vwap_is_proxy")
+    is_proxy = True if proxy_column is None else bool(proxy_column.any())
+    return values, is_proxy
+
+
+def stochastic_values(
+    frame: pd.DataFrame,
+    *,
+    stochastic_fn: Callable[..., tuple[pd.Series[float], pd.Series[float]]],
+    k_period: int,
+    d_period: int,
+    smooth_k: int,
+) -> tuple[list[float | None], list[float | None]]:
+    """%K and %D for every bar, from the strategies' own stochastic helper.
+
+    A frame shorter than the warm-up simply yields `None` throughout -- that is
+    the honest answer, and it keeps NaN away from the renderer.
+    """
+
+    if frame.empty:
+        return [], []
+    k_series, d_series = stochastic_fn(
+        frame, k_period=k_period, d_period=d_period, smooth_k=smooth_k
+    )
+    return _series_values(k_series), _series_values(d_series)
+
+
+# ---------------------------------------------------------------------------
+# Assembly
+# ---------------------------------------------------------------------------
+def timeframe_block(
+    *,
+    minutes: int,
+    bars: Sequence[Mapping[str, object]],
+    vwap: Sequence[float | None],
+    stoch_k: Sequence[float | None],
+    stoch_d: Sequence[float | None],
+    forming_from: int | None = None,
+) -> dict[str, object]:
+    """One timeframe's candles and indicator columns.
+
+    Indicator columns are parallel ARRAYS zipped against `bars[i].time`, not
+    `{time, value}` objects: a bare number is ~9 bytes against ~36, and there
+    are three of them per timeframe.
+
+    The arrays are right-aligned to the bars and padded with `None` at the
+    front, so a caller that computed indicators over more history than it
+    displays still lines up.
+    """
+
+    count = len(bars)
+
+    def aligned(values: Sequence[float | None]) -> list[float | None]:
+        if len(values) >= count:
+            return list(values[len(values) - count :])
+        return [None] * (count - len(values)) + list(values)
+
+    block: dict[str, object] = {
+        "minutes": int(minutes),
+        "bars": list(bars),
+        "vwap": aligned(vwap),
+        "stoch_k": aligned(stoch_k),
+        "stoch_d": aligned(stoch_d),
+    }
+    if forming_from is not None:
+        block["forming_from"] = int(forming_from)
+    return block
+
+
+def chart_document(
+    *,
+    series_version: int,
+    timeframes: Mapping[str, Mapping[str, object]],
+    cpr: ChartCpr,
+    vwap_is_proxy: bool,
+    stochastic_settings: Mapping[str, int],
+) -> dict[str, object]:
+    """The whole `/api/chart` payload."""
+
+    return {
+        "series_version": int(series_version),
+        "timeframes": {key: dict(value) for key, value in timeframes.items()},
+        "cpr": cpr.as_dict(),
+        "indicators": {
+            "vwap": {
+                "label": "VWAP*" if vwap_is_proxy else "VWAP",
+                "is_proxy": bool(vwap_is_proxy),
+                "note": (
+                    "Equal-weight proxy: the index feed carries no volume, so this is the "
+                    "running mean of (H+L+C)/3 since the session open."
+                )
+                if vwap_is_proxy
+                else "Volume-weighted.",
+            },
+            "stochastic": {
+                **{key: int(value) for key, value in stochastic_settings.items()},
+                "overbought": 80,
+                "oversold": 20,
+                "note": "Computed on completed bars; the forming candle carries no indicator point.",
+            },
+        },
+    }

--- a/Tests/Dependencies/test_dashboard_indicators.py
+++ b/Tests/Dependencies/test_dashboard_indicators.py
@@ -1,0 +1,529 @@
+"""Tests for the dashboard's chart indicators (`Dependencies/dashboard_indicators.py`).
+
+Two properties carry most of the weight:
+
+* **The maths is not forked.** The chart's CPR deliberately reads a truncated
+  prior session, but nothing else about it may differ from what the CPR
+  strategies compute. One test feeds an UNTRUNCATED session through both and
+  demands the levels match, so "only the input window differs" is enforced
+  rather than asserted in a comment.
+* **Nothing reaches the renderer as NaN.** `render_document_bytes` uses
+  `allow_nan=False`, so a single NaN raises inside the renderer and freezes the
+  live dashboard on its last good document for the rest of the session. Every
+  fixture here is run through it.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import math
+import sys
+from datetime import date, time
+from pathlib import Path
+
+import pandas as pd
+import pytest
+from check_env_config import env_keys_read_by
+
+# Bare import: this folder's conftest.py puts the SOURCE `Dependencies/` on
+# sys.path, which is the same resolution the runtime performs.
+from dashboard_indicators import (
+    CPR_SESSION_END,
+    CPR_SESSION_START,
+    ChartCpr,
+    bar_records,
+    chart_cpr,
+    chart_document,
+    finite_or_none,
+    forming_bucket,
+    pivot_levels,
+    prior_session_window,
+    round_or_none,
+    session_vwap_values,
+    stochastic_values,
+    timeframe_block,
+)
+from dashboard_snapshot import render_document_bytes
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_strategy_module(name: str, relative: str):
+    """Load a real strategy module the way the master's `load_module` does.
+
+    These live under the spaced `Signal Generators/` tree, so they cannot be
+    imported normally. The equality tests below need the genuine article --
+    a stand-in would prove nothing about drift.
+    """
+
+    if name in sys.modules:
+        return sys.modules[name]
+    # `cpr_strategy_logic` imports `Dependencies.market_data_health`, so the
+    # repository root has to be importable as a package root.
+    if str(_REPO_ROOT) not in sys.path:
+        sys.path.insert(0, str(_REPO_ROOT))
+    path = _REPO_ROOT / relative
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _real_modules():
+    """The three strategy modules, or a skip when TA-Lib is unavailable."""
+
+    try:
+        misc = _load_strategy_module(
+            "misc_strategy_common", "Signal Generators/misc_strategy_common.py"
+        )
+        regime = _load_strategy_module(
+            "regime_common", "Signal Generators/Regime Adaptive Strategy/regime_common.py"
+        )
+        cpr = _load_strategy_module(
+            "cpr_strategy_logic", "Signal Generators/CPR Strategy/cpr_strategy_logic.py"
+        )
+    except Exception as exc:  # pragma: no cover - environment dependent
+        pytest.skip(f"strategy modules unavailable ({exc})")
+    return misc, regime, cpr
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+def session_frame(
+    sessions: tuple[str, ...] = ("2026-09-10", "2026-09-11"),
+    bars: tuple[int, ...] = (375, 120),
+    *,
+    start: str = "09:15",
+    seed: float = 24500.0,
+) -> pd.DataFrame:
+    """A realistic multi-session 1-minute frame.
+
+    A deterministic zig-zag rather than a straight line, so highs and lows are
+    not degenerate and a stochastic has something to range over.
+    """
+
+    rows = []
+    price = seed
+    for session, count in zip(sessions, bars, strict=True):
+        opening = pd.Timestamp(f"{session} {start}")
+        for index in range(count):
+            # Two interfering periods: never flat, never monotonic.
+            price = seed + 40.0 * math.sin(index / 17.0) + 12.0 * math.sin(index / 3.0)
+            rows.append(
+                {
+                    "timestamp": opening + pd.Timedelta(minutes=index),
+                    "open": round(price - 1.5, 2),
+                    "high": round(price + 3.0, 2),
+                    "low": round(price - 3.0, 2),
+                    "close": round(price, 2),
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+# ---------------------------------------------------------------------------
+# Guards
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "value", [None, "24500", float("nan"), float("inf"), float("-inf"), True, [1], {}]
+)
+def test_non_numbers_and_non_finite_values_become_none(value):
+    """The gate in front of `allow_nan=False`."""
+    assert finite_or_none(value) is None
+    assert round_or_none(value) is None
+
+
+def test_real_numbers_survive_and_round():
+    assert finite_or_none(3) == 3.0
+    assert round_or_none(24500.12345) == 24500.12
+
+
+# ---------------------------------------------------------------------------
+# Bars
+# ---------------------------------------------------------------------------
+def test_bar_records_match_the_masters_row_at_a_time_version():
+    """The whole reason the vectorized serializer is allowed to exist.
+
+    pandas 3 defaults to microsecond resolution, so the obvious
+    `astype("int64") // 10**9` yields timestamps a thousand times too small and
+    draws the session in 1970. This test is what catches that.
+    """
+
+    master = _load_strategy_module("master_for_bar_record", "nifty_multi_strategy_master.py")
+    frame = session_frame(("2026-09-11",), (40,))
+    assert bar_records(frame) == [master._bar_record(row) for _, row in frame.iterrows()]
+
+
+def test_bar_times_are_the_exchange_wall_clock():
+    frame = session_frame(("2026-09-11",), (3,))
+    first = bar_records(frame)[0]
+    assert pd.Timestamp(first["time"], unit="s").strftime("%H:%M") == "09:15"
+
+
+def test_an_empty_frame_serializes_to_nothing():
+    assert bar_records(session_frame(("2026-09-11",), (0,))) == []
+
+
+def test_the_forming_bucket_aggregates_only_the_finished_minutes():
+    frame = session_frame(("2026-09-11",), (17,))  # 09:15..09:31 -> 09:30 bucket has 2 bars
+    record, anchor = forming_bucket(frame, timeframe_minutes=5)
+    assert anchor == pd.Timestamp("2026-09-11 09:30")
+    tail = frame.tail(2)
+    assert record["open"] == pytest.approx(tail["open"].iloc[0])
+    assert record["high"] == pytest.approx(tail["high"].max())
+    assert record["low"] == pytest.approx(tail["low"].min())
+    assert record["close"] == pytest.approx(tail["close"].iloc[-1])
+
+
+def test_a_complete_bucket_is_left_to_the_resampler():
+    """15 bars ends exactly on a boundary, so nothing is forming."""
+    assert forming_bucket(session_frame(("2026-09-11",), (15,)), timeframe_minutes=5) == (None, None)
+
+
+def test_one_minute_has_no_forming_bucket():
+    assert forming_bucket(session_frame(("2026-09-11",), (7,)), timeframe_minutes=1) == (None, None)
+
+
+# ---------------------------------------------------------------------------
+# CPR
+# ---------------------------------------------------------------------------
+def test_the_prior_session_is_truncated_at_1515():
+    """A high printed after 15:15 must not reach the levels."""
+    frame = session_frame(("2026-09-10", "2026-09-11"), (375, 30))
+    # 09:15 + 374 minutes = 15:29, so this session genuinely runs past the cut.
+    spike_at = frame.index[(frame["timestamp"] == pd.Timestamp("2026-09-10 15:22"))][0]
+    frame.loc[spike_at, "high"] = 99999.0
+
+    window = prior_session_window(frame)
+    assert window.last_bar == "15:15"
+    assert window.bars_used == 361  # 09:15..15:15 inclusive
+    levels = chart_cpr(frame)
+    assert levels.prev_high != 99999.0
+
+    # ...and the untruncated view would have seen it.
+    assert frame.loc[frame["timestamp"].dt.date == date(2026, 9, 10), "high"].max() == 99999.0
+
+
+def test_only_the_input_window_differs_from_the_strategies_cpr():
+    """Fed an UNTRUNCATED prior session, the chart reproduces `_add_daily_cpr`.
+
+    This is the test that pins the algebra. If someone "improves" a formula on
+    either side, this fails.
+    """
+
+    _misc, _regime, cpr_logic = _real_modules()
+    frame = session_frame(("2026-09-10", "2026-09-11"), (375, 30))
+
+    # Widen the chart's window so both see the whole prior session.
+    mine = chart_cpr(frame, session_start=time(0, 0), session_end=time(23, 59))
+
+    theirs = cpr_logic._add_daily_cpr(frame)
+    today = theirs.loc[theirs["timestamp"].dt.date == date(2026, 9, 11)].iloc[-1]
+
+    for name in ("pivot", "bc", "tc", "r1", "r2", "r3", "r4", "s1", "s2", "s3", "s4"):
+        assert getattr(mine, name) == pytest.approx(float(today[name]), abs=5e-3), name
+    assert mine.prev_high == pytest.approx(float(today["prev_high"]), abs=5e-3)
+    assert mine.prev_low == pytest.approx(float(today["prev_low"]), abs=5e-3)
+    assert mine.prev_close == pytest.approx(float(today["prev_close"]), abs=5e-3)
+
+
+def test_levels_follow_the_standard_algebra():
+    levels = pivot_levels(110.0, 90.0, 100.0)
+    assert levels["pivot"] == pytest.approx(100.0)
+    assert levels["bc"] == pytest.approx(100.0)
+    assert levels["tc"] == pytest.approx(100.0)
+    assert levels["r1"] == pytest.approx(110.0)
+    assert levels["s1"] == pytest.approx(90.0)
+    assert levels["r4"] == pytest.approx(levels["r3"] + 20.0)
+    assert levels["s4"] == pytest.approx(levels["s3"] - 20.0)
+
+
+def test_a_weekend_gap_uses_the_previous_available_session():
+    frame = session_frame(("2026-09-11", "2026-09-14"), (375, 30))  # Friday then Monday
+    assert prior_session_window(frame).session_date == date(2026, 9, 11)
+
+
+def test_a_half_day_prior_session_still_yields_levels():
+    frame = session_frame(("2026-09-10", "2026-09-11"), (180, 30))  # prior ends 12:14
+    levels = chart_cpr(frame)
+    assert levels.available
+    assert levels.last_bar == "12:14"
+    assert levels.partial is False  # it started at the open; it simply ended early
+
+
+def test_no_prior_session_reports_unavailable_with_every_level_none():
+    """A confident zero would be far worse than an empty chart."""
+    levels = chart_cpr(session_frame(("2026-09-11",), (120,)))
+    assert levels.available is False
+    assert levels.unavailable_reason
+    for name in ("pivot", "bc", "tc", "r1", "s1", "prev_high", "prev_close"):
+        assert getattr(levels, name) is None
+
+
+def test_a_prior_session_starting_late_is_flagged_but_still_drawn():
+    frame = session_frame(("2026-09-10", "2026-09-11"), (375, 30))
+    late = frame.loc[
+        (frame["timestamp"].dt.date != date(2026, 9, 10))
+        | (frame["timestamp"] >= pd.Timestamp("2026-09-10 11:00"))
+    ].reset_index(drop=True)
+    levels = chart_cpr(late)
+    assert levels.available
+    assert levels.partial is True
+
+
+def test_the_strategies_pivot_is_carried_for_contrast():
+    frame = session_frame(("2026-09-10", "2026-09-11"), (375, 30))
+    levels = chart_cpr(frame)
+    assert levels.strategies_pivot is not None
+    # Different windows, so normally different numbers -- both must be real.
+    assert math.isfinite(levels.pivot) and math.isfinite(levels.strategies_pivot)
+
+
+def test_the_payload_always_says_it_is_chart_only():
+    payload = chart_cpr(session_frame()).as_dict()
+    assert payload["chart_only"] is True
+    assert "chart cpr reads the prior session 09:15-15:15" in payload["caveat"].lower()
+    assert "09:15" in payload["caveat"] and "15:15" in payload["caveat"]
+
+
+def test_the_window_constants_are_the_documented_ones():
+    assert (time(9, 15), time(15, 15)) == (CPR_SESSION_START, CPR_SESSION_END)
+
+
+# ---------------------------------------------------------------------------
+# VWAP and stochastic (against the real strategy helpers)
+# ---------------------------------------------------------------------------
+def test_vwap_equals_the_regime_strategys_own_vwap():
+    _misc, regime, _cpr = _real_modules()
+    frame = session_frame()
+    values, is_proxy = session_vwap_values(
+        frame,
+        attach_session_date=regime.attach_session_date,
+        attach_session_vwap=regime.attach_session_vwap,
+    )
+    expected = regime.attach_session_vwap(regime.attach_session_date(frame))["vwap"]
+    assert values == [round(float(value), 2) for value in expected]
+    assert is_proxy is True  # the index feed carries no volume
+
+
+def test_vwap_resets_at_the_session_boundary():
+    _misc, regime, _cpr = _real_modules()
+    frame = session_frame()
+    values, _ = session_vwap_values(
+        frame,
+        attach_session_date=regime.attach_session_date,
+        attach_session_vwap=regime.attach_session_vwap,
+    )
+    first_of_today = len(frame.loc[frame["timestamp"].dt.date == date(2026, 9, 10)])
+    typical = frame.iloc[first_of_today][["high", "low", "close"]].mean()
+    assert values[first_of_today] == pytest.approx(round(float(typical), 2), abs=0.02)
+
+
+def test_stochastic_equals_the_strategys_own_helper():
+    misc, _regime, _cpr = _real_modules()
+    frame = session_frame(("2026-09-11",), (200,))
+    k_values, d_values = stochastic_values(
+        frame, stochastic_fn=misc.stochastic, k_period=14, d_period=3, smooth_k=3
+    )
+    k_expected, d_expected = misc.stochastic(frame, k_period=14, d_period=3, smooth_k=3)
+    assert k_values == [round_or_none(value) for value in k_expected]
+    assert d_values == [round_or_none(value) for value in d_expected]
+    assert all(value is None or 0.0 <= value <= 100.0 for value in k_values)
+
+
+def test_a_frame_shorter_than_the_warmup_is_all_none_never_nan():
+    misc, _regime, _cpr = _real_modules()
+    k_values, d_values = stochastic_values(
+        session_frame(("2026-09-11",), (5,)),
+        stochastic_fn=misc.stochastic, k_period=14, d_period=3, smooth_k=3,
+    )
+    assert k_values == [None] * 5
+    assert d_values == [None] * 5
+
+
+# ---------------------------------------------------------------------------
+# Assembly
+# ---------------------------------------------------------------------------
+def test_indicator_columns_are_right_aligned_to_the_bars():
+    """Indicators are computed over more history than is displayed."""
+    block = timeframe_block(
+        minutes=1,
+        bars=[{"time": 1}, {"time": 2}, {"time": 3}],
+        vwap=[10.0, 11.0, 12.0, 13.0, 14.0],  # longer: keep the newest 3
+        stoch_k=[50.0],  # shorter: pad the front
+        stoch_d=[],
+    )
+    assert block["vwap"] == [12.0, 13.0, 14.0]
+    assert block["stoch_k"] == [None, None, 50.0]
+    assert block["stoch_d"] == [None, None, None]
+    assert "forming_from" not in block
+
+
+def test_a_forming_bar_is_named_in_the_payload():
+    block = timeframe_block(
+        minutes=5, bars=[{"time": 1}], vwap=[], stoch_k=[], stoch_d=[], forming_from=1757600700
+    )
+    assert block["forming_from"] == 1757600700
+
+
+def test_the_document_labels_the_vwap_as_a_proxy():
+    document = chart_document(
+        series_version=3,
+        timeframes={"1": timeframe_block(minutes=1, bars=[], vwap=[], stoch_k=[], stoch_d=[])},
+        cpr=ChartCpr(False),
+        vwap_is_proxy=True,
+        stochastic_settings={"k_period": 14, "d_period": 3, "smooth_k": 3},
+    )
+    assert document["indicators"]["vwap"]["label"] == "VWAP*"
+    assert "no volume" in document["indicators"]["vwap"]["note"]
+    assert document["indicators"]["stochastic"]["overbought"] == 80
+
+
+# ---------------------------------------------------------------------------
+# The renderer trap
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    ("sessions", "bars"),
+    [
+        (("2026-09-10", "2026-09-11"), (375, 120)),  # ordinary
+        (("2026-09-11",), (120,)),                   # no prior session
+        (("2026-09-10", "2026-09-11"), (180, 5)),    # half day, tiny today
+        (("2026-09-11",), (1,)),                     # a single bar
+    ],
+)
+def test_every_shape_survives_the_json_renderer(sessions, bars):
+    """`allow_nan=False`: one NaN would freeze the live dashboard for the day."""
+    misc, regime, _cpr = _real_modules()
+    frame = session_frame(sessions, bars)
+    vwap, is_proxy = session_vwap_values(
+        frame,
+        attach_session_date=regime.attach_session_date,
+        attach_session_vwap=regime.attach_session_vwap,
+    )
+    k_values, d_values = stochastic_values(
+        frame, stochastic_fn=misc.stochastic, k_period=14, d_period=3, smooth_k=3
+    )
+    document = chart_document(
+        series_version=1,
+        timeframes={
+            "1": timeframe_block(
+                minutes=1, bars=bar_records(frame), vwap=vwap, stoch_k=k_values, stoch_d=d_values
+            )
+        },
+        cpr=chart_cpr(frame),
+        vwap_is_proxy=is_proxy,
+        stochastic_settings={"k_period": 14, "d_period": 3, "smooth_k": 3},
+    )
+    assert render_document_bytes(document)  # must not raise
+
+
+def test_the_module_reads_no_configuration():
+    """All config is read in the master, the only place check-env audits."""
+
+
+    path = _REPO_ROOT / "Dependencies" / "dashboard_indicators.py"
+    # The repo's own AST auditor, so this and `algo.py check-env` can never
+    # disagree about what counts as reading a setting.
+    assert env_keys_read_by(path) == set()
+    # `os` is the only other route to an unaudited read, and this module has no
+    # use for it. Checked structurally: the docstring legitimately NAMES
+    # `os.getenv` while explaining the rule.
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    imported = {
+        alias.name.split(".")[0]
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    } | {
+        node.module.split(".")[0]
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module
+    }
+    assert "os" not in imported
+
+
+# ---------------------------------------------------------------------------
+# Degenerate inputs: every one of these has been seen or is one bad feed away
+# ---------------------------------------------------------------------------
+def test_an_empty_frame_has_no_prior_session():
+    assert prior_session_window(pd.DataFrame()).session_date is None
+    assert chart_cpr(pd.DataFrame()).available is False
+
+
+def test_a_frame_without_a_timestamp_column_is_refused_not_crashed():
+    assert prior_session_window(pd.DataFrame({"close": [1.0]})).session_date is None
+
+
+def test_a_prior_session_entirely_outside_the_window_reports_why():
+    """An afternoon-only prior session has nothing in 09:15-15:15."""
+    frame = session_frame(("2026-09-10", "2026-09-11"), (375, 30))
+    afternoon = frame.loc[
+        (frame["timestamp"].dt.date != date(2026, 9, 10))
+        | (frame["timestamp"] > pd.Timestamp("2026-09-10 15:15"))
+    ].reset_index(drop=True)
+    levels = chart_cpr(afternoon)
+    assert levels.available is False
+    assert levels.prior_session_date == "2026-09-10"
+    assert "no bars between" in levels.unavailable_reason
+
+
+def test_a_non_finite_prior_close_is_refused_rather_than_drawn():
+    frame = session_frame(("2026-09-10", "2026-09-11"), (30, 10))
+    frame.loc[frame["timestamp"] == pd.Timestamp("2026-09-10 09:44"), "close"] = float("nan")
+    levels = chart_cpr(frame)
+    assert levels.available is False
+    assert "finite" in levels.unavailable_reason
+
+
+def test_a_width_classifier_that_raises_costs_only_the_label():
+    """A cosmetic tag must never take the levels down with it."""
+
+    def explode(*_args):
+        raise RuntimeError("classifier is broken")
+
+    levels = chart_cpr(session_frame(), width_classifier=explode)
+    assert levels.available is True
+    assert levels.pivot is not None
+    assert levels.width is None
+
+
+def test_the_width_label_comes_from_the_injected_classifier():
+    levels = chart_cpr(session_frame(), width_classifier=lambda *_: "narrow")
+    assert levels.width == "narrow"
+
+
+def test_the_strategies_pivot_is_omitted_when_the_full_day_cannot_be_read():
+    frame = session_frame(("2026-09-10", "2026-09-11"), (30, 10))
+    frame.loc[frame["timestamp"].dt.date == date(2026, 9, 10), "high"] = float("nan")
+    # The truncated window fails first, so this simply must not raise.
+    assert chart_cpr(frame).available is False
+
+
+def test_empty_frames_yield_empty_indicator_columns():
+    empty = pd.DataFrame(columns=["timestamp", "open", "high", "low", "close"])
+    assert session_vwap_values(
+        empty, attach_session_date=lambda f: f, attach_session_vwap=lambda f: f
+    ) == ([], True)
+    assert stochastic_values(
+        empty, stochastic_fn=lambda *a, **k: (None, None), k_period=14, d_period=3, smooth_k=3
+    ) == ([], [])
+
+
+def test_a_vwap_helper_without_the_proxy_flag_is_assumed_to_be_a_proxy():
+    """Erring toward the caveat: an unlabelled VWAP is treated as the proxy."""
+    frame = session_frame(("2026-09-11",), (5,))
+
+    def attach(f):
+        out = f.copy()
+        out["vwap"] = f["close"]
+        return out  # deliberately no `vwap_is_proxy` column
+
+    values, is_proxy = session_vwap_values(
+        frame, attach_session_date=lambda f: f, attach_session_vwap=attach
+    )
+    assert is_proxy is True
+    assert values == [round(float(v), 2) for v in frame["close"]]

--- a/Tests/test_nifty_multi_strategy_master.py
+++ b/Tests/test_nifty_multi_strategy_master.py
@@ -13450,7 +13450,38 @@ class TestDashboardConfiguration(unittest.TestCase):
     """Config lives in the master, and every knob is clamped rather than trusted."""
 
     def test_the_dashboard_is_off_by_default(self):
-        self.assertFalse(master_file.DASHBOARD_ENABLED)
+        """The DEFAULT must be asserted with the env var UNSET.
+
+        The earlier version read `master_file.DASHBOARD_ENABLED`, which is
+        resolved from the environment at import time. That made it pass in CI
+        and in a fresh worktree, where `Dependencies/.env` is absent, and FAIL
+        on the operator's own box the moment the dashboard was switched on --
+        green everywhere except the machine that actually runs it. Identical
+        failure mode to
+        `test_no_new_entry_cutoff_fallback_is_not_masked_by_local_env`.
+
+        Two halves, because either alone is insufficient: the helper must fall
+        back to OFF with the knob unset, AND the master must be the thing
+        passing that default -- otherwise flipping the source to `True` would
+        still leave this test green.
+        """
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("DASHBOARD_ENABLED", None)
+            self.assertFalse(master_file._env_bool("DASHBOARD_ENABLED", False))
+
+            # ...and a set value must still win, so the knob is not inert.
+            os.environ["DASHBOARD_ENABLED"] = "true"
+            self.assertTrue(master_file._env_bool("DASHBOARD_ENABLED", False))
+
+        # Read as source for the same reason as the shutdown-order test below:
+        # this machine's .env has already bound the module constant, so the
+        # call site is the only place the code's OWN default can be pinned.
+        # Whitespace is stripped so reformatting cannot silently void it.
+        source = (REPO_ROOT / "nifty_multi_strategy_master.py").read_text(encoding="utf-8")
+        self.assertIn(
+            'DASHBOARD_ENABLED=_env_bool("DASHBOARD_ENABLED",False)',
+            "".join(source.split()),
+        )
 
     def test_the_clamped_knobs_stay_inside_their_documented_ranges(self):
         self.assertGreaterEqual(master_file.DASHBOARD_REFRESH_SECONDS, 0.25)

--- a/Tests/test_nifty_multi_strategy_master.py
+++ b/Tests/test_nifty_multi_strategy_master.py
@@ -3,6 +3,7 @@ import importlib
 import importlib.util
 import inspect
 import json
+import math
 import os
 import re
 import sys
@@ -13364,7 +13365,7 @@ class TestDashboardCollector(unittest.TestCase):
         this wrong draws the session starting at 03:45."""
         self.store.update("1", self._frame(rows=1))
         master_file._dashboard_chart_payload(self.store, self.cache)
-        bar = master_file._dashboard_chart_series(self.cache)["bars"][0]
+        bar = master_file._dashboard_chart_series(self.cache)["timeframes"]["1"]["bars"][0]
         self.assertEqual(
             datetime.fromtimestamp(bar["time"], UTC).strftime("%H:%M"), "09:15"
         )
@@ -13477,3 +13478,273 @@ class TestDashboardConfiguration(unittest.TestCase):
         stop_at = source.index("dashboard.stop(timeout=DASHBOARD_SHUTDOWN_TIMEOUT_SECONDS)")
         self.assertLess(source.index("mark_clean_shutdown("), stop_at)
         self.assertLess(stop_at, source.index("# Only a fully finalized flat session"))
+
+
+class TestDashboardChartIndicators(unittest.TestCase):
+    """CPR, VWAP, stochastic and the 5-minute view, wired into the collector.
+
+    The pure maths is covered in Tests/Dependencies/test_dashboard_indicators.py.
+    What matters here is the wiring: that the chart reuses the STRATEGIES' own
+    helpers rather than a copy, that the expensive work happens once a minute
+    rather than once a poll, and that a broken indicator costs its own line and
+    nothing else.
+    """
+
+    def setUp(self):
+        self.store = master_file.SharedMarketDataStore()
+        self.cache = master_file._DashboardChartCache(max_bars=120)
+
+    def _frame(self, rows=400, session="2026-09-11", start="09:15"):
+        """A single session of 1-minute bars with a non-degenerate shape."""
+        opening = pd.Timestamp(f"{session} {start}")
+        closes = [
+            24500.0 + 40.0 * math.sin(index / 17.0) + 12.0 * math.sin(index / 3.0)
+            for index in range(rows)
+        ]
+        return pd.DataFrame(
+            {
+                "timestamp": [opening + pd.Timedelta(minutes=i) for i in range(rows)],
+                "open": [round(c - 1.5, 2) for c in closes],
+                "high": [round(c + 3.0, 2) for c in closes],
+                "low": [round(c - 3.0, 2) for c in closes],
+                "close": [round(c, 2) for c in closes],
+            }
+        )
+
+    def _two_sessions(self, prior_rows=375, today_rows=40):
+        return pd.concat(
+            [self._frame(prior_rows, "2026-09-10"), self._frame(today_rows, "2026-09-11")],
+            ignore_index=True,
+        )
+
+    # -- the chart uses the strategies' own maths ------------------------
+    def test_the_indicator_helpers_are_the_strategies_own_objects(self):
+        """Not a second copy: `load_module` returns the instance already loaded.
+
+        A parallel copy would type-check, run, and silently diverge the moment
+        anyone retuned a strategy helper.
+        """
+        deps = master_file._DASHBOARD_CHART_DEPS
+        self.assertIs(deps.stochastic_fn, sys.modules["misc_strategy_common"].stochastic)
+        self.assertIs(
+            deps.attach_session_vwap, sys.modules["regime_common"].attach_session_vwap
+        )
+        self.assertIs(deps.width_classifier, master_file.CPR_LOGIC.classify_daily_cpr_width)
+
+    def test_the_stochastic_tracks_the_strategys_configured_periods(self):
+        deps = master_file._DASHBOARD_CHART_DEPS
+        self.assertEqual(deps.k_period, master_file.STOCHASTIC_CONFIG.k_period)
+        self.assertEqual(deps.d_period, master_file.STOCHASTIC_CONFIG.d_period)
+        self.assertEqual(deps.smooth_k, master_file.STOCHASTIC_CONFIG.smooth_k)
+
+    # -- the payload -----------------------------------------------------
+    def test_both_timeframes_arrive_in_one_payload(self):
+        """One payload is what makes the toggle instant and unable to fail."""
+        self.store.update("1", self._two_sessions())
+        master_file._dashboard_chart_payload(self.store, self.cache)
+        payload = master_file._dashboard_chart_series(self.cache)
+
+        self.assertEqual(set(payload["timeframes"]), {"1", "5"})
+        one, five = payload["timeframes"]["1"], payload["timeframes"]["5"]
+        self.assertEqual(one["minutes"], 1)
+        self.assertEqual(five["minutes"], 5)
+        self.assertTrue(one["bars"] and five["bars"])
+        # Indicator columns are right-aligned to their bars.
+        for block in (one, five):
+            for column in ("vwap", "stoch_k", "stoch_d"):
+                self.assertEqual(len(block[column]), len(block["bars"]), column)
+
+    def test_the_leftmost_visible_bar_is_already_warm(self):
+        """Indicators run over more history than is shown, so the chart does
+        not open with a run of nulls."""
+        self.store.update("1", self._two_sessions(375, 300))
+        master_file._dashboard_chart_payload(self.store, self.cache)
+        one = master_file._dashboard_chart_series(self.cache)["timeframes"]["1"]
+        self.assertIsNotNone(one["stoch_k"][0])
+        self.assertIsNotNone(one["vwap"][0])
+
+    def test_cpr_is_identical_in_both_timeframes(self):
+        """A daily level is horizontal: it cannot depend on the bar size."""
+        self.store.update("1", self._two_sessions())
+        master_file._dashboard_chart_payload(self.store, self.cache)
+        payload = master_file._dashboard_chart_series(self.cache)
+        self.assertTrue(payload["cpr"]["available"])
+        self.assertTrue(payload["cpr"]["chart_only"])
+        self.assertEqual(payload["cpr"]["window"], "09:15-15:15")
+
+    def test_the_payload_survives_the_json_renderer(self):
+        """`allow_nan=False`: one NaN freezes the dashboard for the session."""
+        for rows in (1, 5, 30, 400):
+            with self.subTest(rows=rows):
+                cache = master_file._DashboardChartCache(max_bars=120)
+                store = master_file.SharedMarketDataStore()
+                store.update("1", self._frame(rows))
+                store.get = store.get  # explicit: the real store, no mocks
+                master_file._dashboard_chart_payload(store, cache)
+                payload = master_file._dashboard_chart_series(cache)
+                self.assertTrue(master_file.dashboard_snapshot.render_document_bytes(payload))
+
+    def test_the_forming_five_minute_bar_is_named_not_hidden(self):
+        """It is not what the 5-minute strategies act on, so the page says so."""
+        self.store.update("1", self._frame(rows=17))  # 09:15..09:31 -> 09:30 forming
+        state = master_file._dashboard_chart_payload(self.store, self.cache)
+        self.assertIsNotNone(state["last_bar_5m"])
+        payload = master_file._dashboard_chart_series(self.cache)
+        self.assertIn("forming_from", payload["timeframes"]["5"])
+
+    # -- cadence: what stops the cheap path rotting ----------------------
+    def test_the_expensive_work_happens_once_a_minute_not_once_a_poll(self):
+        """The whole performance argument, pinned.
+
+        A future edit that moves indicator work onto the per-poll path turns a
+        ~90 ms build into a ~400 ms one and takes the store lock every second.
+        """
+        frame = self._two_sessions(375, 60)
+        self.store.update("1", frame)
+        deps = master_file._DASHBOARD_CHART_DEPS
+        spy = SimpleNamespace(resample=0, vwap=0, stoch=0)
+
+        def counted(name, real):
+            def wrapper(*args, **kwargs):
+                setattr(spy, name, getattr(spy, name) + 1)
+                return real(*args, **kwargs)
+            return wrapper
+
+        traced = master_file._DashboardChartDeps(
+            stochastic_fn=counted("stoch", deps.stochastic_fn),
+            attach_session_date=deps.attach_session_date,
+            attach_session_vwap=counted("vwap", deps.attach_session_vwap),
+            width_classifier=deps.width_classifier,
+            resample=counted("resample", deps.resample),
+            k_period=deps.k_period, d_period=deps.d_period, smooth_k=deps.smooth_k,
+        )
+
+        master_file._dashboard_chart_payload(self.store, self.cache, traced)
+        after_first = (spy.resample, spy.vwap, spy.stoch)
+
+        # Twenty polls with NOTHING new: the store must not even be read.
+        with patch.object(self.store, "get", side_effect=AssertionError("copied!")):
+            for _ in range(20):
+                master_file._dashboard_chart_payload(self.store, self.cache, traced)
+        self.assertEqual((spy.resample, spy.vwap, spy.stoch), after_first)
+
+        # Twenty NEW MINUTES: the 5-minute resample runs at most once per
+        # bucket, not once per minute.
+        for extra in range(1, 21):
+            self.store.update("1", frame.iloc[: len(frame) + 0].pipe(
+                lambda f, n=extra: pd.concat([f, self._frame(n, "2026-09-11", "15:16")],
+                                             ignore_index=True)
+            ))
+            master_file._dashboard_chart_payload(self.store, self.cache, traced)
+        self.assertLessEqual(spy.resample - after_first[0], 6, "resample ran too often")
+        self.assertLessEqual(spy.vwap - after_first[1], 42)
+
+    def test_cpr_is_computed_once_per_session_not_once_per_minute(self):
+        frame = self._two_sessions(375, 30)
+        self.store.update("1", frame)
+        calls = {"n": 0}
+        deps = master_file._DASHBOARD_CHART_DEPS
+
+        def counting(*args):
+            calls["n"] += 1
+            return deps.width_classifier(*args)
+
+        traced = master_file._DashboardChartDeps(
+            stochastic_fn=deps.stochastic_fn,
+            attach_session_date=deps.attach_session_date,
+            attach_session_vwap=deps.attach_session_vwap,
+            width_classifier=counting, resample=deps.resample,
+            k_period=deps.k_period, d_period=deps.d_period, smooth_k=deps.smooth_k,
+        )
+        for extra in range(1, 11):
+            self.store.update("1", pd.concat(
+                [frame, self._frame(extra, "2026-09-11", "09:46")], ignore_index=True))
+            master_file._dashboard_chart_payload(self.store, self.cache, traced)
+        self.assertEqual(calls["n"], 1, "CPR recomputed more than once in a session")
+
+    # -- fail-soft -------------------------------------------------------
+    def test_a_broken_indicator_costs_its_own_line_and_nothing_else(self):
+        """A chart with no stochastic still beats no chart at all."""
+        self.store.update("1", self._two_sessions())
+        deps = master_file._DASHBOARD_CHART_DEPS
+
+        def explode(*_args, **_kwargs):
+            raise RuntimeError("indicator is broken")
+
+        broken = master_file._DashboardChartDeps(
+            stochastic_fn=explode,
+            attach_session_date=deps.attach_session_date,
+            attach_session_vwap=explode,
+            width_classifier=deps.width_classifier,
+            resample=explode,
+            k_period=deps.k_period, d_period=deps.d_period, smooth_k=deps.smooth_k,
+        )
+        state = master_file._dashboard_chart_payload(self.store, self.cache, broken)
+        payload = master_file._dashboard_chart_series(self.cache, broken)
+
+        self.assertEqual(state["state"], "OK")
+        self.assertTrue(payload["timeframes"]["1"]["bars"], "candles must survive")
+        self.assertTrue(all(v is None for v in payload["timeframes"]["1"]["stoch_k"]))
+        self.assertTrue(master_file.dashboard_snapshot.render_document_bytes(payload))
+
+    def test_a_gap_in_the_five_minute_buckets_rebuilds_rather_than_skips(self):
+        """After a stall the incremental path would silently miss buckets."""
+        self.store.update("1", self._frame(rows=60))
+        master_file._dashboard_chart_payload(self.store, self.cache)
+        first = len(self.cache.series_5m)
+
+        # Jump forward an hour: far more than one bucket.
+        self.store.update("1", self._frame(rows=120))
+        master_file._dashboard_chart_payload(self.store, self.cache)
+        self.assertGreater(len(self.cache.series_5m), first)
+        bars = self.cache.series_5m
+        gaps = {bars[i + 1]["time"] - bars[i]["time"] for i in range(len(bars) - 1)}
+        self.assertEqual(gaps, {300}, "the 5-minute series must have no holes")
+
+    def test_the_safety_contract_still_holds_with_indicators_on(self):
+        """The assertion that matters most, re-run on a realistic frame."""
+        self.store.update("1", self._two_sessions())
+        health = MagicMock()
+        self.store.market_data_health = health
+        worker = master_file.AtmSingleLegStrategyWorker(
+            store=self.store, stop_event=threading.Event(), broker=MagicMock()
+        )
+        worker.strategy_name = "Renko"
+        session_state = MagicMock()
+        worker.session_state = session_state
+
+        master_file._dashboard_document(
+            [worker], self.store, master_file.DashboardEventSink(maxlen=10), self.cache
+        )
+
+        health.snapshot.assert_not_called()
+        worker.broker.fetch_ltp_map.assert_not_called()
+        session_state.snapshot.assert_not_called()
+
+    def test_the_five_minute_view_survives_a_session_boundary(self):
+        """Regression: a TIME-based lookback emptied this chart every morning.
+
+        Anchored to "now minus 575 minutes", the window reaches back past
+        midnight at 09:15 and so excludes the entire previous session -- while
+        the 1-minute chart beside it still shows yesterday's close. Counting
+        ROWS keeps both views over the same bars.
+        """
+        cache = master_file._DashboardChartCache(max_bars=375)
+        yesterday = pd.concat(
+            [self._frame(375, "2026-09-09"), self._frame(375, "2026-09-10")], ignore_index=True
+        )
+        self.store.update("1", yesterday)
+        master_file._dashboard_chart_payload(self.store, cache)
+        self.assertEqual(len(cache.series_5m), cache.max_bars_5m)
+
+        # The first few minutes of a new session must not blank the pane.
+        for minutes_in in (1, 3, 7, 20):
+            with self.subTest(minutes_in=minutes_in):
+                self.store.update(
+                    "1",
+                    pd.concat(
+                        [yesterday, self._frame(minutes_in, "2026-09-11")], ignore_index=True
+                    ),
+                )
+                master_file._dashboard_chart_payload(self.store, cache)
+                self.assertEqual(len(cache.series_5m), cache.max_bars_5m)

--- a/Tests/test_nifty_multi_strategy_master.py
+++ b/Tests/test_nifty_multi_strategy_master.py
@@ -13748,3 +13748,31 @@ class TestDashboardChartIndicators(unittest.TestCase):
                 )
                 master_file._dashboard_chart_payload(self.store, cache)
                 self.assertEqual(len(cache.series_5m), cache.max_bars_5m)
+
+    def test_the_five_minute_series_is_strictly_ascending(self):
+        """lightweight-charts silently drops bars on a repeated timestamp.
+
+        The bulk rebuild can already hold the bucket the incremental append
+        re-derives, when the newest minute happened to complete it. The result
+        was a chart that rendered with most of its candles missing and no
+        console error to explain why.
+        """
+        cache = master_file._DashboardChartCache(max_bars=375)
+        base = pd.concat(
+            [self._frame(375, "2026-09-10"), self._frame(240, "2026-09-11")], ignore_index=True
+        )
+        # Walk a minute at a time across several bucket boundaries, which is
+        # exactly the sequence that produced the duplicate.
+        for extra in range(0, 24):
+            self.store.update(
+                "1",
+                base if extra == 0
+                else pd.concat(
+                    [base, self._frame(extra, "2026-09-11", "13:15")], ignore_index=True
+                ),
+            )
+            master_file._dashboard_chart_payload(self.store, cache)
+            times = [bar["time"] for bar in cache.series_5m]
+            with self.subTest(extra=extra):
+                self.assertEqual(len(times), len(set(times)), "duplicate bar timestamp")
+                self.assertEqual(times, sorted(times), "bars are out of order")

--- a/docs/README.md
+++ b/docs/README.md
@@ -62,6 +62,7 @@ component folder's own `Readme.md`.
 | [0014](adr/0014-tiered-rename-of-spaced-filenames.md) | Spaced filenames renamed in reviewable tiers, master last (supersedes 0009) |
 | [0015](adr/0015-rolling-relative-strike-expired-options.md) | Expired-options history kept in rolling relative-strike form, expiry date derived |
 | [0016](adr/0016-read-only-loopback-monitoring-dashboard.md) | A read-only loopback dashboard, served by the runner itself |
+| [0017](adr/0017-chart-only-cpr-on-a-truncated-prior-session.md) | The dashboard's CPR reads a truncated prior session; the strategies' does not |
 
 ## Keeping these documents honest
 

--- a/docs/adr/0017-chart-only-cpr-on-a-truncated-prior-session.md
+++ b/docs/adr/0017-chart-only-cpr-on-a-truncated-prior-session.md
@@ -1,0 +1,98 @@
+# ADR-0017: The dashboard's CPR reads a truncated prior session, and the strategies' does not
+
+**Status:** Accepted
+**Date:** 2026-09-11
+**Deciders:** repository owner
+
+## Context
+
+[`ADR-0016`](0016-read-only-loopback-monitoring-dashboard.md) added a read-only chart. Reading it
+against what the strategies are doing needs the levels they watch, so the chart gained CPR, a
+session VWAP and a stochastic oscillator.
+
+VWAP and the stochastic were easy: the chart is handed the *same callables* the live strategies use
+(`regime_common.attach_session_vwap`, `misc_strategy_common.stochastic`), so a drawn line cannot
+drift from a traded figure.
+
+CPR was not, because the operator wanted a different input window from the one the strategies use.
+
+**What the strategies do today.** `cpr_strategy_logic.py::_add_daily_cpr` aggregates the previous
+session as `prev_high=("high","max")`, `prev_low=("low","min")`, `prev_close=("close","last")` over
+the whole day. Note it already takes the last *intraday* bar (~15:29), **not** the official
+CAS-settled close — so the runner is not, and never was, using the auction print.
+
+**What the operator asked for.** The prior session read from **09:15–15:15 inclusive** — high, low
+**and** close — on the reasoning that an index close is settled by an auction and the last prints of
+the day are the least trustworthy input to a pivot.
+
+These cannot both be one number. The choice was between changing what two live strategies trade on,
+and drawing a line on the chart that those strategies do not use.
+
+## Decision
+
+### 1. The chart's CPR is chart-only. The strategies are untouched.
+
+`cpr_strategy_logic.py` and the CPR / CPR Algo 3 / CPR AI workers are not modified by one line.
+A charting preference is not a reason to change live-money behaviour.
+
+### 2. Only the input WINDOW differs — and a test enforces that
+
+The pivot/BC/TC/R1–R4/S1–S4 algebra in `Dependencies/dashboard_indicators.py::pivot_levels` is
+transcribed from `cpr_strategy_logic.py` unchanged. `test_only_the_input_window_differs_from_the_strategies_cpr`
+feeds an **untruncated** prior session through both implementations and asserts the levels match
+level-for-level. If anyone "improves" a formula on either side, that test fails.
+
+### 3. Say it, in four places, one of them derived from the data
+
+A caveat nobody reads is not a mitigation. So:
+
+- the pane heading names the window and says *(chart only)*;
+- an amber `CHART-ONLY` chip sits beside the CPR checkbox, its tooltip carrying the full caveat;
+- every price line is titled `(chart)`, so a screenshot of the chart alone still carries it;
+- a provenance caption prints the **actual inputs** — `Prior 2026-09-10 09:15-15:15 · 361 bars ·
+  H 24630.08 L 24376.35 C 24485.94 · pivot 24497.46 (chart) · strategies 24491.21 (full session)`.
+
+That last line is the real mitigation: it shows **both** figures. An operator can see the gap rather
+than be warned one exists.
+
+### 4. High and low are truncated too
+
+The operator chose one consistent window over textbook CPR.
+
+## Options considered
+
+| Option | Verdict |
+|---|---|
+| **Chart only, strategies untouched** | **Chosen.** Reversible, zero live-money risk. Cost: the drawn line is not the traded line, which is why §3 exists. |
+| Change `_add_daily_cpr` so both agree | Rejected *for now*. It is the only way to make chart and strategy provably identical, but it shifts the pivot and all eight R/S levels for CPR and CPR Algo 3, and CPR AI keeps a second copy that would silently diverge. Not a change to make as a side effect of a charting request. |
+| Draw both sets of lines | Rejected. It answers the question honestly but puts up to 22 horizontal lines on one chart. Superseded by printing both *numbers* in the caption, which costs one aggregation per session and no clutter. |
+| Truncate the close only, keep full-session H/L | Rejected by the operator, recorded here because it is the better-argued position. The auction argument is strong for the close and weak for the extremes: a genuine high printed at 15:22 is real price action, and discarding it moves R1–R4/S1–S4 more than the close change moves the pivot. The window is a parameter, so splitting it later is a two-line change. |
+
+## Trade-off analysis
+
+**What this costs.** Two definitions of CPR in one repository. That is a real cost and the reason
+for the enforcement test and the four labels.
+
+**What bounds it.** The chart is read-only and moves nothing; the divergence is small (a 15:15 close
+differing by ~5 points moves the pivot by ~1.7); and the page shows both numbers.
+
+**Why not compute the strategies' CPR by calling their code.** `_add_daily_cpr` is private, runs
+inside a pipeline that resamples to 5-minute bars and needs TA-Lib, and returns a full enriched
+frame. The chart needs three numbers from a different window. Re-using the *algebra* while
+supplying a different window is the smaller coupling, and the equality test keeps it honest.
+
+## Consequences
+
+- **`Dependencies/dashboard_indicators.py` is pure** — pandas, no threads, I/O, clock or `.env`. It
+  carries a 90 % branch-coverage budget and measures 98.9 %.
+- **VWAP and the stochastic carry no such divergence**: they are the strategies' own objects,
+  resolved through `load_module` under bare names, which returns the already-loaded instance. A test
+  asserts identity with `sys.modules` — a prefixed alias would create a second copy that type-checks,
+  runs, and diverges silently.
+- **VWAP must always be labelled `VWAP*`.** It is an equal-weight proxy on every live row because
+  the index feed carries no volume. Calling it plain "VWAP" would be a correctness error.
+- **The 15:15 boundary is a module constant**, not an `.env` key, so it cannot drift per machine and
+  cannot escape the config audit the module is deliberately outside.
+- **If the operator later wants one definition everywhere**, the path is: change `_add_daily_cpr`,
+  delete the truncation from `chart_cpr`, and the equality test starts passing on the *default*
+  window rather than a widened one.

--- a/docs/lld/monitoring-dashboard.md
+++ b/docs/lld/monitoring-dashboard.md
@@ -39,6 +39,7 @@ worker objects         ──attribute reads──────────┤
 
 | Unit | File | Responsibility |
 |---|---|---|
+| Chart indicators | `Dependencies/dashboard_indicators.py` | CPR from a truncated prior session, session VWAP, stochastic %K/%D, the forming higher-timeframe bucket, and the `/api/chart` document. Pure: pandas allowed, nothing else. The VWAP and stochastic helpers are INJECTED so the chart uses the strategies' own objects. |
 | Pure shaping | `Dependencies/dashboard_snapshot.py` | Pairs the event stream into closed trades and open-entry times; rolls up per-strategy and session totals; renders the document. No threads, no I/O, no clock, no `.env`. |
 | Transport | `Dependencies/dashboard_server.py` | Event sink, publisher, builder thread, HTTP server, asset whitelist. Reads **no** configuration of its own. |
 | Collector | `nifty_multi_strategy_master.py` (after `_session_state_snapshots`) | The only code that reaches into live workers and the store. It lives in the master because a `Dependencies/` module doing that would have to import the master back. |
@@ -101,6 +102,44 @@ and the SL-Hunting mirror all appear (see
 from `store.get_ltp_by_secid`, which never calls the broker; a mark is "stale"
 when the same read with `max_age_seconds=DASHBOARD_STALE_MARK_SECONDS` returns
 nothing while the unbounded read returns a price.
+
+### Chart indicators and the 1m/5m toggle
+
+Three overlays, and a toggle because several strategies derive 5-minute bars.
+
+| Indicator | Source | Note |
+|---|---|---|
+| CPR | `dashboard_indicators.chart_cpr` | **Chart-only.** Prior session 09:15-15:15 inclusive -- high, low AND close -- against the strategies' full session. Drawn with `createPriceLine`, so it is timeframe-independent by construction. See [`ADR-0017`](../adr/0017-chart-only-cpr-on-a-truncated-prior-session.md). |
+| VWAP | `regime_common.attach_session_vwap`, injected | The strategies' own object. Always an equal-weight proxy in live running -- the index feed carries no volume -- so it is labelled `VWAP*` with a footnote. |
+| Stochastic %K/%D | `misc_strategy_common.stochastic`, injected | The same TA-Lib `STOCH` and the same `STOCHASTIC_*` periods the Stochastic Oscillator strategy trades on. Own pane, 80/20 guides. |
+
+The helpers are reached with `load_module` under **bare** names, which returns
+`sys.modules[name]` when already loaded -- so these are the very objects the
+strategies use, not copies. A prefixed alias would create a second instance
+that type-checks, runs, and diverges the moment anyone retunes a helper; a
+test asserts identity against `sys.modules`.
+
+Indicators are computed on **completed bars**; the forming candle carries no
+indicator point. Cheaper, and truer to what the strategies evaluate.
+
+Both timeframes ride in ONE `/api/chart` payload, so switching is instant from
+data the browser already holds -- measured at zero network requests -- and the
+transport keeps its single publisher slot and zero-argument builder.
+`resample_ohlc_from_1m` is used unchanged for the completed 5-minute bars; the
+forming bucket is aggregated separately and concatenated, so the resampler's
+"completed buckets only" guarantee stays intact for the strategies that depend
+on it.
+
+Two things that look like details and are not:
+
+- The 5-minute window is a **row** tail, not a time window. Anchored to
+  "now minus 575 minutes" it reaches past midnight at 09:15 and excludes the
+  entire prior session, leaving the pane near-empty every morning while the
+  1-minute chart beside it shows yesterday's close.
+- The 5-minute series is **de-duplicated** on append. The bulk rebuild can
+  already hold the bucket the incremental path re-derives, and
+  lightweight-charts requires strictly ascending times -- one repeat makes it
+  silently drop bars, with nothing in the console to say why.
 
 ### The chart
 
@@ -179,7 +218,20 @@ whole reconciliation — which is when an operator most wants to watch. Its
 threads are daemons, so `DASHBOARD_SHUTDOWN_TIMEOUT_SECONDS` is a courtesy, not
 something process exit depends on. A source-order test pins that sequence.
 
-## A trap worth remembering
+## Traps worth remembering
+
+**`fitContent()` against a zero-width container silently does nothing** and
+leaves a nonsense bar spacing behind, drawing every candle squeezed into a few
+pixels. On a first paint, or in a tab that is still hidden, the container can
+genuinely have no width. A `ResizeObserver` fits the range when layout gives
+the element a size, with a per-render retry behind it.
+
+**pandas 3 defaults to MICROSECOND datetime resolution.** The obvious
+`astype("int64") // 10**9` for epoch seconds therefore yields values a
+thousand times too small and draws the whole session in 1970. `bar_records`
+integer-divides a `Timedelta` instead, which is resolution-independent, and a
+test asserts it matches the master's `_bar_record` bar for bar.
+
 
 `DashboardBuilderThread` keeps its stop flag in `_stop_event`, **not** `_stop`.
 `threading.Thread` has a private `_stop()` *method* that CPython 3.12's
@@ -215,9 +267,11 @@ deliberately no host key.
 |---|---|
 | `Tests/Dependencies/test_dashboard_snapshot.py` | Every pairing confidence, the Delta-0.2 / SL-Hunting-mirror / re-entry shapes, `EXIT_FAILED` not closing, malformed events, the honesty rules, NaN rejection |
 | `Tests/Dependencies/test_dashboard_server.py` | Real loopback socket: 200/304/403/404/405, security headers, no CORS, empty stderr, root logger untouched, bind-in-use, no config read |
-| `Tests/test_nifty_multi_strategy_master.py` | The collector, the chart cache, the sink wiring in `publish_trade_event`, and the "never reaches the broker or a mutating gate" assertion |
+| `Tests/Dependencies/test_dashboard_indicators.py` | CPR truncation and every degenerate session shape; **the equality test that pins the CPR algebra against `_add_daily_cpr`**; VWAP and stochastic equality with the strategies' helpers; the forming bucket; and every fixture rendered through `render_document_bytes` |
+| `Tests/test_nifty_multi_strategy_master.py` | The collector, the chart cache, the sink wiring in `publish_trade_event`, the "never reaches the broker or a mutating gate" assertion, the recompute-cadence guards, and fail-soft when an indicator raises |
 
-`Dependencies/dashboard_snapshot.py` carries a 90 % coverage budget in
-`scripts/check_coverage_thresholds.py`. `dashboard_server.py` deliberately does
+`Dependencies/dashboard_snapshot.py` and `Dependencies/dashboard_indicators.py`
+each carry a 90 % coverage budget in `scripts/check_coverage_thresholds.py`
+(the latter measures 98.9 %). `dashboard_server.py` deliberately does
 not: socket-bound code has branches that cannot honestly be covered, and a
 budget you cannot meet is worse than none.

--- a/nifty_multi_strategy_master.py
+++ b/nifty_multi_strategy_master.py
@@ -18144,9 +18144,18 @@ def _refresh_chart_five_minute(
         closed = frame.loc[(frame["timestamp"] >= previous) & (frame["timestamp"] < anchor)]
         finished = deps.resample(closed, minutes)
         if not finished.empty:
-            cache.completed_5m = pd.concat(
-                [cache.completed_5m, finished], ignore_index=True
-            ).tail(cache.max_bars_5m + _DASHBOARD_INDICATOR_WARMUP_BARS)
+            # De-duplicate on the way in. The bulk rebuild may already hold the
+            # bucket this append re-derives -- when the newest minute happened
+            # to complete it -- and lightweight-charts requires STRICTLY
+            # ascending times: one repeat makes it silently drop bars, which
+            # shows up as a chart that is mysteriously half empty.
+            cache.completed_5m = (
+                pd.concat([cache.completed_5m, finished], ignore_index=True)
+                .drop_duplicates(subset="timestamp", keep="last")
+                .sort_values("timestamp")
+                .reset_index(drop=True)
+                .tail(cache.max_bars_5m + _DASHBOARD_INDICATOR_WARMUP_BARS)
+            )
 
     cache.bucket_anchor = anchor
     completed = cache.completed_5m

--- a/nifty_multi_strategy_master.py
+++ b/nifty_multi_strategy_master.py
@@ -253,7 +253,7 @@ import threading
 import time
 import uuid
 import warnings
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta
 from datetime import time as dt_time
@@ -279,7 +279,7 @@ import requests
 # when MARKET_DATA_SOURCE=WEBSOCKET selects the tick-driven producer below.
 from dhanhq import DhanContext, DhanLogin, MarketFeed, dhanhq
 
-from Dependencies import dashboard_snapshot
+from Dependencies import dashboard_indicators, dashboard_snapshot
 from Dependencies.broker_contract import ExecutionClient, OrderResult, OrderStatus
 from Dependencies.dashboard_server import DashboardEventSink, DashboardServer, start_dashboard
 from Dependencies.execution_ledger import (
@@ -17919,6 +17919,70 @@ def _session_state_snapshots(workers: Sequence[BasePaperStrategyWorker]) -> list
 # =============================================================================
 
 
+@dataclass(frozen=True)
+class _DashboardChartDeps:
+    """Indicator callables and settings, resolved ONCE at import.
+
+    Every callable here is the SAME object a live strategy uses, so a line on
+    the chart cannot silently drift from the maths the runner trades on. They
+    are injected rather than imported inside `Dependencies/dashboard_indicators.py`
+    because that module is pure: it may not reach into the spaced
+    `Signal Generators/` tree, and it may not read configuration.
+
+    Frozen and allocation-free -- the builder thread only ever reads it.
+    """
+
+    stochastic_fn: Callable[..., tuple[pd.Series, pd.Series]]
+    attach_session_date: Callable[[pd.DataFrame], pd.DataFrame]
+    attach_session_vwap: Callable[[pd.DataFrame], pd.DataFrame]
+    width_classifier: Callable[[float, float, float], str]
+    resample: Callable[[pd.DataFrame, int], pd.DataFrame]
+    k_period: int
+    d_period: int
+    smooth_k: int
+
+
+def _build_dashboard_chart_deps() -> _DashboardChartDeps:
+    """Resolve the strategies' own indicator helpers for the chart.
+
+    `load_module` returns `sys.modules[name]` when a bare name is already
+    loaded, and both of these are loaded by the ported signal generators, so
+    this hands back the very same module objects -- NOT a second copy. Loading
+    them under a prefixed alias instead would create a parallel instance and
+    defeat the entire point.
+    """
+
+    misc = load_module("misc_strategy_common", SIGNAL_GEN_DIR / "misc_strategy_common.py")
+    regime = load_module(
+        "regime_common", SIGNAL_GEN_DIR / "Regime Adaptive Strategy" / "regime_common.py"
+    )
+    return _DashboardChartDeps(
+        stochastic_fn=misc.stochastic,
+        attach_session_date=regime.attach_session_date,
+        attach_session_vwap=regime.attach_session_vwap,
+        width_classifier=CPR_LOGIC.classify_daily_cpr_width,
+        resample=resample_ohlc_from_1m,
+        # The SAME periods the Stochastic Oscillator strategy trades on, so the
+        # sub-pane shows that strategy's actual oscillator. Clamped anyway: a
+        # typo in a strategy knob must not be able to break the monitor.
+        k_period=min(max(int(STOCHASTIC_CONFIG.k_period), 2), 60),
+        d_period=min(max(int(STOCHASTIC_CONFIG.d_period), 1), 20),
+        smooth_k=min(max(int(STOCHASTIC_CONFIG.smooth_k), 1), 20),
+    )
+
+
+_DASHBOARD_CHART_DEPS = _build_dashboard_chart_deps()
+
+
+#: Extra bars fed to the stochastic beyond what is displayed, so the first
+#: visible bar is already warm instead of a run of nulls.
+_DASHBOARD_INDICATOR_WARMUP_BARS = 40
+
+#: Minutes per bar in the dashboard's higher timeframe. Several strategies
+#: derive exactly this, which is why it is the one the toggle offers.
+_DASHBOARD_HIGHER_TIMEFRAME_MINUTES = 5
+
+
 class _DashboardChartCache:
     """Remembers the last chart series so a poll rarely copies the frame.
 
@@ -17928,23 +17992,51 @@ class _DashboardChartCache:
     that question for free, and the frame is copied only when the answer is
     yes.
 
-    Three outcomes, cheapest first:
+    Four tiers, cheapest first:
 
     * nothing changed            -> no copy at all;
-    * the forming candle moved   -> copy, keep only the last row (`last_bar`);
-    * a new minute closed        -> copy, re-serialize the tail, bump
-                                    `series_version` so the browser refetches
-                                    the full array (about 375 times a day
-                                    rather than 22,500).
+    * the forming candle moved   -> copy, refresh only the two forming bars;
+    * a new minute closed        -> copy, re-serialize the 1-minute tail and
+                                    its indicators, bump `series_version`;
+    * a 5-minute bucket closed   -> additionally extend the 5-minute series,
+                                    resampling ONLY the bucket that just
+                                    closed (~9 ms) rather than the whole
+                                    window (~54 ms).
+
+    Single-threaded by contract: only the dashboard's builder thread touches
+    it, which is why none of this needs a lock.
     """
 
     def __init__(self, max_bars: int) -> None:
         self.max_bars = max(1, int(max_bars))
+        # Same span in both views, so switching timeframe does not change the
+        # window the operator is looking at.
+        self.max_bars_5m = max(24, math.ceil(self.max_bars / _DASHBOARD_HIGHER_TIMEFRAME_MINUTES))
+
         self.series: list[dict] = []
         self.series_version = 0
         self.last_bar: dict | None = None
         self.signature: tuple | None = None
         self.source_candle_ts: object = None
+
+        # Indicator columns, aligned to `series`.
+        self.vwap: list[float | None] = []
+        self.stoch_k: list[float | None] = []
+        self.stoch_d: list[float | None] = []
+        self.vwap_is_proxy = True
+
+        # The higher timeframe. `completed_5m` is grown a bucket at a time.
+        self.completed_5m: pd.DataFrame | None = None
+        self.bucket_anchor: pd.Timestamp | None = None
+        self.series_5m: list[dict] = []
+        self.vwap_5m: list[float | None] = []
+        self.stoch_k_5m: list[float | None] = []
+        self.stoch_d_5m: list[float | None] = []
+        self.forming_5m: dict | None = None
+
+        # CPR is a daily level: computed once per session, not per minute.
+        self.cpr: dashboard_indicators.ChartCpr = dashboard_indicators.ChartCpr(False)
+        self.cpr_key: tuple[date, int] | None = None
 
 
 def _bar_record(row: pd.Series[Any]) -> dict:
@@ -17966,10 +18058,129 @@ def _bar_record(row: pd.Series[Any]) -> dict:
     }
 
 
+def _refresh_chart_indicators(
+    frame: pd.DataFrame, cache: _DashboardChartCache, deps: _DashboardChartDeps
+) -> None:
+    """Recompute the 1-minute series and its indicator columns. Tier A.
+
+    Runs once a minute, not once a poll. Indicators are computed over a window
+    wider than the display so the leftmost visible bar is already warm, then
+    `timeframe_block` right-aligns the columns to the bars.
+
+    VWAP is computed over the DISPLAY window rather than the whole frame: it
+    resets per session anyway, so the slice is equivalent and cheaper.
+    """
+
+    display = frame.tail(cache.max_bars)
+    warm = frame.tail(cache.max_bars + _DASHBOARD_INDICATOR_WARMUP_BARS)
+
+    cache.series = dashboard_indicators.bar_records(display)
+    cache.series_version += 1
+
+    # Each indicator is guarded on its own. A broken one must cost its own
+    # line, not the candles: a chart with no VWAP is still worth looking at,
+    # and an exception here would freeze the whole dashboard on its last good
+    # document for the rest of the session.
+    try:
+        cache.vwap, cache.vwap_is_proxy = dashboard_indicators.session_vwap_values(
+            display,
+            attach_session_date=deps.attach_session_date,
+            attach_session_vwap=deps.attach_session_vwap,
+        )
+    except Exception:  # noqa: BLE001 - reporting only
+        cache.vwap, cache.vwap_is_proxy = [], True
+        logger.debug("Dashboard VWAP unavailable this minute.", exc_info=True)
+
+    try:
+        cache.stoch_k, cache.stoch_d = dashboard_indicators.stochastic_values(
+            warm,
+            stochastic_fn=deps.stochastic_fn,
+            k_period=deps.k_period,
+            d_period=deps.d_period,
+            smooth_k=deps.smooth_k,
+        )
+    except Exception:  # noqa: BLE001 - reporting only
+        cache.stoch_k, cache.stoch_d = [], []
+        logger.debug("Dashboard stochastic unavailable this minute.", exc_info=True)
+
+
+def _refresh_chart_five_minute(
+    frame: pd.DataFrame, cache: _DashboardChartCache, deps: _DashboardChartDeps
+) -> None:
+    """Extend the 5-minute series when a bucket closes. Tier A-prime.
+
+    `resample_ohlc_from_1m` is used UNCHANGED -- its "completed buckets only"
+    guarantee is what the 5-minute strategies stand on. It is simply fed the
+    five rows of the bucket that just closed (~9 ms) instead of the whole
+    window (~54 ms); the output is byte-identical either way.
+
+    A bucket that the resampler rejects (a missing or duplicated minute) is
+    absent here too, which is correct: the 5-minute strategies skipped that
+    bucket as well.
+    """
+
+    minutes = _DASHBOARD_HIGHER_TIMEFRAME_MINUTES
+    newest = pd.Timestamp(frame["timestamp"].iloc[-1])
+    anchor = newest.floor(f"{minutes}min")
+    previous = cache.bucket_anchor
+
+    rebuild = cache.completed_5m is None or previous is None
+    if previous is not None and not rebuild:
+        # More than one bucket has gone by (a stall, or a restart): the
+        # incremental path would silently skip the gap, so rebuild instead.
+        elapsed = (anchor - previous) // pd.Timedelta(minutes=minutes)
+        rebuild = not 0 <= elapsed <= 1
+
+    if rebuild or previous is None:
+        # A ROW tail, not a time window. A time window anchored to "now" reaches
+        # back past midnight at the start of a session and so excludes the whole
+        # previous day, leaving the 5-minute chart nearly empty every morning --
+        # while the 1-minute chart beside it happily shows yesterday's close.
+        # Counting rows keeps both views over the same bars. Any partial leading
+        # bucket is dropped by the resampler, as it is for the strategies.
+        span_rows = (cache.max_bars_5m + _DASHBOARD_INDICATOR_WARMUP_BARS) * minutes
+        cache.completed_5m = deps.resample(frame.tail(span_rows), minutes)
+    elif anchor != previous:
+        closed = frame.loc[(frame["timestamp"] >= previous) & (frame["timestamp"] < anchor)]
+        finished = deps.resample(closed, minutes)
+        if not finished.empty:
+            cache.completed_5m = pd.concat(
+                [cache.completed_5m, finished], ignore_index=True
+            ).tail(cache.max_bars_5m + _DASHBOARD_INDICATOR_WARMUP_BARS)
+
+    cache.bucket_anchor = anchor
+    completed = cache.completed_5m
+    if completed is None or completed.empty:
+        cache.series_5m, cache.vwap_5m, cache.stoch_k_5m, cache.stoch_d_5m = [], [], [], []
+        return
+
+    display = completed.tail(cache.max_bars_5m)
+    cache.series_5m = dashboard_indicators.bar_records(display)
+    cache.vwap_5m, _ = dashboard_indicators.session_vwap_values(
+        display,
+        attach_session_date=deps.attach_session_date,
+        attach_session_vwap=deps.attach_session_vwap,
+    )
+    cache.stoch_k_5m, cache.stoch_d_5m = dashboard_indicators.stochastic_values(
+        completed,
+        stochastic_fn=deps.stochastic_fn,
+        k_period=deps.k_period,
+        d_period=deps.d_period,
+        smooth_k=deps.smooth_k,
+    )
+
+
 def _dashboard_chart_payload(
-    store: SharedMarketDataStore, cache: _DashboardChartCache
+    store: SharedMarketDataStore,
+    cache: _DashboardChartCache,
+    deps: _DashboardChartDeps = _DASHBOARD_CHART_DEPS,
 ) -> dict:
-    """The chart half of the document: a version, and the forming candle."""
+    """The chart half of the `/api/state` document: a version and the forming bars.
+
+    The heavy arrays live behind `/api/chart` and are refetched only when
+    `series_version` moves. Everything here is deliberately small enough to
+    ride along with every poll.
+    """
 
     meta = store.peek_snapshot_meta("1")
     if meta is None:
@@ -17977,12 +18188,8 @@ def _dashboard_chart_payload(
     signature, source_candle_ts, _fetched_at = meta
 
     if signature == cache.signature:
-        return {
-            "state": "OK",
-            "series_version": cache.series_version,
-            "last_bar": cache.last_bar,
-            "bars": len(cache.series),
-        }
+        # TIER C. The store is never touched here, and a test pins that.
+        return _chart_state_block(cache)
 
     snapshot = store.get("1")
     if snapshot is None or snapshot.frame.empty:
@@ -17990,33 +18197,103 @@ def _dashboard_chart_payload(
                 "last_bar": None, "bars": 0}
 
     frame = snapshot.frame
-    new_minute = source_candle_ts != cache.source_candle_ts or not cache.series
-    if new_minute:
-        tail = frame.tail(cache.max_bars)
-        cache.series = [_bar_record(row) for _, row in tail.iterrows()]
-        cache.series_version += 1
+    if source_candle_ts != cache.source_candle_ts or not cache.series:
+        # TIER A, once a minute.
+        _refresh_chart_indicators(frame, cache, deps)
+        # The higher timeframe and CPR are each expendable: losing one leaves
+        # the other two panes intact rather than blanking the chart.
+        try:
+            _refresh_chart_five_minute(frame, cache, deps)
+        except Exception:  # noqa: BLE001 - reporting only
+            logger.debug("Dashboard 5-minute series unavailable this minute.", exc_info=True)
+        try:
+            _refresh_chart_cpr(frame, cache, deps)
+        except Exception:  # noqa: BLE001 - reporting only
+            logger.debug("Dashboard CPR unavailable this minute.", exc_info=True)
         cache.source_candle_ts = source_candle_ts
+
+    # TIER B, at most once a poll: only the two forming bars move.
     cache.last_bar = _bar_record(frame.iloc[-1])
+    cache.forming_5m, _anchor = dashboard_indicators.forming_bucket(
+        frame, timeframe_minutes=_DASHBOARD_HIGHER_TIMEFRAME_MINUTES
+    )
     cache.signature = signature
+    return _chart_state_block(cache)
+
+
+def _refresh_chart_cpr(
+    frame: pd.DataFrame, cache: _DashboardChartCache, deps: _DashboardChartDeps
+) -> None:
+    """Recompute CPR only when the session it is derived from changes.
+
+    A daily level does not move intraday, so this runs about once per session
+    rather than once per minute.
+    """
+
+    today = frame["timestamp"].iloc[-1].date()
+    key = (today, len(frame))
+    if cache.cpr_key is not None and cache.cpr_key[0] == today and cache.cpr.available:
+        return
+    cache.cpr = dashboard_indicators.chart_cpr(frame, width_classifier=deps.width_classifier)
+    cache.cpr_key = key
+
+
+def _chart_state_block(cache: _DashboardChartCache) -> dict:
+    """The small per-poll block. No frame, no arrays -- just what moves."""
 
     return {
-        "state": "OK",
+        "state": "OK" if cache.series else "NO_DATA",
         "series_version": cache.series_version,
         "last_bar": cache.last_bar,
+        "last_bar_5m": cache.forming_5m,
         "bars": len(cache.series),
+        "bars_5m": len(cache.series_5m),
     }
 
 
-def _dashboard_chart_series(cache: _DashboardChartCache) -> dict:
-    """The full candle array behind `/api/chart`.
+def _dashboard_chart_series(
+    cache: _DashboardChartCache, deps: _DashboardChartDeps = _DASHBOARD_CHART_DEPS
+) -> dict:
+    """The full `/api/chart` payload: both timeframes, their indicators, and CPR.
 
     Read straight out of the cache the state document already filled, so this
     touches neither the store nor its lock. The builder thread calls it only
-    when `series_version` has moved, i.e. once a minute rather than once a
-    poll.
+    when `series_version` has moved -- once a minute rather than once a poll.
+
+    BOTH timeframes ride in one payload on purpose: the toggle then switches
+    instantly from data the browser already holds, so it has no way to fail,
+    and the transport keeps its single publisher slot and zero-argument
+    builder.
     """
 
-    return {"series_version": cache.series_version, "bars": cache.series}
+    timeframes = {
+        "1": dashboard_indicators.timeframe_block(
+            minutes=1,
+            bars=cache.series,
+            vwap=cache.vwap,
+            stoch_k=cache.stoch_k,
+            stoch_d=cache.stoch_d,
+        ),
+        str(_DASHBOARD_HIGHER_TIMEFRAME_MINUTES): dashboard_indicators.timeframe_block(
+            minutes=_DASHBOARD_HIGHER_TIMEFRAME_MINUTES,
+            bars=cache.series_5m,
+            vwap=cache.vwap_5m,
+            stoch_k=cache.stoch_k_5m,
+            stoch_d=cache.stoch_d_5m,
+            forming_from=(cache.forming_5m or {}).get("time"),
+        ),
+    }
+    return dashboard_indicators.chart_document(
+        series_version=cache.series_version,
+        timeframes=timeframes,
+        cpr=cache.cpr,
+        vwap_is_proxy=cache.vwap_is_proxy,
+        stochastic_settings={
+            "k_period": deps.k_period,
+            "d_period": deps.d_period,
+            "smooth_k": deps.smooth_k,
+        },
+    )
 
 
 def _dashboard_feed_view(store: SharedMarketDataStore) -> dict:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ files = [
     # carries a 90% coverage budget in scripts/check_coverage_thresholds.py.
     "Dependencies/dashboard_snapshot.py",
     "Dependencies/dashboard_server.py",
+    "Dependencies/dashboard_indicators.py",
     "Dependencies/diagnostic_preflight.py",
     "Dependencies/next_open_entry.py",
     "Dependencies/order_splitting.py",

--- a/scripts/check_coverage_thresholds.py
+++ b/scripts/check_coverage_thresholds.py
@@ -48,6 +48,10 @@ SAFETY_THRESHOLDS = {
     # has branches that cannot honestly be covered, and a budget you cannot
     # meet is worse than none.
     "Dependencies/dashboard_snapshot.py": 90.0,
+    # The chart's indicator maths. A defect here draws a CPR level or a
+    # stochastic in the wrong place beside real positions, and it is pure
+    # pandas with no I/O, so the budget is cheap to honour.
+    "Dependencies/dashboard_indicators.py": 90.0,
     # The rolling-window rate limiter, hoisted out of the Flattrade and Dhan
     # adapters (2026-09-02). It sits directly in front of every live broker
     # request those two make: if it under-counts, orders breach the broker's


### PR DESCRIPTION
Adds the three indicators to the dashboard chart, a 1m/5m toggle, and a taller pane. Also carries a
fix for the staleness banner that was flashing during a live session.

> Built in a worktree because `nifty_multi_strategy_master.py` had uncommitted v5c work in it at the
> time. `Dependencies/dashboard_server.py` is **byte-identical to `main`** — `git diff main` on it is
> empty — because one payload carrying both timeframes never asks the transport a question.

## What you get

| | |
|---|---|
| **Chart pane** | 40vh → `clamp(340px, 58vh, 760px)` with a drag handle. On 1080p the *price* pane goes ~432px → ~510px **and** gains the oscillator. |
| **CPR** | Pivot/BC/TC on by default; R1/R2·S1/S2 and R3/R4·S3/S4 behind checkboxes. |
| **VWAP** | Labelled `VWAP*` — it is an equal-weight proxy on every live row, because the index feed carries no volume. |
| **Stochastic** | %K/%D in their own pane with 80/20 guides, using the `STOCHASTIC_*` periods that strategy trades on. |
| **1m/5m toggle** | Both timeframes ride in one payload, so switching is **zero network requests** and cannot fail. |
| **Preferences** | Persisted under a versioned `localStorage` key inside `try/catch`. |

**No new `.env` keys.** Chart height is CSS, the 5-minute bar count is derived, the stochastic
periods track `STOCHASTIC_CONFIG`, and the 15:15 cut-off is a module constant.

## The one deliberate divergence — [ADR-0017](docs/adr/0017-chart-only-cpr-on-a-truncated-prior-session.md)

The chart's CPR reads the prior session **09:15–15:15 inclusive** (high, low *and* close). The live
CPR / CPR Algo 3 / CPR AI strategies are **untouched** and keep using the full session.

Worth knowing: those strategies already take the last *intraday* bar (~15:29), **not** the official
CAS-settled close — so 15:15 moves further from the auction rather than rescuing them from it.

Only the input *window* differs. `test_only_the_input_window_differs_from_the_strategies_cpr` feeds
an **untruncated** session through both implementations and demands the levels match level-for-level,
so nobody can quietly fork a formula.

And rather than just warning, the page prints **both** numbers:

```
Prior 2026-09-10 09:15-15:15 · 361 bars · H 24630.08 L 24376.35 C 24485.94
  · pivot 24497.46 (chart) · strategies 24491.21 (full session) · narrow
```

Plus a `CHART-ONLY` chip, `(chart)` on every price-line title, and the window in the pane heading.

## VWAP and the stochastic cannot drift

They are the strategies' **own objects**, reached with `load_module` under *bare* names — which
returns `sys.modules[name]` when already loaded. A prefixed alias would create a second copy that
type-checks, runs, and diverges the moment anyone retunes a helper. A test asserts identity with
`sys.modules`.

## Performance — measured before a line of feature code

Phase 0 changed two decisions and then paid for the whole feature:

| | |
|---|---|
| `resample_ohlc_from_1m`, 575-row window vs the single closed bucket | **54 ms → 9 ms**, byte-identical output → incremental 5-minute build |
| Bar serialization, `iterrows()` vs vectorized | **39 ms → 1.6 ms** |

Wired up, on a 2,200-row frame: **0.0 ms idle, 10.5 ms median on a new minute, 37 ms worst**, against
a 1000 ms interval. Cold start 59 ms, once per process.

Cadence is pinned by tests: 20 idle polls recompute **nothing** (the existing `store.get`
`AssertionError` guard still passes verbatim), 20 new minutes trigger **5** resamples — one per
bucket, not one per minute.

## Five bugs found, four of them only because something was checked

1. **pandas 3 uses `datetime64[us]`** — `astype("int64") // 10**9` yields timestamps 1000× too small
   and draws the session in **1970**. Caught by asserting the vectorized serializer equals
   `_bar_record` bar for bar.
2. **5-minute window was time-based** (`anchor − 575 min`), which at 09:15 reaches back to 23:40 and
   excludes the whole prior session — a near-empty 5m chart *every morning*. Now a row tail, with a
   session-boundary regression test.
3. **Duplicate timestamp** in the 5-minute series; lightweight-charts requires strictly ascending
   times and silently drops bars. Test verified to fail (75 ≠ 74) before the fix.
4. **`fitContent()` against a zero-width container silently does nothing**, squeezing every candle
   into a few pixels. Diagnosed by measuring `clientWidth`, after first wrongly assuming the
   overnight gap was to blame. Now a `ResizeObserver`.
5. **Hiding the oscillator left its pane as dead space** — the opposite of what unticking it is for.

## Also in here: the staleness-banner fix

`visibilitychange` called `poll()` while the previous `setTimeout` was still pending, so every
tab-return added a permanent extra poll loop (measured: 3 polls/5s → 15 after four returns). N loops
against one publisher means mostly 304s, which the page read as "the runner has gone quiet". Now one
loop, and staleness measured in *time* rather than by counting 304s.

## Gates

605 master unittests · 28 market-data-health · 1484 pytest · coverage **72.0 %** against the 70.0
floor, with `dashboard_indicators.py` at **98.9 %** on a new 90 % budget · ruff · mypy ×2 ·
compileall · bandit · pre-commit · no undocumented env keys.

Verified end to end in a browser against a fixture runner: both timeframes, every checkbox, a reload
for persistence, and defaults after clearing storage.

## Before enabling live

Run a paper session with `DASHBOARD_ENABLED=true` first. Worth a glance on the first morning
specifically: that the 5-minute pane is populated at 09:20 (bug 2) and that the provenance line's
H/L/C match a hand-check of the prior session's 09:15–15:15 bars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
